### PR TITLE
Refactor admin status page to use OOP request handler

### DIFF
--- a/wwwroot/admin/status.php
+++ b/wwwroot/admin/status.php
@@ -1,37 +1,18 @@
 <?php
-require_once("../init.php");
-require_once '../classes/GameStatusService.php';
+declare(strict_types=1);
+
+require_once '../init.php';
+require_once '../classes/Admin/GameStatusRequestHandler.php';
 
 $gameStatusService = new GameStatusService($database);
-$success = null;
-$error = null;
+$requestHandler = new GameStatusRequestHandler($gameStatusService);
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $gameId = filter_input(INPUT_POST, 'game', FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
-    $status = filter_input(INPUT_POST, 'status', FILTER_VALIDATE_INT);
+$requestMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$postData = $_POST ?? [];
 
-    if ($gameId === null || $gameId === false) {
-        $error = '<p>Invalid game ID provided.</p>';
-    } elseif ($status === null || $status === false) {
-        $error = '<p>Invalid status provided.</p>';
-    } else {
-        try {
-            $statusText = $gameStatusService->updateGameStatus((int) $gameId, (int) $status);
-            $gameIdText = htmlentities((string) $gameId, ENT_QUOTES, 'UTF-8');
-            $statusText = htmlentities($statusText, ENT_QUOTES, 'UTF-8');
-
-            $success = sprintf(
-                '<p>Game %s is now set as %s. All affected players will be updated soon, and ranks updated the next whole hour.</p>',
-                $gameIdText,
-                $statusText
-            );
-        } catch (InvalidArgumentException $exception) {
-            $error = '<p>' . htmlentities($exception->getMessage(), ENT_QUOTES, 'UTF-8') . '</p>';
-        } catch (Throwable $exception) {
-            $error = '<p>Failed to update game status. Please try again.</p>';
-        }
-    }
-}
+$result = $requestHandler->handleRequest($requestMethod, $postData);
+$success = $result->getSuccessMessage();
+$error = $result->getErrorMessage();
 
 ?>
 <!doctype html>

--- a/wwwroot/classes/Admin/GameStatusRequestHandler.php
+++ b/wwwroot/classes/Admin/GameStatusRequestHandler.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/GameStatusRequestResult.php';
+require_once __DIR__ . '/../GameStatusService.php';
+
+class GameStatusRequestHandler
+{
+    private GameStatusService $gameStatusService;
+
+    public function __construct(GameStatusService $gameStatusService)
+    {
+        $this->gameStatusService = $gameStatusService;
+    }
+
+    /**
+     * @param array<string, mixed> $postData
+     */
+    public function handleRequest(string $requestMethod, array $postData): GameStatusRequestResult
+    {
+        if (strtoupper($requestMethod) !== 'POST') {
+            return GameStatusRequestResult::empty();
+        }
+
+        $gameId = $this->parseNonNegativeInt($postData['game'] ?? null);
+        if ($gameId === null) {
+            return GameStatusRequestResult::error('<p>Invalid game ID provided.</p>');
+        }
+
+        $status = $this->parseInt($postData['status'] ?? null);
+        if ($status === null) {
+            return GameStatusRequestResult::error('<p>Invalid status provided.</p>');
+        }
+
+        try {
+            $statusText = $this->gameStatusService->updateGameStatus($gameId, $status);
+            $message = $this->formatSuccessMessage($gameId, $statusText);
+
+            return GameStatusRequestResult::success($message);
+        } catch (InvalidArgumentException $exception) {
+            $message = $this->escapeMessage($exception->getMessage());
+
+            return GameStatusRequestResult::error('<p>' . $message . '</p>');
+        } catch (Throwable $exception) {
+            return GameStatusRequestResult::error('<p>Failed to update game status. Please try again.</p>');
+        }
+    }
+
+    private function parseInt(mixed $value): ?int
+    {
+        if (!is_scalar($value)) {
+            return null;
+        }
+
+        $filtered = filter_var($value, FILTER_VALIDATE_INT);
+
+        return $filtered === false ? null : (int) $filtered;
+    }
+
+    private function parseNonNegativeInt(mixed $value): ?int
+    {
+        $number = $this->parseInt($value);
+
+        if ($number === null || $number < 0) {
+            return null;
+        }
+
+        return $number;
+    }
+
+    private function formatSuccessMessage(int $gameId, string $statusText): string
+    {
+        $gameIdText = $this->escapeMessage((string) $gameId);
+        $statusTextEscaped = $this->escapeMessage($statusText);
+
+        return sprintf(
+            '<p>Game %s is now set as %s. All affected players will be updated soon, and ranks updated the next whole hour.</p>',
+            $gameIdText,
+            $statusTextEscaped
+        );
+    }
+
+    private function escapeMessage(string $message): string
+    {
+        return htmlentities($message, ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/wwwroot/classes/Admin/GameStatusRequestResult.php
+++ b/wwwroot/classes/Admin/GameStatusRequestResult.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+class GameStatusRequestResult
+{
+    private ?string $successMessage;
+
+    private ?string $errorMessage;
+
+    private function __construct(?string $successMessage, ?string $errorMessage)
+    {
+        $this->successMessage = $successMessage;
+        $this->errorMessage = $errorMessage;
+    }
+
+    public static function success(string $message): self
+    {
+        return new self($message, null);
+    }
+
+    public static function error(string $message): self
+    {
+        return new self(null, $message);
+    }
+
+    public static function empty(): self
+    {
+        return new self(null, null);
+    }
+
+    public function getSuccessMessage(): ?string
+    {
+        return $this->successMessage;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+}


### PR DESCRIPTION
## Summary
- extract game status admin form handling into dedicated GameStatusRequestHandler and result classes
- update the admin status page to delegate POST processing to the new handler while keeping rendered output intact

## Testing
- php -l wwwroot/classes/Admin/GameStatusRequestHandler.php
- php -l wwwroot/classes/Admin/GameStatusRequestResult.php
- php -l wwwroot/admin/status.php

------
https://chatgpt.com/codex/tasks/task_e_68d13f3c3b58832fa9a64a868eeccfdb