### PR TITLE
Refactor trophy achievers queries into service

### DIFF
--- a/wwwroot/classes/TrophyService.php
+++ b/wwwroot/classes/TrophyService.php
@@ -101,4 +101,68 @@ class TrophyService
 
         return $playerTrophy;
     }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getFirstAchievers(string $npCommunicationId, int $orderId): array
+    {
+        return $this->getAchievers($npCommunicationId, $orderId, false);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getLatestAchievers(string $npCommunicationId, int $orderId): array
+    {
+        return $this->getAchievers($npCommunicationId, $orderId, true);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getAchievers(string $npCommunicationId, int $orderId, bool $latest): array
+    {
+        $orderClause = $latest
+            ? 'ORDER BY te.earned_date DESC'
+            : 'ORDER BY te.earned_date IS NULL, te.earned_date';
+
+        $sql = <<<SQL
+            WITH filtered_trophy_earned AS (
+                SELECT
+                    account_id,
+                    earned_date
+                FROM
+                    trophy_earned
+                WHERE
+                    np_communication_id = :np_communication_id
+                    AND order_id = :order_id
+                    AND earned = 1
+            )
+            SELECT
+                p.avatar_url,
+                p.online_id,
+                p.trophy_count_npwr,
+                p.trophy_count_sony,
+                IFNULL(te.earned_date, 'No Timestamp') AS earned_date
+            FROM
+                filtered_trophy_earned te
+                JOIN player_ranking r ON te.account_id = r.account_id
+                JOIN player p ON r.account_id = p.account_id
+            WHERE
+                r.ranking <= 10000
+            %s
+            LIMIT 50
+        SQL;
+
+        $query = $this->database->prepare(sprintf($sql, $orderClause));
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':order_id', $orderId, PDO::PARAM_INT);
+        $query->execute();
+
+        /** @var array<int, array<string, mixed>> $achievers */
+        $achievers = $query->fetchAll(PDO::FETCH_ASSOC);
+
+        return $achievers;
+    }
 }

--- a/wwwroot/trophy.php
+++ b/wwwroot/trophy.php
@@ -38,6 +38,12 @@ if (isset($player)) {
     );
 }
 
+$npCommunicationId = (string) $trophy["np_communication_id"];
+$orderId = (int) $trophy["order_id"];
+
+$firstAchievers = $trophyService->getFirstAchievers($npCommunicationId, $orderId);
+$latestAchievers = $trophyService->getLatestAchievers($npCommunicationId, $orderId);
+
 $metaData = new stdClass();
 $metaData->title = $trophy["trophy_name"] ." Trophy";
 $metaData->description = htmlentities($trophy["trophy_detail"], ENT_QUOTES, "UTF-8");
@@ -185,41 +191,9 @@ require_once("header.php");
 
                                 <tbody>
                                     <?php
-                                    $query = $database->prepare("
-                                        WITH filtered_trophy_earned AS (
-                                            SELECT
-                                                account_id,
-                                                earned_date
-                                            FROM
-                                                trophy_earned
-                                            WHERE
-                                                np_communication_id = :np_communication_id
-                                                AND order_id = :order_id
-                                                AND earned = 1
-                                        )
-                                        SELECT
-                                            p.avatar_url,
-                                            p.online_id,
-                                            p.trophy_count_npwr,
-                                            p.trophy_count_sony,
-                                            IFNULL(te.earned_date, 'No Timestamp') AS earned_date
-                                        FROM
-                                            filtered_trophy_earned te
-                                            JOIN player_ranking r ON te.account_id = r.account_id
-                                            JOIN player p ON r.account_id = p.account_id
-                                        WHERE
-                                            r.ranking <= 10000
-                                        ORDER BY
-                                            te.earned_date IS NULL, te.earned_date
-                                        LIMIT 50");
-                                    $query->bindValue(":np_communication_id", $trophy["np_communication_id"], PDO::PARAM_STR);
-                                    $query->bindValue(":order_id", $trophy["order_id"], PDO::PARAM_STR);
-                                    $query->execute();
-                                    $results = $query->fetchAll();
-
                                     $count = 0;
 
-                                    foreach ($results as $result) {
+                                    foreach ($firstAchievers as $result) {
                                         ?>
                                         <tr<?= ($result["online_id"] == $player) ? " class='table-primary'" : ""; ?>>
                                             <th class="align-middle" scope="row">
@@ -274,41 +248,9 @@ require_once("header.php");
 
                                 <tbody>
                                     <?php
-                                    $query = $database->prepare("
-                                        WITH filtered_trophy_earned AS (
-                                            SELECT
-                                                account_id,
-                                                earned_date
-                                            FROM
-                                                trophy_earned
-                                            WHERE
-                                                np_communication_id = :np_communication_id
-                                                AND order_id = :order_id
-                                                AND earned = 1
-                                        )
-                                        SELECT
-                                            p.avatar_url,
-                                            p.online_id,
-                                            p.trophy_count_npwr,
-                                            p.trophy_count_sony,
-                                            IFNULL(te.earned_date, 'No Timestamp') AS earned_date
-                                        FROM
-                                            filtered_trophy_earned te
-                                            JOIN player_ranking r ON te.account_id = r.account_id
-                                            JOIN player p ON r.account_id = p.account_id
-                                        WHERE
-                                            r.ranking <= 10000
-                                        ORDER BY
-                                            te.earned_date DESC
-                                        LIMIT 50");
-                                    $query->bindValue(":np_communication_id", $trophy["np_communication_id"], PDO::PARAM_STR);
-                                    $query->bindValue(":order_id", $trophy["order_id"], PDO::PARAM_STR);
-                                    $query->execute();
-                                    $results = $query->fetchAll();
-
                                     $count = 0;
 
-                                    foreach ($results as $result) {
+                                    foreach ($latestAchievers as $result) {
                                         ?>
                                         <tr<?= ($result["online_id"] == $player) ? " class='table-primary'" : ""; ?>>
                                             <th class="align-middle" scope="row">


### PR DESCRIPTION
## Summary
- move repeated trophy achiever queries into `TrophyService` so achiever lists can be reused
- update the trophy page to consume the service instead of running inline SQL

## Testing
- php -l wwwroot/classes/TrophyService.php
- php -l wwwroot/trophy.php

------
https://chatgpt.com/codex/tasks/task_e_68d01950c3d0832fb738f5281b49bb59