### PR TITLE
Refactor about page to service

### DIFF
--- a/wwwroot/classes/AboutPagePlayer.php
+++ b/wwwroot/classes/AboutPagePlayer.php
@@ -1,0 +1,181 @@
+<?php
+
+class AboutPagePlayer
+{
+    private const STATUS_LABELS = [
+        1 => 'Cheater',
+        3 => 'Private',
+        4 => 'Inactive',
+    ];
+
+    private Utility $utility;
+    private string $onlineId;
+    private string $countryCode;
+    private string $avatarUrl;
+    private ?string $lastUpdatedDate;
+    private ?int $level;
+    private ?string $progress;
+    private int $rankLastWeek;
+    private int $status;
+    private int $trophyCountNpwr;
+    private int $trophyCountSony;
+    private ?int $ranking;
+
+    public function __construct(
+        Utility $utility,
+        string $onlineId,
+        ?string $countryCode,
+        string $avatarUrl,
+        ?string $lastUpdatedDate,
+        ?int $level,
+        ?string $progress,
+        ?int $rankLastWeek,
+        ?int $status,
+        ?int $trophyCountNpwr,
+        ?int $trophyCountSony,
+        ?int $ranking
+    ) {
+        $this->utility = $utility;
+        $this->onlineId = $onlineId;
+        $this->countryCode = $countryCode ?? '';
+        $this->avatarUrl = $avatarUrl;
+        $this->lastUpdatedDate = $lastUpdatedDate;
+        $this->level = $level;
+        $this->progress = $progress;
+        $this->rankLastWeek = $rankLastWeek ?? 0;
+        $this->status = $status ?? 0;
+        $this->trophyCountNpwr = $trophyCountNpwr ?? 0;
+        $this->trophyCountSony = $trophyCountSony ?? 0;
+        $this->ranking = $ranking;
+    }
+
+    public static function fromArray(array $row, Utility $utility): self
+    {
+        return new self(
+            $utility,
+            (string) ($row['online_id'] ?? ''),
+            isset($row['country']) ? (string) $row['country'] : null,
+            (string) ($row['avatar_url'] ?? ''),
+            isset($row['last_updated_date']) ? (string) $row['last_updated_date'] : null,
+            isset($row['level']) ? (int) $row['level'] : null,
+            isset($row['progress']) ? (string) $row['progress'] : null,
+            isset($row['rank_last_week']) ? (int) $row['rank_last_week'] : null,
+            isset($row['status']) ? (int) $row['status'] : null,
+            isset($row['trophy_count_npwr']) ? (int) $row['trophy_count_npwr'] : null,
+            isset($row['trophy_count_sony']) ? (int) $row['trophy_count_sony'] : null,
+            isset($row['ranking']) ? (int) $row['ranking'] : null,
+        );
+    }
+
+    public function getOnlineId(): string
+    {
+        return $this->onlineId;
+    }
+
+    public function getCountryCode(): string
+    {
+        return $this->countryCode;
+    }
+
+    public function getCountryName(): string
+    {
+        return $this->utility->getCountryName($this->countryCode);
+    }
+
+    public function getAvatarUrl(): string
+    {
+        return $this->avatarUrl;
+    }
+
+    public function getLastUpdatedDate(): ?string
+    {
+        return $this->lastUpdatedDate;
+    }
+
+    public function getLevel(): ?int
+    {
+        return $this->level;
+    }
+
+    public function getProgress(): ?string
+    {
+        return $this->progress;
+    }
+
+    public function isRanked(): bool
+    {
+        return $this->status === 0 && $this->ranking !== null;
+    }
+
+    public function getRanking(): ?int
+    {
+        return $this->ranking;
+    }
+
+    public function hasHiddenTrophies(): bool
+    {
+        return $this->trophyCountNpwr < $this->trophyCountSony;
+    }
+
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+
+    public function getStatusLabel(): ?string
+    {
+        return self::STATUS_LABELS[$this->status] ?? null;
+    }
+
+    public function isNew(): bool
+    {
+        return $this->rankLastWeek === 0 || $this->rankLastWeek === 16777215;
+    }
+
+    public function getRankDelta(): ?int
+    {
+        if (!$this->isRanked() || $this->isNew()) {
+            return null;
+        }
+
+        return $this->rankLastWeek - (int) $this->ranking;
+    }
+
+    public function getRankDeltaColor(): ?string
+    {
+        $delta = $this->getRankDelta();
+
+        if ($delta === null) {
+            return null;
+        }
+
+        if ($delta < 0) {
+            return '#d40b0b';
+        }
+
+        if ($delta > 0) {
+            return '#0bd413';
+        }
+
+        return '#0070d1';
+    }
+
+    public function getRankDeltaLabel(): ?string
+    {
+        $delta = $this->getRankDelta();
+
+        if ($delta === null) {
+            return null;
+        }
+
+        if ($delta < 0) {
+            return '(' . $delta . ')';
+        }
+
+        if ($delta > 0) {
+            return '(+' . $delta . ')';
+        }
+
+        return '(=)';
+    }
+}

--- a/wwwroot/classes/AboutPageScanSummary.php
+++ b/wwwroot/classes/AboutPageScanSummary.php
@@ -1,0 +1,23 @@
+<?php
+
+class AboutPageScanSummary
+{
+    private int $scannedPlayers;
+    private int $newPlayers;
+
+    public function __construct(int $scannedPlayers, int $newPlayers)
+    {
+        $this->scannedPlayers = $scannedPlayers;
+        $this->newPlayers = $newPlayers;
+    }
+
+    public function getScannedPlayers(): int
+    {
+        return $this->scannedPlayers;
+    }
+
+    public function getNewPlayers(): int
+    {
+        return $this->newPlayers;
+    }
+}

--- a/wwwroot/classes/AboutPageService.php
+++ b/wwwroot/classes/AboutPageService.php
@@ -1,0 +1,78 @@
+<?php
+
+require_once __DIR__ . '/AboutPagePlayer.php';
+require_once __DIR__ . '/AboutPageScanSummary.php';
+
+class AboutPageService
+{
+    private const DEFAULT_SCAN_LOG_LIMIT = 10;
+
+    private PDO $database;
+    private Utility $utility;
+
+    public function __construct(PDO $database, Utility $utility)
+    {
+        $this->database = $database;
+        $this->utility = $utility;
+    }
+
+    public function getScanSummary(): AboutPageScanSummary
+    {
+        $scannedPlayers = $this->fetchCount(
+            'SELECT COUNT(*) FROM player WHERE last_updated_date >= now() - INTERVAL 1 DAY'
+        );
+        $newPlayers = $this->fetchCount(
+            'SELECT COUNT(*) FROM player WHERE status = 0 AND rank_last_week = 0'
+        );
+
+        return new AboutPageScanSummary($scannedPlayers, $newPlayers);
+    }
+
+    public function getScanLogPlayers(int $limit = self::DEFAULT_SCAN_LOG_LIMIT): array
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                p.online_id,
+                p.country,
+                p.avatar_url,
+                p.last_updated_date,
+                p.level,
+                p.progress,
+                p.rank_last_week,
+                p.status,
+                p.trophy_count_npwr,
+                p.trophy_count_sony,
+                r.ranking
+            FROM
+                player p
+                LEFT JOIN player_ranking r ON p.account_id = r.account_id
+            WHERE
+                p.status = 0
+            ORDER BY
+                p.last_updated_date DESC
+            LIMIT
+                :limit
+            SQL
+        );
+        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $query->execute();
+
+        $players = [];
+        while ($row = $query->fetch(PDO::FETCH_ASSOC)) {
+            $players[] = AboutPagePlayer::fromArray($row, $this->utility);
+        }
+
+        return $players;
+    }
+
+    private function fetchCount(string $sql): int
+    {
+        $query = $this->database->prepare($sql);
+        $query->execute();
+
+        $count = $query->fetchColumn();
+
+        return is_numeric($count) ? (int) $count : 0;
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the about page to retrieve scan summary and player data through a dedicated service
- introduce dedicated value objects to expose scan summary details and per-player information for the view

## Testing
- php -l wwwroot/about.php
- php -l wwwroot/classes/AboutPageService.php
- php -l wwwroot/classes/AboutPagePlayer.php
- php -l wwwroot/classes/AboutPageScanSummary.php

------
https://chatgpt.com/codex/tasks/task_e_68d00c56fe74832f8f104a75da27a139