### PR TITLE
Refactor admin cheater form to use request handler

### DIFF
--- a/wwwroot/admin/cheater.php
+++ b/wwwroot/admin/cheater.php
@@ -3,25 +3,17 @@
 declare(strict_types=1);
 
 require_once '../init.php';
-require_once '../classes/Admin/CheaterService.php';
+require_once '../classes/Admin/CheaterRequestHandler.php';
 
 $cheaterService = new CheaterService($database);
+$requestHandler = new CheaterRequestHandler($cheaterService);
 
-$successMessage = null;
-$errorMessage = null;
+$requestMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$postData = $_POST ?? [];
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $onlineId = isset($_POST['player']) ? trim((string) $_POST['player']) : '';
-
-    try {
-        $cheaterService->markPlayerAsCheater($onlineId);
-        $successMessage = sprintf('<p>Player %s is now tagged as a cheater.</p>', htmlentities($onlineId));
-    } catch (InvalidArgumentException $exception) {
-        $errorMessage = sprintf('<p class="text-danger">%s</p>', htmlentities($exception->getMessage()));
-    } catch (Throwable $exception) {
-        $errorMessage = '<p class="text-danger">An unexpected error occurred while updating the player.</p>';
-    }
-}
+$result = $requestHandler->handle($requestMethod, $postData);
+$successMessage = $result->getSuccessMessage();
+$errorMessage = $result->getErrorMessage();
 
 ?>
 <!doctype html>

--- a/wwwroot/classes/Admin/CheaterRequestHandler.php
+++ b/wwwroot/classes/Admin/CheaterRequestHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/CheaterRequestResult.php';
+require_once __DIR__ . '/CheaterService.php';
+
+class CheaterRequestHandler
+{
+    private CheaterService $cheaterService;
+
+    public function __construct(CheaterService $cheaterService)
+    {
+        $this->cheaterService = $cheaterService;
+    }
+
+    /**
+     * @param array<string, mixed> $postData
+     */
+    public function handle(string $requestMethod, array $postData): CheaterRequestResult
+    {
+        if (strtoupper($requestMethod) !== 'POST') {
+            return CheaterRequestResult::empty();
+        }
+
+        $onlineId = $this->sanitizeOnlineId($postData['player'] ?? null);
+
+        if ($onlineId === '') {
+            return CheaterRequestResult::error('<p class="text-danger">Online ID cannot be empty.</p>');
+        }
+
+        try {
+            $this->cheaterService->markPlayerAsCheater($onlineId);
+        } catch (InvalidArgumentException $exception) {
+            $message = $this->escapeHtml($exception->getMessage());
+
+            return CheaterRequestResult::error('<p class="text-danger">' . $message . '</p>');
+        } catch (Throwable $exception) {
+            return CheaterRequestResult::error('<p class="text-danger">An unexpected error occurred while updating the player.</p>');
+        }
+
+        $player = $this->escapeHtml($onlineId);
+        $message = sprintf('<p>Player %s is now tagged as a cheater.</p>', $player);
+
+        return CheaterRequestResult::success($message);
+    }
+
+    private function sanitizeOnlineId(mixed $onlineId): string
+    {
+        return trim((string) ($onlineId ?? ''));
+    }
+
+    private function escapeHtml(string $value): string
+    {
+        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/wwwroot/classes/Admin/CheaterRequestResult.php
+++ b/wwwroot/classes/Admin/CheaterRequestResult.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+class CheaterRequestResult
+{
+    private ?string $successMessage;
+
+    private ?string $errorMessage;
+
+    private function __construct(?string $successMessage, ?string $errorMessage)
+    {
+        $this->successMessage = $successMessage;
+        $this->errorMessage = $errorMessage;
+    }
+
+    public static function success(string $message): self
+    {
+        return new self($message, null);
+    }
+
+    public static function error(string $message): self
+    {
+        return new self(null, $message);
+    }
+
+    public static function empty(): self
+    {
+        return new self(null, null);
+    }
+
+    public function getSuccessMessage(): ?string
+    {
+        return $this->successMessage;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+}


### PR DESCRIPTION
## Summary
- add `CheaterRequestHandler` and `CheaterRequestResult` classes to encapsulate admin cheater form handling
- update the admin cheater page to delegate processing to the handler for improved OOP structure

## Testing
- php -l wwwroot/admin/cheater.php
- php -l wwwroot/classes/Admin/CheaterRequestHandler.php
- php -l wwwroot/classes/Admin/CheaterRequestResult.php

------
https://chatgpt.com/codex/tasks/task_e_68d149666408832fbd55a114e90f885b