### PR TITLE
Refactor changelog page to use services

### DIFF
--- a/wwwroot/classes/ChangelogEntry.php
+++ b/wwwroot/classes/ChangelogEntry.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+
+class ChangelogEntry
+{
+    public const TYPE_GAME_CLONE = 'GAME_CLONE';
+    public const TYPE_GAME_COPY = 'GAME_COPY';
+    public const TYPE_GAME_DELETE = 'GAME_DELETE';
+    public const TYPE_GAME_DELISTED = 'GAME_DELISTED';
+    public const TYPE_GAME_DELISTED_AND_OBSOLETE = 'GAME_DELISTED_AND_OBSOLETE';
+    public const TYPE_GAME_MERGE = 'GAME_MERGE';
+    public const TYPE_GAME_NORMAL = 'GAME_NORMAL';
+    public const TYPE_GAME_OBSOLETE = 'GAME_OBSOLETE';
+    public const TYPE_GAME_OBTAINABLE = 'GAME_OBTAINABLE';
+    public const TYPE_GAME_RESCAN = 'GAME_RESCAN';
+    public const TYPE_GAME_RESET = 'GAME_RESET';
+    public const TYPE_GAME_UNOBTAINABLE = 'GAME_UNOBTAINABLE';
+    public const TYPE_GAME_UPDATE = 'GAME_UPDATE';
+    public const TYPE_GAME_VERSION = 'GAME_VERSION';
+
+    private DateTimeImmutable $time;
+    private string $changeType;
+    private ?int $param1Id;
+    private ?string $param1Name;
+    /**
+     * @var array<int, string>
+     */
+    private array $param1Platforms;
+    private ?string $param1Region;
+    private ?int $param2Id;
+    private ?string $param2Name;
+    /**
+     * @var array<int, string>
+     */
+    private array $param2Platforms;
+    private ?string $param2Region;
+    private ?string $extra;
+
+    /**
+     * @param array<int, string> $param1Platforms
+     * @param array<int, string> $param2Platforms
+     */
+    private function __construct(
+        DateTimeImmutable $time,
+        string $changeType,
+        ?int $param1Id,
+        ?string $param1Name,
+        array $param1Platforms,
+        ?string $param1Region,
+        ?int $param2Id,
+        ?string $param2Name,
+        array $param2Platforms,
+        ?string $param2Region,
+        ?string $extra
+    ) {
+        $this->time = $time;
+        $this->changeType = $changeType;
+        $this->param1Id = $param1Id;
+        $this->param1Name = $param1Name;
+        $this->param1Platforms = $param1Platforms;
+        $this->param1Region = $param1Region;
+        $this->param2Id = $param2Id;
+        $this->param2Name = $param2Name;
+        $this->param2Platforms = $param2Platforms;
+        $this->param2Region = $param2Region;
+        $this->extra = $extra;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        return new self(
+            self::createDateTime(isset($row['time']) ? (string) $row['time'] : 'now'),
+            isset($row['change_type']) ? (string) $row['change_type'] : '',
+            isset($row['param_1']) ? (int) $row['param_1'] : null,
+            isset($row['param_1_name']) ? (string) $row['param_1_name'] : null,
+            self::normalizePlatforms($row['param_1_platform'] ?? null),
+            isset($row['param_1_region']) ? (string) $row['param_1_region'] : null,
+            isset($row['param_2']) ? (int) $row['param_2'] : null,
+            isset($row['param_2_name']) ? (string) $row['param_2_name'] : null,
+            self::normalizePlatforms($row['param_2_platform'] ?? null),
+            isset($row['param_2_region']) ? (string) $row['param_2_region'] : null,
+            isset($row['extra']) ? (string) $row['extra'] : null
+        );
+    }
+
+    private static function createDateTime(string $value): DateTimeImmutable
+    {
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception $exception) {
+            return new DateTimeImmutable('@0');
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function normalizePlatforms(?string $platforms): array
+    {
+        if ($platforms === null || $platforms === '') {
+            return [];
+        }
+
+        $parts = array_map('trim', explode(',', $platforms));
+        $parts = array_filter(
+            $parts,
+            static fn(string $platform): bool => $platform !== ''
+        );
+
+        return array_values($parts);
+    }
+
+    public function getTime(): DateTimeImmutable
+    {
+        return $this->time;
+    }
+
+    public function getChangeType(): string
+    {
+        return $this->changeType;
+    }
+
+    public function getParam1Id(): ?int
+    {
+        return $this->param1Id;
+    }
+
+    public function getParam1Name(): ?string
+    {
+        return $this->param1Name;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getParam1Platforms(): array
+    {
+        return $this->param1Platforms;
+    }
+
+    public function getParam1Region(): ?string
+    {
+        return $this->param1Region;
+    }
+
+    public function getParam2Id(): ?int
+    {
+        return $this->param2Id;
+    }
+
+    public function getParam2Name(): ?string
+    {
+        return $this->param2Name;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getParam2Platforms(): array
+    {
+        return $this->param2Platforms;
+    }
+
+    public function getParam2Region(): ?string
+    {
+        return $this->param2Region;
+    }
+
+    public function getExtra(): ?string
+    {
+        return $this->extra;
+    }
+}

--- a/wwwroot/classes/ChangelogPaginator.php
+++ b/wwwroot/classes/ChangelogPaginator.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+class ChangelogPaginator
+{
+    private int $currentPage;
+    private int $totalCount;
+    private int $limit;
+    private int $totalPages;
+
+    public function __construct(int $requestedPage, int $totalCount, int $limit)
+    {
+        $this->totalCount = max($totalCount, 0);
+        $this->limit = max($limit, 1);
+        $this->totalPages = $this->totalCount > 0 ? (int) ceil($this->totalCount / $this->limit) : 0;
+
+        if ($this->totalPages > 0) {
+            $this->currentPage = min(max($requestedPage, 1), $this->totalPages);
+        } else {
+            $this->currentPage = 1;
+        }
+    }
+
+    public function getCurrentPage(): int
+    {
+        return $this->currentPage;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function getOffset(): int
+    {
+        return ($this->currentPage - 1) * $this->limit;
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->totalCount;
+    }
+
+    public function getTotalPages(): int
+    {
+        return $this->totalPages;
+    }
+
+    public function hasResults(): bool
+    {
+        return $this->totalCount > 0;
+    }
+
+    public function getRangeStart(): int
+    {
+        return $this->hasResults() ? $this->getOffset() + 1 : 0;
+    }
+
+    public function getRangeEnd(): int
+    {
+        return $this->hasResults() ? min($this->getOffset() + $this->limit, $this->totalCount) : 0;
+    }
+
+    public function hasPreviousPage(): bool
+    {
+        return $this->currentPage > 1;
+    }
+
+    public function hasNextPage(): bool
+    {
+        return $this->currentPage < $this->getLastPageNumber();
+    }
+
+    public function getPreviousPage(): int
+    {
+        return max($this->currentPage - 1, 1);
+    }
+
+    public function getNextPage(): int
+    {
+        return min($this->currentPage + 1, $this->getLastPageNumber());
+    }
+
+    public function getLastPageNumber(): int
+    {
+        return max($this->totalPages, 1);
+    }
+}

--- a/wwwroot/classes/ChangelogService.php
+++ b/wwwroot/classes/ChangelogService.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/ChangelogEntry.php';
+require_once __DIR__ . '/ChangelogPaginator.php';
+
+class ChangelogService
+{
+    public const PAGE_SIZE = 50;
+
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function getTotalChangeCount(): int
+    {
+        $query = $this->database->prepare('SELECT COUNT(*) FROM psn100_change');
+        $query->execute();
+
+        $count = $query->fetchColumn();
+
+        if ($count === false) {
+            return 0;
+        }
+
+        return (int) $count;
+    }
+
+    /**
+     * @return array<int, ChangelogEntry>
+     */
+    public function getChanges(ChangelogPaginator $paginator): array
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                c.*,
+                tt1.name AS param_1_name,
+                tt1.platform AS param_1_platform,
+                tt1.region AS param_1_region,
+                tt2.name AS param_2_name,
+                tt2.platform AS param_2_platform,
+                tt2.region AS param_2_region
+            FROM psn100_change c
+            LEFT JOIN trophy_title tt1 ON tt1.id = c.param_1
+            LEFT JOIN trophy_title tt2 ON tt2.id = c.param_2
+            ORDER BY c.time DESC
+            LIMIT :offset, :limit
+            SQL
+        );
+        $query->bindValue(':offset', $paginator->getOffset(), PDO::PARAM_INT);
+        $query->bindValue(':limit', $paginator->getLimit(), PDO::PARAM_INT);
+        $query->execute();
+
+        $rows = $query->fetchAll(PDO::FETCH_ASSOC);
+
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($rows as $row) {
+            $entries[] = ChangelogEntry::fromArray($row);
+        }
+
+        return $entries;
+    }
+}


### PR DESCRIPTION
## Summary
- extract changelog data access into a dedicated ChangelogService and supporting value objects
- update the changelog page to consume the new service, paginator, and entry objects instead of inline database logic
- centralize formatting helpers for regions and platform badges while keeping the view layer focused on rendering

## Testing
- php -l wwwroot/classes/ChangelogEntry.php
- php -l wwwroot/classes/ChangelogPaginator.php
- php -l wwwroot/classes/ChangelogService.php
- php -l wwwroot/changelog.php

------
https://chatgpt.com/codex/tasks/task_e_68d16080dd4c832f9e681bee27d1c27b