### PR TITLE
Refactor player summary queries to service

### DIFF
--- a/wwwroot/classes/PlayerSummary.php
+++ b/wwwroot/classes/PlayerSummary.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerSummary
+{
+    private int $numberOfGames;
+
+    private int $numberOfCompletedGames;
+
+    private ?float $averageProgress;
+
+    private int $unearnedTrophies;
+
+    public function __construct(int $numberOfGames, int $numberOfCompletedGames, ?float $averageProgress, int $unearnedTrophies)
+    {
+        $this->numberOfGames = $numberOfGames;
+        $this->numberOfCompletedGames = $numberOfCompletedGames;
+        $this->averageProgress = $averageProgress;
+        $this->unearnedTrophies = $unearnedTrophies;
+    }
+
+    public function getNumberOfGames(): int
+    {
+        return $this->numberOfGames;
+    }
+
+    public function getNumberOfCompletedGames(): int
+    {
+        return $this->numberOfCompletedGames;
+    }
+
+    public function getAverageProgress(): ?float
+    {
+        return $this->averageProgress;
+    }
+
+    public function getUnearnedTrophies(): int
+    {
+        return $this->unearnedTrophies;
+    }
+}
+

--- a/wwwroot/classes/PlayerSummaryService.php
+++ b/wwwroot/classes/PlayerSummaryService.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerSummaryService
+{
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function getSummary(int $accountId): PlayerSummary
+    {
+        $numberOfGames = $this->fetchNumberOfGames($accountId);
+        $numberOfCompletedGames = $this->fetchNumberOfCompletedGames($accountId);
+        $averageProgress = $this->fetchAverageProgress($accountId);
+        $unearnedTrophies = $this->fetchUnearnedTrophies($accountId);
+
+        return new PlayerSummary($numberOfGames, $numberOfCompletedGames, $averageProgress, $unearnedTrophies);
+    }
+
+    private function fetchNumberOfGames(int $accountId): int
+    {
+        $query = $this->database->prepare(
+            'SELECT COUNT(*) FROM trophy_title_player ttp JOIN trophy_title tt USING (np_communication_id) WHERE tt.status = 0 AND ttp.account_id = :account_id'
+        );
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+
+        $result = $query->fetchColumn();
+
+        return $this->toInt($result);
+    }
+
+    private function fetchNumberOfCompletedGames(int $accountId): int
+    {
+        $query = $this->database->prepare(
+            'SELECT COUNT(*) FROM trophy_title_player ttp JOIN trophy_title tt USING (np_communication_id) WHERE tt.status = 0 AND ttp.progress = 100 AND ttp.account_id = :account_id'
+        );
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+
+        $result = $query->fetchColumn();
+
+        return $this->toInt($result);
+    }
+
+    private function fetchAverageProgress(int $accountId): ?float
+    {
+        $query = $this->database->prepare(
+            'SELECT ROUND(AVG(ttp.progress), 2) FROM trophy_title_player ttp JOIN trophy_title tt USING (np_communication_id) WHERE tt.status = 0 AND ttp.account_id = :account_id'
+        );
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+
+        $result = $query->fetchColumn();
+
+        if ($result === false || $result === null) {
+            return null;
+        }
+
+        return (float) $result;
+    }
+
+    private function fetchUnearnedTrophies(int $accountId): int
+    {
+        $query = $this->database->prepare(
+            'SELECT SUM(tt.bronze - ttp.bronze + tt.silver - ttp.silver + tt.gold - ttp.gold + tt.platinum - ttp.platinum) FROM trophy_title_player ttp JOIN trophy_title tt USING(np_communication_id) WHERE tt.status = 0 AND ttp.account_id = :account_id'
+        );
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+
+        $result = $query->fetchColumn();
+
+        return $this->toInt($result);
+    }
+
+    private function toInt(mixed $value): int
+    {
+        if ($value === false || $value === null) {
+            return 0;
+        }
+
+        return (int) $value;
+    }
+}

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -1,13 +1,15 @@
 <?php
+require_once __DIR__ . '/classes/PlayerSummary.php';
+require_once __DIR__ . '/classes/PlayerSummaryService.php';
+
 if (!isset($accountId)) {
     header("Location: /player/", true, 303);
     die();
 }
 
-$query = $database->prepare("SELECT COUNT(*) FROM trophy_title_player ttp JOIN trophy_title tt USING (np_communication_id) WHERE tt.status = 0 AND ttp.account_id = :account_id");
-$query->bindValue(":account_id", $accountId, PDO::PARAM_INT);
-$query->execute();
-$numberOfGames = $query->fetchColumn();
+$playerSummaryService = new PlayerSummaryService($database);
+$playerSummary = $playerSummaryService->getSummary((int) $accountId);
+$numberOfGames = $playerSummary->getNumberOfGames();
 
 $metaData = new stdClass();
 $metaData->title = $player["online_id"] ."'s Trophy Progress";

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/classes/PlayerAdvisorFilter.php';
 require_once __DIR__ . '/classes/PlayerAdvisorService.php';
+require_once __DIR__ . '/classes/PlayerSummary.php';
+require_once __DIR__ . '/classes/PlayerSummaryService.php';
 
 if (!isset($accountId)) {
     header("Location: /player/", true, 303);
@@ -11,6 +13,8 @@ if (!isset($accountId)) {
 
 $playerAdvisorFilter = PlayerAdvisorFilter::fromArray($_GET ?? []);
 $playerAdvisorService = new PlayerAdvisorService($database);
+$playerSummaryService = new PlayerSummaryService($database);
+$playerSummary = $playerSummaryService->getSummary((int) $accountId);
 
 $page = $playerAdvisorFilter->getPage();
 $limit = PlayerAdvisorService::PAGE_SIZE;

--- a/wwwroot/player_header.php
+++ b/wwwroot/player_header.php
@@ -2,6 +2,10 @@
 $aboutMe = nl2br(htmlentities($player["about_me"], ENT_QUOTES, 'UTF-8'));
 $countryName = $utility->getCountryName($player["country"]);
 $trophies = $player["bronze"] + $player["silver"] + $player["gold"] + $player["platinum"];
+$numberOfGames = $playerSummary->getNumberOfGames();
+$numberOfCompletedGames = $playerSummary->getNumberOfCompletedGames();
+$averageProgress = $playerSummary->getAverageProgress();
+$unearnedTrophies = $playerSummary->getUnearnedTrophies();
 ?>
 
 <div class="row">
@@ -139,18 +143,6 @@ $trophies = $player["bronze"] + $player["silver"] + $player["gold"] + $player["p
         </div>
     </div>
 
-    <?php
-    $query = $database->prepare("SELECT COUNT(*) FROM trophy_title_player ttp JOIN trophy_title tt USING (np_communication_id) WHERE tt.status = 0 AND ttp.account_id = :account_id");
-    $query->bindValue(":account_id", $accountId, PDO::PARAM_INT);
-    $query->execute();
-    $numberOfGames = $query->fetchColumn();
-
-    $query = $database->prepare("SELECT COUNT(*) FROM trophy_title_player ttp JOIN trophy_title tt USING (np_communication_id) WHERE tt.status = 0 AND ttp.progress = 100 AND ttp.account_id = :account_id");
-    $query->bindValue(":account_id", $accountId, PDO::PARAM_INT);
-    $query->execute();
-    $numberOfCompletedGames = $query->fetchColumn();
-    ?>
-
     <div class="col-12 col-lg-4 mb-3">
         <div class="vstack gap-3 h-100 text-center">
             <div class="hstack gap-3">
@@ -269,26 +261,6 @@ $trophies = $player["bronze"] + $player["silver"] + $player["gold"] + $player["p
         </div>
     </div>
 
-    <?php
-    $query = $database->prepare("SELECT ROUND(AVG(ttp.progress), 2) FROM trophy_title_player ttp JOIN trophy_title tt USING (np_communication_id) WHERE tt.status = 0 AND ttp.account_id = :account_id");
-    $query->bindValue(":account_id", $accountId, PDO::PARAM_INT);
-    $query->execute();
-    $averageProgress = $query->fetchColumn();
-
-    $query = $database->prepare("SELECT
-            SUM(
-                tt.bronze - ttp.bronze + tt.silver - ttp.silver + tt.gold - ttp.gold + tt.platinum - ttp.platinum
-            )
-        FROM
-            trophy_title_player ttp
-        JOIN trophy_title tt USING(np_communication_id)
-        WHERE
-            tt.status = 0 AND ttp.account_id = :account_id");
-    $query->bindValue(":account_id", $accountId, PDO::PARAM_INT);
-    $query->execute();
-    $unearnedTrophies = $query->fetchColumn();
-    ?>
-
     <div class="col-12 col-lg-4 mb-3">
         <div class="vstack gap-3 text-center h-100">
             <div class="hstack gap-3">
@@ -300,7 +272,7 @@ $trophies = $player["bronze"] + $player["silver"] + $player["gold"] + $player["p
                         echo "N/A";
                     } else {
                         ?>
-                        <h2><?= $averageProgress; ?>%</h2>
+                        <h2><?= number_format($averageProgress ?? 0.0, 2); ?>%</h2>
                         <?php
                     }
                     ?>
@@ -314,7 +286,7 @@ $trophies = $player["bronze"] + $player["silver"] + $player["gold"] + $player["p
                         echo "N/A";
                     } else {
                         ?>
-                        <h2><?= number_format($unearnedTrophies ?? 0); ?></h2>
+                        <h2><?= number_format($unearnedTrophies); ?></h2>
                         <?php
                     }
                     ?>

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/classes/PlayerLogFilter.php';
 require_once __DIR__ . '/classes/PlayerLogService.php';
+require_once __DIR__ . '/classes/PlayerSummary.php';
+require_once __DIR__ . '/classes/PlayerSummaryService.php';
 
 if (!isset($accountId)) {
     header("Location: /player/", true, 303);
@@ -11,6 +13,8 @@ if (!isset($accountId)) {
 
 $playerLogFilter = PlayerLogFilter::fromArray($_GET ?? []);
 $playerLogService = new PlayerLogService($database);
+$playerSummaryService = new PlayerSummaryService($database);
+$playerSummary = $playerSummaryService->getSummary((int) $accountId);
 
 $url = $_SERVER["REQUEST_URI"];
 $url_parts = parse_url($url);

--- a/wwwroot/player_random.php
+++ b/wwwroot/player_random.php
@@ -4,10 +4,14 @@ if (!isset($accountId)) {
     die();
 }
 
-require_once 'classes/PlayerRandomGame.php';
-require_once 'classes/PlayerRandomGamesService.php';
+require_once __DIR__ . '/classes/PlayerRandomGame.php';
+require_once __DIR__ . '/classes/PlayerRandomGamesService.php';
+require_once __DIR__ . '/classes/PlayerSummary.php';
+require_once __DIR__ . '/classes/PlayerSummaryService.php';
 
 $playerRandomGamesService = new PlayerRandomGamesService($database, $utility);
+$playerSummaryService = new PlayerSummaryService($database);
+$playerSummary = $playerSummaryService->getSummary((int) $accountId);
 $randomGames = [];
 
 if ($player["status"] != 1 && $player["status"] != 3) {

--- a/wwwroot/player_report.php
+++ b/wwwroot/player_report.php
@@ -4,9 +4,13 @@ if (!isset($accountId)) {
     die();
 }
 
-require_once 'classes/PlayerReportService.php';
+require_once __DIR__ . '/classes/PlayerReportService.php';
+require_once __DIR__ . '/classes/PlayerSummary.php';
+require_once __DIR__ . '/classes/PlayerSummaryService.php';
 
 $playerReportService = new PlayerReportService($database);
+$playerSummaryService = new PlayerSummaryService($database);
+$playerSummary = $playerSummaryService->getSummary((int) $accountId);
 
 if (!empty($_GET["explanation"])) {
     $ipAddress = $_SERVER["REMOTE_ADDR"] ?? '';


### PR DESCRIPTION
## Summary
- add PlayerSummary and PlayerSummaryService classes to encapsulate player trophy statistics queries
- update player header and related pages to consume the service instead of running inline SQL

## Testing
- php -l wwwroot/classes/PlayerSummary.php
- php -l wwwroot/classes/PlayerSummaryService.php
- php -l wwwroot/player.php
- php -l wwwroot/player_header.php
- php -l wwwroot/player_log.php
- php -l wwwroot/player_advisor.php
- php -l wwwroot/player_random.php
- php -l wwwroot/player_report.php

------
https://chatgpt.com/codex/tasks/task_e_68d10acc809c832f80ce78e6184c6bfb