### PR TITLE
Refactor hourly and weekly cron jobs to OOP classes

### DIFF
--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+class HourlyCronJob
+{
+    private const STATISTICS_UPDATE_QUERY = <<<'SQL'
+        WITH game AS (
+            SELECT
+                ttp.np_communication_id,
+                COUNT(*) AS owners,
+                COUNT(CASE WHEN ttp.progress = 100 THEN 1 END) AS owners_completed,
+                COUNT(CASE WHEN ttp.last_updated_date >= CURDATE() - INTERVAL 7 DAY THEN 1 END) AS recent_players
+            FROM
+                trophy_title_player ttp
+                JOIN player_ranking pr ON pr.account_id = ttp.account_id AND pr.ranking <= 10000
+            GROUP BY
+                ttp.np_communication_id
+        )
+        UPDATE trophy_title tt
+        JOIN game g ON tt.np_communication_id = g.np_communication_id
+        SET
+            tt.owners = g.owners,
+            tt.owners_completed = g.owners_completed,
+            tt.recent_players = g.recent_players,
+            tt.difficulty = IF(g.owners = 0, 0, (g.owners_completed / g.owners) * 100)
+        SQL;
+
+    private PDO $database;
+
+    private int $retryDelaySeconds;
+
+    public function __construct(PDO $database, int $retryDelaySeconds = 3)
+    {
+        $this->database = $database;
+        $this->retryDelaySeconds = $retryDelaySeconds;
+    }
+
+    public function run(): void
+    {
+        $this->executeWithRetry([$this, 'updateTrophyTitleStatistics']);
+    }
+
+    private function updateTrophyTitleStatistics(): void
+    {
+        $query = $this->database->prepare(self::STATISTICS_UPDATE_QUERY);
+        $query->execute();
+    }
+
+    private function executeWithRetry(callable $operation): void
+    {
+        while (true) {
+            try {
+                $operation();
+
+                return;
+            } catch (Exception $exception) {
+                sleep($this->retryDelaySeconds);
+            }
+        }
+    }
+}

--- a/wwwroot/classes/Cron/WeeklyCronJob.php
+++ b/wwwroot/classes/Cron/WeeklyCronJob.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+class WeeklyCronJob
+{
+    private const UPDATE_PLAYER_RANKINGS_QUERY = <<<'SQL'
+        UPDATE player p
+        JOIN player_ranking r ON p.account_id = r.account_id
+        SET
+            p.rank_last_week = r.ranking,
+            p.rarity_rank_last_week = r.rarity_ranking,
+            p.rank_country_last_week = r.ranking_country,
+            p.rarity_rank_country_last_week = r.rarity_ranking_country
+        WHERE p.status = 0
+        SQL;
+
+    private const RESET_INACTIVE_RANKINGS_QUERY = <<<'SQL'
+        UPDATE
+            player p
+        SET
+            p.rank_last_week = 0,
+            p.rank_country_last_week = 0,
+            p.rarity_rank_last_week = 0,
+            p.rarity_rank_country_last_week = 0
+        WHERE
+            p.status != 0
+        SQL;
+
+    private PDO $database;
+
+    private int $retryDelaySeconds;
+
+    public function __construct(PDO $database, int $retryDelaySeconds = 3)
+    {
+        $this->database = $database;
+        $this->retryDelaySeconds = $retryDelaySeconds;
+    }
+
+    public function run(): void
+    {
+        $this->executeWithRetry([$this, 'updateLeaderboardsForActivePlayers']);
+        $this->resetRankingsForInactivePlayers();
+    }
+
+    private function updateLeaderboardsForActivePlayers(): void
+    {
+        $query = $this->database->prepare(self::UPDATE_PLAYER_RANKINGS_QUERY);
+        $query->execute();
+    }
+
+    private function resetRankingsForInactivePlayers(): void
+    {
+        $query = $this->database->prepare(self::RESET_INACTIVE_RANKINGS_QUERY);
+        $query->execute();
+    }
+
+    private function executeWithRetry(callable $operation): void
+    {
+        while (true) {
+            try {
+                $operation();
+
+                return;
+            } catch (Exception $exception) {
+                sleep($this->retryDelaySeconds);
+            }
+        }
+    }
+}

--- a/wwwroot/cron/hourly.php
+++ b/wwwroot/cron/hourly.php
@@ -1,38 +1,13 @@
 <?php
+
+declare(strict_types=1);
+
 ini_set("max_execution_time", "0");
 ini_set("mysql.connect_timeout", "0");
 set_time_limit(0);
-require_once("/home/psn100/public_html/init.php");
 
-// Recalculate recent players, owners, completed and difficulty
-do {
-    try {
-        $query = $database->prepare("
-            WITH game AS (
-                SELECT
-                    ttp.np_communication_id,
-                    COUNT(*) AS owners,
-                    COUNT(CASE WHEN ttp.progress = 100 THEN 1 END) AS owners_completed,
-                    COUNT(CASE WHEN ttp.last_updated_date >= CURDATE() - INTERVAL 7 DAY THEN 1 END) AS recent_players
-                FROM
-                    trophy_title_player ttp
-                    JOIN player_ranking pr ON pr.account_id = ttp.account_id AND pr.ranking <= 10000
-                GROUP BY
-                    ttp.np_communication_id
-            )
-            UPDATE trophy_title tt
-            JOIN game g ON tt.np_communication_id = g.np_communication_id
-            SET
-                tt.owners = g.owners,
-                tt.owners_completed = g.owners_completed,
-                tt.recent_players = g.recent_players,
-                tt.difficulty = IF(g.owners = 0, 0, (g.owners_completed / g.owners) * 100)
-        ");
-        $query->execute();
+require_once dirname(__DIR__) . '/init.php';
+require_once dirname(__DIR__) . '/classes/Cron/HourlyCronJob.php';
 
-        $deadlock = false;
-    } catch (Exception $e) {
-        sleep(3);
-        $deadlock = true;
-    }
-} while ($deadlock);
+$hourlyCronJob = new HourlyCronJob($database);
+$hourlyCronJob->run();

--- a/wwwroot/cron/weekly.php
+++ b/wwwroot/cron/weekly.php
@@ -1,41 +1,13 @@
 <?php
+
+declare(strict_types=1);
+
 ini_set("max_execution_time", "0");
 ini_set("mysql.connect_timeout", "0");
 set_time_limit(0);
-require_once("/home/psn100/public_html/init.php");
 
-// Set ranks last week
-do {
-    try {
-        $query = $database->prepare("
-            UPDATE player p
-            JOIN player_ranking r ON p.account_id = r.account_id
-            SET
-                p.rank_last_week = r.ranking,
-                p.rarity_rank_last_week = r.rarity_ranking,
-                p.rank_country_last_week = r.ranking_country,
-                p.rarity_rank_country_last_week = r.rarity_ranking_country
-            WHERE p.status = 0
-        ");
-        $query->execute();
-        
-        $deadlock = false;
-    } catch (Exception $e) {
-        sleep(3);
-        $deadlock = true;
-    }
-} while ($deadlock);
+require_once dirname(__DIR__) . '/init.php';
+require_once dirname(__DIR__) . '/classes/Cron/WeeklyCronJob.php';
 
-// Reset last week ranks for those not on the leaderboard
-$query = $database->prepare("
-    UPDATE
-        player p
-    SET
-        p.rank_last_week = 0,
-        p.rank_country_last_week = 0,
-        p.rarity_rank_last_week = 0,
-        p.rarity_rank_country_last_week = 0
-    WHERE
-        p.status != 0
-");
-$query->execute();
+$weeklyCronJob = new WeeklyCronJob($database);
+$weeklyCronJob->run();


### PR DESCRIPTION
## Summary
- extract the hourly cron logic into a reusable `HourlyCronJob` class with retry handling
- wrap the weekly leaderboard recalculations in a `WeeklyCronJob` class and simplify the cron entry points

## Testing
- php -l wwwroot/classes/Cron/HourlyCronJob.php
- php -l wwwroot/classes/Cron/WeeklyCronJob.php
- php -l wwwroot/cron/hourly.php
- php -l wwwroot/cron/weekly.php

------
https://chatgpt.com/codex/tasks/task_e_68cda7f14df8832fa02496ee1613122d