### PR TITLE
Refactor avatar listing to object-oriented view model

### DIFF
--- a/wwwroot/avatars.php
+++ b/wwwroot/avatars.php
@@ -1,16 +1,10 @@
 <?php
 require_once 'classes/AvatarService.php';
+require_once 'classes/AvatarPage.php';
 
 $title = "Avatars ~ PSN 100%";
 $avatarService = new AvatarService($database);
-
-$page = isset($_GET['page']) && is_numeric($_GET['page']) ? (int) $_GET['page'] : 1;
-$page = max($page, 1);
-$limit = 48;
-
-$totalAvatarCount = $avatarService->getTotalUniqueAvatarCount();
-$totalPages = $totalAvatarCount > 0 ? (int) ceil($totalAvatarCount / $limit) : 0;
-$avatars = $avatarService->getAvatars($page, $limit);
+$avatarPage = AvatarPage::fromQueryParameters($avatarService, $_GET ?? []);
 
 require_once("header.php");
 ?>
@@ -24,7 +18,7 @@ require_once("header.php");
 
     <div class="row">
         <?php
-        foreach ($avatars as $avatar) {
+        foreach ($avatarPage->getAvatars() as $avatar) {
             ?>
             <div class="col">
                 <div class="bg-body-tertiary p-3 rounded mb-3 text-center vstack gap-1">
@@ -44,57 +38,55 @@ require_once("header.php");
             <nav aria-label="Avatars page navigation">
                 <ul class="pagination justify-content-center">
                     <?php
-                    if ($page > 1) {
+                    if ($avatarPage->hasPreviousPage()) {
                         ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $page - 1; ?>" aria-label="Previous">&lt;</a></li>
+                        <li class="page-item"><a class="page-link" href="?page=<?= $avatarPage->getPreviousPage(); ?>" aria-label="Previous">&lt;</a></li>
                         <?php
                     }
 
-                    if ($page > 3) {
+                    if ($avatarPage->shouldShowFirstPage()) {
                         ?>
-                        <li class="page-item"><a class="page-link" href="?page=1">1</a></li>
+                        <li class="page-item"><a class="page-link" href="?page=<?= $avatarPage->getFirstPage(); ?>"><?= $avatarPage->getFirstPage(); ?></a></li>
+                        <?php
+                    }
+
+                    if ($avatarPage->shouldShowLeadingEllipsis()) {
+                        ?>
                         <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
                         <?php
                     }
 
-                    if ($page - 2 > 0) {
+                    foreach ($avatarPage->getPreviousPages() as $previousPage) {
                         ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $page - 2; ?>"><?= $page - 2; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page - 1 > 0) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $page - 1; ?>"><?= $page - 1; ?></a></li>
+                        <li class="page-item"><a class="page-link" href="?page=<?= $previousPage; ?>"><?= $previousPage; ?></a></li>
                         <?php
                     }
                     ?>
 
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?page=<?= $page; ?>"><?= $page; ?></a></li>
+                    <li class="page-item active" aria-current="page"><a class="page-link" href="?page=<?= $avatarPage->getCurrentPage(); ?>"><?= $avatarPage->getCurrentPage(); ?></a></li>
 
                     <?php
-                    if ($page + 1 <= $totalPages) {
+                    foreach ($avatarPage->getNextPages() as $nextPage) {
                         ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $page + 1; ?>"><?= $page + 1; ?></a></li>
+                        <li class="page-item"><a class="page-link" href="?page=<?= $nextPage; ?>"><?= $nextPage; ?></a></li>
                         <?php
                     }
 
-                    if ($page + 2 <= $totalPages) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $page + 2; ?>"><?= $page + 2; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page < $totalPages - 2) {
+                    if ($avatarPage->shouldShowTrailingEllipsis()) {
                         ?>
                         <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $totalPages; ?>"><?= $totalPages; ?></a></li>
                         <?php
                     }
 
-                    if ($page < $totalPages) {
+                    if ($avatarPage->shouldShowLastPage()) {
                         ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $page + 1; ?>" aria-label="Next">&gt;</a></li>
+                        <li class="page-item"><a class="page-link" href="?page=<?= $avatarPage->getLastPage(); ?>"><?= $avatarPage->getLastPage(); ?></a></li>
+                        <?php
+                    }
+
+                    if ($avatarPage->hasNextPage()) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?page=<?= $avatarPage->getNextPage(); ?>" aria-label="Next">&gt;</a></li>
                         <?php
                     }
                     ?>

--- a/wwwroot/classes/AvatarPage.php
+++ b/wwwroot/classes/AvatarPage.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/AvatarService.php';
+
+class AvatarPage
+{
+    private AvatarService $avatarService;
+
+    private int $currentPage;
+
+    private int $limit;
+
+    private int $totalAvatarCount;
+
+    private int $totalPages;
+
+    /**
+     * @var Avatar[]
+     */
+    private array $avatars;
+
+    public function __construct(AvatarService $avatarService, int $currentPage = 1, int $limit = 48)
+    {
+        $this->avatarService = $avatarService;
+        $this->limit = max($limit, 1);
+        $this->currentPage = max($currentPage, 1);
+
+        $this->totalAvatarCount = $this->avatarService->getTotalUniqueAvatarCount();
+        $this->totalPages = $this->totalAvatarCount > 0
+            ? (int) ceil($this->totalAvatarCount / $this->limit)
+            : 0;
+
+        $this->avatars = $this->avatarService->getAvatars($this->currentPage, $this->limit);
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public static function fromQueryParameters(AvatarService $avatarService, array $queryParameters, int $limit = 48): self
+    {
+        $page = 1;
+
+        if (isset($queryParameters['page']) && is_numeric($queryParameters['page'])) {
+            $page = (int) $queryParameters['page'];
+        }
+
+        return new self($avatarService, $page, $limit);
+    }
+
+    public function getCurrentPage(): int
+    {
+        return $this->currentPage;
+    }
+
+    public function getTotalPages(): int
+    {
+        return $this->totalPages;
+    }
+
+    public function getTotalAvatarCount(): int
+    {
+        return $this->totalAvatarCount;
+    }
+
+    /**
+     * @return Avatar[]
+     */
+    public function getAvatars(): array
+    {
+        return $this->avatars;
+    }
+
+    public function hasPreviousPage(): bool
+    {
+        return $this->currentPage > 1;
+    }
+
+    public function getPreviousPage(): int
+    {
+        return max(1, $this->currentPage - 1);
+    }
+
+    public function hasNextPage(): bool
+    {
+        return $this->totalPages > 0 && $this->currentPage < $this->totalPages;
+    }
+
+    public function getNextPage(): int
+    {
+        return min($this->currentPage + 1, $this->totalPages);
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getPreviousPages(): array
+    {
+        $pages = [];
+
+        for ($i = 2; $i >= 1; $i--) {
+            $candidate = $this->currentPage - $i;
+
+            if ($candidate > 0) {
+                $pages[] = $candidate;
+            }
+        }
+
+        return $pages;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getNextPages(): array
+    {
+        $pages = [];
+
+        if ($this->totalPages === 0) {
+            return $pages;
+        }
+
+        for ($i = 1; $i <= 2; $i++) {
+            $candidate = $this->currentPage + $i;
+
+            if ($candidate <= $this->totalPages) {
+                $pages[] = $candidate;
+            }
+        }
+
+        return $pages;
+    }
+
+    public function shouldShowFirstPage(): bool
+    {
+        return $this->totalPages > 0 && $this->currentPage > 3;
+    }
+
+    public function shouldShowLeadingEllipsis(): bool
+    {
+        return $this->shouldShowFirstPage();
+    }
+
+    public function shouldShowLastPage(): bool
+    {
+        return $this->totalPages > 0 && $this->currentPage < $this->totalPages - 2;
+    }
+
+    public function shouldShowTrailingEllipsis(): bool
+    {
+        return $this->shouldShowLastPage();
+    }
+
+    public function getFirstPage(): int
+    {
+        return 1;
+    }
+
+    public function getLastPage(): int
+    {
+        return $this->totalPages > 0 ? $this->totalPages : 1;
+    }
+}


### PR DESCRIPTION
## Summary
- add an `AvatarPage` view model to encapsulate avatar pagination state and navigation helpers
- update the avatars page to consume the view model instead of manual pagination math

## Testing
- php -l wwwroot/classes/AvatarPage.php
- php -l wwwroot/avatars.php

------
https://chatgpt.com/codex/tasks/task_e_68d23a83d344832f80c6c97120ab8342