### PR TITLE
Ensure templates have access to global services

### DIFF
--- a/wwwroot/classes/Application.php
+++ b/wwwroot/classes/Application.php
@@ -78,6 +78,10 @@ class Application
 
             $include = $routeResult->getInclude();
             if ($include !== null) {
+                // The included templates expect global variables like $database and $utility
+                // to be available, just as they were when index.php handled the routing in
+                // the global scope. Make them available here before including the template.
+                global $database, $utility;
                 require_once $include;
             }
         }


### PR DESCRIPTION
## Summary
- import the global database and utility objects before including route templates so they can use them

## Testing
- php -l wwwroot/classes/Application.php

------
https://chatgpt.com/codex/tasks/task_e_68d234d9c034832fa5671e66d2844dfb