### PR TITLE
Refactor homepage data retrieval into service

### DIFF
--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -1,0 +1,95 @@
+<?php
+
+class HomepageContentService
+{
+    private const DEFAULT_NEW_GAME_LIMIT = 8;
+    private const DEFAULT_NEW_DLCS_LIMIT = 8;
+    private const DEFAULT_POPULAR_GAME_LIMIT = 10;
+
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function getNewGames(int $limit = self::DEFAULT_NEW_GAME_LIMIT): array
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                *
+            FROM
+                trophy_title
+            WHERE
+                `status` != 2
+            ORDER BY
+                id DESC
+            LIMIT
+                :limit
+            SQL
+        );
+        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $query->execute();
+
+        return $query->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function getNewDlcs(int $limit = self::DEFAULT_NEW_DLCS_LIMIT): array
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                tt.id,
+                tt.name AS game_name,
+                tt.platform,
+                tg.icon_url,
+                tg.name AS group_name,
+                tg.group_id,
+                tg.bronze,
+                tg.silver,
+                tg.gold
+            FROM
+                trophy_group tg
+                JOIN trophy_title tt USING (np_communication_id)
+            WHERE
+                tt.status != 2
+                AND tg.group_id != 'default'
+            ORDER BY
+                tg.id DESC
+            LIMIT
+                :limit
+            SQL
+        );
+        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $query->execute();
+
+        return $query->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function getPopularGames(int $limit = self::DEFAULT_POPULAR_GAME_LIMIT): array
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                id,
+                icon_url,
+                platform,
+                `name`,
+                recent_players
+            FROM
+                trophy_title
+            WHERE
+                `status` != 2
+            ORDER BY
+                recent_players DESC
+            LIMIT
+                :limit
+            SQL
+        );
+        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $query->execute();
+
+        return $query->fetchAll(PDO::FETCH_ASSOC);
+    }
+}

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -1,5 +1,11 @@
 <?php
+require_once 'classes/HomepageContentService.php';
+
 $title = "PSN 100% ~ PlayStation Leaderboards & Trophies";
+$homepageContentService = new HomepageContentService($database);
+$newGames = $homepageContentService->getNewGames();
+$newDlcs = $homepageContentService->getNewDlcs();
+$popularGames = $homepageContentService->getPopularGames();
 require_once("header.php");
 ?>
 
@@ -30,14 +36,7 @@ require_once("header.php");
                         <h1>New Games</h1>
                         <div class="row">
                             <?php
-                            $query = $database->prepare("SELECT * FROM trophy_title
-                                WHERE `status` != 2
-                                ORDER BY id DESC
-                                LIMIT 8");
-                            $query->execute();
-                            $games = $query->fetchAll();
-
-                            foreach ($games as $game) {
+                            foreach ($newGames as $game) {
                                 ?>
                                 <div class="col-12 col-md-6 col-lg-4 col-xl-3 text-center mb-2">
                                     <div class="vstack gap-1">
@@ -87,15 +86,7 @@ require_once("header.php");
                         <h1>New DLCs</h1>
                         <div class="row">
                             <?php
-                            $query = $database->prepare("SELECT tt.id, tt.name AS game_name, tt.platform, tg.icon_url, tg.name AS group_name, tg.group_id, tg.bronze, tg.silver, tg.gold FROM trophy_group tg
-                                JOIN trophy_title tt USING (np_communication_id)
-                                WHERE tt.status != 2 AND tg.group_id != 'default'
-                                ORDER BY tg.id DESC
-                                LIMIT 8");
-                            $query->execute();
-                            $games = $query->fetchAll();
-
-                            foreach ($games as $game) {
+                            foreach ($newDlcs as $game) {
                                 ?>
                                 <div class="col-12 col-md-6 col-lg-4 col-xl-3 text-center mb-2">
                                     <!-- image, platforms and status -->
@@ -144,14 +135,7 @@ require_once("header.php");
             <div class="bg-body-tertiary p-3 rounded">
                 <h1>Popular Games</h1>
                 <?php
-                $query = $database->prepare("SELECT id, icon_url, platform, `name`, recent_players FROM trophy_title
-                    WHERE `status` != 2
-                    ORDER BY recent_players DESC
-                    LIMIT 10");
-                $query->execute();
-                $games = $query->fetchAll();
-
-                foreach ($games as $game) {
+                foreach ($popularGames as $game) {
                     ?>
                     <div class="row mb-3">
                         <!-- image -->


### PR DESCRIPTION
## Summary
- add a HomepageContentService to encapsulate the queries used by the homepage
- update home.php to rely on the new service when rendering new games, DLCs, and popular games

## Testing
- php -l wwwroot/classes/HomepageContentService.php
- php -l wwwroot/home.php

------
https://chatgpt.com/codex/tasks/task_e_68cddd6c6858832fa131a6267f438b71