### PR TITLE
Add fallback for country name localization

### DIFF
--- a/wwwroot/about.php
+++ b/wwwroot/about.php
@@ -111,7 +111,7 @@ require_once("header.php");
                                     $players = $query->fetchAll();
 
                                     foreach ($players as $player) {
-                                        $countryName = Locale::getDisplayRegion("-" . $player["country"], "en");
+                                        $countryName = getCountryName($player["country"]);
                                         
                                         if ($player["status"] != 0) {
                                             $rank = "N/A";

--- a/wwwroot/functions.php
+++ b/wwwroot/functions.php
@@ -31,3 +31,25 @@ function slugify($text)
     $text = preg_replace('/[^a-z0-9]+/', '-', $text);
     return trim($text, '-');
 }
+
+function getCountryName($countryCode)
+{
+    $countryCode = strtoupper(trim((string) ($countryCode ?? '')));
+
+    if ($countryCode === '') {
+        return 'Unknown';
+    }
+
+    if (class_exists('Locale')) {
+        try {
+            $name = \Locale::getDisplayRegion('-' . $countryCode, 'en');
+            if (is_string($name) && $name !== '') {
+                return $name;
+            }
+        } catch (\Throwable $exception) {
+            // Ignore and fall back to returning the country code.
+        }
+    }
+
+    return $countryCode;
+}

--- a/wwwroot/game_leaderboard.php
+++ b/wwwroot/game_leaderboard.php
@@ -178,7 +178,7 @@ unset($paramsWithoutPage["page"]);
 
                             $rank = $offset;
                             foreach ($rows as $row) {
-                                $countryName = Locale::getDisplayRegion("-" . $row["country"], 'en');
+                                $countryName = getCountryName($row["country"]);
                                 $paramsAvatar = $paramsWithoutPage;
                                 $paramsAvatar["avatar"] = $row["avatar_url"];
                                 $paramsCountry = $paramsWithoutPage;

--- a/wwwroot/game_recent_players.php
+++ b/wwwroot/game_recent_players.php
@@ -135,7 +135,7 @@ if (isset($url_parts["query"])) { // Avoid 'Undefined index: query'
 
                             $rank = 0;
                             foreach ($rows as $row) {
-                                $countryName = Locale::getDisplayRegion("-" . $row["country"], 'en');
+                                $countryName = getCountryName($row["country"]);
                                 $paramsAvatar = $params;
                                 $paramsAvatar["avatar"] = $row["avatar_url"];
                                 $paramsCountry = $params;

--- a/wwwroot/leaderboard_main.php
+++ b/wwwroot/leaderboard_main.php
@@ -122,7 +122,7 @@ unset($paramsWithoutPage["page"]);
 
                             foreach ($players as $player) {
                                 $trophies = $player["bronze"] + $player["silver"] + $player["gold"] + $player["platinum"];
-                                $countryName = Locale::getDisplayRegion("-" . $player["country"], "en");
+                                $countryName = getCountryName($player["country"]);
                                 if (isset($_GET["player"]) && $_GET["player"] == $player["online_id"]) {
                                     echo "<tr id=\"". $player["online_id"] ."\" class=\"table-primary\">";
                                 } else {

--- a/wwwroot/leaderboard_rarity.php
+++ b/wwwroot/leaderboard_rarity.php
@@ -122,7 +122,7 @@ unset($paramsWithoutPage["page"]);
                             $players = $query->fetchAll();
 
                             foreach ($players as $player) {
-                                $countryName = Locale::getDisplayRegion("-" . $player["country"], "en");
+                                $countryName = getCountryName($player["country"]);
                                 if (isset($_GET["player"]) && $_GET["player"] == $player["online_id"]) {
                                     echo "<tr id=\"". $player["online_id"] ."\" class=\"table-primary\">";
                                 } else {

--- a/wwwroot/player_header.php
+++ b/wwwroot/player_header.php
@@ -1,6 +1,6 @@
 <?php
 $aboutMe = nl2br(htmlentities($player["about_me"], ENT_QUOTES, 'UTF-8'));
-$countryName = Locale::getDisplayRegion("-" . $player["country"], 'en');
+$countryName = getCountryName($player["country"]);
 $trophies = $player["bronze"] + $player["silver"] + $player["gold"] + $player["platinum"];
 ?>
 


### PR DESCRIPTION
## Summary
- add a helper that gracefully formats country names even when the intl extension is missing or misconfigured
- update leaderboard, profile, and about pages to rely on the helper instead of calling Locale::getDisplayRegion directly

## Testing
- php -l wwwroot/functions.php
- php -l wwwroot/player_header.php
- php -l wwwroot/leaderboard_main.php
- php -l wwwroot/leaderboard_rarity.php
- php -l wwwroot/game_leaderboard.php
- php -l wwwroot/game_recent_players.php
- php -l wwwroot/about.php

------
https://chatgpt.com/codex/tasks/task_e_68cc86f6ac1c832fb7f4f1d69807acfd