### PR TITLE
Refactor cheater admin page to use service

### DIFF
--- a/wwwroot/classes/Admin/CheaterService.php
+++ b/wwwroot/classes/Admin/CheaterService.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+class CheaterService
+{
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function markPlayerAsCheater(string $onlineId): void
+    {
+        if ($onlineId === '') {
+            throw new InvalidArgumentException('Online ID cannot be empty.');
+        }
+
+        $this->database->beginTransaction();
+
+        try {
+            $query = $this->database->prepare(
+                'UPDATE player
+                SET `status` = 1,
+                    rank_last_week = 0,
+                    rarity_rank_last_week = 0,
+                    rank_country_last_week = 0,
+                    rarity_rank_country_last_week = 0
+                WHERE online_id = :online_id'
+            );
+            $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
+            $query->execute();
+
+            $this->database->commit();
+        } catch (Throwable $exception) {
+            if ($this->database->inTransaction()) {
+                $this->database->rollBack();
+            }
+
+            throw $exception;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract the cheater flagging SQL into a reusable CheaterService class
- update the admin cheater page to rely on the new service and add basic validation/error handling

## Testing
- php -l wwwroot/classes/Admin/CheaterService.php
- php -l wwwroot/admin/cheater.php

------
https://chatgpt.com/codex/tasks/task_e_68d102360000832f8b79c4c5cc732e2c