### PR TITLE
Refactor leaderboard page to use service objects

### DIFF
--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerLeaderboardFilter
+{
+    private ?string $country;
+    private ?string $avatar;
+    private int $page;
+
+    public function __construct(?string $country, ?string $avatar, int $page)
+    {
+        $country = $country !== null ? trim($country) : null;
+        $avatar = $avatar !== null ? trim($avatar) : null;
+
+        $this->country = $country === '' ? null : $country;
+        $this->avatar = $avatar === '' ? null : $avatar;
+        $this->page = max($page, 1);
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public static function fromArray(array $queryParameters): self
+    {
+        $country = isset($queryParameters['country']) ? (string) $queryParameters['country'] : null;
+        $avatar = isset($queryParameters['avatar']) ? (string) $queryParameters['avatar'] : null;
+
+        $page = $queryParameters['page'] ?? 1;
+        if (!is_numeric($page)) {
+            $page = 1;
+        }
+
+        return new self($country, $avatar, (int) $page);
+    }
+
+    public function getCountry(): ?string
+    {
+        return $this->country;
+    }
+
+    public function hasCountry(): bool
+    {
+        return $this->country !== null;
+    }
+
+    public function getAvatar(): ?string
+    {
+        return $this->avatar;
+    }
+
+    public function hasAvatar(): bool
+    {
+        return $this->avatar !== null;
+    }
+
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    public function getOffset(int $limit): int
+    {
+        return ($this->page - 1) * $limit;
+    }
+
+    /**
+     * @return array{country?: string, avatar?: string}
+     */
+    public function getFilterParameters(): array
+    {
+        $parameters = [];
+
+        if ($this->country !== null) {
+            $parameters['country'] = $this->country;
+        }
+
+        if ($this->avatar !== null) {
+            $parameters['avatar'] = $this->avatar;
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    public function toQueryParameters(): array
+    {
+        return $this->withPage($this->page);
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    public function withPage(int $page): array
+    {
+        $parameters = $this->getFilterParameters();
+        $parameters['page'] = max($page, 1);
+
+        return $parameters;
+    }
+}

--- a/wwwroot/classes/PlayerLeaderboardService.php
+++ b/wwwroot/classes/PlayerLeaderboardService.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerLeaderboardService
+{
+    public const PAGE_SIZE = 50;
+
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function countPlayers(PlayerLeaderboardFilter $filter): int
+    {
+        $sql = <<<'SQL'
+            SELECT
+                COUNT(*)
+            FROM
+                player p
+            WHERE
+                p.status = 0
+        SQL;
+
+        $sql .= $this->buildFilterSql($filter);
+
+        $query = $this->database->prepare($sql);
+        $this->bindFilterParameters($query, $filter);
+        $query->execute();
+
+        return (int) $query->fetchColumn();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getPlayers(PlayerLeaderboardFilter $filter, int $limit = self::PAGE_SIZE): array
+    {
+        $sql = <<<'SQL'
+            SELECT
+                p.*,
+                r.ranking,
+                r.ranking_country
+            FROM
+                player p
+            JOIN player_ranking r ON p.account_id = r.account_id
+            WHERE
+                p.status = 0
+        SQL;
+
+        $sql .= $this->buildFilterSql($filter);
+
+        $sql .= <<<'SQL'
+            ORDER BY
+                r.ranking
+            LIMIT :offset, :limit
+        SQL;
+
+        $query = $this->database->prepare($sql);
+        $query->bindValue(':offset', $filter->getOffset($limit), PDO::PARAM_INT);
+        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $this->bindFilterParameters($query, $filter);
+        $query->execute();
+
+        $players = $query->fetchAll(PDO::FETCH_ASSOC);
+
+        if (!is_array($players)) {
+            return [];
+        }
+
+        return $players;
+    }
+
+    private function buildFilterSql(PlayerLeaderboardFilter $filter): string
+    {
+        $clauses = '';
+
+        if ($filter->hasCountry()) {
+            $clauses .= "\n                AND p.country = :country";
+        }
+
+        if ($filter->hasAvatar()) {
+            $clauses .= "\n                AND p.avatar_url = :avatar";
+        }
+
+        return $clauses;
+    }
+
+    private function bindFilterParameters(PDOStatement $query, PlayerLeaderboardFilter $filter): void
+    {
+        if ($filter->hasCountry()) {
+            $query->bindValue(':country', (string) $filter->getCountry(), PDO::PARAM_STR);
+        }
+
+        if ($filter->hasAvatar()) {
+            $query->bindValue(':avatar', (string) $filter->getAvatar(), PDO::PARAM_STR);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PlayerLeaderboardFilter to encapsulate parsing leaderboard query parameters
- add PlayerLeaderboardService to centralize leaderboard data retrieval
- refactor leaderboard_main.php to use the new service and filter classes

## Testing
- php -l wwwroot/classes/PlayerLeaderboardFilter.php
- php -l wwwroot/classes/PlayerLeaderboardService.php
- php -l wwwroot/leaderboard_main.php

------
https://chatgpt.com/codex/tasks/task_e_68d016a754d8832fa55d6fda2bb6f227