### PR TITLE
Fix router path detection without SCRIPT_URL

### DIFF
--- a/wwwroot/index.php
+++ b/wwwroot/index.php
@@ -7,7 +7,11 @@ if ($maintenance) {
 
 require_once("init.php");
 
-$path = ltrim($_SERVER["SCRIPT_URL"], "/"); // Trim leading slash(es)
+// SCRIPT_URL isn't available in all web server configurations (for example,
+// the PHP built-in development server). Fall back to REQUEST_URI and strip any
+// query string so routing works everywhere without PHP notices.
+$requestUri = $_SERVER["SCRIPT_URL"] ?? ($_SERVER["REQUEST_URI"] ?? "/");
+$path = ltrim(parse_url($requestUri, PHP_URL_PATH) ?: "", "/"); // Trim leading slash(es)
 $elements = explode("/", $path); // Split path on slashes
 
 if (empty($elements[0])) { // No path elements means home


### PR DESCRIPTION
## Summary
- ensure the front controller falls back to REQUEST_URI when SCRIPT_URL is unavailable so routing works without notices

## Testing
- php -l wwwroot/index.php

------
https://chatgpt.com/codex/tasks/task_e_68cb236d85d0832f9c8b20b10f3ee5db