### PR TITLE
Refactor player report handling to be object oriented

### DIFF
--- a/wwwroot/classes/PlayerReportHandler.php
+++ b/wwwroot/classes/PlayerReportHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerReportService.php';
+require_once __DIR__ . '/PlayerReportResult.php';
+
+class PlayerReportHandler
+{
+    private PlayerReportService $playerReportService;
+
+    public function __construct(PlayerReportService $playerReportService)
+    {
+        $this->playerReportService = $playerReportService;
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public function getExplanation(array $queryParameters): string
+    {
+        return $this->sanitizeExplanation($queryParameters['explanation'] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed> $serverParameters
+     */
+    public function handleReportRequest(int $accountId, string $explanation, array $serverParameters): PlayerReportResult
+    {
+        if ($explanation === '') {
+            return PlayerReportResult::empty();
+        }
+
+        $ipAddress = $this->resolveIpAddress($serverParameters);
+
+        return $this->playerReportService->submitReport($accountId, $ipAddress, $explanation);
+    }
+
+    private function sanitizeExplanation(mixed $explanation): string
+    {
+        if (!is_scalar($explanation)) {
+            return '';
+        }
+
+        return trim((string) $explanation);
+    }
+
+    /**
+     * @param array<string, mixed> $serverParameters
+     */
+    private function resolveIpAddress(array $serverParameters): string
+    {
+        $ipAddress = (string) ($serverParameters['REMOTE_ADDR'] ?? '');
+        if ($ipAddress === '') {
+            return '';
+        }
+
+        $validatedAddress = filter_var($ipAddress, FILTER_VALIDATE_IP);
+
+        return is_string($validatedAddress) ? $validatedAddress : '';
+    }
+}

--- a/wwwroot/classes/PlayerReportResult.php
+++ b/wwwroot/classes/PlayerReportResult.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerReportResult
+{
+    private bool $hasMessage;
+
+    private bool $success;
+
+    private string $message;
+
+    private function __construct(bool $hasMessage, bool $success, string $message)
+    {
+        $this->hasMessage = $hasMessage;
+        $this->success = $success;
+        $this->message = $message;
+    }
+
+    public static function success(string $message): self
+    {
+        return new self(true, true, $message);
+    }
+
+    public static function error(string $message): self
+    {
+        return new self(true, false, $message);
+    }
+
+    public static function empty(): self
+    {
+        return new self(false, false, '');
+    }
+
+    public function hasMessage(): bool
+    {
+        return $this->hasMessage;
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->success;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/wwwroot/classes/PlayerReportService.php
+++ b/wwwroot/classes/PlayerReportService.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerReportResult.php';
+
 class PlayerReportService
 {
     private const MAX_PENDING_REPORTS_PER_IP = 10;
@@ -13,19 +15,19 @@ class PlayerReportService
         $this->database = $database;
     }
 
-    public function submitReport(int $accountId, string $ipAddress, string $explanation): string
+    public function submitReport(int $accountId, string $ipAddress, string $explanation): PlayerReportResult
     {
         if ($this->hasExistingReport($accountId, $ipAddress)) {
-            return "You've already reported this player.";
+            return PlayerReportResult::error("You've already reported this player.");
         }
 
         if ($this->getReportCountForIp($ipAddress) >= self::MAX_PENDING_REPORTS_PER_IP) {
-            return "You've already 10 players reported waiting to be processed. Please try again later.";
+            return PlayerReportResult::error("You've already 10 players reported waiting to be processed. Please try again later.");
         }
 
         $this->insertReport($accountId, $ipAddress, $explanation);
 
-        return "Player reported successfully.";
+        return PlayerReportResult::success('Player reported successfully.');
     }
 
     private function hasExistingReport(int $accountId, string $ipAddress): bool


### PR DESCRIPTION
## Summary
- introduce PlayerReportResult and PlayerReportHandler classes to encapsulate report processing
- update PlayerReportService and player_report.php to use the new objects and expose clearer status handling

## Testing
- php -l wwwroot/classes/PlayerReportResult.php
- php -l wwwroot/classes/PlayerReportHandler.php
- php -l wwwroot/classes/PlayerReportService.php
- php -l wwwroot/player_report.php

------
https://chatgpt.com/codex/tasks/task_e_68d3077dc318832fbb3b882cccb188ec