### PR TITLE
Refactor player view to use OOP service

### DIFF
--- a/wwwroot/classes/PlayerGame.php
+++ b/wwwroot/classes/PlayerGame.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerGame
+{
+    private const STATUS_DELISTED = 1;
+    private const STATUS_OBSOLETE = 3;
+    private const STATUS_DELISTED_AND_OBSOLETE = 4;
+
+    private int $id;
+    private string $npCommunicationId;
+    private string $name;
+    private string $iconUrl;
+    private string $platform;
+    private int $status;
+    private int $maxRarityPoints;
+    private int $bronze;
+    private int $silver;
+    private int $gold;
+    private int $platinum;
+    private int $progress;
+    private string $lastUpdatedDate;
+    private int $rarityPoints;
+    private ?string $completionDurationLabel;
+
+    private function __construct()
+    {
+        $this->id = 0;
+        $this->npCommunicationId = '';
+        $this->name = '';
+        $this->iconUrl = '';
+        $this->platform = '';
+        $this->status = 0;
+        $this->maxRarityPoints = 0;
+        $this->bronze = 0;
+        $this->silver = 0;
+        $this->gold = 0;
+        $this->platinum = 0;
+        $this->progress = 0;
+        $this->lastUpdatedDate = '';
+        $this->rarityPoints = 0;
+        $this->completionDurationLabel = null;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row, ?string $completionDurationLabel = null): self
+    {
+        $game = new self();
+        $game->id = (int) ($row['id'] ?? 0);
+        $game->npCommunicationId = (string) ($row['np_communication_id'] ?? '');
+        $game->name = (string) ($row['name'] ?? '');
+        $game->iconUrl = (string) ($row['icon_url'] ?? '');
+        $game->platform = (string) ($row['platform'] ?? '');
+        $game->status = (int) ($row['status'] ?? 0);
+        $game->maxRarityPoints = (int) ($row['max_rarity_points'] ?? 0);
+        $game->bronze = (int) ($row['bronze'] ?? 0);
+        $game->silver = (int) ($row['silver'] ?? 0);
+        $game->gold = (int) ($row['gold'] ?? 0);
+        $game->platinum = (int) ($row['platinum'] ?? 0);
+        $game->progress = (int) ($row['progress'] ?? 0);
+        $game->lastUpdatedDate = (string) ($row['last_updated_date'] ?? '');
+        $game->rarityPoints = (int) ($row['rarity_points'] ?? 0);
+        $game->completionDurationLabel = $completionDurationLabel;
+
+        return $game;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getNpCommunicationId(): string
+    {
+        return $this->npCommunicationId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getIconFileName(): string
+    {
+        if ($this->iconUrl === '.png') {
+            return str_contains($this->platform, 'PS5')
+                ? '../missing-ps5-game-and-trophy.png'
+                : '../missing-ps4-game.png';
+        }
+
+        return $this->iconUrl;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getPlatforms(): array
+    {
+        $platforms = array_map('trim', explode(',', $this->platform));
+
+        return array_filter(
+            $platforms,
+            static fn(string $platform): bool => $platform !== ''
+        );
+    }
+
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->status === 0;
+    }
+
+    public function isCompleted(): bool
+    {
+        return $this->progress === 100;
+    }
+
+    public function getRowClass(): ?string
+    {
+        if ($this->status === self::STATUS_DELISTED || $this->status === self::STATUS_OBSOLETE || $this->status === self::STATUS_DELISTED_AND_OBSOLETE) {
+            return 'table-warning';
+        }
+
+        if ($this->isCompleted()) {
+            return 'table-success';
+        }
+
+        return null;
+    }
+
+    public function getRowTitle(): ?string
+    {
+        return match ($this->status) {
+            self::STATUS_DELISTED => 'This game is delisted, no trophies will be accounted for on any leaderboard.',
+            self::STATUS_OBSOLETE => 'This game is obsolete, no trophies will be accounted for on any leaderboard.',
+            self::STATUS_DELISTED_AND_OBSOLETE => 'This game is delisted &amp; obsolete, no trophies will be accounted for on any leaderboard.',
+            default => null,
+        };
+    }
+
+    public function getBronze(): int
+    {
+        return $this->bronze;
+    }
+
+    public function getSilver(): int
+    {
+        return $this->silver;
+    }
+
+    public function getGold(): int
+    {
+        return $this->gold;
+    }
+
+    public function getPlatinum(): int
+    {
+        return $this->platinum;
+    }
+
+    public function getProgress(): int
+    {
+        return $this->progress;
+    }
+
+    public function getLastUpdatedDate(): string
+    {
+        return $this->lastUpdatedDate;
+    }
+
+    public function getRarityPoints(): int
+    {
+        return $this->rarityPoints;
+    }
+
+    public function getMaxRarityPoints(): int
+    {
+        return $this->maxRarityPoints;
+    }
+
+    public function getCompletionDurationLabel(): ?string
+    {
+        return $this->completionDurationLabel;
+    }
+}

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerGamesFilter
+{
+    public const SORT_DATE = 'date';
+    public const SORT_MAX_RARITY = 'max-rarity';
+    public const SORT_NAME = 'name';
+    public const SORT_RARITY = 'rarity';
+    public const SORT_SEARCH = 'search';
+
+    public const PLATFORM_PC = 'pc';
+    public const PLATFORM_PS3 = 'ps3';
+    public const PLATFORM_PS4 = 'ps4';
+    public const PLATFORM_PS5 = 'ps5';
+    public const PLATFORM_PSVITA = 'psvita';
+    public const PLATFORM_PSVR = 'psvr';
+    public const PLATFORM_PSVR2 = 'psvr2';
+
+    private const ALLOWED_SORTS = [
+        self::SORT_DATE,
+        self::SORT_MAX_RARITY,
+        self::SORT_NAME,
+        self::SORT_RARITY,
+        self::SORT_SEARCH,
+    ];
+
+    private const PLATFORM_KEYS = [
+        self::PLATFORM_PC,
+        self::PLATFORM_PS3,
+        self::PLATFORM_PS4,
+        self::PLATFORM_PS5,
+        self::PLATFORM_PSVITA,
+        self::PLATFORM_PSVR,
+        self::PLATFORM_PSVR2,
+    ];
+
+    private const DEFAULT_LIMIT = 50;
+
+    private string $search;
+    private string $sort;
+    private bool $completed;
+    private bool $uncompleted;
+    private bool $base;
+    /**
+     * @var array<int, string>
+     */
+    private array $platforms;
+    private int $page;
+    private int $limit;
+
+    private function __construct()
+    {
+        $this->search = '';
+        $this->sort = self::SORT_DATE;
+        $this->completed = false;
+        $this->uncompleted = false;
+        $this->base = false;
+        $this->platforms = [];
+        $this->page = 1;
+        $this->limit = self::DEFAULT_LIMIT;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public static function fromArray(array $parameters): self
+    {
+        $filter = new self();
+
+        $filter->search = isset($parameters['search']) ? (string) $parameters['search'] : '';
+
+        $sort = isset($parameters['sort']) ? (string) $parameters['sort'] : '';
+        if ($sort !== '' && in_array($sort, self::ALLOWED_SORTS, true)) {
+            $filter->sort = $sort;
+        } elseif (!empty($filter->search)) {
+            $filter->sort = self::SORT_SEARCH;
+        }
+
+        $filter->completed = !empty($parameters['completed']);
+        $filter->uncompleted = !empty($parameters['uncompleted']);
+        $filter->base = !empty($parameters['base']);
+
+        foreach (self::PLATFORM_KEYS as $platformKey) {
+            if (!empty($parameters[$platformKey])) {
+                $filter->platforms[] = $platformKey;
+            }
+        }
+
+        $page = isset($parameters['page']) && is_numeric($parameters['page'])
+            ? (int) $parameters['page']
+            : 1;
+        $filter->page = max($page, 1);
+
+        return $filter;
+    }
+
+    public function getSearch(): string
+    {
+        return $this->search;
+    }
+
+    public function hasSearchTerm(): bool
+    {
+        return !empty($this->search);
+    }
+
+    public function shouldApplyFulltextCondition(): bool
+    {
+        return $this->hasSearchTerm() || $this->sort === self::SORT_SEARCH;
+    }
+
+    public function shouldIncludeScoreColumn(): bool
+    {
+        return $this->shouldApplyFulltextCondition();
+    }
+
+    public function getSort(): string
+    {
+        return $this->sort;
+    }
+
+    public function isCompletedSelected(): bool
+    {
+        return $this->completed;
+    }
+
+    public function isUncompletedSelected(): bool
+    {
+        return $this->uncompleted;
+    }
+
+    public function isBaseSelected(): bool
+    {
+        return $this->base;
+    }
+
+    public function hasPlatformFilters(): bool
+    {
+        return $this->platforms !== [];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getPlatforms(): array
+    {
+        return $this->platforms;
+    }
+
+    public function isPlatformSelected(string $platformKey): bool
+    {
+        return in_array($platformKey, $this->platforms, true);
+    }
+
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function getOffset(): int
+    {
+        return ($this->page - 1) * $this->limit;
+    }
+}

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerGame.php';
+require_once __DIR__ . '/PlayerGamesFilter.php';
+
+class PlayerGamesService
+{
+    private const PLATFORM_CONDITIONS = [
+        PlayerGamesFilter::PLATFORM_PC => "tt.platform LIKE '%PC%'",
+        PlayerGamesFilter::PLATFORM_PS3 => "tt.platform LIKE '%PS3%'",
+        PlayerGamesFilter::PLATFORM_PS4 => "tt.platform LIKE '%PS4%'",
+        PlayerGamesFilter::PLATFORM_PS5 => "tt.platform LIKE '%PS5%'",
+        PlayerGamesFilter::PLATFORM_PSVITA => "tt.platform LIKE '%PSVITA%'",
+        PlayerGamesFilter::PLATFORM_PSVR => "(tt.platform LIKE '%PSVR' OR tt.platform LIKE '%PSVR,%')",
+        PlayerGamesFilter::PLATFORM_PSVR2 => "tt.platform LIKE '%PSVR2%'",
+    ];
+
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function countPlayerGames(int $accountId, PlayerGamesFilter $filter): int
+    {
+        $sql = sprintf(
+            'SELECT COUNT(*)
+            FROM trophy_title_player ttp
+                JOIN trophy_title tt USING (np_communication_id)
+                JOIN trophy_group_player tgp USING (account_id, np_communication_id)
+            WHERE %s',
+            $this->buildWhereClause($filter, true)
+        );
+
+        $statement = $this->database->prepare($sql);
+        $this->bindCommonParameters($statement, $accountId, $filter);
+        $statement->execute();
+
+        $count = $statement->fetchColumn();
+
+        return $count === false ? 0 : (int) $count;
+    }
+
+    /**
+     * @return PlayerGame[]
+     */
+    public function getPlayerGames(int $accountId, PlayerGamesFilter $filter): array
+    {
+        $columns = [
+            'tt.id',
+            'tt.np_communication_id',
+            'tt.name',
+            'tt.icon_url',
+            'tt.platform',
+            'tt.status',
+            'tt.rarity_points AS max_rarity_points',
+            'ttp.bronze',
+            'ttp.silver',
+            'ttp.gold',
+            'ttp.platinum',
+            'ttp.progress',
+            'ttp.last_updated_date',
+            'ttp.rarity_points',
+        ];
+
+        if ($filter->shouldIncludeScoreColumn()) {
+            $columns[] = 'MATCH(tt.name) AGAINST (:search) AS score';
+        }
+
+        $sql = sprintf(
+            'SELECT %s
+            FROM trophy_title_player ttp
+                JOIN trophy_title tt USING (np_communication_id)
+                JOIN trophy_group_player tgp USING (account_id, np_communication_id)
+            WHERE %s
+            %s
+            LIMIT :offset, :limit',
+            implode(', ', $columns),
+            $this->buildWhereClause($filter, false),
+            $this->buildOrderByClause($filter)
+        );
+
+        $statement = $this->database->prepare($sql);
+        $this->bindCommonParameters($statement, $accountId, $filter);
+        $statement->bindValue(':offset', $filter->getOffset(), PDO::PARAM_INT);
+        $statement->bindValue(':limit', $filter->getLimit(), PDO::PARAM_INT);
+        $statement->execute();
+
+        $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        $completionLabels = $this->fetchCompletionLabels($accountId, $rows);
+
+        $games = [];
+        foreach ($rows as $row) {
+            $npCommunicationId = (string) ($row['np_communication_id'] ?? '');
+            $completionLabel = $completionLabels[$npCommunicationId] ?? null;
+            $games[] = PlayerGame::fromArray($row, $completionLabel);
+        }
+
+        return $games;
+    }
+
+    private function buildWhereClause(PlayerGamesFilter $filter, bool $forCount): string
+    {
+        $conditions = [
+            'tt.status != 2',
+            'ttp.account_id = :account_id',
+            "tgp.group_id = 'default'",
+        ];
+
+        if ($filter->shouldApplyFulltextCondition()) {
+            $conditions[] = $forCount
+                ? '(MATCH(tt.name) AGAINST (:search)) > 0'
+                : '(MATCH(tt.name) AGAINST (:search))';
+        }
+
+        if ($filter->isCompletedSelected()) {
+            $conditions[] = 'ttp.progress = 100';
+        }
+
+        if ($filter->isUncompletedSelected()) {
+            $conditions[] = 'ttp.progress != 100';
+        }
+
+        if ($filter->isBaseSelected()) {
+            $conditions[] = 'tgp.progress = 100';
+        }
+
+        if ($filter->hasPlatformFilters()) {
+            $platformConditions = [];
+            foreach ($filter->getPlatforms() as $platformKey) {
+                $condition = self::PLATFORM_CONDITIONS[$platformKey] ?? null;
+                if ($condition !== null) {
+                    $platformConditions[] = $condition;
+                }
+            }
+
+            if ($platformConditions !== []) {
+                $conditions[] = '(' . implode(' OR ', $platformConditions) . ')';
+            }
+        }
+
+        return implode(' AND ', $conditions);
+    }
+
+    private function buildOrderByClause(PlayerGamesFilter $filter): string
+    {
+        return match ($filter->getSort()) {
+            PlayerGamesFilter::SORT_MAX_RARITY => 'ORDER BY max_rarity_points DESC, `name`',
+            PlayerGamesFilter::SORT_NAME => 'ORDER BY `name`',
+            PlayerGamesFilter::SORT_RARITY => 'ORDER BY rarity_points DESC, `name`',
+            PlayerGamesFilter::SORT_SEARCH => 'ORDER BY score DESC',
+            default => 'ORDER BY last_updated_date DESC',
+        };
+    }
+
+    private function bindCommonParameters(PDOStatement $statement, int $accountId, PlayerGamesFilter $filter): void
+    {
+        $statement->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+
+        if ($filter->shouldApplyFulltextCondition()) {
+            $statement->bindValue(':search', $filter->getSearch(), PDO::PARAM_STR);
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @return array<string, string>
+     */
+    private function fetchCompletionLabels(int $accountId, array $rows): array
+    {
+        $npCommunicationIds = [];
+        foreach ($rows as $row) {
+            if ((int) ($row['progress'] ?? 0) === 100) {
+                $npCommunicationId = (string) ($row['np_communication_id'] ?? '');
+                if ($npCommunicationId !== '') {
+                    $npCommunicationIds[$npCommunicationId] = $npCommunicationId;
+                }
+            }
+        }
+
+        if ($npCommunicationIds === []) {
+            return [];
+        }
+
+        $placeholders = [];
+        $index = 0;
+        foreach (array_values($npCommunicationIds) as $npCommunicationId) {
+            $placeholders[] = ':np_' . $index;
+            $index++;
+        }
+
+        $sql = sprintf(
+            'SELECT np_communication_id, MIN(earned_date) AS first_trophy, MAX(earned_date) AS last_trophy
+            FROM trophy_earned
+            WHERE account_id = :account_id
+                AND earned = 1
+                AND np_communication_id IN (%s)
+            GROUP BY np_communication_id',
+            implode(', ', $placeholders)
+        );
+
+        $statement = $this->database->prepare($sql);
+        $statement->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+
+        $index = 0;
+        foreach (array_values($npCommunicationIds) as $npCommunicationId) {
+            $statement->bindValue(':np_' . $index, $npCommunicationId, PDO::PARAM_STR);
+            $index++;
+        }
+
+        $statement->execute();
+        $completionRows = $statement->fetchAll(PDO::FETCH_ASSOC);
+        if (!is_array($completionRows)) {
+            return [];
+        }
+
+        $labels = [];
+        foreach ($completionRows as $completionRow) {
+            $npCommunicationId = (string) ($completionRow['np_communication_id'] ?? '');
+            $label = $this->formatCompletionLabel(
+                $completionRow['first_trophy'] ?? null,
+                $completionRow['last_trophy'] ?? null
+            );
+
+            if ($npCommunicationId !== '' && $label !== null) {
+                $labels[$npCommunicationId] = $label;
+            }
+        }
+
+        return $labels;
+    }
+
+    private function formatCompletionLabel(mixed $firstTrophy, mixed $lastTrophy): ?string
+    {
+        if (!is_string($firstTrophy) || $firstTrophy === '' || !is_string($lastTrophy) || $lastTrophy === '') {
+            return null;
+        }
+
+        try {
+            $start = new \DateTimeImmutable($firstTrophy);
+            $end = new \DateTimeImmutable($lastTrophy);
+        } catch (\Exception) {
+            return null;
+        }
+
+        $interval = $start->diff($end);
+        $formatted = $interval->format('%y years, %m months, %d days, %h hours, %i minutes, %s seconds');
+        $parts = explode(', ', $formatted);
+
+        $nonZeroParts = [];
+        foreach ($parts as $part) {
+            if ($part !== '' && $part[0] !== '0') {
+                $nonZeroParts[] = $part;
+            }
+        }
+
+        if ($nonZeroParts === []) {
+            return null;
+        }
+
+        if (count($nonZeroParts) >= 2) {
+            return 'Completed in ' . $nonZeroParts[0] . ', ' . $nonZeroParts[1];
+        }
+
+        return 'Completed in ' . $nonZeroParts[0];
+    }
+}


### PR DESCRIPTION
## Summary
- add PlayerGamesFilter, PlayerGamesService, and PlayerGame classes to encapsulate player game retrieval and formatting
- refactor player.php to use the new service/filter objects and remove inline SQL and procedural data shaping

## Testing
- php -l wwwroot/classes/PlayerGamesFilter.php
- php -l wwwroot/classes/PlayerGame.php
- php -l wwwroot/classes/PlayerGamesService.php
- php -l wwwroot/player.php

------
https://chatgpt.com/codex/tasks/task_e_68d141a44fd4832fa51c7b2a6a32e340