### PR TITLE
Fix extra redirect when opening games without player filter

### DIFF
--- a/wwwroot/games.php
+++ b/wwwroot/games.php
@@ -300,7 +300,7 @@ $offset = ($page - 1) * $limit;
             }
 
             $gameLink = $game["id"] ."-". slugify($game["name"]);
-            if (isset($player)) {
+            if (!empty($player)) {
                 $gameLink .= "/". $player;
             }
             ?>


### PR DESCRIPTION
## Summary
- avoid appending an empty player segment to game detail links on the games listing
- prevent generating URLs that force an unnecessary redirect before serving the game page

## Testing
- php -l wwwroot/games.php

------
https://chatgpt.com/codex/tasks/task_e_68cabb02b670832fa36eb211ff771b7c