### PR TITLE
Refactor trophy listing to OOP structure

### DIFF
--- a/wwwroot/classes/TrophyListFilter.php
+++ b/wwwroot/classes/TrophyListFilter.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+class TrophyListFilter
+{
+    private int $page;
+
+    public function __construct(int $page)
+    {
+        $this->page = max($page, 1);
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public static function fromArray(array $queryParameters): self
+    {
+        $page = $queryParameters['page'] ?? 1;
+
+        if (!is_numeric($page)) {
+            $page = 1;
+        }
+
+        return new self((int) $page);
+    }
+
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    public function getOffset(int $limit): int
+    {
+        return ($this->page - 1) * $limit;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function getFilterParameters(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function toQueryParameters(): array
+    {
+        return $this->withPage($this->page);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function withPage(int $page): array
+    {
+        $parameters = $this->getFilterParameters();
+        $parameters['page'] = max($page, 1);
+
+        return $parameters;
+    }
+}
+

--- a/wwwroot/classes/TrophyListPage.php
+++ b/wwwroot/classes/TrophyListPage.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/ChangelogPaginator.php';
+require_once __DIR__ . '/TrophyListFilter.php';
+require_once __DIR__ . '/TrophyListService.php';
+
+class TrophyListPage
+{
+    private TrophyListFilter $filter;
+
+    private ChangelogPaginator $paginator;
+
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private array $trophies;
+
+    public function __construct(TrophyListService $service, TrophyListFilter $filter)
+    {
+        $this->filter = $filter;
+
+        $totalTrophies = $service->countTrophies();
+        $this->paginator = new ChangelogPaginator(
+            $filter->getPage(),
+            $totalTrophies,
+            TrophyListService::PAGE_SIZE
+        );
+
+        $this->trophies = $service->getTrophies(
+            $this->paginator->getOffset(),
+            $this->paginator->getLimit()
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getTrophies(): array
+    {
+        return $this->trophies;
+    }
+
+    public function getRangeStart(): int
+    {
+        return $this->paginator->getRangeStart();
+    }
+
+    public function getRangeEnd(): int
+    {
+        return $this->paginator->getRangeEnd();
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->paginator->getTotalCount();
+    }
+
+    public function getCurrentPage(): int
+    {
+        return $this->paginator->getCurrentPage();
+    }
+
+    public function getTotalPages(): int
+    {
+        return $this->paginator->getTotalPages();
+    }
+
+    public function hasPreviousPage(): bool
+    {
+        return $this->paginator->hasPreviousPage();
+    }
+
+    public function getPreviousPage(): int
+    {
+        return $this->paginator->getPreviousPage();
+    }
+
+    public function hasNextPage(): bool
+    {
+        return $this->paginator->hasNextPage();
+    }
+
+    public function getNextPage(): int
+    {
+        return $this->paginator->getNextPage();
+    }
+
+    public function shouldShowFirstPage(): bool
+    {
+        return $this->getTotalPages() > 0 && $this->getCurrentPage() > 3;
+    }
+
+    public function shouldShowLeadingEllipsis(): bool
+    {
+        return $this->shouldShowFirstPage();
+    }
+
+    public function shouldShowLastPage(): bool
+    {
+        return $this->getTotalPages() > 0 && $this->getCurrentPage() < $this->getLastPage() - 2;
+    }
+
+    public function shouldShowTrailingEllipsis(): bool
+    {
+        return $this->shouldShowLastPage();
+    }
+
+    public function getFirstPage(): int
+    {
+        return 1;
+    }
+
+    public function getLastPage(): int
+    {
+        return $this->paginator->getLastPageNumber();
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getPreviousPages(): array
+    {
+        $pages = [];
+
+        for ($i = 2; $i >= 1; $i--) {
+            $candidate = $this->getCurrentPage() - $i;
+
+            if ($candidate > 0) {
+                $pages[] = $candidate;
+            }
+        }
+
+        return $pages;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getNextPages(): array
+    {
+        $pages = [];
+        $lastPage = $this->getLastPage();
+
+        for ($i = 1; $i <= 2; $i++) {
+            $candidate = $this->getCurrentPage() + $i;
+
+            if ($candidate <= $lastPage) {
+                $pages[] = $candidate;
+            }
+        }
+
+        return $pages;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function getPageQueryParameters(int $page): array
+    {
+        return $this->filter->withPage($page);
+    }
+}
+

--- a/wwwroot/classes/TrophyListService.php
+++ b/wwwroot/classes/TrophyListService.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+class TrophyListService
+{
+    public const PAGE_SIZE = 50;
+
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function countTrophies(): int
+    {
+        $query = $this->database->prepare(
+            'SELECT COUNT(*)
+            FROM trophy t
+            JOIN trophy_title tt USING (np_communication_id)
+            WHERE t.status = 0 AND tt.status = 0'
+        );
+
+        $query->execute();
+        $total = $query->fetchColumn();
+
+        return $total === false ? 0 : (int) $total;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getTrophies(int $offset, int $limit = self::PAGE_SIZE): array
+    {
+        $offset = max($offset, 0);
+        $limit = max($limit, 1);
+
+        $query = $this->database->prepare(
+            'SELECT
+                t.id AS trophy_id,
+                t.type AS trophy_type,
+                t.name AS trophy_name,
+                t.detail AS trophy_detail,
+                t.icon_url AS trophy_icon,
+                t.rarity_percent,
+                t.progress_target_value,
+                t.reward_name,
+                t.reward_image_url,
+                tt.id AS game_id,
+                tt.name AS game_name,
+                tt.icon_url AS game_icon,
+                tt.platform
+            FROM trophy t
+            JOIN trophy_title tt USING(np_communication_id)
+            WHERE t.status = 0 AND tt.status = 0
+            ORDER BY t.rarity_percent DESC
+            LIMIT :offset, :limit'
+        );
+
+        $query->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $query->execute();
+
+        /** @var array<int, array<string, mixed>> $trophies */
+        $trophies = $query->fetchAll(PDO::FETCH_ASSOC);
+
+        return $trophies;
+    }
+}
+

--- a/wwwroot/trophies.php
+++ b/wwwroot/trophies.php
@@ -1,25 +1,17 @@
 <?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/classes/TrophyListFilter.php';
+require_once __DIR__ . '/classes/TrophyListPage.php';
+require_once __DIR__ . '/classes/TrophyListService.php';
+
+$trophyListFilter = TrophyListFilter::fromArray($_GET ?? []);
+$trophyListService = new TrophyListService($database);
+$trophyListPage = new TrophyListPage($trophyListService, $trophyListFilter);
+
 $title = "Trophies ~ PSN 100%";
-require_once("header.php");
-
-$url = $_SERVER["REQUEST_URI"];
-$url_parts = parse_url($url);
-// If URL doesn't have a query string.
-if (isset($url_parts["query"])) { // Avoid 'Undefined index: query'
-    parse_str($url_parts["query"], $params);
-} else {
-    $params = array();
-}
-
-$query = $database->prepare("SELECT COUNT(*) FROM trophy t
-    JOIN trophy_title tt USING (np_communication_id)
-    WHERE t.status = 0 AND tt.status = 0");
-$query->execute();
-$total_pages = $query->fetchColumn();
-
-$page = max(isset($_GET["page"]) && is_numeric($_GET["page"]) ? $_GET["page"] : 1, 1);
-$limit = 50;
-$offset = ($page - 1) * $limit;
+require_once('header.php');
 ?>
 
 <main class="container">
@@ -46,63 +38,37 @@ $offset = ($page - 1) * $limit;
 
                         <tbody>
                             <?php
-                            $trophies = $database->prepare("SELECT
-                                    t.id AS trophy_id,
-                                    t.type AS trophy_type,
-                                    t.name AS trophy_name,
-                                    t.detail AS trophy_detail,
-                                    t.icon_url AS trophy_icon,
-                                    t.rarity_percent,
-                                    t.progress_target_value,
-                                    t.reward_name,
-                                    t.reward_image_url,
-                                    tt.id AS game_id,
-                                    tt.name AS game_name,
-                                    tt.icon_url AS game_icon,
-                                    tt.platform
-                                FROM
-                                    trophy t
-                                JOIN trophy_title tt USING(np_communication_id)
-                                WHERE
-                                    t.status = 0 AND tt.status = 0
-                                ORDER BY
-                                    t.rarity_percent DESC
-                                LIMIT :offset, :limit");
-                            $trophies->bindValue(":offset", $offset, PDO::PARAM_INT);
-                            $trophies->bindValue(":limit", $limit, PDO::PARAM_INT);
-                            $trophies->execute();
-
-                            while ($trophy = $trophies->fetch()) {
+                            foreach ($trophyListPage->getTrophies() as $trophy) {
                                 ?>
                                 <tr>
                                     <td scope="row" class="text-center align-middle">
-                                        <a href="/game/<?= $trophy["game_id"] ."-". $utility->slugify($trophy["game_name"]); ?>">
-                                            <img src="/img/title/<?= ($trophy["game_icon"] == ".png") ? ((str_contains($trophy["platform"], "PS5")) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-game.png") : $trophy["game_icon"]; ?>" alt="<?= htmlentities($trophy["game_name"], ENT_QUOTES, "UTF-8"); ?>" title="<?= htmlentities($trophy["game_name"], ENT_QUOTES, "UTF-8"); ?>" style="width: 10rem;" />
+                                        <a href="/game/<?= $trophy['game_id'] . '-' . $utility->slugify($trophy['game_name']); ?>">
+                                            <img src="/img/title/<?= ($trophy['game_icon'] == '.png') ? ((str_contains($trophy['platform'], 'PS5')) ? '../missing-ps5-game-and-trophy.png' : '../missing-ps4-game.png') : $trophy['game_icon']; ?>" alt="<?= htmlentities($trophy['game_name'], ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy['game_name'], ENT_QUOTES, 'UTF-8'); ?>" style="width: 10rem;" />
                                         </a>
                                     </td>
                                     <td class="align-middle">
                                         <div class="hstack gap-3">
                                             <div class="d-flex align-items-center justify-content-center">
-                                                <a href="/trophy/<?= $trophy["trophy_id"] ."-". $utility->slugify($trophy["trophy_name"]); ?>">
-                                                    <img src="/img/trophy/<?= ($trophy["trophy_icon"] == ".png") ? ((str_contains($trophy["platform"], "PS5")) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-trophy.png") : $trophy["trophy_icon"]; ?>" alt="<?= htmlentities($trophy["trophy_name"], ENT_QUOTES, "UTF-8"); ?>" title="<?= htmlentities($trophy["trophy_name"], ENT_QUOTES, "UTF-8"); ?>" style="width: 5rem;" />
+                                                <a href="/trophy/<?= $trophy['trophy_id'] . '-' . $utility->slugify($trophy['trophy_name']); ?>">
+                                                    <img src="/img/trophy/<?= ($trophy['trophy_icon'] == '.png') ? ((str_contains($trophy['platform'], 'PS5')) ? '../missing-ps5-game-and-trophy.png' : '../missing-ps4-trophy.png') : $trophy['trophy_icon']; ?>" alt="<?= htmlentities($trophy['trophy_name'], ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy['trophy_name'], ENT_QUOTES, 'UTF-8'); ?>" style="width: 5rem;" />
                                                 </a>
                                             </div>
 
                                             <div>
                                                 <div class="vstack">
                                                     <span>
-                                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/trophy/<?= $trophy["trophy_id"] ."-". $utility->slugify($trophy["trophy_name"]); ?>">
-                                                            <b><?= htmlentities($trophy["trophy_name"]); ?></b>
+                                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/trophy/<?= $trophy['trophy_id'] . '-' . $utility->slugify($trophy['trophy_name']); ?>">
+                                                            <b><?= htmlentities($trophy['trophy_name']); ?></b>
                                                         </a>
                                                     </span>
-                                                    <?= nl2br(htmlentities($trophy["trophy_detail"], ENT_QUOTES, "UTF-8")); ?>
+                                                    <?= nl2br(htmlentities($trophy['trophy_detail'], ENT_QUOTES, 'UTF-8')); ?>
                                                     <?php
-                                                    if ($trophy["progress_target_value"] != null) {
-                                                        echo "<br><b>0/". $trophy["progress_target_value"] ."</b>";
+                                                    if ($trophy['progress_target_value'] != null) {
+                                                        echo '<br><b>0/' . $trophy['progress_target_value'] . '</b>';
                                                     }
 
-                                                    if ($trophy["reward_name"] != null && $trophy["reward_image_url"] != null) {
-                                                        echo "<br>Reward: <a href='/img/reward/". $trophy["reward_image_url"] ."'>". $trophy["reward_name"] ."</a>";
+                                                    if ($trophy['reward_name'] != null && $trophy['reward_image_url'] != null) {
+                                                        echo "<br>Reward: <a href='/img/reward/" . $trophy['reward_image_url'] . "'>" . $trophy['reward_name'] . '</a>';
                                                     }
                                                     ?>
                                                 </div>
@@ -112,29 +78,29 @@ $offset = ($page - 1) * $limit;
                                     <td class="text-center align-middle">
                                         <div class="vstack gap-1">
                                             <?php
-                                            foreach (explode(",", $trophy["platform"]) as $platform) {
-                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2\">". $platform ."</span> ";
+                                            foreach (explode(',', $trophy['platform']) as $platform) {
+                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2\">" . $platform . '</span> ';
                                             }
                                             ?>
                                         </div>
                                     </td>
                                     <td class="text-center align-middle">
                                         <?php
-                                        if ($trophy["rarity_percent"] <= 0.02) {
-                                            echo "<span class='trophy-legendary'>". $trophy["rarity_percent"] ."%<br>Legendary</span>";
-                                        } elseif ($trophy["rarity_percent"] <= 0.2) {
-                                            echo "<span class='trophy-epic'>". $trophy["rarity_percent"] ."%<br>Epic</span>";
-                                        } elseif ($trophy["rarity_percent"] <= 2) {
-                                            echo "<span class='trophy-rare'>". $trophy["rarity_percent"] ."%<br>Rare</span>";
-                                        } elseif ($trophy["rarity_percent"] <= 10) {
-                                            echo "<span class='trophy-uncommon'>". $trophy["rarity_percent"] ."%<br>Uncommon</span>";
+                                        if ($trophy['rarity_percent'] <= 0.02) {
+                                            echo "<span class='trophy-legendary'>" . $trophy['rarity_percent'] . "%<br>Legendary</span>";
+                                        } elseif ($trophy['rarity_percent'] <= 0.2) {
+                                            echo "<span class='trophy-epic'>" . $trophy['rarity_percent'] . "%<br>Epic</span>";
+                                        } elseif ($trophy['rarity_percent'] <= 2) {
+                                            echo "<span class='trophy-rare'>" . $trophy['rarity_percent'] . "%<br>Rare</span>";
+                                        } elseif ($trophy['rarity_percent'] <= 10) {
+                                            echo "<span class='trophy-uncommon'>" . $trophy['rarity_percent'] . "%<br>Uncommon</span>";
                                         } else {
-                                            echo "<span class='trophy-common'>". $trophy["rarity_percent"] ."%<br>Common</span>";
+                                            echo "<span class='trophy-common'>" . $trophy['rarity_percent'] . "%<br>Common</span>";
                                         }
                                         ?>
                                     </td>
                                     <td class="text-center align-middle">
-                                        <img src="/img/trophy-<?= $trophy["trophy_type"]; ?>.svg" alt="<?= ucfirst($trophy["trophy_type"]); ?>" title="<?= ucfirst($trophy["trophy_type"]); ?>" height="50" />
+                                        <img src="/img/trophy-<?= $trophy['trophy_type']; ?>.svg" alt="<?= ucfirst($trophy['trophy_type']); ?>" title="<?= ucfirst($trophy['trophy_type']); ?>" height="50" />
                                     </td>
                                 </tr>
                                 <?php
@@ -150,67 +116,62 @@ $offset = ($page - 1) * $limit;
     <div class="row mt-3">
         <div class="col-12">
             <p class="text-center">
-                <?= ($total_pages == 0 ? "0" : $offset + 1); ?>-<?= min($offset + $limit, $total_pages); ?> of <?= number_format($total_pages); ?>
+                <?= $trophyListPage->getRangeStart(); ?>-<?= $trophyListPage->getRangeEnd(); ?> of <?= number_format($trophyListPage->getTotalCount()); ?>
             </p>
         </div>
         <div class="col-12">
             <nav aria-label="Trophies page navigation">
                 <ul class="pagination justify-content-center">
                     <?php
-                    if ($page > 1) {
-                        $params["page"] = $page - 1; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>">&lt;</a></li>
+                    if ($trophyListPage->hasPreviousPage()) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($trophyListPage->getPreviousPage())); ?>">&lt;</a></li>
                         <?php
                     }
 
-                    if ($page > 3) {
-                        $params["page"] = 1; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>">1</a></li>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
+                    if ($trophyListPage->shouldShowFirstPage()) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($trophyListPage->getFirstPage())); ?>"><?= $trophyListPage->getFirstPage(); ?></a></li>
                         <?php
+
+                        if ($trophyListPage->shouldShowLeadingEllipsis()) {
+                            ?>
+                            <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
+                            <?php
+                        }
                     }
 
-                    if ($page-2 > 0) {
-                        $params["page"] = $page - 2; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= $page-2; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page-1 > 0) {
-                        $params["page"] = $page - 1; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= $page-1; ?></a></li>
+                    foreach ($trophyListPage->getPreviousPages() as $previousPage) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($previousPage)); ?>"><?= $previousPage; ?></a></li>
                         <?php
                     }
                     ?>
 
-                    <?php
-                    $params["page"] = $page;
-                    ?>
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= $page; ?></a></li>
+                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($trophyListPage->getCurrentPage())); ?>"><?= $trophyListPage->getCurrentPage(); ?></a></li>
 
                     <?php
-                    if ($page+1 < ceil($total_pages / $limit)+1) {
-                        $params["page"] = $page + 1; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= $page+1; ?></a></li>
+                    foreach ($trophyListPage->getNextPages() as $nextPage) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($nextPage)); ?>"><?= $nextPage; ?></a></li>
                         <?php
                     }
 
-                    if ($page+2 < ceil($total_pages / $limit)+1) {
-                        $params["page"] = $page + 2; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= $page+2; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page < ceil($total_pages / $limit)-2) {
-                        $params["page"] = ceil($total_pages / $limit); ?>
+                    if ($trophyListPage->shouldShowTrailingEllipsis()) {
+                        ?>
                         <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= ceil($total_pages / $limit); ?></a></li>
                         <?php
                     }
 
-                    if ($page < ceil($total_pages / $limit)) {
-                        $params["page"] = $page + 1; ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>">&gt;</a></li>
+                    if ($trophyListPage->shouldShowLastPage()) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($trophyListPage->getLastPage())); ?>"><?= $trophyListPage->getLastPage(); ?></a></li>
+                        <?php
+                    }
+
+                    if ($trophyListPage->hasNextPage()) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($trophyListPage->getNextPage())); ?>">&gt;</a></li>
                         <?php
                     }
                     ?>
@@ -221,5 +182,5 @@ $offset = ($page - 1) * $limit;
 </main>
 
 <?php
-require_once("footer.php");
+require_once('footer.php');
 ?>


### PR DESCRIPTION
## Summary
- add TrophyListFilter, TrophyListService, and TrophyListPage classes to encapsulate trophy list filtering, pagination, and queries
- refactor trophies.php to use the new service objects and pagination helpers

## Testing
- php -l wwwroot/trophies.php
- php -l wwwroot/classes/TrophyListService.php
- php -l wwwroot/classes/TrophyListFilter.php
- php -l wwwroot/classes/TrophyListPage.php

------
https://chatgpt.com/codex/tasks/task_e_68d23fcbd5a0832f9a9f9e3082120217