### PR TITLE
Refactor player log to use service objects

### DIFF
--- a/wwwroot/classes/PlayerLogFilter.php
+++ b/wwwroot/classes/PlayerLogFilter.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerLogFilter
+{
+    public const SORT_DATE = 'date';
+    public const SORT_RARITY = 'rarity';
+
+    /** @var array<int, string> */
+    private const ALLOWED_PLATFORMS = [
+        'pc',
+        'ps3',
+        'ps4',
+        'ps5',
+        'psvita',
+        'psvr',
+        'psvr2',
+    ];
+
+    /** @var array<int, string> */
+    private array $platforms = [];
+
+    private string $sort;
+
+    private function __construct(string $sort)
+    {
+        $this->sort = $this->normaliseSort($sort);
+    }
+
+    public static function fromArray(array $parameters): self
+    {
+        $filter = new self(is_string($parameters['sort'] ?? null) ? (string) $parameters['sort'] : self::SORT_DATE);
+
+        foreach (self::ALLOWED_PLATFORMS as $platform) {
+            if (!empty($parameters[$platform])) {
+                $filter->platforms[] = $platform;
+            }
+        }
+
+        $filter->platforms = array_values(array_unique($filter->platforms));
+
+        return $filter;
+    }
+
+    public function getSort(): string
+    {
+        return $this->sort;
+    }
+
+    public function isSort(string $sort): bool
+    {
+        return $this->sort === $this->normaliseSort($sort);
+    }
+
+    public function isPlatformSelected(string $platform): bool
+    {
+        return in_array($platform, $this->platforms, true);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getPlatforms(): array
+    {
+        return $this->platforms;
+    }
+
+    public function hasPlatformFilters(): bool
+    {
+        return $this->platforms !== [];
+    }
+
+    private function normaliseSort(string $sort): string
+    {
+        if ($sort === self::SORT_RARITY) {
+            return self::SORT_RARITY;
+        }
+
+        return self::SORT_DATE;
+    }
+}

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerLogService
+{
+    public const PAGE_SIZE = 50;
+
+    private const PLATFORM_FILTERS = [
+        'pc' => "tt.platform LIKE '%PC%'",
+        'ps3' => "tt.platform LIKE '%PS3%'",
+        'ps4' => "tt.platform LIKE '%PS4%'",
+        'ps5' => "tt.platform LIKE '%PS5%'",
+        'psvita' => "tt.platform LIKE '%PSVITA%'",
+        'psvr' => "tt.platform LIKE '%PSVR' OR tt.platform LIKE '%PSVR,%'",
+        'psvr2' => "tt.platform LIKE '%PSVR2%'",
+    ];
+
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function countTrophies(int $accountId, PlayerLogFilter $filter): int
+    {
+        $sql = <<<'SQL'
+            SELECT COUNT(*)
+            FROM trophy_earned te
+            JOIN trophy_title tt USING (np_communication_id)
+            WHERE tt.status != 2
+                AND te.account_id = :account_id
+        SQL;
+
+        $sql .= $this->buildPlatformClause($filter);
+
+        $query = $this->database->prepare($sql);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+
+        return (int) $query->fetchColumn();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getTrophies(int $accountId, PlayerLogFilter $filter, int $offset, int $limit = self::PAGE_SIZE): array
+    {
+        $sql = <<<'SQL'
+            SELECT
+                te.*,
+                t.id AS trophy_id,
+                t.type AS trophy_type,
+                t.name AS trophy_name,
+                t.detail AS trophy_detail,
+                t.icon_url AS trophy_icon,
+                t.rarity_percent,
+                t.status AS trophy_status,
+                t.progress_target_value,
+                t.reward_name,
+                t.reward_image_url,
+                tt.id AS game_id,
+                tt.name AS game_name,
+                tt.status AS game_status,
+                tt.icon_url AS game_icon,
+                tt.platform
+            FROM trophy_earned te
+            LEFT JOIN trophy t USING (np_communication_id, order_id)
+            LEFT JOIN trophy_title tt USING (np_communication_id)
+            WHERE tt.status != 2
+                AND te.account_id = :account_id
+                AND te.earned = 1
+        SQL;
+
+        $sql .= $this->buildPlatformClause($filter);
+        $sql .= $this->buildOrderByClause($filter);
+        $sql .= '\n            LIMIT :offset, :limit';
+
+        $query = $this->database->prepare($sql);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $query->execute();
+
+        $trophies = $query->fetchAll(PDO::FETCH_ASSOC);
+
+        if (!is_array($trophies)) {
+            return [];
+        }
+
+        return $trophies;
+    }
+
+    private function buildPlatformClause(PlayerLogFilter $filter): string
+    {
+        if (!$filter->hasPlatformFilters()) {
+            return '';
+        }
+
+        $clauses = [];
+
+        foreach ($filter->getPlatforms() as $platform) {
+            if (isset(self::PLATFORM_FILTERS[$platform])) {
+                $clauses[] = self::PLATFORM_FILTERS[$platform];
+            }
+        }
+
+        if ($clauses === []) {
+            return '';
+        }
+
+        return '\n                AND (' . implode(' OR ', $clauses) . ')';
+    }
+
+    private function buildOrderByClause(PlayerLogFilter $filter): string
+    {
+        if ($filter->isSort(PlayerLogFilter::SORT_RARITY)) {
+            return '\n            ORDER BY t.rarity_percent, te.earned_date';
+        }
+
+        return '\n            ORDER BY te.earned_date DESC';
+    }
+}


### PR DESCRIPTION
## Summary
- add PlayerLogFilter and PlayerLogService classes to encapsulate player log filtering and data access
- refactor player_log.php to consume the new services for retrieving trophies and maintaining UI state

## Testing
- php -l wwwroot/classes/PlayerLogFilter.php
- php -l wwwroot/classes/PlayerLogService.php
- php -l wwwroot/player_log.php

------
https://chatgpt.com/codex/tasks/task_e_68d01b5446dc832f872f3f400a6c77ff