### PR TITLE
Refactor games listing to use services

### DIFF
--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+class GameListFilter
+{
+    public const SORT_ADDED = 'added';
+    public const SORT_COMPLETION = 'completion';
+    public const SORT_OWNERS = 'owners';
+    public const SORT_RARITY = 'rarity';
+    public const SORT_SEARCH = 'search';
+
+    public const PLATFORM_PC = 'pc';
+    public const PLATFORM_PS3 = 'ps3';
+    public const PLATFORM_PS4 = 'ps4';
+    public const PLATFORM_PS5 = 'ps5';
+    public const PLATFORM_PSVITA = 'psvita';
+    public const PLATFORM_PSVR = 'psvr';
+    public const PLATFORM_PSVR2 = 'psvr2';
+
+    /**
+     * @var list<string>
+     */
+    private const PLATFORM_KEYS = [
+        self::PLATFORM_PC,
+        self::PLATFORM_PS3,
+        self::PLATFORM_PS4,
+        self::PLATFORM_PS5,
+        self::PLATFORM_PSVITA,
+        self::PLATFORM_PSVR,
+        self::PLATFORM_PSVR2,
+    ];
+
+    private ?string $player;
+    private string $sort;
+    private bool $sortSpecified;
+    private string $search;
+    private int $page;
+    private bool $uncompletedOnly;
+    /**
+     * @var array<string, bool>
+     */
+    private array $platformFilters;
+    /**
+     * @var array<string, string>
+     */
+    private array $originalParameters;
+
+    private function __construct(
+        ?string $player,
+        string $sort,
+        bool $sortSpecified,
+        string $search,
+        int $page,
+        bool $uncompletedOnly,
+        array $platformFilters,
+        array $originalParameters
+    ) {
+        $this->player = $player;
+        $this->sort = $sort;
+        $this->sortSpecified = $sortSpecified;
+        $this->search = $search;
+        $this->page = $page;
+        $this->uncompletedOnly = $uncompletedOnly;
+        $this->platformFilters = $platformFilters;
+        $this->originalParameters = $originalParameters;
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public static function fromArray(array $queryParameters): self
+    {
+        $originalParameters = self::extractOriginalParameters($queryParameters);
+        $sortSpecified = array_key_exists('sort', $originalParameters);
+
+        $player = self::sanitizeNullableString($queryParameters['player'] ?? null);
+        $search = self::sanitizeString($queryParameters['search'] ?? null);
+        $page = self::sanitizePage($queryParameters['page'] ?? null);
+        $sort = self::normalizeSort($queryParameters['sort'] ?? null, $search, $sortSpecified);
+        $uncompletedOnly = self::toBool($queryParameters['filter'] ?? null);
+
+        $platformFilters = [];
+        foreach (self::PLATFORM_KEYS as $platform) {
+            $platformFilters[$platform] = self::toBool($queryParameters[$platform] ?? null);
+        }
+
+        return new self(
+            $player,
+            $sort,
+            $sortSpecified,
+            $search,
+            $page,
+            $uncompletedOnly,
+            $platformFilters,
+            $originalParameters
+        );
+    }
+
+    public function getPlayer(): ?string
+    {
+        return $this->player;
+    }
+
+    public function hasPlayer(): bool
+    {
+        return $this->player !== null;
+    }
+
+    public function withPlayer(?string $player): self
+    {
+        $clone = clone $this;
+        if ($player !== null) {
+            $player = trim($player);
+            $player = $player === '' ? null : $player;
+        }
+
+        $clone->player = $player;
+
+        return $clone;
+    }
+
+    public function getSort(): string
+    {
+        return $this->sort;
+    }
+
+    public function isSort(string $sort): bool
+    {
+        return $this->sort === $sort;
+    }
+
+    public function hasExplicitSort(): bool
+    {
+        return $this->sortSpecified;
+    }
+
+    public function getSearch(): string
+    {
+        return $this->search;
+    }
+
+    public function hasSearch(): bool
+    {
+        return $this->search !== '';
+    }
+
+    public function shouldApplySearch(): bool
+    {
+        return $this->hasSearch() || $this->sort === self::SORT_SEARCH;
+    }
+
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    public function getOffset(int $limit): int
+    {
+        return ($this->page - 1) * $limit;
+    }
+
+    public function shouldFilterUncompleted(): bool
+    {
+        return $this->uncompletedOnly;
+    }
+
+    public function shouldShowUncompletedOption(): bool
+    {
+        return $this->hasPlayer();
+    }
+
+    public function hasPlatformFilters(): bool
+    {
+        foreach ($this->platformFilters as $selected) {
+            if ($selected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function isPlatformSelected(string $platform): bool
+    {
+        return $this->platformFilters[$platform] ?? false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSelectedPlatforms(): array
+    {
+        $platforms = [];
+
+        foreach (self::PLATFORM_KEYS as $platform) {
+            if ($this->platformFilters[$platform]) {
+                $platforms[] = $platform;
+            }
+        }
+
+        return $platforms;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getQueryParametersForPagination(): array
+    {
+        $parameters = $this->originalParameters;
+
+        if ($this->player !== null) {
+            $parameters['player'] = $this->player;
+        } else {
+            unset($parameters['player']);
+        }
+
+        if ($this->sortSpecified) {
+            $parameters['sort'] = $this->sort;
+        } else {
+            unset($parameters['sort']);
+        }
+
+        if ($this->search !== '') {
+            $parameters['search'] = $this->search;
+        } else {
+            unset($parameters['search']);
+        }
+
+        if ($this->uncompletedOnly) {
+            $parameters['filter'] = 'true';
+        } else {
+            unset($parameters['filter']);
+        }
+
+        foreach (self::PLATFORM_KEYS as $platform) {
+            if ($this->platformFilters[$platform]) {
+                $parameters[$platform] = 'true';
+            } else {
+                unset($parameters[$platform]);
+            }
+        }
+
+        unset($parameters['page']);
+
+        return $parameters;
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     * @return array<string, string>
+     */
+    private static function extractOriginalParameters(array $queryParameters): array
+    {
+        $parameters = [];
+
+        foreach ($queryParameters as $key => $value) {
+            if (!is_string($key)) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                continue;
+            }
+
+            $parameters[$key] = (string) $value;
+        }
+
+        return $parameters;
+    }
+
+    private static function sanitizeNullableString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value) || is_numeric($value)) {
+            $trimmed = trim((string) $value);
+
+            return $trimmed === '' ? null : $trimmed;
+        }
+
+        return null;
+    }
+
+    private static function sanitizeString(mixed $value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        if (is_string($value) || is_numeric($value)) {
+            return trim((string) $value);
+        }
+
+        return '';
+    }
+
+    private static function sanitizePage(mixed $value): int
+    {
+        if (is_int($value)) {
+            $page = $value;
+        } elseif (is_string($value) && is_numeric($value)) {
+            $page = (int) $value;
+        } elseif (is_numeric($value)) {
+            $page = (int) $value;
+        } else {
+            $page = 1;
+        }
+
+        return max($page, 1);
+    }
+
+    private static function normalizeSort(mixed $value, string $search, bool $sortSpecified): string
+    {
+        $sort = is_string($value) ? strtolower(trim($value)) : '';
+
+        return match ($sort) {
+            self::SORT_ADDED,
+            self::SORT_COMPLETION,
+            self::SORT_OWNERS,
+            self::SORT_RARITY => $sort,
+            self::SORT_SEARCH => ($search !== '' || $sortSpecified) ? self::SORT_SEARCH : self::SORT_ADDED,
+            default => $search !== '' ? self::SORT_SEARCH : self::SORT_ADDED,
+        };
+    }
+
+    private static function toBool(mixed $value): bool
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value !== 0;
+        }
+
+        if (is_string($value)) {
+            $value = strtolower(trim($value));
+
+            if ($value === '' || $value === 'false' || $value === '0') {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+class GameListService
+{
+    private const PAGE_LIMIT = 40;
+
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function resolvePlayer(?string $onlineId): ?string
+    {
+        if ($onlineId === null) {
+            return null;
+        }
+
+        $onlineId = trim($onlineId);
+        if ($onlineId === '') {
+            return null;
+        }
+
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                `status`
+            FROM
+                player
+            WHERE
+                online_id = :online_id
+            SQL
+        );
+        $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
+        $query->execute();
+
+        $status = $query->fetchColumn();
+        if ($status === false) {
+            return $onlineId;
+        }
+
+        $status = (int) $status;
+        if ($status === 1 || $status === 3) {
+            return null;
+        }
+
+        return $onlineId;
+    }
+
+    public function getLimit(): int
+    {
+        return self::PAGE_LIMIT;
+    }
+
+    public function getOffset(GameListFilter $filter): int
+    {
+        return $filter->getOffset(self::PAGE_LIMIT);
+    }
+
+    public function countGames(GameListFilter $filter): int
+    {
+        $sql = $this->buildCountQuery($filter);
+        $statement = $this->database->prepare($sql);
+        $this->bindCommonParameters($statement, $filter);
+        $statement->execute();
+
+        $count = $statement->fetchColumn();
+
+        return $count === false ? 0 : (int) $count;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getGames(GameListFilter $filter): array
+    {
+        $sql = $this->buildListQuery($filter);
+        $statement = $this->database->prepare($sql);
+        $this->bindCommonParameters($statement, $filter);
+        $statement->bindValue(':offset', $this->getOffset($filter), PDO::PARAM_INT);
+        $statement->bindValue(':limit', self::PAGE_LIMIT, PDO::PARAM_INT);
+        $statement->execute();
+
+        $games = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+        return is_array($games) ? $games : [];
+    }
+
+    private function bindCommonParameters(PDOStatement $statement, GameListFilter $filter): void
+    {
+        $player = $filter->getPlayer() ?? '';
+        $statement->bindValue(':online_id', $player, PDO::PARAM_STR);
+
+        if ($filter->shouldApplySearch()) {
+            $statement->bindValue(':search', $filter->getSearch(), PDO::PARAM_STR);
+        }
+    }
+
+    private function buildCountQuery(GameListFilter $filter): string
+    {
+        $conditions = $this->buildConditions($filter, true);
+
+        return sprintf(
+            <<<'SQL'
+            SELECT
+                COUNT(*)
+            FROM
+                trophy_title tt
+            LEFT JOIN trophy_title_player ttp ON
+                ttp.np_communication_id = tt.np_communication_id
+                AND ttp.progress = 100
+                AND ttp.account_id = (
+                    SELECT
+                        account_id
+                    FROM
+                        player
+                    WHERE
+                        online_id = :online_id
+                )
+            WHERE
+                %s
+            SQL,
+            $conditions
+        );
+    }
+
+    private function buildListQuery(GameListFilter $filter): string
+    {
+        $columns = [
+            'tt.np_communication_id',
+            'tt.id',
+            'tt.name',
+            'tt.status',
+            'tt.icon_url',
+            'tt.platform',
+            'tt.owners',
+            'tt.difficulty',
+            'tt.platinum',
+            'tt.gold',
+            'tt.silver',
+            'tt.bronze',
+            'tt.rarity_points',
+            'ttp.progress',
+        ];
+
+        if ($filter->shouldApplySearch()) {
+            $columns[] = 'MATCH(tt.name) AGAINST (:search) AS score';
+        }
+
+        $conditions = $this->buildConditions($filter, false);
+        $orderBy = $this->buildOrderByClause($filter);
+
+        return sprintf(
+            <<<'SQL'
+            SELECT
+                %s
+            FROM
+                trophy_title tt
+            LEFT JOIN trophy_title_player ttp ON
+                ttp.np_communication_id = tt.np_communication_id
+                AND ttp.progress = 100
+                AND ttp.account_id = (
+                    SELECT
+                        account_id
+                    FROM
+                        player
+                    WHERE
+                        online_id = :online_id
+                )
+            WHERE
+                %s
+            %s
+            LIMIT
+                :offset, :limit
+            SQL,
+            implode(', ', $columns),
+            $conditions,
+            $orderBy
+        );
+    }
+
+    private function buildConditions(GameListFilter $filter, bool $forCount): string
+    {
+        $conditions = [];
+
+        switch ($filter->getSort()) {
+            case GameListFilter::SORT_COMPLETION:
+                $conditions[] = "tt.status = 0 AND (tt.bronze + tt.silver + tt.gold + tt.platinum) != 0";
+                break;
+            case GameListFilter::SORT_RARITY:
+                $conditions[] = 'tt.status = 0';
+                break;
+            default:
+                $conditions[] = 'tt.status != 2';
+                break;
+        }
+
+        if ($filter->shouldApplySearch()) {
+            if ($forCount) {
+                $conditions[] = '(MATCH(tt.name) AGAINST (:search)) > 0';
+            } else {
+                $conditions[] = '(MATCH(tt.name) AGAINST (:search))';
+            }
+        }
+
+        if ($filter->shouldFilterUncompleted()) {
+            $conditions[] = 'ttp.progress IS NULL';
+        }
+
+        $platformCondition = $this->buildPlatformCondition($filter);
+        if ($platformCondition !== null) {
+            $conditions[] = $platformCondition;
+        }
+
+        return implode(' AND ', $conditions);
+    }
+
+    private function buildOrderByClause(GameListFilter $filter): string
+    {
+        return match ($filter->getSort()) {
+            GameListFilter::SORT_COMPLETION => 'ORDER BY difficulty DESC, owners DESC, `name`',
+            GameListFilter::SORT_OWNERS => 'ORDER BY owners DESC, `name`',
+            GameListFilter::SORT_RARITY => 'ORDER BY rarity_points DESC, owners DESC, `name`',
+            GameListFilter::SORT_SEARCH => 'ORDER BY score DESC',
+            default => 'ORDER BY id DESC',
+        };
+    }
+
+    private function buildPlatformCondition(GameListFilter $filter): ?string
+    {
+        if (!$filter->hasPlatformFilters()) {
+            return null;
+        }
+
+        $conditions = [];
+
+        foreach ($filter->getSelectedPlatforms() as $platform) {
+            if ($platform === GameListFilter::PLATFORM_PSVR) {
+                $conditions[] = "tt.platform LIKE '%PSVR'";
+                $conditions[] = "tt.platform LIKE '%PSVR,%'";
+                continue;
+            }
+
+            $conditions[] = sprintf("tt.platform LIKE '%%%s%%'", strtoupper($platform));
+        }
+
+        if ($conditions === []) {
+            return null;
+        }
+
+        return '(' . implode(' OR ', $conditions) . ')';
+    }
+}


### PR DESCRIPTION
## Summary
- add a GameListFilter value object to normalize game list query parameters
- introduce a GameListService that encapsulates fetching, counting and player handling for the games catalogue
- refactor games.php to rely on the new classes, simplifying pagination, sorting and filter rendering
- update the GameListService SQL builders to avoid embedding newline escape sequences in generated queries

## Testing
- php -l wwwroot/classes/GameListService.php

------
https://chatgpt.com/codex/tasks/task_e_68d12b76dec0832fb4b3225e1d5282ed