### PR TITLE
Refactor game header queries to service

### DIFF
--- a/wwwroot/classes/Game/GameHeaderData.php
+++ b/wwwroot/classes/Game/GameHeaderData.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+class GameHeaderData
+{
+    private ?GameHeaderParent $parentGame;
+
+    /**
+     * @var GameHeaderStack[]
+     */
+    private array $stacks;
+
+    private int $unobtainableTrophyCount;
+
+    /**
+     * @param GameHeaderStack[] $stacks
+     */
+    public function __construct(?GameHeaderParent $parentGame, array $stacks, int $unobtainableTrophyCount)
+    {
+        $this->parentGame = $parentGame;
+        $this->stacks = $stacks;
+        $this->unobtainableTrophyCount = $unobtainableTrophyCount;
+    }
+
+    public function hasMergedParent(): bool
+    {
+        return $this->parentGame !== null;
+    }
+
+    public function getParentGame(): ?GameHeaderParent
+    {
+        return $this->parentGame;
+    }
+
+    /**
+     * @return GameHeaderStack[]
+     */
+    public function getStacks(): array
+    {
+        return $this->stacks;
+    }
+
+    public function hasStacks(): bool
+    {
+        return $this->stacks !== [];
+    }
+
+    public function getUnobtainableTrophyCount(): int
+    {
+        return $this->unobtainableTrophyCount;
+    }
+
+    public function hasUnobtainableTrophies(): bool
+    {
+        return $this->unobtainableTrophyCount > 0;
+    }
+}

--- a/wwwroot/classes/Game/GameHeaderParent.php
+++ b/wwwroot/classes/Game/GameHeaderParent.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+class GameHeaderParent
+{
+    private int $id;
+    private string $name;
+
+    private function __construct(int $id, string $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        return new self(
+            (int) ($row['id'] ?? 0),
+            (string) ($row['name'] ?? '')
+        );
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/wwwroot/classes/Game/GameHeaderStack.php
+++ b/wwwroot/classes/Game/GameHeaderStack.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+class GameHeaderStack
+{
+    private int $id;
+    private string $name;
+    private string $platform;
+    private ?string $region;
+
+    private function __construct(int $id, string $name, string $platform, ?string $region)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->platform = $platform;
+        $this->region = $region;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        $region = $row['region'] ?? null;
+        if ($region !== null) {
+            $region = trim((string) $region);
+            if ($region === '') {
+                $region = null;
+            }
+        }
+
+        return new self(
+            (int) ($row['id'] ?? 0),
+            (string) ($row['name'] ?? ''),
+            (string) ($row['platform'] ?? ''),
+            $region
+        );
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getPlatform(): string
+    {
+        return $this->platform;
+    }
+
+    public function getRegion(): ?string
+    {
+        return $this->region;
+    }
+}

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Game/GameHeaderData.php';
+require_once __DIR__ . '/Game/GameHeaderParent.php';
+require_once __DIR__ . '/Game/GameHeaderStack.php';
+
+class GameHeaderService
+{
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    /**
+     * @param array<string, mixed> $game
+     */
+    public function buildHeaderData(array $game): GameHeaderData
+    {
+        $status = (int) ($game['status'] ?? 0);
+        $npCommunicationId = (string) ($game['np_communication_id'] ?? '');
+        $parentNpCommunicationId = $game['parent_np_communication_id'] ?? null;
+
+        $parentGame = null;
+        if ($status === 2 && is_string($parentNpCommunicationId) && $parentNpCommunicationId !== '') {
+            $parentGame = $this->fetchParentGame($parentNpCommunicationId);
+        }
+
+        $stacks = [];
+        if ($npCommunicationId !== '' && str_starts_with($npCommunicationId, 'MERGE')) {
+            $stacks = $this->fetchStacks($npCommunicationId);
+        }
+
+        $unobtainableTrophyCount = 0;
+        if ($npCommunicationId !== '') {
+            $unobtainableTrophyCount = $this->countUnobtainableTrophies($npCommunicationId);
+        }
+
+        return new GameHeaderData($parentGame, $stacks, $unobtainableTrophyCount);
+    }
+
+    private function fetchParentGame(string $npCommunicationId): ?GameHeaderParent
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                id,
+                `name`
+            FROM
+                trophy_title
+            WHERE
+                np_communication_id = :np_communication_id
+            SQL
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        $row = $query->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        return GameHeaderParent::fromArray($row);
+    }
+
+    /**
+     * @return GameHeaderStack[]
+     */
+    private function fetchStacks(string $npCommunicationId): array
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                id,
+                `name`,
+                platform,
+                region
+            FROM
+                trophy_title
+            WHERE
+                parent_np_communication_id = :parent_np_communication_id
+            ORDER BY
+                `name`,
+                platform,
+                region
+            SQL
+        );
+        $query->bindValue(':parent_np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        $rows = $query->fetchAll(PDO::FETCH_ASSOC);
+
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        return array_map(
+            static fn(array $row): GameHeaderStack => GameHeaderStack::fromArray($row),
+            $rows
+        );
+    }
+
+    private function countUnobtainableTrophies(string $npCommunicationId): int
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                COUNT(*)
+            FROM
+                trophy
+            WHERE
+                `status` = 1
+                AND np_communication_id = :np_communication_id
+            SQL
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        return (int) $query->fetchColumn();
+    }
+}

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/GameHeaderService.php';
 require_once __DIR__ . '/classes/GameService.php';
 
 if (!isset($gameId)) {
@@ -16,6 +17,9 @@ if ($game === null) {
     header("Location: /game/", true, 303);
     die();
 }
+
+$gameHeaderService = new GameHeaderService($database);
+$gameHeaderData = $gameHeaderService->buildHeaderData($game);
 
 $sort = $gameService->resolveSort($_GET);
 

--- a/wwwroot/game_leaderboard.php
+++ b/wwwroot/game_leaderboard.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/GameHeaderService.php';
 require_once __DIR__ . '/classes/GamePlayerFilter.php';
 require_once __DIR__ . '/classes/GameLeaderboardFilter.php';
 require_once __DIR__ . '/classes/GameLeaderboardService.php';
@@ -18,6 +19,9 @@ if ($game === null) {
     header("Location: /game/", true, 303);
     die();
 }
+
+$gameHeaderService = new GameHeaderService($database);
+$gameHeaderData = $gameHeaderService->buildHeaderData($game);
 
 $accountId = null;
 if (isset($player)) {

--- a/wwwroot/game_recent_players.php
+++ b/wwwroot/game_recent_players.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/GameHeaderService.php';
 require_once __DIR__ . '/classes/GamePlayerFilter.php';
 require_once __DIR__ . '/classes/GameRecentPlayersService.php';
 
@@ -17,6 +18,9 @@ if ($game === null) {
     header("Location: /game/", true, 303);
     die();
 }
+
+$gameHeaderService = new GameHeaderService($database);
+$gameHeaderData = $gameHeaderService->buildHeaderData($game);
 
 $accountId = null;
 if (isset($player)) {


### PR DESCRIPTION
## Summary
- introduce GameHeaderService with data objects to encapsulate parent, stack, and unobtainable trophy lookups
- update game related pages to build GameHeaderData and remove inline queries from the shared header include
- render the game header via the new OOP data accessors for cleaner logic

## Testing
- php -l wwwroot/classes/GameHeaderService.php
- php -l wwwroot/classes/Game/GameHeaderData.php
- php -l wwwroot/classes/Game/GameHeaderParent.php
- php -l wwwroot/classes/Game/GameHeaderStack.php
- php -l wwwroot/game.php
- php -l wwwroot/game_leaderboard.php
- php -l wwwroot/game_recent_players.php
- php -l wwwroot/game_header.php

------
https://chatgpt.com/codex/tasks/task_e_68d14c5d0c6c832fa2f1d080d08f5b19