### PR TITLE
Refactor player ranking updater into reusable class

### DIFF
--- a/wwwroot/classes/Cron/PlayerRankingUpdater.php
+++ b/wwwroot/classes/Cron/PlayerRankingUpdater.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerRankingUpdater
+{
+    private const TEMPORARY_TABLE = 'player_ranking_new';
+    private const PRIMARY_TABLE = 'player_ranking';
+    private const PREVIOUS_TABLE = 'player_ranking_old';
+    private const INSERT_TEMPLATE = <<<'SQL'
+INSERT INTO %s (account_id, ranking, ranking_country, rarity_ranking, rarity_ranking_country)
+SELECT
+    account_id,
+    RANK() OVER (
+        ORDER BY points DESC, platinum DESC, gold DESC, silver DESC
+    ) AS ranking,
+    RANK() OVER (
+        PARTITION BY country
+        ORDER BY points DESC, platinum DESC, gold DESC, silver DESC
+    ) AS ranking_country,
+    RANK() OVER (
+        ORDER BY `rarity_points` DESC
+    ) AS rarity_ranking,
+    RANK() OVER (
+        PARTITION BY country
+        ORDER BY `rarity_points` DESC
+    ) AS rarity_ranking_country
+FROM player
+WHERE `status` = 0
+SQL;
+
+    private PDO $database;
+
+    private int $retryDelaySeconds;
+
+    public function __construct(PDO $database, int $retryDelaySeconds = 3)
+    {
+        $this->database = $database;
+        $this->retryDelaySeconds = $retryDelaySeconds;
+    }
+
+    public function recalculate(): void
+    {
+        $this->executeWithRetry(function (): void {
+            $this->createTemporaryTable();
+            $this->clearTemporaryTable();
+            $this->populateTemporaryTable();
+            $this->replaceRankingTable();
+        });
+    }
+
+    private function executeWithRetry(callable $operation): void
+    {
+        while (true) {
+            try {
+                $operation();
+
+                return;
+            } catch (Throwable $exception) {
+                sleep($this->retryDelaySeconds);
+            }
+        }
+    }
+
+    private function createTemporaryTable(): void
+    {
+        $sql = sprintf(
+            'CREATE TABLE IF NOT EXISTS %s LIKE %s',
+            self::TEMPORARY_TABLE,
+            self::PRIMARY_TABLE
+        );
+
+        $this->database->exec($sql);
+    }
+
+    private function clearTemporaryTable(): void
+    {
+        $sql = sprintf('TRUNCATE TABLE %s', self::TEMPORARY_TABLE);
+        $this->database->exec($sql);
+    }
+
+    private function populateTemporaryTable(): void
+    {
+        $sql = sprintf(self::INSERT_TEMPLATE, self::TEMPORARY_TABLE);
+        $this->database->exec($sql);
+    }
+
+    private function replaceRankingTable(): void
+    {
+        $renameSql = sprintf(
+            'RENAME TABLE %s TO %s, %s TO %s',
+            self::PRIMARY_TABLE,
+            self::PREVIOUS_TABLE,
+            self::TEMPORARY_TABLE,
+            self::PRIMARY_TABLE
+        );
+
+        $this->database->exec($renameSql);
+
+        $dropSql = sprintf('DROP TABLE %s', self::PREVIOUS_TABLE);
+        $this->database->exec($dropSql);
+    }
+}

--- a/wwwroot/cron/5th_minute.php
+++ b/wwwroot/cron/5th_minute.php
@@ -1,105 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 ini_set("max_execution_time", "0");
 ini_set("mysql.connect_timeout", "0");
 set_time_limit(0);
 
-require_once("/home/psn100/public_html/init.php");
-
-class PlayerRankingUpdater
-{
-    private const TEMPORARY_TABLE = 'player_ranking_new';
-    private const PRIMARY_TABLE = 'player_ranking';
-    private const PREVIOUS_TABLE = 'player_ranking_old';
-    private const INSERT_TEMPLATE = <<<'SQL'
-INSERT INTO %s (account_id, ranking, ranking_country, rarity_ranking, rarity_ranking_country)
-SELECT
-    account_id,
-    RANK() OVER (
-        ORDER BY points DESC, platinum DESC, gold DESC, silver DESC
-    ) AS ranking,
-    RANK() OVER (
-        PARTITION BY country
-        ORDER BY points DESC, platinum DESC, gold DESC, silver DESC
-    ) AS ranking_country,
-    RANK() OVER (
-        ORDER BY `rarity_points` DESC
-    ) AS rarity_ranking,
-    RANK() OVER (
-        PARTITION BY country
-        ORDER BY `rarity_points` DESC
-    ) AS rarity_ranking_country
-FROM player
-WHERE `status` = 0
-SQL;
-
-    /**
-     * @var PDO
-     */
-    private $database;
-
-    public function __construct(PDO $database)
-    {
-        $this->database = $database;
-    }
-
-    public function recalculate(): void
-    {
-        do {
-            $shouldRetry = false;
-
-            try {
-                $this->createTemporaryTable();
-                $this->clearTemporaryTable();
-                $this->populateTemporaryTable();
-                $this->replaceRankingTable();
-            } catch (Throwable $exception) {
-                $shouldRetry = true;
-                sleep(3);
-            }
-        } while ($shouldRetry);
-    }
-
-    private function createTemporaryTable(): void
-    {
-        $sql = sprintf(
-            'CREATE TABLE IF NOT EXISTS %s LIKE %s',
-            self::TEMPORARY_TABLE,
-            self::PRIMARY_TABLE
-        );
-
-        $this->database->exec($sql);
-    }
-
-    private function clearTemporaryTable(): void
-    {
-        $sql = sprintf('TRUNCATE TABLE %s', self::TEMPORARY_TABLE);
-        $this->database->exec($sql);
-    }
-
-    private function populateTemporaryTable(): void
-    {
-        $sql = sprintf(self::INSERT_TEMPLATE, self::TEMPORARY_TABLE);
-        $this->database->exec($sql);
-    }
-
-    private function replaceRankingTable(): void
-    {
-        $renameSql = sprintf(
-            'RENAME TABLE %s TO %s, %s TO %s',
-            self::PRIMARY_TABLE,
-            self::PREVIOUS_TABLE,
-            self::TEMPORARY_TABLE,
-            self::PRIMARY_TABLE
-        );
-
-        $this->database->exec($renameSql);
-
-        $dropSql = sprintf('DROP TABLE %s', self::PREVIOUS_TABLE);
-        $this->database->exec($dropSql);
-    }
-}
+require_once dirname(__DIR__) . '/init.php';
+require_once dirname(__DIR__) . '/classes/Cron/PlayerRankingUpdater.php';
 
 $updater = new PlayerRankingUpdater($database);
 $updater->recalculate();


### PR DESCRIPTION
## Summary
- extract the player ranking recalculation logic into a dedicated Cron\PlayerRankingUpdater class
- update the 5th minute cron entry point to load and invoke the reusable updater class

## Testing
- php -l wwwroot/classes/Cron/PlayerRankingUpdater.php
- php -l wwwroot/cron/5th_minute.php

------
https://chatgpt.com/codex/tasks/task_e_68d002cd8bf4832fbb176ca7285f7db9