### PR TITLE
Refactor homepage content to use OOP view models

### DIFF
--- a/wwwroot/classes/Homepage/HomepageDlc.php
+++ b/wwwroot/classes/Homepage/HomepageDlc.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+class HomepageDlc extends HomepageTitle
+{
+    private string $groupId;
+
+    private string $groupName;
+
+    private int $gold;
+
+    private int $silver;
+
+    private int $bronze;
+
+    private function __construct(
+        int $id,
+        string $gameName,
+        string $groupId,
+        string $groupName,
+        string $iconUrl,
+        string $platform,
+        int $gold,
+        int $silver,
+        int $bronze
+    ) {
+        parent::__construct($id, $gameName, $iconUrl, $platform, 'group');
+        $this->groupId = $groupId;
+        $this->groupName = $groupName;
+        $this->gold = $gold;
+        $this->silver = $silver;
+        $this->bronze = $bronze;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        return new self(
+            isset($row['id']) ? (int) $row['id'] : 0,
+            (string) ($row['game_name'] ?? ''),
+            (string) ($row['group_id'] ?? ''),
+            (string) ($row['group_name'] ?? ''),
+            (string) ($row['icon_url'] ?? ''),
+            (string) ($row['platform'] ?? ''),
+            isset($row['gold']) ? (int) $row['gold'] : 0,
+            isset($row['silver']) ? (int) $row['silver'] : 0,
+            isset($row['bronze']) ? (int) $row['bronze'] : 0
+        );
+    }
+
+    public function getGroupName(): string
+    {
+        return $this->groupName;
+    }
+
+    public function getGroupId(): string
+    {
+        return $this->groupId;
+    }
+
+    public function getGold(): int
+    {
+        return $this->gold;
+    }
+
+    public function getSilver(): int
+    {
+        return $this->silver;
+    }
+
+    public function getBronze(): int
+    {
+        return $this->bronze;
+    }
+
+    public function getRelativeUrl(Utility $utility): string
+    {
+        return parent::getRelativeUrl($utility) . '#' . $this->groupId;
+    }
+}

--- a/wwwroot/classes/Homepage/HomepageItem.php
+++ b/wwwroot/classes/Homepage/HomepageItem.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+abstract class HomepageItem
+{
+    private const MISSING_PS5_ICON = '/img/missing-ps5-game-and-trophy.png';
+    private const MISSING_PS4_ICON = '/img/missing-ps4-game.png';
+
+    private string $iconUrl;
+
+    private string $platform;
+
+    private string $iconDirectory;
+
+    protected function __construct(string $iconUrl, string $platform, string $iconDirectory)
+    {
+        $this->iconUrl = $iconUrl;
+        $this->platform = $platform;
+        $this->iconDirectory = trim($iconDirectory, '/');
+    }
+
+    public function getIconPath(): string
+    {
+        if ($this->iconUrl === '' || $this->iconUrl === '.png') {
+            return $this->isPs5Title() ? self::MISSING_PS5_ICON : self::MISSING_PS4_ICON;
+        }
+
+        return '/img/' . $this->iconDirectory . '/' . $this->iconUrl;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPlatforms(): array
+    {
+        if ($this->platform === '') {
+            return [];
+        }
+
+        $platforms = array_map('trim', explode(',', $this->platform));
+
+        $platforms = array_filter(
+            $platforms,
+            static fn(string $value): bool => $value !== ''
+        );
+
+        return array_values($platforms);
+    }
+
+    private function isPs5Title(): bool
+    {
+        return str_contains($this->platform, 'PS5') || str_contains($this->platform, 'PSVR2');
+    }
+}

--- a/wwwroot/classes/Homepage/HomepageNewGame.php
+++ b/wwwroot/classes/Homepage/HomepageNewGame.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+class HomepageNewGame extends HomepageTitle
+{
+    private int $platinum;
+
+    private int $gold;
+
+    private int $silver;
+
+    private int $bronze;
+
+    private function __construct(
+        int $id,
+        string $name,
+        string $iconUrl,
+        string $platform,
+        int $platinum,
+        int $gold,
+        int $silver,
+        int $bronze
+    ) {
+        parent::__construct($id, $name, $iconUrl, $platform, 'title');
+        $this->platinum = $platinum;
+        $this->gold = $gold;
+        $this->silver = $silver;
+        $this->bronze = $bronze;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        return new self(
+            isset($row['id']) ? (int) $row['id'] : 0,
+            (string) ($row['name'] ?? ''),
+            (string) ($row['icon_url'] ?? ''),
+            (string) ($row['platform'] ?? ''),
+            isset($row['platinum']) ? (int) $row['platinum'] : 0,
+            isset($row['gold']) ? (int) $row['gold'] : 0,
+            isset($row['silver']) ? (int) $row['silver'] : 0,
+            isset($row['bronze']) ? (int) $row['bronze'] : 0
+        );
+    }
+
+    public function getPlatinum(): int
+    {
+        return $this->platinum;
+    }
+
+    public function getGold(): int
+    {
+        return $this->gold;
+    }
+
+    public function getSilver(): int
+    {
+        return $this->silver;
+    }
+
+    public function getBronze(): int
+    {
+        return $this->bronze;
+    }
+}

--- a/wwwroot/classes/Homepage/HomepagePopularGame.php
+++ b/wwwroot/classes/Homepage/HomepagePopularGame.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+class HomepagePopularGame extends HomepageTitle
+{
+    private int $recentPlayers;
+
+    private function __construct(int $id, string $name, string $iconUrl, string $platform, int $recentPlayers)
+    {
+        parent::__construct($id, $name, $iconUrl, $platform, 'title');
+        $this->recentPlayers = $recentPlayers;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        return new self(
+            isset($row['id']) ? (int) $row['id'] : 0,
+            (string) ($row['name'] ?? ''),
+            (string) ($row['icon_url'] ?? ''),
+            (string) ($row['platform'] ?? ''),
+            isset($row['recent_players']) ? (int) $row['recent_players'] : 0
+        );
+    }
+
+    public function getRecentPlayers(): int
+    {
+        return $this->recentPlayers;
+    }
+}

--- a/wwwroot/classes/Homepage/HomepageTitle.php
+++ b/wwwroot/classes/Homepage/HomepageTitle.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+class HomepageTitle extends HomepageItem
+{
+    private int $id;
+
+    private string $name;
+
+    protected function __construct(int $id, string $name, string $iconUrl, string $platform, string $iconDirectory)
+    {
+        parent::__construct($iconUrl, $platform, $iconDirectory);
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getSluggedId(Utility $utility): string
+    {
+        return $this->id . '-' . $utility->slugify($this->name);
+    }
+
+    public function getRelativeUrl(Utility $utility): string
+    {
+        return '/game/' . $this->getSluggedId($utility);
+    }
+}

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -1,5 +1,11 @@
 <?php
 
+require_once __DIR__ . '/Homepage/HomepageItem.php';
+require_once __DIR__ . '/Homepage/HomepageTitle.php';
+require_once __DIR__ . '/Homepage/HomepageNewGame.php';
+require_once __DIR__ . '/Homepage/HomepageDlc.php';
+require_once __DIR__ . '/Homepage/HomepagePopularGame.php';
+
 class HomepageContentService
 {
     private const DEFAULT_NEW_GAME_LIMIT = 8;
@@ -13,6 +19,9 @@ class HomepageContentService
         $this->database = $database;
     }
 
+    /**
+     * @return HomepageNewGame[]
+     */
     public function getNewGames(int $limit = self::DEFAULT_NEW_GAME_LIMIT): array
     {
         $query = $this->database->prepare(
@@ -32,9 +41,17 @@ class HomepageContentService
         $query->bindValue(':limit', $limit, PDO::PARAM_INT);
         $query->execute();
 
-        return $query->fetchAll(PDO::FETCH_ASSOC);
+        $rows = $query->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(
+            static fn(array $row): HomepageNewGame => HomepageNewGame::fromArray($row),
+            $rows
+        );
     }
 
+    /**
+     * @return HomepageDlc[]
+     */
     public function getNewDlcs(int $limit = self::DEFAULT_NEW_DLCS_LIMIT): array
     {
         $query = $this->database->prepare(
@@ -64,9 +81,17 @@ class HomepageContentService
         $query->bindValue(':limit', $limit, PDO::PARAM_INT);
         $query->execute();
 
-        return $query->fetchAll(PDO::FETCH_ASSOC);
+        $rows = $query->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(
+            static fn(array $row): HomepageDlc => HomepageDlc::fromArray($row),
+            $rows
+        );
     }
 
+    /**
+     * @return HomepagePopularGame[]
+     */
     public function getPopularGames(int $limit = self::DEFAULT_POPULAR_GAME_LIMIT): array
     {
         $query = $this->database->prepare(
@@ -90,6 +115,11 @@ class HomepageContentService
         $query->bindValue(':limit', $limit, PDO::PARAM_INT);
         $query->execute();
 
-        return $query->fetchAll(PDO::FETCH_ASSOC);
+        $rows = $query->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(
+            static fn(array $row): HomepagePopularGame => HomepagePopularGame::fromArray($row),
+            $rows
+        );
     }
 }

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -37,6 +37,7 @@ require_once("header.php");
                         <div class="row">
                             <?php
                             foreach ($newGames as $game) {
+                                $gameUrl = $game->getRelativeUrl($utility);
                                 ?>
                                 <div class="col-12 col-md-6 col-lg-4 col-xl-3 text-center mb-2">
                                     <div class="vstack gap-1">
@@ -44,12 +45,12 @@ require_once("header.php");
                                         <div>
                                             <div class="card">
                                                 <div class="d-flex justify-content-center align-items-center" style="min-height: 11.5rem;">
-                                                    <a href="/game/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?>">
-                                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= ($game["icon_url"] == ".png") ? ((str_contains($game["platform"], "PS5") || str_contains($game["platform"], "PSVR2")) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-game.png") : $game["icon_url"]; ?>" alt="<?= htmlentities($game["name"]); ?>">
+                                                    <a href="<?= $gameUrl; ?>">
+                                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="<?= $game->getIconPath(); ?>" alt="<?= htmlentities($game->getName()); ?>">
                                                         <div class="card-img-overlay d-flex align-items-end p-2">
                                                             <?php
-                                                            foreach (explode(",", $game["platform"]) as $platform) {
-                                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">". $platform ."</span> ";
+                                                            foreach ($game->getPlatforms() as $platform) {
+                                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">" . htmlentities($platform) . "</span> ";
                                                             }
                                                             ?>
                                                         </div>
@@ -60,13 +61,13 @@ require_once("header.php");
 
                                         <!-- trophies -->
                                         <div>
-                                            <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $game["platinum"]; ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $game["gold"]; ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $game["silver"]; ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $game["bronze"]; ?></span>
+                                            <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $game->getPlatinum(); ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $game->getGold(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $game->getSilver(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $game->getBronze(); ?></span>
                                         </div>
 
                                         <!-- name -->
                                         <div class="text-center">
-                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?>">
-                                                <?= htmlentities($game["name"]); ?>
+                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= $gameUrl; ?>">
+                                                <?= htmlentities($game->getName()); ?>
                                             </a>
                                         </div>
                                     </div>
@@ -86,7 +87,8 @@ require_once("header.php");
                         <h1>New DLCs</h1>
                         <div class="row">
                             <?php
-                            foreach ($newDlcs as $game) {
+                            foreach ($newDlcs as $dlc) {
+                                $dlcUrl = $dlc->getRelativeUrl($utility);
                                 ?>
                                 <div class="col-12 col-md-6 col-lg-4 col-xl-3 text-center mb-2">
                                     <!-- image, platforms and status -->
@@ -94,12 +96,12 @@ require_once("header.php");
                                         <div>
                                             <div class="card">
                                                 <div class="d-flex justify-content-center align-items-center" style="min-height: 11.5rem;">
-                                                    <a href="/game/<?= $game["id"] ."-". $utility->slugify($game["game_name"]); ?>#<?= $game["group_id"]; ?>">
-                                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/group/<?= ($game["icon_url"] == ".png") ? ((str_contains($game["platform"], "PS5") || str_contains($game["platform"], "PSVR2")) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-game.png") : $game["icon_url"]; ?>" alt="<?= htmlentities($game["group_name"]); ?>">
+                                                    <a href="<?= $dlcUrl; ?>">
+                                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="<?= $dlc->getIconPath(); ?>" alt="<?= htmlentities($dlc->getGroupName()); ?>">
                                                         <div class="card-img-overlay d-flex align-items-end p-2">
                                                             <?php
-                                                            foreach (explode(",", $game["platform"]) as $platform) {
-                                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">". $platform ."</span> ";
+                                                            foreach ($dlc->getPlatforms() as $platform) {
+                                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">" . htmlentities($platform) . "</span> ";
                                                             }
                                                             ?>
                                                         </div>
@@ -110,13 +112,13 @@ require_once("header.php");
 
                                         <!-- trophies -->
                                         <div>
-                                            <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $game["gold"]; ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $game["silver"]; ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $game["bronze"]; ?></span>
+                                            <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $dlc->getGold(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $dlc->getSilver(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $dlc->getBronze(); ?></span>
                                         </div>
 
                                         <!-- name -->
                                         <div class="text-center">
-                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= $game["id"] ."-". $utility->slugify($game["game_name"]); ?>#<?= $game["group_id"]; ?>">
-                                                <small><?= htmlentities($game["game_name"]); ?></small><br><?= htmlentities($game["group_name"]); ?>
+                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= $dlcUrl; ?>">
+                                                <small><?= htmlentities($dlc->getName()); ?></small><br><?= htmlentities($dlc->getGroupName()); ?>
                                             </a>
                                         </div>
                                     </div>
@@ -136,14 +138,15 @@ require_once("header.php");
                 <h1>Popular Games</h1>
                 <?php
                 foreach ($popularGames as $game) {
+                    $gameUrl = $game->getRelativeUrl($utility);
                     ?>
                     <div class="row mb-3">
                         <!-- image -->
                         <div class="col-4">
                             <div class="card">
                                 <div class="d-flex justify-content-center align-items-center" style="height: 7rem;">
-                                    <a href="/game/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?>">
-                                        <img class="card-img object-fit-cover" style="height: 7rem;" src="/img/title/<?= ($game["icon_url"] == ".png") ? ((str_contains($game["platform"], "PS5") || str_contains($game["platform"], "PSVR2")) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-game.png") : $game["icon_url"]; ?>" alt="<?= htmlentities($game["name"]); ?>">
+                                    <a href="<?= $gameUrl; ?>">
+                                        <img class="card-img object-fit-cover" style="height: 7rem;" src="<?= $game->getIconPath(); ?>" alt="<?= htmlentities($game->getName()); ?>">
                                     </a>
                                 </div>
                             </div>
@@ -154,16 +157,16 @@ require_once("header.php");
                             <div>
                                 <div class="row">
                                     <div class="col">
-                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?>">
-                                            <?= htmlentities($game["name"]); ?>
+                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= $gameUrl; ?>">
+                                            <?= htmlentities($game->getName()); ?>
                                         </a>
                                     </div>
                                 </div>
                                 <div class="row">
                                     <div class="col">
                                         <?php
-                                        foreach (explode(",", $game["platform"]) as $platform) {
-                                            echo "<span class=\"badge rounded-pill text-bg-primary p-2 mt-2\">". $platform ."</span> ";
+                                        foreach ($game->getPlatforms() as $platform) {
+                                            echo "<span class=\"badge rounded-pill text-bg-primary p-2 mt-2\">" . htmlentities($platform) . "</span> ";
                                         }
                                         ?>
                                     </div>
@@ -174,7 +177,7 @@ require_once("header.php");
                         <!-- Recent Players -->
                         <div class="col-3 text-end d-flex align-items-center">
                             <div class="ms-auto">
-                                <span class="fw-bold"><?= number_format($game["recent_players"]); ?></span><br>Players
+                                <span class="fw-bold"><?= number_format($game->getRecentPlayers()); ?></span><br>Players
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- add dedicated Homepage* view model classes to encapsulate icon, platform and slug logic for homepage items
- update HomepageContentService to hydrate and return these objects instead of raw arrays
- adjust home.php template to consume the new objects and rely on their helpers for rendering links, badges and trophy data

## Testing
- php -l wwwroot/classes/Homepage/HomepageItem.php
- php -l wwwroot/classes/Homepage/HomepageTitle.php
- php -l wwwroot/classes/Homepage/HomepageNewGame.php
- php -l wwwroot/classes/Homepage/HomepagePopularGame.php
- php -l wwwroot/classes/Homepage/HomepageDlc.php
- php -l wwwroot/classes/HomepageContentService.php
- php -l wwwroot/home.php

------
https://chatgpt.com/codex/tasks/task_e_68d138954eac832f965701ed0c082990