### PR TITLE
Refactor leaderboard pages with OOP paginator

### DIFF
--- a/wwwroot/classes/PlayerLeaderboardDataProvider.php
+++ b/wwwroot/classes/PlayerLeaderboardDataProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerLeaderboardFilter.php';
+
+interface PlayerLeaderboardDataProvider
+{
+    public function countPlayers(PlayerLeaderboardFilter $filter): int;
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getPlayers(PlayerLeaderboardFilter $filter, int $limit): array;
+
+    public function getPageSize(): int;
+}

--- a/wwwroot/classes/PlayerLeaderboardPage.php
+++ b/wwwroot/classes/PlayerLeaderboardPage.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/ChangelogPaginator.php';
+require_once __DIR__ . '/PlayerLeaderboardDataProvider.php';
+require_once __DIR__ . '/PlayerLeaderboardFilter.php';
+
+class PlayerLeaderboardPage
+{
+    private PlayerLeaderboardFilter $requestedFilter;
+
+    private ChangelogPaginator $paginator;
+
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private array $players;
+
+    public function __construct(PlayerLeaderboardDataProvider $service, PlayerLeaderboardFilter $filter)
+    {
+        $this->requestedFilter = $filter;
+
+        $totalPlayers = $service->countPlayers($filter);
+        $this->paginator = new ChangelogPaginator(
+            $filter->getPage(),
+            $totalPlayers,
+            $service->getPageSize()
+        );
+
+        $resolvedFilter = $this->createFilterForPage($this->paginator->getCurrentPage());
+        $this->players = $service->getPlayers(
+            $resolvedFilter,
+            $this->paginator->getLimit()
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getPlayers(): array
+    {
+        return $this->players;
+    }
+
+    public function getTotalPlayers(): int
+    {
+        return $this->paginator->getTotalCount();
+    }
+
+    public function getRangeStart(): int
+    {
+        return $this->paginator->getRangeStart();
+    }
+
+    public function getRangeEnd(): int
+    {
+        return $this->paginator->getRangeEnd();
+    }
+
+    public function getCurrentPage(): int
+    {
+        return $this->paginator->getCurrentPage();
+    }
+
+    public function getTotalPages(): int
+    {
+        return $this->paginator->getTotalPages();
+    }
+
+    public function hasPreviousPage(): bool
+    {
+        return $this->paginator->hasPreviousPage();
+    }
+
+    public function getPreviousPage(): int
+    {
+        return $this->paginator->getPreviousPage();
+    }
+
+    public function hasNextPage(): bool
+    {
+        return $this->paginator->hasNextPage();
+    }
+
+    public function getNextPage(): int
+    {
+        return $this->paginator->getNextPage();
+    }
+
+    public function shouldShowFirstPage(): bool
+    {
+        return $this->getTotalPages() > 0 && $this->getCurrentPage() > 3;
+    }
+
+    public function shouldShowLeadingEllipsis(): bool
+    {
+        return $this->shouldShowFirstPage();
+    }
+
+    public function shouldShowLastPage(): bool
+    {
+        return $this->getTotalPages() > 0 && $this->getCurrentPage() < $this->getLastPage() - 2;
+    }
+
+    public function shouldShowTrailingEllipsis(): bool
+    {
+        return $this->shouldShowLastPage();
+    }
+
+    public function getFirstPage(): int
+    {
+        return 1;
+    }
+
+    public function getLastPage(): int
+    {
+        return $this->paginator->getLastPageNumber();
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getPreviousPages(): array
+    {
+        $pages = [];
+
+        for ($i = 2; $i >= 1; $i--) {
+            $candidate = $this->getCurrentPage() - $i;
+
+            if ($candidate > 0) {
+                $pages[] = $candidate;
+            }
+        }
+
+        return $pages;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getNextPages(): array
+    {
+        $pages = [];
+        $lastPage = $this->getLastPage();
+
+        for ($i = 1; $i <= 2; $i++) {
+            $candidate = $this->getCurrentPage() + $i;
+
+            if ($candidate <= $lastPage) {
+                $pages[] = $candidate;
+            }
+        }
+
+        return $pages;
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    public function getPageQueryParameters(int $page): array
+    {
+        return $this->requestedFilter->withPage($page);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getFilterParameters(): array
+    {
+        return $this->requestedFilter->getFilterParameters();
+    }
+
+    private function createFilterForPage(int $page): PlayerLeaderboardFilter
+    {
+        if ($this->requestedFilter->getPage() === $page) {
+            return $this->requestedFilter;
+        }
+
+        return new PlayerLeaderboardFilter(
+            $this->requestedFilter->getCountry(),
+            $this->requestedFilter->getAvatar(),
+            $page
+        );
+    }
+}

--- a/wwwroot/classes/PlayerLeaderboardService.php
+++ b/wwwroot/classes/PlayerLeaderboardService.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class PlayerLeaderboardService
+require_once __DIR__ . '/PlayerLeaderboardDataProvider.php';
+
+class PlayerLeaderboardService implements PlayerLeaderboardDataProvider
 {
     public const PAGE_SIZE = 50;
 
@@ -71,6 +73,11 @@ class PlayerLeaderboardService
         }
 
         return $players;
+    }
+
+    public function getPageSize(): int
+    {
+        return self::PAGE_SIZE;
     }
 
     private function buildFilterSql(PlayerLeaderboardFilter $filter): string

--- a/wwwroot/classes/PlayerRarityLeaderboardService.php
+++ b/wwwroot/classes/PlayerRarityLeaderboardService.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class PlayerRarityLeaderboardService
+require_once __DIR__ . '/PlayerLeaderboardDataProvider.php';
+
+class PlayerRarityLeaderboardService implements PlayerLeaderboardDataProvider
 {
     public const PAGE_SIZE = 50;
 
@@ -71,6 +73,11 @@ class PlayerRarityLeaderboardService
         }
 
         return $players;
+    }
+
+    public function getPageSize(): int
+    {
+        return self::PAGE_SIZE;
     }
 
     private function buildFilterSql(PlayerLeaderboardFilter $filter): string

--- a/wwwroot/leaderboard_rarity.php
+++ b/wwwroot/leaderboard_rarity.php
@@ -1,23 +1,18 @@
 <?php
 require_once 'classes/PlayerLeaderboardFilter.php';
 require_once 'classes/PlayerRarityLeaderboardService.php';
+require_once 'classes/PlayerLeaderboardPage.php';
 
 $title = "PSN Rarity Leaderboard ~ PSN 100%";
 require_once("header.php");
 
 $playerLeaderboardFilter = PlayerLeaderboardFilter::fromArray($_GET ?? []);
 $playerLeaderboardService = new PlayerRarityLeaderboardService($database);
+$playerLeaderboardPage = new PlayerLeaderboardPage($playerLeaderboardService, $playerLeaderboardFilter);
 
-$limit = PlayerRarityLeaderboardService::PAGE_SIZE;
-$page = $playerLeaderboardFilter->getPage();
-$offset = $playerLeaderboardFilter->getOffset($limit);
-
-$totalPlayers = $playerLeaderboardService->countPlayers($playerLeaderboardFilter);
-$totalPages = (int) ceil($totalPlayers / $limit);
-$players = $playerLeaderboardService->getPlayers($playerLeaderboardFilter, $limit);
-
-$filterParameters = $playerLeaderboardFilter->getFilterParameters();
-$pageParameters = $playerLeaderboardFilter->toQueryParameters();
+$players = $playerLeaderboardPage->getPlayers();
+$filterParameters = $playerLeaderboardPage->getFilterParameters();
+$pageParameters = $playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getCurrentPage());
 ?>
 
 <main class="container">
@@ -177,64 +172,62 @@ $pageParameters = $playerLeaderboardFilter->toQueryParameters();
     <div class="row mt-3">
         <div class="col-12">
             <p class="text-center">
-                <?= ($totalPlayers == 0 ? "0" : $offset + 1); ?>-<?= min($offset + $limit, $totalPlayers); ?> of <?= number_format($totalPlayers); ?>
+                <?= ($playerLeaderboardPage->getTotalPlayers() === 0 ? '0' : $playerLeaderboardPage->getRangeStart()); ?>-<?= $playerLeaderboardPage->getRangeEnd(); ?> of <?= number_format($playerLeaderboardPage->getTotalPlayers()); ?>
             </p>
         </div>
         <div class="col-12">
             <nav aria-label="Leaderboard page navigation">
                 <ul class="pagination justify-content-center">
                     <?php
-                    if ($page > 1) {
+                    if ($playerLeaderboardPage->hasPreviousPage()) {
                         ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($page - 1)); ?>">&lt;</a></li>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getPreviousPage())); ?>">&lt;</a></li>
                         <?php
                     }
 
-                    if ($page > 3) {
+                    if ($playerLeaderboardPage->shouldShowFirstPage()) {
                         ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage(1)); ?>">1</a></li>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getFirstPage())); ?>"><?= $playerLeaderboardPage->getFirstPage(); ?></a></li>
+                        <?php
+                    }
+
+                    if ($playerLeaderboardPage->shouldShowLeadingEllipsis()) {
+                        ?>
                         <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
                         <?php
                     }
 
-                    if ($page - 2 > 0) {
+                    foreach ($playerLeaderboardPage->getPreviousPages() as $previousPage) {
                         ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($page - 2)); ?>"><?= $page - 2; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page - 1 > 0) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($page - 1)); ?>"><?= $page - 1; ?></a></li>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($previousPage)); ?>"><?= $previousPage; ?></a></li>
                         <?php
                     }
                     ?>
 
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($pageParameters); ?>"><?= $page; ?></a></li>
+                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($pageParameters); ?>"><?= $playerLeaderboardPage->getCurrentPage(); ?></a></li>
 
                     <?php
-                    if ($page + 1 <= $totalPages) {
+                    foreach ($playerLeaderboardPage->getNextPages() as $nextPage) {
                         ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($page + 1)); ?>"><?= $page + 1; ?></a></li>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($nextPage)); ?>"><?= $nextPage; ?></a></li>
                         <?php
                     }
 
-                    if ($page + 2 <= $totalPages) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($page + 2)); ?>"><?= $page + 2; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page < $totalPages - 2) {
+                    if ($playerLeaderboardPage->shouldShowTrailingEllipsis()) {
                         ?>
                         <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($totalPages)); ?>"><?= $totalPages; ?></a></li>
                         <?php
                     }
 
-                    if ($page < $totalPages) {
+                    if ($playerLeaderboardPage->shouldShowLastPage()) {
                         ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardFilter->withPage($page + 1)); ?>">&gt;</a></li>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getLastPage())); ?>"><?= $playerLeaderboardPage->getLastPage(); ?></a></li>
+                        <?php
+                    }
+
+                    if ($playerLeaderboardPage->hasNextPage()) {
+                        ?>
+                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getNextPage())); ?>">&gt;</a></li>
                         <?php
                     }
                     ?>


### PR DESCRIPTION
## Summary
- introduce a shared PlayerLeaderboardDataProvider interface and PlayerLeaderboardPage helper to centralize pagination
- refactor the trophy and rarity leaderboard templates to pull data via the new page object
- update leaderboard services to implement the new interface and expose their page size

## Testing
- php -l wwwroot/classes/PlayerLeaderboardDataProvider.php
- php -l wwwroot/classes/PlayerLeaderboardPage.php
- php -l wwwroot/classes/PlayerLeaderboardService.php
- php -l wwwroot/classes/PlayerRarityLeaderboardService.php
- php -l wwwroot/leaderboard_main.php
- php -l wwwroot/leaderboard_rarity.php

------
https://chatgpt.com/codex/tasks/task_e_68d316d3fe34832f8a060546be904c58