### PR TITLE
Refactor game leaderboard filtering to OOP objects

### DIFF
--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+class GameLeaderboardFilter extends GamePlayerFilter
+{
+    private int $page;
+
+    public function __construct(?string $country, ?string $avatar, int $page)
+    {
+        parent::__construct($country, $avatar);
+        $this->page = max($page, 1);
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public static function fromArray(array $queryParameters): self
+    {
+        $country = isset($queryParameters['country']) ? (string) $queryParameters['country'] : null;
+        $avatar = isset($queryParameters['avatar']) ? (string) $queryParameters['avatar'] : null;
+
+        $pageValue = $queryParameters['page'] ?? 1;
+        $page = is_numeric($pageValue) ? (int) $pageValue : 1;
+
+        return new self($country, $avatar, $page);
+    }
+
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    public function getOffset(int $limit): int
+    {
+        return ($this->page - 1) * $limit;
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    public function toQueryParameters(): array
+    {
+        $parameters = parent::getFilterParameters();
+        $parameters['page'] = $this->page;
+
+        return $parameters;
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    public function withPage(int $page): array
+    {
+        $parameters = parent::getFilterParameters();
+        $parameters['page'] = max($page, 1);
+
+        return $parameters;
+    }
+}

--- a/wwwroot/classes/GamePlayerFilter.php
+++ b/wwwroot/classes/GamePlayerFilter.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+class GamePlayerFilter
+{
+    private ?string $country;
+
+    private ?string $avatar;
+
+    public function __construct(?string $country, ?string $avatar)
+    {
+        $country = $country !== null ? trim($country) : null;
+        $avatar = $avatar !== null ? trim($avatar) : null;
+
+        $this->country = $country === '' ? null : $country;
+        $this->avatar = $avatar === '' ? null : $avatar;
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public static function fromArray(array $queryParameters): self
+    {
+        $country = isset($queryParameters['country']) ? (string) $queryParameters['country'] : null;
+        $avatar = isset($queryParameters['avatar']) ? (string) $queryParameters['avatar'] : null;
+
+        return new self($country, $avatar);
+    }
+
+    public function getCountry(): ?string
+    {
+        return $this->country;
+    }
+
+    public function hasCountry(): bool
+    {
+        return $this->country !== null;
+    }
+
+    public function getAvatar(): ?string
+    {
+        return $this->avatar;
+    }
+
+    public function hasAvatar(): bool
+    {
+        return $this->avatar !== null;
+    }
+
+    /**
+     * @return array{country?: string, avatar?: string}
+     */
+    public function getFilterParameters(): array
+    {
+        $parameters = [];
+
+        if ($this->country !== null) {
+            $parameters['country'] = $this->country;
+        }
+
+        if ($this->avatar !== null) {
+            $parameters['avatar'] = $this->avatar;
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function toQueryParameters(): array
+    {
+        return $this->getFilterParameters();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function withCountry(?string $country): array
+    {
+        $parameters = $this->getFilterParameters();
+        $country = $country !== null ? trim($country) : null;
+
+        if ($country === null || $country === '') {
+            unset($parameters['country']);
+        } else {
+            $parameters['country'] = $country;
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function withAvatar(?string $avatar): array
+    {
+        $parameters = $this->getFilterParameters();
+        $avatar = $avatar !== null ? trim($avatar) : null;
+
+        if ($avatar === null || $avatar === '') {
+            unset($parameters['avatar']);
+        } else {
+            $parameters['avatar'] = $avatar;
+        }
+
+        return $parameters;
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable `GamePlayerFilter` and `GameLeaderboardFilter` objects to encapsulate request parameters
- update the game leaderboard and recent player services to accept filter objects and manage pagination offsets internally
- refactor the leaderboard and recent players pages to build query strings via the new filters

## Testing
- `for file in \
    wwwroot/classes/GamePlayerFilter.php \
    wwwroot/classes/GameLeaderboardFilter.php \
    wwwroot/classes/GameLeaderboardService.php \
    wwwroot/classes/GameRecentPlayersService.php \
    wwwroot/game_leaderboard.php \
    wwwroot/game_recent_players.php; do
    php -l $file || exit 1
done`


------
https://chatgpt.com/codex/tasks/task_e_68d115cc7df0832fbe8943bbb5b00d68