### PR TITLE
Refactor rarity leaderboard to use service class

### DIFF
--- a/wwwroot/classes/PlayerRarityLeaderboardService.php
+++ b/wwwroot/classes/PlayerRarityLeaderboardService.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerRarityLeaderboardService
+{
+    public const PAGE_SIZE = 50;
+
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function countPlayers(PlayerLeaderboardFilter $filter): int
+    {
+        $sql = <<<'SQL'
+            SELECT
+                COUNT(*)
+            FROM
+                player p
+            WHERE
+                p.status = 0
+        SQL;
+
+        $sql .= $this->buildFilterSql($filter);
+
+        $query = $this->database->prepare($sql);
+        $this->bindFilterParameters($query, $filter);
+        $query->execute();
+
+        return (int) $query->fetchColumn();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getPlayers(PlayerLeaderboardFilter $filter, int $limit = self::PAGE_SIZE): array
+    {
+        $sql = <<<'SQL'
+            SELECT
+                p.*,
+                r.rarity_ranking AS ranking,
+                r.rarity_ranking_country AS ranking_country
+            FROM
+                player p
+            JOIN player_ranking r ON p.account_id = r.account_id
+            WHERE
+                p.status = 0
+        SQL;
+
+        $sql .= $this->buildFilterSql($filter);
+
+        $sql .= <<<'SQL'
+            ORDER BY
+                r.rarity_ranking
+            LIMIT :offset, :limit
+        SQL;
+
+        $query = $this->database->prepare($sql);
+        $query->bindValue(':offset', $filter->getOffset($limit), PDO::PARAM_INT);
+        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $this->bindFilterParameters($query, $filter);
+        $query->execute();
+
+        $players = $query->fetchAll(PDO::FETCH_ASSOC);
+
+        if (!is_array($players)) {
+            return [];
+        }
+
+        return $players;
+    }
+
+    private function buildFilterSql(PlayerLeaderboardFilter $filter): string
+    {
+        $clauses = '';
+
+        if ($filter->hasCountry()) {
+            $clauses .= ' AND p.country = :country';
+        }
+
+        if ($filter->hasAvatar()) {
+            $clauses .= ' AND p.avatar_url = :avatar';
+        }
+
+        return $clauses;
+    }
+
+    private function bindFilterParameters(PDOStatement $query, PlayerLeaderboardFilter $filter): void
+    {
+        if ($filter->hasCountry()) {
+            $query->bindValue(':country', (string) $filter->getCountry(), PDO::PARAM_STR);
+        }
+
+        if ($filter->hasAvatar()) {
+            $query->bindValue(':avatar', (string) $filter->getAvatar(), PDO::PARAM_STR);
+        }
+    }
+}

--- a/wwwroot/leaderboard_rarity.php
+++ b/wwwroot/leaderboard_rarity.php
@@ -1,42 +1,23 @@
 <?php
+require_once 'classes/PlayerLeaderboardFilter.php';
+require_once 'classes/PlayerRarityLeaderboardService.php';
+
 $title = "PSN Rarity Leaderboard ~ PSN 100%";
 require_once("header.php");
 
-$url = $_SERVER["REQUEST_URI"];
-$url_parts = parse_url($url);
-// If URL doesn't have a query string.
-if (isset($url_parts["query"])) { // Avoid 'Undefined index: query'
-    parse_str($url_parts["query"], $params);
-} else {
-    $params = array();
-}
+$playerLeaderboardFilter = PlayerLeaderboardFilter::fromArray($_GET ?? []);
+$playerLeaderboardService = new PlayerRarityLeaderboardService($database);
 
-$sql = "SELECT COUNT(*) FROM player WHERE `status` = 0";
-if (!empty($_GET["country"])) {
-    $sql .= " AND country = :country";
-}
-if (!empty($_GET["avatar"])) {
-    $sql .= " AND avatar_url = :avatar";
-}
+$limit = PlayerRarityLeaderboardService::PAGE_SIZE;
+$page = $playerLeaderboardFilter->getPage();
+$offset = $playerLeaderboardFilter->getOffset($limit);
 
-$query = $database->prepare($sql);
-if (!empty($_GET["country"])) {
-    $country = $_GET["country"];
-    $query->bindValue(":country", $country, PDO::PARAM_STR);
-}
-if (!empty($_GET["avatar"])) {
-    $avatar = $_GET["avatar"];
-    $query->bindValue(":avatar", $avatar, PDO::PARAM_STR);
-}
-$query->execute();
-$total_pages = $query->fetchColumn();
+$totalPlayers = $playerLeaderboardService->countPlayers($playerLeaderboardFilter);
+$totalPages = (int) ceil($totalPlayers / $limit);
+$players = $playerLeaderboardService->getPlayers($playerLeaderboardFilter, $limit);
 
-$page = max(isset($_GET["page"]) && is_numeric($_GET["page"]) ? $_GET["page"] : 1, 1);
-$limit = 50;
-$offset = ($page - 1) * $limit;
-
-$paramsWithoutPage = $params;
-unset($paramsWithoutPage["page"]);
+$filterParameters = $playerLeaderboardFilter->getFilterParameters();
+$pageParameters = $playerLeaderboardFilter->toQueryParameters();
 ?>
 
 <main class="container">
@@ -46,7 +27,7 @@ unset($paramsWithoutPage["page"]);
                 <h1>PSN Rarity Leaderboard</h1>
                 <div class="bg-body-tertiary p-3 rounded">
                     <div class="btn-group">
-                        <a class="btn btn-outline-primary" href="/leaderboard/trophy?<?= http_build_query($paramsWithoutPage); ?>">Trophy</a>
+                        <a class="btn btn-outline-primary" href="/leaderboard/trophy?<?= http_build_query($filterParameters); ?>">Trophy</a>
                         <a class="btn btn-primary active" href="/leaderboard/rarity">Rarity</a>
                     </div>
                 </div>
@@ -62,7 +43,7 @@ unset($paramsWithoutPage["page"]);
                         <thead>
                             <tr class="text-uppercase">
                                 <?php
-                                if (isset($_GET["country"])) {
+                                if ($playerLeaderboardFilter->hasCountry()) {
                                     ?>
                                     <th scope="col" class="text-center">Country<br>Rank</th>
                                     <?php
@@ -85,58 +66,22 @@ unset($paramsWithoutPage["page"]);
 
                         <tbody>
                             <?php
-                            $sql = "
-                                SELECT
-                                    p.*,
-                                    r.rarity_ranking AS ranking,
-                                    r.rarity_ranking_country AS ranking_country
-                                FROM
-                                    player p
-                                JOIN player_ranking r ON p.account_id = r.account_id
-                                WHERE
-                                    p.status = 0
-                            ";
-                            if (!empty($_GET["country"])) {
-                                $sql .= " AND p.country = :country";
-                            }
-                            if (!empty($_GET["avatar"])) {
-                                $sql .= " AND p.avatar_url = :avatar";
-                            }
-                            $sql .= "
-                                ORDER BY r.rarity_ranking
-                                LIMIT :offset, :limit
-                            ";
-
-                            $query = $database->prepare($sql);
-
-                            if (!empty($_GET["country"])) {
-                                $query->bindValue(":country", $_GET["country"], PDO::PARAM_STR);
-                            }
-                            if (!empty($_GET["avatar"])) {
-                                $query->bindValue(":avatar", $_GET["avatar"], PDO::PARAM_STR);
-                            }
-                            $query->bindValue(":offset", $offset, PDO::PARAM_INT);
-                            $query->bindValue(":limit", $limit, PDO::PARAM_INT);
-
-                            $query->execute();
-                            $players = $query->fetchAll();
-
                             foreach ($players as $player) {
                                 $countryName = $utility->getCountryName($player["country"]);
                                 if (isset($_GET["player"]) && $_GET["player"] == $player["online_id"]) {
-                                    echo "<tr id=\"". $player["online_id"] ."\" class=\"table-primary\">";
+                                    echo "<tr id=\"" . $player["online_id"] . "\" class=\"table-primary\">";
                                 } else {
-                                    echo "<tr id=\"". $player["online_id"] ."\">";
+                                    echo "<tr id=\"" . $player["online_id"] . "\">";
                                 }
 
-                                $paramsAvatar = $paramsWithoutPage;
+                                $paramsAvatar = $filterParameters;
                                 $paramsAvatar["avatar"] = $player["avatar_url"];
-                                $paramsCountry = $paramsWithoutPage;
+                                $paramsCountry = $filterParameters;
                                 $paramsCountry["country"] = $player["country"];
                                 ?>
                                 <th scope="row" class="text-center align-middle">
                                     <?php
-                                    if (isset($_GET["country"])) {
+                                    if ($playerLeaderboardFilter->hasCountry()) {
                                         if ($player["rarity_rank_country_last_week"] == 0 || $player["rarity_rank_country_last_week"] == 16777215) {
                                             echo "New!";
                                             if ($player["trophy_count_npwr"] < $player["trophy_count_sony"]) {
@@ -147,17 +92,17 @@ unset($paramsWithoutPage["page"]);
 
                                             echo "<div class='vstack'>";
                                             if ($delta > 0) {
-                                                echo "<span style='color: #0bd413; cursor: default;' title='+". $delta ."'>&#9650;</span>";
+                                                echo "<span style='color: #0bd413; cursor: default;' title='+" . $delta . "'>&#9650;</span>";
                                             }
-                                            
+
                                             echo $player["ranking_country"];
                                             if ($player["trophy_count_npwr"] < $player["trophy_count_sony"]) {
                                                 echo " <span style='color: #9d9d9d;'>(H)</span>";
                                             }
 
                                             if ($delta < 0) {
-                                                echo "<span style='color: #d40b0b; cursor: default;' title='". $delta ."'>&#9660;</span>";
-                                            } 
+                                                echo "<span style='color: #d40b0b; cursor: default;' title='" . $delta . "'>&#9660;</span>";
+                                            }
                                             echo "</div>";
                                         }
                                     } else {
@@ -168,20 +113,20 @@ unset($paramsWithoutPage["page"]);
                                             }
                                         } else {
                                             $delta = $player["rarity_rank_last_week"] - $player["ranking"];
-            
+
                                             echo "<div class='vstack'>";
                                             if ($delta > 0) {
-                                                echo "<span style='color: #0bd413; cursor: default;' title='+". $delta ."'>&#9650;</span>";
+                                                echo "<span style='color: #0bd413; cursor: default;' title='+" . $delta . "'>&#9650;</span>";
                                             }
-                                            
+
                                             echo $player["ranking"];
                                             if ($player["trophy_count_npwr"] < $player["trophy_count_sony"]) {
                                                 echo " <span style='color: #9d9d9d;'>(H)</span>";
                                             }
 
                                             if ($delta < 0) {
-                                                echo "<span style='color: #d40b0b; cursor: default;' title='". $delta ."'>&#9660;</span>";
-                                            } 
+                                                echo "<span style='color: #d40b0b; cursor: default;' title='" . $delta . "'>&#9660;</span>";
+                                            }
                                             echo "</div>";
                                         }
                                     }
@@ -232,7 +177,7 @@ unset($paramsWithoutPage["page"]);
     <div class="row mt-3">
         <div class="col-12">
             <p class="text-center">
-                <?= ($total_pages == 0 ? "0" : $offset + 1); ?>-<?= min($offset + $limit, $total_pages); ?> of <?= number_format($total_pages); ?>
+                <?= ($totalPlayers == 0 ? "0" : $offset + 1); ?>-<?= min($offset + $limit, $totalPlayers); ?> of <?= number_format($totalPlayers); ?>
             </p>
         </div>
         <div class="col-12">
@@ -240,59 +185,56 @@ unset($paramsWithoutPage["page"]);
                 <ul class="pagination justify-content-center">
                     <?php
                     if ($page > 1) {
-                        $params["page"] = $page - 1; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>">&lt;</a></li>
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($page - 1)); ?>">&lt;</a></li>
                         <?php
                     }
 
                     if ($page > 3) {
-                        $params["page"] = 1; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>">1</a></li>
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage(1)); ?>">1</a></li>
                         <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
                         <?php
                     }
 
-                    if ($page-2 > 0) {
-                        $params["page"] = $page - 2; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= $page-2; ?></a></li>
+                    if ($page - 2 > 0) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($page - 2)); ?>"><?= $page - 2; ?></a></li>
                         <?php
                     }
 
-                    if ($page-1 > 0) {
-                        $params["page"] = $page - 1; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= $page-1; ?></a></li>
+                    if ($page - 1 > 0) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($page - 1)); ?>"><?= $page - 1; ?></a></li>
                         <?php
                     }
                     ?>
 
-                    <?php
-                    $params["page"] = $page;
-                    ?>
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= $page; ?></a></li>
+                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($pageParameters); ?>"><?= $page; ?></a></li>
 
                     <?php
-                    if ($page+1 < ceil($total_pages / $limit)+1) {
-                        $params["page"] = $page + 1; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= $page+1; ?></a></li>
+                    if ($page + 1 <= $totalPages) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($page + 1)); ?>"><?= $page + 1; ?></a></li>
                         <?php
                     }
 
-                    if ($page+2 < ceil($total_pages / $limit)+1) {
-                        $params["page"] = $page + 2; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= $page+2; ?></a></li>
+                    if ($page + 2 <= $totalPages) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($page + 2)); ?>"><?= $page + 2; ?></a></li>
                         <?php
                     }
 
-                    if ($page < ceil($total_pages / $limit)-2) {
-                        $params["page"] = ceil($total_pages / $limit); ?>
+                    if ($page < $totalPages - 2) {
+                        ?>
                         <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= ceil($total_pages / $limit); ?></a></li>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($totalPages)); ?>"><?= $totalPages; ?></a></li>
                         <?php
                     }
 
-                    if ($page < ceil($total_pages / $limit)) {
-                        $params["page"] = $page + 1; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>">&gt;</a></li>
+                    if ($page < $totalPages) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($page + 1)); ?>">&gt;</a></li>
                         <?php
                     }
                     ?>


### PR DESCRIPTION
## Summary
- add a dedicated PlayerRarityLeaderboardService to encapsulate rarity leaderboard queries
- update leaderboard_rarity.php to consume the new service and existing filter utilities for pagination

## Testing
- php -l wwwroot/classes/PlayerRarityLeaderboardService.php
- php -l wwwroot/leaderboard_rarity.php

------
https://chatgpt.com/codex/tasks/task_e_68d1345a0f84832fa88de63adf3d005e