### PR TITLE
Refactor queue handling to object-oriented services

### DIFF
--- a/wwwroot/add_to_queue.php
+++ b/wwwroot/add_to_queue.php
@@ -1,75 +1,10 @@
 <?php
-require_once("init.php");
 
-$player = trim($_REQUEST["q"]);
-$ipAddress = $_SERVER["REMOTE_ADDR"];
+require_once 'init.php';
+require_once 'classes/PlayerQueueService.php';
+require_once 'classes/PlayerQueueHandler.php';
 
-$query = $database->prepare("SELECT
-        COUNT(*)
-    FROM
-        player_queue
-    WHERE
-        ip_address = :ip_address
-    ");
-$query->bindValue(":ip_address", $ipAddress, PDO::PARAM_STR);
-$query->execute();
-$count = $query->fetchColumn();
+$playerQueueService = new PlayerQueueService($database);
+$playerQueueHandler = new PlayerQueueHandler($playerQueueService);
 
-// Check cheater status
-$query = $database->prepare("SELECT
-        account_id
-    FROM
-        player
-    WHERE
-        online_id = :online_id AND status = 1
-    ");
-$query->bindValue(":online_id", $player, PDO::PARAM_STR);
-$query->execute();
-$accountId = $query->fetchColumn();
-
-if (!isset($player) || $player === "") {
-    echo "PSN name can't be empty.";
-} elseif ($accountId !== false) {
-    $player = htmlentities($player, ENT_QUOTES, "UTF-8");
-    ?>
-    Player '<a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/player/<?= $player; ?>"><?= $player; ?></a>' is tagged as a cheater and won't be scanned. <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="https://github.com/Ragowit/psn100/issues?q=label%3Acheater+<?= $player; ?>+OR+<?= $accountId; ?>">Dispute</a>?
-    <?php
-} elseif ($count >= 10) {
-    echo "You have already entered 10 players into the queue. Please wait a while.";
-} elseif (preg_match("/^[\w\-]{3,16}$/", $player)) {
-    // Insert player into the queue
-    // $query = $database->prepare("INSERT IGNORE INTO player_queue (online_id, ip_address)
-    //     VALUES
-    //         (:online_id, :ip_address)
-    //     ");
-    // Currently our initial backlog is huge, so use this for a while.
-    $query = $database->prepare("INSERT INTO
-            player_queue (online_id, ip_address)
-        VALUES
-            (:online_id, :ip_address) ON DUPLICATE KEY
-        UPDATE
-            ip_address = IF(
-                request_time >= '2030-01-01 00:00:00',
-                :ip_address,
-                ip_address
-            ),
-            request_time = IF(
-                request_time >= '2030-01-01 00:00:00',
-                NOW(),
-                request_time
-            )
-        ");
-    $query->bindValue(":online_id", $player, PDO::PARAM_STR);
-    $query->bindValue(":ip_address", $ipAddress, PDO::PARAM_STR);
-    $query->execute();
-
-    $player = htmlentities($player, ENT_QUOTES, "UTF-8");
-    ?>
-    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/player/<?= $player; ?>"><?= $player; ?></a> is being added to the queue.
-    <div class="spinner-border" role="status">
-        <span class="visually-hidden">Loading...</span>
-    </div>
-    <?php
-} else {
-    echo "PSN name must contain between three and 16 characters, and can consist of letters, numbers, hyphens (-) and underscores (_).";
-}
+echo $playerQueueHandler->handleAddToQueueRequest($_REQUEST, $_SERVER);

--- a/wwwroot/check_queue_position.php
+++ b/wwwroot/check_queue_position.php
@@ -1,87 +1,10 @@
 <?php
-require_once("init.php");
 
-$player = trim($_REQUEST["q"]);
+require_once 'init.php';
+require_once 'classes/PlayerQueueService.php';
+require_once 'classes/PlayerQueueHandler.php';
 
-$ipAddress = $_SERVER["REMOTE_ADDR"];
-$query = $database->prepare("SELECT
-        COUNT(*)
-    FROM
-        player_queue
-    WHERE
-        ip_address = :ip_address
-    ");
-$query->bindValue(":ip_address", $ipAddress, PDO::PARAM_STR);
-$query->execute();
-$count = $query->fetchColumn();
+$playerQueueService = new PlayerQueueService($database);
+$playerQueueHandler = new PlayerQueueHandler($playerQueueService);
 
-// Check if scanning
-$query = $database->prepare("SELECT scanning FROM setting WHERE scanning = :online_id");
-$query->bindValue(":online_id", $player, PDO::PARAM_STR);
-$query->execute();
-$scanning = $query->fetchColumn();
-
-// Check position
-$query = $database->prepare("WITH temp AS(
-        SELECT
-            request_time,
-            online_id,
-            ROW_NUMBER() OVER(
-                ORDER BY
-                    request_time
-            ) AS 'rownum'
-        FROM
-            player_queue
-    )
-    SELECT
-        rownum
-    FROM
-        temp
-    WHERE
-        online_id = :online_id
-    ");
-$query->bindValue(":online_id", $player, PDO::PARAM_STR);
-$query->execute();
-$position = $query->fetchColumn();
-
-// Check status
-$query = $database->prepare("SELECT account_id, `status` FROM player WHERE online_id = :online_id");
-$query->bindValue(":online_id", $player, PDO::PARAM_STR);
-$query->execute();
-$playerData = $query->fetch();
-$accountId = $playerData["account_id"] ?? "";
-$status = $playerData["status"] ?? 0;
-
-$player = htmlentities($player, ENT_QUOTES, "UTF-8");
-
-if (!isset($player) || $player === "") {
-    echo "PSN name can't be empty.";
-} elseif ($count >= 10) {
-    echo "You have already entered 10 players into the queue. Please wait a while.";
-} elseif (!preg_match("/^[\w\-]{3,16}$/", $player)) {
-    echo "PSN name must contain between three and 16 characters, and can consist of letters, numbers, hyphens (-) and underscores (_).";
-} elseif ($status == 1) { // cheater
-    ?>
-    Player '<a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/player/<?= $player; ?>"><?= $player; ?></a>' is tagged as a cheater and won't be scanned. <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="https://github.com/Ragowit/psn100/issues?q=label%3Acheater+<?= $player; ?>+OR+<?= $accountId; ?>">Dispute</a>?
-    <?php
-} elseif ($scanning) {
-    ?>
-    <a class='link-underline link-underline-opacity-0 link-underline-opacity-100-hover' href="/player/<?= $player; ?>"><?= $player; ?></a> is currently being scanned.
-    <div class="spinner-border" role="status">
-        <span class="visually-hidden">Loading...</span>
-    </div>
-    <?php
-} elseif ($position) {
-    ?>
-    <a class='link-underline link-underline-opacity-0 link-underline-opacity-100-hover' href="/player/<?= $player; ?>"><?= $player; ?></a> is in the update queue, currently in position <?= $position; ?>.
-    <div class="spinner-border" role="status">
-        <span class="visually-hidden">Loading...</span>
-    </div>
-    <?php
-} else {
-    ?>
-    <a class='link-underline link-underline-opacity-0 link-underline-opacity-100-hover' href="/player/<?= $player; ?>"><?= $player; ?></a> has been updated!
-    <?php
-}
-?>
-
+echo $playerQueueHandler->handleQueuePositionRequest($_REQUEST, $_SERVER);

--- a/wwwroot/classes/PlayerQueueHandler.php
+++ b/wwwroot/classes/PlayerQueueHandler.php
@@ -1,0 +1,110 @@
+<?php
+
+class PlayerQueueHandler
+{
+    private PlayerQueueService $service;
+
+    public function __construct(PlayerQueueService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function handleAddToQueueRequest(array $requestData, array $serverData): string
+    {
+        $playerName = $this->service->sanitizePlayerName($requestData['q'] ?? '');
+        $ipAddress = $this->service->sanitizeIpAddress($serverData['REMOTE_ADDR'] ?? '');
+
+        if ($playerName === '') {
+            return "PSN name can't be empty.";
+        }
+
+        $cheaterAccountId = $this->service->getCheaterAccountId($playerName);
+        if ($cheaterAccountId !== null) {
+            return $this->createCheaterMessage($playerName, $cheaterAccountId);
+        }
+
+        if ($this->service->hasReachedIpSubmissionLimit($ipAddress)) {
+            return $this->createQueueLimitMessage();
+        }
+
+        if (!$this->service->isValidPlayerName($playerName)) {
+            return "PSN name must contain between three and 16 characters, and can consist of letters, numbers, hyphens (-) and underscores (_).";
+        }
+
+        $this->service->addPlayerToQueue($playerName, $ipAddress);
+
+        $playerLink = $this->createPlayerLink($playerName);
+
+        return $this->createSpinnerMessage("{$playerLink} is being added to the queue.");
+    }
+
+    public function handleQueuePositionRequest(array $requestData, array $serverData): string
+    {
+        $playerName = $this->service->sanitizePlayerName($requestData['q'] ?? '');
+        $ipAddress = $this->service->sanitizeIpAddress($serverData['REMOTE_ADDR'] ?? '');
+
+        if ($playerName === '') {
+            return "PSN name can't be empty.";
+        }
+
+        if ($this->service->hasReachedIpSubmissionLimit($ipAddress)) {
+            return $this->createQueueLimitMessage();
+        }
+
+        if (!$this->service->isValidPlayerName($playerName)) {
+            return "PSN name must contain between three and 16 characters, and can consist of letters, numbers, hyphens (-) and underscores (_).";
+        }
+
+        $playerData = $this->service->getPlayerStatusData($playerName);
+        if ($this->service->isCheaterStatus($playerData['status'])) {
+            return $this->createCheaterMessage($playerName, $playerData['account_id']);
+        }
+
+        if ($this->service->isPlayerBeingScanned($playerName)) {
+            $playerLink = $this->createPlayerLink($playerName);
+
+            return $this->createSpinnerMessage("{$playerLink} is currently being scanned.");
+        }
+
+        $position = $this->service->getQueuePosition($playerName);
+        if ($position !== null) {
+            $playerLink = $this->createPlayerLink($playerName);
+            $positionText = $this->service->escapeHtml((string) $position);
+
+            return $this->createSpinnerMessage("{$playerLink} is in the update queue, currently in position {$positionText}.");
+        }
+
+        $playerLink = $this->createPlayerLink($playerName);
+
+        return "{$playerLink} has been updated!";
+    }
+
+    private function createPlayerLink(string $playerName): string
+    {
+        $escapedPlayerName = $this->service->escapeHtml($playerName);
+
+        return '<a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/player/' . $escapedPlayerName . '">' . $escapedPlayerName . '</a>';
+    }
+
+    private function createSpinnerMessage(string $message): string
+    {
+        return $message . "\n<div class=\"spinner-border\" role=\"status\">\n    <span class=\"visually-hidden\">Loading...</span>\n</div>";
+    }
+
+    private function createCheaterMessage(string $playerName, ?string $accountId): string
+    {
+        $playerLink = $this->createPlayerLink($playerName);
+        $accountIdValue = $accountId ?? '';
+        $playerQuery = rawurlencode($playerName);
+        $accountQuery = rawurlencode((string) $accountIdValue);
+        $disputeUrl = 'https://github.com/Ragowit/psn100/issues?q=label%3Acheater+' . $playerQuery . '+OR+' . $accountQuery;
+        $disputeLink = '<a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="' . $this->service->escapeHtml($disputeUrl) . '">Dispute</a>';
+
+        return "Player '{$playerLink}' is tagged as a cheater and won't be scanned. {$disputeLink}?";
+    }
+
+    private function createQueueLimitMessage(): string
+    {
+        return 'You have already entered ' . PlayerQueueService::MAX_QUEUE_SUBMISSIONS_PER_IP . ' players into the queue. Please wait a while.';
+    }
+}

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -1,0 +1,198 @@
+<?php
+
+class PlayerQueueService
+{
+    public const MAX_QUEUE_SUBMISSIONS_PER_IP = 10;
+    public const CHEATER_STATUS = 1;
+
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function sanitizePlayerName(?string $playerName): string
+    {
+        return trim((string) ($playerName ?? ''));
+    }
+
+    public function sanitizeIpAddress(?string $ipAddress): string
+    {
+        return trim((string) ($ipAddress ?? ''));
+    }
+
+    public function getIpSubmissionCount(string $ipAddress): int
+    {
+        if ($ipAddress === '') {
+            return 0;
+        }
+
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                COUNT(*)
+            FROM
+                player_queue
+            WHERE
+                ip_address = :ip_address
+            SQL
+        );
+        $query->bindValue(":ip_address", $ipAddress, PDO::PARAM_STR);
+        $query->execute();
+
+        return (int) $query->fetchColumn();
+    }
+
+    public function hasReachedIpSubmissionLimit(string $ipAddress): bool
+    {
+        return $this->getIpSubmissionCount($ipAddress) >= self::MAX_QUEUE_SUBMISSIONS_PER_IP;
+    }
+
+    public function getCheaterAccountId(string $playerName): ?string
+    {
+        if ($playerName === '') {
+            return null;
+        }
+
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                account_id
+            FROM
+                player
+            WHERE
+                online_id = :online_id
+                AND status = :status
+            SQL
+        );
+        $query->bindValue(":online_id", $playerName, PDO::PARAM_STR);
+        $query->bindValue(":status", self::CHEATER_STATUS, PDO::PARAM_INT);
+        $query->execute();
+
+        $accountId = $query->fetchColumn();
+
+        return $accountId === false ? null : (string) $accountId;
+    }
+
+    public function addPlayerToQueue(string $playerName, string $ipAddress): void
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO
+                player_queue (online_id, ip_address)
+            VALUES
+                (:online_id, :ip_address)
+            ON DUPLICATE KEY UPDATE
+                ip_address = IF(
+                    request_time >= '2030-01-01 00:00:00',
+                    :ip_address,
+                    ip_address
+                ),
+                request_time = IF(
+                    request_time >= '2030-01-01 00:00:00',
+                    NOW(),
+                    request_time
+                )
+            SQL
+        );
+        $query->bindValue(":online_id", $playerName, PDO::PARAM_STR);
+        $query->bindValue(":ip_address", $ipAddress, PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    public function isValidPlayerName(string $playerName): bool
+    {
+        return preg_match('/^[\\w\-]{3,16}$/', $playerName) === 1;
+    }
+
+    public function escapeHtml(string $value): string
+    {
+        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+    }
+
+    public function isPlayerBeingScanned(string $playerName): bool
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                scanning
+            FROM
+                setting
+            WHERE
+                scanning = :online_id
+            SQL
+        );
+        $query->bindValue(":online_id", $playerName, PDO::PARAM_STR);
+        $query->execute();
+
+        return $query->fetchColumn() !== false;
+    }
+
+    public function getQueuePosition(string $playerName): ?int
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            WITH temp AS (
+                SELECT
+                    request_time,
+                    online_id,
+                    ROW_NUMBER() OVER (
+                        ORDER BY
+                            request_time
+                    ) AS rownum
+                FROM
+                    player_queue
+            )
+            SELECT
+                rownum
+            FROM
+                temp
+            WHERE
+                online_id = :online_id
+            SQL
+        );
+        $query->bindValue(":online_id", $playerName, PDO::PARAM_STR);
+        $query->execute();
+
+        $position = $query->fetchColumn();
+
+        return $position === false ? null : (int) $position;
+    }
+
+    public function getPlayerStatusData(string $playerName): array
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                account_id,
+                `status`
+            FROM
+                player
+            WHERE
+                online_id = :online_id
+            SQL
+        );
+        $query->bindValue(":online_id", $playerName, PDO::PARAM_STR);
+        $query->execute();
+
+        $result = $query->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($result)) {
+            return [
+                'account_id' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'account_id' => array_key_exists('account_id', $result) ? (string) $result['account_id'] : null,
+            'status' => array_key_exists('status', $result) ? (int) $result['status'] : null,
+        ];
+    }
+
+    public function isCheaterStatus(?int $status): bool
+    {
+        return $status === self::CHEATER_STATUS;
+    }
+}


### PR DESCRIPTION
## Summary
- encapsulate queue validation and persistence logic in a reusable PlayerQueueService class
- add a PlayerQueueHandler to format queue responses and share UI messaging
- update add_to_queue.php and check_queue_position.php to delegate to the new object-oriented workflow
- format PlayerQueueService SQL queries with heredoc strings to avoid escaped newlines

## Testing
- php -l wwwroot/classes/PlayerQueueService.php

------
https://chatgpt.com/codex/tasks/task_e_68cd0f193a20832fb147891e469d3564