### PR TITLE
Refactor admin reported players to service classes

### DIFF
--- a/wwwroot/admin/report.php
+++ b/wwwroot/admin/report.php
@@ -1,14 +1,16 @@
 <?php
-require_once("../init.php");
+declare(strict_types=1);
 
-if (!empty($_GET["delete"])) {
-    $reportId = $_GET["delete"];
+require_once '../init.php';
+require_once '../classes/Admin/PlayerReportAdminService.php';
 
-    $sql = "DELETE FROM player_report WHERE report_id = :report_id";
-    $query = $database->prepare($sql);
-    $query->bindValue(":report_id", $reportId, PDO::PARAM_INT);
-    $query->execute();
+$playerReportAdminService = new PlayerReportAdminService($database);
+
+if (isset($_GET['delete']) && ctype_digit((string) $_GET['delete'])) {
+    $playerReportAdminService->deleteReportById((int) $_GET['delete']);
 }
+
+$reportedPlayers = $playerReportAdminService->getReportedPlayers();
 ?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">
@@ -22,16 +24,20 @@ if (!empty($_GET["delete"])) {
     <body>
         <div class="p-4">
             <a href="/admin/">Back</a><br><br>
-            <?php
-            $sql = "SELECT pr.report_id, p.online_id, pr.explanation FROM player_report pr JOIN player p USING (account_id)";
-            $query = $database->prepare($sql);
-            $query->execute();
-            $reportedPlayers = $query->fetchAll();
-
-            foreach ($reportedPlayers as $reportedPlayer) {
-                echo "<a href='/player/". $reportedPlayer["online_id"] ."'>". $reportedPlayer["online_id"] ."</a><br>". nl2br(htmlentities($reportedPlayer["explanation"], ENT_QUOTES, 'UTF-8')) ."<br><a href='?delete=". $reportedPlayer["report_id"] ."'>Delete</a><hr>";
-            }
-            ?>
+            <?php foreach ($reportedPlayers as $reportedPlayer) { ?>
+                <div class="mb-3">
+                    <a href="/player/<?= htmlentities($reportedPlayer->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>">
+                        <?= htmlentities($reportedPlayer->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>
+                    </a>
+                    <div class="mt-2">
+                        <?= nl2br(htmlentities($reportedPlayer->getExplanation(), ENT_QUOTES, 'UTF-8')); ?>
+                    </div>
+                    <div class="mt-2">
+                        <a href="?delete=<?= $reportedPlayer->getReportId(); ?>">Delete</a>
+                    </div>
+                </div>
+                <hr>
+            <?php } ?>
         </div>
     </body>
 </html>

--- a/wwwroot/classes/Admin/PlayerReportAdminService.php
+++ b/wwwroot/classes/Admin/PlayerReportAdminService.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/ReportedPlayer.php';
+
+class PlayerReportAdminService
+{
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function deleteReportById(int $reportId): void
+    {
+        $query = $this->database->prepare(
+            'DELETE FROM player_report WHERE report_id = :report_id'
+        );
+        $query->bindValue(':report_id', $reportId, PDO::PARAM_INT);
+        $query->execute();
+    }
+
+    /**
+     * @return ReportedPlayer[]
+     */
+    public function getReportedPlayers(): array
+    {
+        $query = $this->database->prepare(
+            'SELECT pr.report_id, p.online_id, pr.explanation
+            FROM player_report pr
+            JOIN player p USING (account_id)
+            ORDER BY pr.report_id'
+        );
+        $query->execute();
+
+        $reportedPlayers = [];
+        while (($row = $query->fetch(PDO::FETCH_ASSOC)) !== false) {
+            $reportId = isset($row['report_id']) ? (int) $row['report_id'] : 0;
+            $onlineId = isset($row['online_id']) ? (string) $row['online_id'] : '';
+            $explanation = isset($row['explanation']) ? (string) $row['explanation'] : '';
+
+            $reportedPlayers[] = new ReportedPlayer($reportId, $onlineId, $explanation);
+        }
+
+        return $reportedPlayers;
+    }
+}

--- a/wwwroot/classes/Admin/ReportedPlayer.php
+++ b/wwwroot/classes/Admin/ReportedPlayer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+class ReportedPlayer
+{
+    private int $reportId;
+
+    private string $onlineId;
+
+    private string $explanation;
+
+    public function __construct(int $reportId, string $onlineId, string $explanation)
+    {
+        $this->reportId = $reportId;
+        $this->onlineId = $onlineId;
+        $this->explanation = $explanation;
+    }
+
+    public function getReportId(): int
+    {
+        return $this->reportId;
+    }
+
+    public function getOnlineId(): string
+    {
+        return $this->onlineId;
+    }
+
+    public function getExplanation(): string
+    {
+        return $this->explanation;
+    }
+}


### PR DESCRIPTION
## Summary
- add PlayerReportAdminService and ReportedPlayer classes to encapsulate admin player report logic
- update the admin reported players page to use the new service and render using typed objects

## Testing
- php -l wwwroot/classes/Admin/ReportedPlayer.php
- php -l wwwroot/classes/Admin/PlayerReportAdminService.php
- php -l wwwroot/admin/report.php

------
https://chatgpt.com/codex/tasks/task_e_68d04bec3150832fb138cb78b5bf44bd