### PR TITLE
Refactor admin detail to use service object

### DIFF
--- a/wwwroot/classes/Admin/GameDetail.php
+++ b/wwwroot/classes/Admin/GameDetail.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+class GameDetail
+{
+    private int $id;
+
+    private ?string $npCommunicationId;
+
+    private string $name;
+
+    private string $iconUrl;
+
+    private string $platform;
+
+    private string $message;
+
+    private string $setVersion;
+
+    private ?string $region;
+
+    private ?string $psnprofilesId;
+
+    public function __construct(
+        int $id,
+        ?string $npCommunicationId,
+        string $name,
+        string $iconUrl,
+        string $platform,
+        string $message,
+        string $setVersion,
+        ?string $region,
+        ?string $psnprofilesId
+    ) {
+        $this->id = $id;
+        $this->npCommunicationId = $npCommunicationId;
+        $this->name = $name;
+        $this->iconUrl = $iconUrl;
+        $this->platform = $platform;
+        $this->message = $message;
+        $this->setVersion = $setVersion;
+        $this->region = $region;
+        $this->psnprofilesId = $psnprofilesId;
+    }
+
+    public static function fromArray(int $id, array $row): self
+    {
+        $npCommunicationId = isset($row['np_communication_id']) ? (string) $row['np_communication_id'] : null;
+        $name = (string) ($row['name'] ?? '');
+        $iconUrl = (string) ($row['icon_url'] ?? '');
+        $platform = (string) ($row['platform'] ?? '');
+        $message = (string) ($row['message'] ?? '');
+        $setVersion = (string) ($row['set_version'] ?? '');
+        $region = array_key_exists('region', $row) ? ($row['region'] !== null ? (string) $row['region'] : null) : null;
+        $psnprofilesId = array_key_exists('psnprofiles_id', $row)
+            ? ($row['psnprofiles_id'] !== null ? (string) $row['psnprofiles_id'] : null)
+            : null;
+
+        return new self(
+            $id,
+            $npCommunicationId,
+            $name,
+            $iconUrl,
+            $platform,
+            $message,
+            $setVersion,
+            $region,
+            $psnprofilesId
+        );
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getNpCommunicationId(): ?string
+    {
+        return $this->npCommunicationId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getIconUrl(): string
+    {
+        return $this->iconUrl;
+    }
+
+    public function getPlatform(): string
+    {
+        return $this->platform;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getSetVersion(): string
+    {
+        return $this->setVersion;
+    }
+
+    public function getRegion(): ?string
+    {
+        return $this->region;
+    }
+
+    public function getPsnprofilesId(): ?string
+    {
+        return $this->psnprofilesId;
+    }
+}

--- a/wwwroot/classes/Admin/GameDetailService.php
+++ b/wwwroot/classes/Admin/GameDetailService.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+class GameDetailService
+{
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function getGameDetail(int $gameId): ?GameDetail
+    {
+        $query = $this->database->prepare(
+            'SELECT
+                np_communication_id,
+                name,
+                icon_url,
+                platform,
+                message,
+                set_version,
+                region,
+                psnprofiles_id
+            FROM
+                trophy_title
+            WHERE
+                id = :game_id'
+        );
+        $query->bindValue(':game_id', $gameId, PDO::PARAM_INT);
+        $query->execute();
+
+        $row = $query->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+
+        return GameDetail::fromArray($gameId, $row);
+    }
+
+    public function updateGameDetail(GameDetail $gameDetail): GameDetail
+    {
+        $this->database->beginTransaction();
+
+        try {
+            $query = $this->database->prepare(
+                'UPDATE
+                    trophy_title
+                SET
+                    name = :name,
+                    icon_url = :icon_url,
+                    platform = :platform,
+                    message = :message,
+                    set_version = :set_version,
+                    region = :region,
+                    psnprofiles_id = :psnprofiles_id
+                WHERE
+                    id = :game_id'
+            );
+            $query->bindValue(':name', $gameDetail->getName(), PDO::PARAM_STR);
+            $query->bindValue(':icon_url', $gameDetail->getIconUrl(), PDO::PARAM_STR);
+            $query->bindValue(':platform', $gameDetail->getPlatform(), PDO::PARAM_STR);
+            $query->bindValue(':message', $gameDetail->getMessage(), PDO::PARAM_STR);
+            $query->bindValue(':set_version', $gameDetail->getSetVersion(), PDO::PARAM_STR);
+            $query->bindValue(':region', $gameDetail->getRegion(), $gameDetail->getRegion() === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+            $query->bindValue(':psnprofiles_id', $gameDetail->getPsnprofilesId(), $gameDetail->getPsnprofilesId() === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+            $query->bindValue(':game_id', $gameDetail->getId(), PDO::PARAM_INT);
+            $query->execute();
+
+            $this->database->commit();
+        } catch (Throwable $exception) {
+            $this->database->rollBack();
+            throw $exception;
+        }
+
+        $this->recordChange($gameDetail->getId());
+
+        $updatedDetail = $this->getGameDetail($gameDetail->getId());
+        if ($updatedDetail === null) {
+            throw new RuntimeException('Failed to load updated game details.');
+        }
+
+        return $updatedDetail;
+    }
+
+    private function recordChange(int $gameId): void
+    {
+        $query = $this->database->prepare(
+            "INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES ('GAME_UPDATE', :param_1)"
+        );
+        $query->bindValue(':param_1', $gameId, PDO::PARAM_INT);
+        $query->execute();
+    }
+}


### PR DESCRIPTION
## Summary
- add a GameDetail value object and service to encapsulate trophy title lookups and updates
- refactor the admin game detail page to delegate persistence to the new service and surface validation errors

## Testing
- php -l wwwroot/classes/Admin/GameDetail.php
- php -l wwwroot/classes/Admin/GameDetailService.php
- php -l wwwroot/admin/detail.php

------
https://chatgpt.com/codex/tasks/task_e_68d1269cc44c832f8fd65f187ee9b9c3