### PR TITLE
Refactor admin copy operation to service

### DIFF
--- a/wwwroot/admin/copy.php
+++ b/wwwroot/admin/copy.php
@@ -1,101 +1,14 @@
 <?php
-require_once("/home/psn100/public_html/init.php");
-$message = "";
 
-if (isset($_POST["parent"]) && ctype_digit(strval($_POST["parent"])) && isset($_POST["child"]) && ctype_digit(strval($_POST["child"]))) {
-    $childId = $_POST["child"];
-    $parentId = $_POST["parent"];
+declare(strict_types=1);
 
-    // Sanity checks
-    $query = $database->prepare("SELECT np_communication_id
-        FROM   trophy_title
-        WHERE  id = :id ");
-    $query->bindValue(":id", $childId, PDO::PARAM_INT);
-    $query->execute();
-    $childNpCommunicationId = $query->fetchColumn();
-    if (str_starts_with($childNpCommunicationId, "MERGE")) {
-        echo "Child can't be a merge title.";
-        die();
-    }
-    $query = $database->prepare("SELECT np_communication_id
-        FROM   trophy_title
-        WHERE  id = :id ");
-    $query->bindValue(":id", $parentId, PDO::PARAM_INT);
-    $query->execute();
-    $parentNpCommunicationId = $query->fetchColumn();
-    if (!str_starts_with($parentNpCommunicationId, "MERGE")) {
-        echo "Parent must be a merge title.";
-        die();
-    }
+require_once '../init.php';
+require_once '../classes/Admin/GameCopyService.php';
+require_once '../classes/Admin/GameCopyHandler.php';
 
-    // Trophy Group
-    $query = $database->prepare("WITH
-            tg_org AS(
-            SELECT
-                group_id,
-                NAME,
-                detail,
-                icon_url
-            FROM
-                trophy_group
-            WHERE
-                np_communication_id = :child_np_communication_id
-        )
-        UPDATE
-            trophy_group tg,
-            tg_org
-        SET
-            tg.name = tg_org.name,
-            tg.detail = tg_org.detail,
-            tg.icon_url = tg_org.icon_url
-        WHERE
-            tg.np_communication_id = :parent_np_communication_id AND tg.group_id = tg_org.group_id");
-    $query->bindValue(":child_np_communication_id", $childNpCommunicationId, PDO::PARAM_STR);
-    $query->bindValue(":parent_np_communication_id", $parentNpCommunicationId, PDO::PARAM_STR);
-    $query->execute();
-
-    // Trophy
-    $query = $database->prepare("WITH
-            tg_org AS(
-            SELECT
-                group_id,
-                order_id,
-                hidden,
-                NAME,
-                detail,
-                icon_url,
-                progress_target_value,
-                reward_name,
-                reward_image_url
-            FROM
-                trophy
-            WHERE
-                np_communication_id = :child_np_communication_id
-        )
-        UPDATE
-            trophy tg,
-            tg_org
-        SET
-            tg.hidden = tg_org.hidden,
-            tg.name = tg_org.name,
-            tg.detail = tg_org.detail,
-            tg.icon_url = tg_org.icon_url,
-            tg.progress_target_value = tg_org.progress_target_value,
-            tg.reward_name = tg_org.reward_name,
-            tg.reward_image_url = tg_org.reward_image_url
-        WHERE
-            tg.np_communication_id = :parent_np_communication_id AND tg.group_id = tg_org.group_id AND tg.order_id = tg_org.order_id");
-    $query->bindValue(":child_np_communication_id", $childNpCommunicationId, PDO::PARAM_STR);
-    $query->bindValue(":parent_np_communication_id", $parentNpCommunicationId, PDO::PARAM_STR);
-    $query->execute();
-
-    $query = $database->prepare("INSERT INTO `psn100_change` (`change_type`, `param_1`, `param_2`) VALUES ('GAME_COPY', :param_1, :param_2)");
-    $query->bindValue(":param_1", $childId, PDO::PARAM_INT);
-    $query->bindValue(":param_2", $parentId, PDO::PARAM_INT);
-    $query->execute();
-
-    $message .= "The group and trophy data have been copied.";
-}
+$gameCopyService = new GameCopyService($database);
+$gameCopyHandler = new GameCopyHandler($gameCopyService);
+$message = $gameCopyHandler->handle($_POST);
 ?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">

--- a/wwwroot/classes/Admin/GameCopyHandler.php
+++ b/wwwroot/classes/Admin/GameCopyHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+class GameCopyHandler
+{
+    private GameCopyService $gameCopyService;
+
+    public function __construct(GameCopyService $gameCopyService)
+    {
+        $this->gameCopyService = $gameCopyService;
+    }
+
+    public function handle(array $postData): string
+    {
+        if (!$this->hasRequiredIds($postData)) {
+            return '';
+        }
+
+        $childId = $this->filterId($postData['child'] ?? null);
+        $parentId = $this->filterId($postData['parent'] ?? null);
+
+        if ($childId === null || $parentId === null) {
+            return 'Child and parent must be numeric IDs.';
+        }
+
+        try {
+            $this->gameCopyService->copyChildToParent($childId, $parentId);
+        } catch (RuntimeException $exception) {
+            return $exception->getMessage();
+        }
+
+        return 'The group and trophy data have been copied.';
+    }
+
+    private function hasRequiredIds(array $postData): bool
+    {
+        return array_key_exists('child', $postData) && array_key_exists('parent', $postData);
+    }
+
+    private function filterId(null|int|string $value): ?int
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!ctype_digit((string) $value)) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+}

--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+class GameCopyService
+{
+    private const TROPHY_GROUP_UPDATE_QUERY = <<<'SQL'
+        WITH
+            tg_org AS(
+            SELECT
+                group_id,
+                name,
+                detail,
+                icon_url
+            FROM
+                trophy_group
+            WHERE
+                np_communication_id = :child_np_communication_id
+        )
+        UPDATE
+            trophy_group tg,
+            tg_org
+        SET
+            tg.name = tg_org.name,
+            tg.detail = tg_org.detail,
+            tg.icon_url = tg_org.icon_url
+        WHERE
+            tg.np_communication_id = :parent_np_communication_id AND tg.group_id = tg_org.group_id
+        SQL;
+
+    private const TROPHY_UPDATE_QUERY = <<<'SQL'
+        WITH
+            tg_org AS(
+            SELECT
+                group_id,
+                order_id,
+                hidden,
+                name,
+                detail,
+                icon_url,
+                progress_target_value,
+                reward_name,
+                reward_image_url
+            FROM
+                trophy
+            WHERE
+                np_communication_id = :child_np_communication_id
+        )
+        UPDATE
+            trophy tg,
+            tg_org
+        SET
+            tg.hidden = tg_org.hidden,
+            tg.name = tg_org.name,
+            tg.detail = tg_org.detail,
+            tg.icon_url = tg_org.icon_url,
+            tg.progress_target_value = tg_org.progress_target_value,
+            tg.reward_name = tg_org.reward_name,
+            tg.reward_image_url = tg_org.reward_image_url
+        WHERE
+            tg.np_communication_id = :parent_np_communication_id AND tg.group_id = tg_org.group_id AND tg.order_id = tg_org.order_id
+        SQL;
+
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function copyChildToParent(int $childId, int $parentId): void
+    {
+        $childNpCommunicationId = $this->getNpCommunicationId($childId);
+        $parentNpCommunicationId = $this->getNpCommunicationId($parentId);
+
+        $this->ensureChildIsNotMergeTitle($childNpCommunicationId);
+        $this->ensureParentIsMergeTitle($parentNpCommunicationId);
+
+        $this->copyTrophyGroups($childNpCommunicationId, $parentNpCommunicationId);
+        $this->copyTrophies($childNpCommunicationId, $parentNpCommunicationId);
+        $this->recordCopyAction($childId, $parentId);
+    }
+
+    private function getNpCommunicationId(int $gameId): string
+    {
+        $query = $this->database->prepare('SELECT np_communication_id FROM trophy_title WHERE id = :id');
+        $query->bindValue(':id', $gameId, PDO::PARAM_INT);
+        $query->execute();
+
+        $npCommunicationId = $query->fetchColumn();
+        if ($npCommunicationId === false) {
+            throw new RuntimeException('Unable to find the specified game.');
+        }
+
+        return (string) $npCommunicationId;
+    }
+
+    private function ensureChildIsNotMergeTitle(string $childNpCommunicationId): void
+    {
+        if (str_starts_with($childNpCommunicationId, 'MERGE')) {
+            throw new RuntimeException("Child can't be a merge title.");
+        }
+    }
+
+    private function ensureParentIsMergeTitle(string $parentNpCommunicationId): void
+    {
+        if (!str_starts_with($parentNpCommunicationId, 'MERGE')) {
+            throw new RuntimeException('Parent must be a merge title.');
+        }
+    }
+
+    private function copyTrophyGroups(string $childNpCommunicationId, string $parentNpCommunicationId): void
+    {
+        $query = $this->database->prepare(self::TROPHY_GROUP_UPDATE_QUERY);
+        $query->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    private function copyTrophies(string $childNpCommunicationId, string $parentNpCommunicationId): void
+    {
+        $query = $this->database->prepare(self::TROPHY_UPDATE_QUERY);
+        $query->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    private function recordCopyAction(int $childId, int $parentId): void
+    {
+        $query = $this->database->prepare("INSERT INTO `psn100_change` (`change_type`, `param_1`, `param_2`) VALUES ('GAME_COPY', :param_1, :param_2)");
+        $query->bindValue(':param_1', $childId, PDO::PARAM_INT);
+        $query->bindValue(':param_2', $parentId, PDO::PARAM_INT);
+        $query->execute();
+    }
+}


### PR DESCRIPTION
## Summary
- replace the procedural admin copy script with an object-oriented handler that validates input and reports errors
- add a dedicated GameCopyService to encapsulate database queries for copying trophies between games

## Testing
- php -l wwwroot/classes/Admin/GameCopyService.php
- php -l wwwroot/classes/Admin/GameCopyHandler.php
- php -l wwwroot/admin/copy.php

------
https://chatgpt.com/codex/tasks/task_e_68cfe341db98832f9e8f033447b21cd5