### PR TITLE
Refactor player reporting into service

### DIFF
--- a/wwwroot/classes/PlayerReportService.php
+++ b/wwwroot/classes/PlayerReportService.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerReportService
+{
+    private const MAX_PENDING_REPORTS_PER_IP = 10;
+
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function submitReport(int $accountId, string $ipAddress, string $explanation): string
+    {
+        if ($this->hasExistingReport($accountId, $ipAddress)) {
+            return "You've already reported this player.";
+        }
+
+        if ($this->getReportCountForIp($ipAddress) >= self::MAX_PENDING_REPORTS_PER_IP) {
+            return "You've already 10 players reported waiting to be processed. Please try again later.";
+        }
+
+        $this->insertReport($accountId, $ipAddress, $explanation);
+
+        return "Player reported successfully.";
+    }
+
+    private function hasExistingReport(int $accountId, string $ipAddress): bool
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                1
+            FROM
+                player_report
+            WHERE
+                account_id = :account_id
+                AND ip_address = :ip_address
+            LIMIT 1
+            SQL
+        );
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
+        $query->execute();
+
+        return $query->fetchColumn() !== false;
+    }
+
+    private function getReportCountForIp(string $ipAddress): int
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                COUNT(*)
+            FROM
+                player_report
+            WHERE
+                ip_address = :ip_address
+            SQL
+        );
+        $query->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
+        $query->execute();
+
+        return (int) $query->fetchColumn();
+    }
+
+    private function insertReport(int $accountId, string $ipAddress, string $explanation): void
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO player_report
+                (account_id, ip_address, explanation)
+            VALUES
+                (:account_id, :ip_address, :explanation)
+            SQL
+        );
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
+        $query->bindValue(':explanation', $explanation, PDO::PARAM_STR);
+        $query->execute();
+    }
+}

--- a/wwwroot/player_report.php
+++ b/wwwroot/player_report.php
@@ -4,35 +4,14 @@ if (!isset($accountId)) {
     die();
 }
 
+require_once 'classes/PlayerReportService.php';
+
+$playerReportService = new PlayerReportService($database);
+
 if (!empty($_GET["explanation"])) {
-    $ipAddress = $_SERVER["REMOTE_ADDR"];
-
-    $query = $database->prepare("SELECT * FROM player_report WHERE account_id = :account_id AND ip_address = :ip_address");
-    $query->bindValue(":account_id", $accountId, PDO::PARAM_INT);
-    $query->bindValue(":ip_address", $ipAddress, PDO::PARAM_STR);
-    $query->execute();
-    $reported = $query->fetch();
-
-    $query = $database->prepare("SELECT COUNT(*) FROM player_report WHERE ip_address = :ip_address");
-    $query->bindValue(":ip_address", $ipAddress, PDO::PARAM_STR);
-    $query->execute();
-    $count = $query->fetchColumn();
-
-    if ($reported) {
-        $result = "You've already reported this player.";
-    } elseif ($count >= 10) {
-        $result = "You've already 10 players reported waiting to be processed. Please try again later.";
-    } else {
-        $explanation = $_GET["explanation"];
-
-        $query = $database->prepare("INSERT INTO player_report (account_id, ip_address, explanation) VALUES (:account_id, :ip_address, :explanation)");
-        $query->bindValue(":account_id", $accountId, PDO::PARAM_INT);
-        $query->bindValue(":ip_address", $ipAddress, PDO::PARAM_STR);
-        $query->bindValue(":explanation", $explanation, PDO::PARAM_STR);
-        $query->execute();
-
-        $result = "Player reported successfully.";
-    }
+    $ipAddress = $_SERVER["REMOTE_ADDR"] ?? '';
+    $explanation = (string) $_GET["explanation"];
+    $result = $playerReportService->submitReport((int) $accountId, $ipAddress, $explanation);
 }
 
 $title = $player["online_id"] . "'s Report ~ PSN 100%";


### PR DESCRIPTION
## Summary
- add a dedicated PlayerReportService class to encapsulate reporting rules
- update the player report page to delegate to the new service for database access

## Testing
- php -l wwwroot/classes/PlayerReportService.php
- php -l wwwroot/player_report.php

------
https://chatgpt.com/codex/tasks/task_e_68cfec9798f4832fb10a0839d1cec569