### PR TITLE
Handle missing transliterator in slugify

### DIFF
--- a/wwwroot/functions.php
+++ b/wwwroot/functions.php
@@ -8,13 +8,26 @@ function slugify($text)
     $text = str_replace("%", "percent", $text);
     $text = str_replace(" - ", " ", $text);
 
-    return \Transliterator::createFromRules(
-        ':: Any-Latin;'
-        . ':: NFD;'
-        . ':: [:Nonspacing Mark:] Remove;'
-        . ':: NFC;'
-        . ':: [:Punctuation:] Remove;'
-        . ':: Lower();'
-        . '[:Separator:] > \'-\''
-    )->transliterate($text);
+    $transliterator = class_exists('Transliterator')
+        ? \Transliterator::createFromRules(
+            ':: Any-Latin;'
+            . ':: NFD;'
+            . ':: [:Nonspacing Mark:] Remove;'
+            . ':: NFC;'
+            . ':: [:Punctuation:] Remove;'
+            . ':: Lower();'
+            . '[:Separator:] > \'-\''
+        )
+        : false;
+
+    if ($transliterator instanceof \Transliterator) {
+        $slug = $transliterator->transliterate($text);
+        if (is_string($slug) && $slug !== '') {
+            return $slug;
+        }
+    }
+
+    $text = strtolower($text);
+    $text = preg_replace('/[^a-z0-9]+/', '-', $text);
+    return trim($text, '-');
 }


### PR DESCRIPTION
## Summary
- add a graceful fallback in `slugify` when the Transliterator extension is unavailable or fails
- ensure slug generation still collapses non-alphanumeric characters even without ICU support

## Testing
- php -l wwwroot/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68caef28a1fc832fb1e481f68e3c7b74