### PR TITLE
Refactor ranking cron job to OOP

### DIFF
--- a/wwwroot/cron/5th_minute.php
+++ b/wwwroot/cron/5th_minute.php
@@ -1,54 +1,105 @@
 <?php
+declare(strict_types=1);
+
 ini_set("max_execution_time", "0");
 ini_set("mysql.connect_timeout", "0");
 set_time_limit(0);
+
 require_once("/home/psn100/public_html/init.php");
 
-// Recalculate all the rankings
-do {
-    try {
-        // 1. Create a new table if it doesn't exist
-        $database->exec("CREATE TABLE IF NOT EXISTS player_ranking_new LIKE player_ranking");
+class PlayerRankingUpdater
+{
+    private const TEMPORARY_TABLE = 'player_ranking_new';
+    private const PRIMARY_TABLE = 'player_ranking';
+    private const PREVIOUS_TABLE = 'player_ranking_old';
+    private const INSERT_TEMPLATE = <<<'SQL'
+INSERT INTO %s (account_id, ranking, ranking_country, rarity_ranking, rarity_ranking_country)
+SELECT
+    account_id,
+    RANK() OVER (
+        ORDER BY points DESC, platinum DESC, gold DESC, silver DESC
+    ) AS ranking,
+    RANK() OVER (
+        PARTITION BY country
+        ORDER BY points DESC, platinum DESC, gold DESC, silver DESC
+    ) AS ranking_country,
+    RANK() OVER (
+        ORDER BY `rarity_points` DESC
+    ) AS rarity_ranking,
+    RANK() OVER (
+        PARTITION BY country
+        ORDER BY `rarity_points` DESC
+    ) AS rarity_ranking_country
+FROM player
+WHERE `status` = 0
+SQL;
 
-        // 2. Empty the new table
-        $database->exec("TRUNCATE TABLE player_ranking_new");
+    /**
+     * @var PDO
+     */
+    private $database;
 
-        // 3. Fill it with new ranked data
-        $insertSQL = "
-            INSERT INTO player_ranking_new (account_id, ranking, ranking_country, rarity_ranking, rarity_ranking_country)
-            SELECT
-                account_id,
-                RANK() OVER (
-                    ORDER BY points DESC, platinum DESC, gold DESC, silver DESC
-                ) AS ranking,
-                RANK() OVER (
-                    PARTITION BY country
-                    ORDER BY points DESC, platinum DESC, gold DESC, silver DESC
-                ) AS ranking_country,
-                RANK() OVER (
-                    ORDER BY `rarity_points` DESC
-                ) AS rarity_ranking,
-                RANK() OVER (
-                    PARTITION BY country
-                    ORDER BY `rarity_points` DESC
-                ) AS rarity_ranking_country
-            FROM player
-            WHERE `status` = 0
-        ";
-        $database->exec($insertSQL);
-
-        // 4. Change table name
-        $database->exec("
-            RENAME TABLE player_ranking TO player_ranking_old,
-                         player_ranking_new TO player_ranking
-        ");
-
-        // 5. Delete the old table
-        $database->exec("DROP TABLE player_ranking_old");
-
-        $deadlock = false;
-    } catch (Exception $e) {
-        sleep(3);
-        $deadlock = true;
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
     }
-} while ($deadlock);
+
+    public function recalculate(): void
+    {
+        do {
+            $shouldRetry = false;
+
+            try {
+                $this->createTemporaryTable();
+                $this->clearTemporaryTable();
+                $this->populateTemporaryTable();
+                $this->replaceRankingTable();
+            } catch (Throwable $exception) {
+                $shouldRetry = true;
+                sleep(3);
+            }
+        } while ($shouldRetry);
+    }
+
+    private function createTemporaryTable(): void
+    {
+        $sql = sprintf(
+            'CREATE TABLE IF NOT EXISTS %s LIKE %s',
+            self::TEMPORARY_TABLE,
+            self::PRIMARY_TABLE
+        );
+
+        $this->database->exec($sql);
+    }
+
+    private function clearTemporaryTable(): void
+    {
+        $sql = sprintf('TRUNCATE TABLE %s', self::TEMPORARY_TABLE);
+        $this->database->exec($sql);
+    }
+
+    private function populateTemporaryTable(): void
+    {
+        $sql = sprintf(self::INSERT_TEMPLATE, self::TEMPORARY_TABLE);
+        $this->database->exec($sql);
+    }
+
+    private function replaceRankingTable(): void
+    {
+        $renameSql = sprintf(
+            'RENAME TABLE %s TO %s, %s TO %s',
+            self::PRIMARY_TABLE,
+            self::PREVIOUS_TABLE,
+            self::TEMPORARY_TABLE,
+            self::PRIMARY_TABLE
+        );
+
+        $this->database->exec($renameSql);
+
+        $dropSql = sprintf('DROP TABLE %s', self::PREVIOUS_TABLE);
+        $this->database->exec($dropSql);
+    }
+}
+
+$updater = new PlayerRankingUpdater($database);
+$updater->recalculate();


### PR DESCRIPTION
## Summary
- refactor the 5-minute cron script into a PlayerRankingUpdater class to encapsulate the ranking update workflow
- extract the SQL statements into focused methods and constants for easier reuse and future maintenance

## Testing
- php -l wwwroot/cron/5th_minute.php

------
https://chatgpt.com/codex/tasks/task_e_68cc8db0d1c8832fbad3ca12ea9d5bf7