### PR TITLE
Refactor metadata handling to PageMetaData class

### DIFF
--- a/wwwroot/classes/PageMetaData.php
+++ b/wwwroot/classes/PageMetaData.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+class PageMetaData
+{
+    private ?string $title;
+    private ?string $description;
+    private ?string $image;
+    private ?string $url;
+
+    public function __construct(?string $title = null, ?string $description = null, ?string $image = null, ?string $url = null)
+    {
+        $this->title = $this->normalize($title);
+        $this->description = $this->normalize($description);
+        $this->image = $this->normalize($image);
+        $this->url = $this->normalize($url);
+    }
+
+    public function setTitle(?string $title): self
+    {
+        $this->title = $this->normalize($title);
+        return $this;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $this->normalize($description);
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setImage(?string $image): self
+    {
+        $this->image = $this->normalize($image);
+        return $this;
+    }
+
+    public function getImage(): ?string
+    {
+        return $this->image;
+    }
+
+    public function setUrl(?string $url): self
+    {
+        $this->url = $this->normalize($url);
+        return $this;
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->title === null
+            && $this->description === null
+            && $this->image === null
+            && $this->url === null;
+    }
+
+    private function normalize(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        return $trimmed === '' ? null : $trimmed;
+    }
+}

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/classes/GameHeaderService.php';
 require_once __DIR__ . '/classes/GameService.php';
+require_once __DIR__ . '/classes/PageMetaData.php';
 
 if (!isset($gameId)) {
     header("Location: /game/", true, 303);
@@ -37,11 +38,11 @@ if (isset($player)) {
     $gamePlayer = $gameService->getGamePlayer($game["np_communication_id"], $accountId);
 }
 
-$metaData = new stdClass();
-$metaData->title = $game["name"] ." Trophies";
-$metaData->description = $game["bronze"] ." Bronze ~ ". $game["silver"] ." Silver ~ ". $game["gold"] ." Gold ~ ". $game["platinum"] ." Platinum";
-$metaData->image = "https://psn100.net/img/title/". $game["icon_url"];
-$metaData->url = "https://psn100.net/game/". $game["id"] ."-". $utility->slugify($game["name"]);
+$metaData = (new PageMetaData())
+    ->setTitle($game["name"] . " Trophies")
+    ->setDescription($game["bronze"] . " Bronze ~ " . $game["silver"] . " Silver ~ " . $game["gold"] . " Gold ~ " . $game["platinum"] . " Platinum")
+    ->setImage("https://psn100.net/img/title/" . $game["icon_url"])
+    ->setUrl("https://psn100.net/game/" . $game["id"] . "-" . $utility->slugify($game["name"]));
 
 $title = $game["name"] ." Trophies ~ PSN 100%";
 require_once("header.php");

--- a/wwwroot/header.php
+++ b/wwwroot/header.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/classes/PageMetaData.php'; ?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">
     <head>
@@ -10,21 +11,21 @@
         <meta name="author" content="Markus 'Ragowit' Persson, and other contributors via GitHub project">
 
         <?php
-        if (isset($metaData)) {
-            $canonicalUrl = htmlspecialchars($metaData->url ?? '', ENT_QUOTES, 'UTF-8');
-            $description = htmlspecialchars($metaData->description ?? '', ENT_QUOTES, 'UTF-8');
-            $image = htmlspecialchars($metaData->image ?? '', ENT_QUOTES, 'UTF-8');
-            $titleMeta = htmlspecialchars($metaData->title ?? '', ENT_QUOTES, 'UTF-8');
+        if (isset($metaData) && $metaData instanceof PageMetaData && !$metaData->isEmpty()) {
+            $canonicalUrl = htmlspecialchars($metaData->getUrl() ?? '', ENT_QUOTES, 'UTF-8');
+            $description = htmlspecialchars($metaData->getDescription() ?? '', ENT_QUOTES, 'UTF-8');
+            $image = htmlspecialchars($metaData->getImage() ?? '', ENT_QUOTES, 'UTF-8');
+            $titleMeta = htmlspecialchars($metaData->getTitle() ?? '', ENT_QUOTES, 'UTF-8');
 
-            echo "<link rel=\"canonical\" href=\"". $canonicalUrl ."\" />";
-            echo "<meta property=\"og:description\" content=\"". $description ."\">";
-            echo "<meta property=\"og:image\" content=\"". $image ."\">";
+            echo "<link rel=\"canonical\" href=\"" . $canonicalUrl . "\" />";
+            echo "<meta property=\"og:description\" content=\"" . $description . "\">";
+            echo "<meta property=\"og:image\" content=\"" . $image . "\">";
             echo "<meta property=\"og:site_name\" content=\"PSN 100%\">";
-            echo "<meta property=\"og:title\" content=\"". $titleMeta ."\">";
+            echo "<meta property=\"og:title\" content=\"" . $titleMeta . "\">";
             echo "<meta property=\"og:type\" content=\"article\">";
-            echo "<meta property=\"og:url\" content=\"". $canonicalUrl ."\">";
+            echo "<meta property=\"og:url\" content=\"" . $canonicalUrl . "\">";
             echo "<meta name=\"twitter:card\" content=\"summary_large_image\">";
-            echo "<meta name=\"twitter:image:alt\" content=\"". $titleMeta ."\">";
+            echo "<meta name=\"twitter:image:alt\" content=\"" . $titleMeta . "\">";
         }
         ?>
 

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/PageMetaData.php';
 require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
 require_once __DIR__ . '/classes/PlayerGamesFilter.php';
@@ -18,17 +19,24 @@ $numberOfGames = $playerSummary->getNumberOfGames();
 $playerGamesFilter = PlayerGamesFilter::fromArray($_GET ?? []);
 $playerGamesService = new PlayerGamesService($database);
 
-$metaData = new stdClass();
-$metaData->title = $player["online_id"] ."'s Trophy Progress";
+$metaData = (new PageMetaData())
+    ->setTitle($player["online_id"] . "'s Trophy Progress");
+
 if ($player["status"] == 1) {
-    $metaData->description = "The player is flagged as a cheater.";
+    $metaData->setDescription('The player is flagged as a cheater.');
 } elseif ($player["status"] == 3) {
-    $metaData->description = "The player is private.";
+    $metaData->setDescription('The player is private.');
 } else {
-    $metaData->description = "Level ". $player["level"] .".". $player["progress"] ." ~ ". $numberOfGames ." Unique Games ~ ". $player["platinum"] ." Unique Platinums";
+    $metaData->setDescription(
+        'Level ' . $player["level"] . '.' . $player["progress"]
+        . ' ~ ' . $numberOfGames . ' Unique Games ~ '
+        . $player["platinum"] . ' Unique Platinums'
+    );
 }
-$metaData->image = "https://psn100.net/img/avatar/". $player["avatar_url"];
-$metaData->url = "https://psn100.net/player/". $player["online_id"];
+
+$metaData
+    ->setImage('https://psn100.net/img/avatar/' . $player["avatar_url"])
+    ->setUrl('https://psn100.net/player/' . $player["online_id"]);
 
 $url = $_SERVER["REQUEST_URI"];
 $url_parts = parse_url($url);

--- a/wwwroot/trophy.php
+++ b/wwwroot/trophy.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once 'classes/PageMetaData.php';
 require_once 'classes/TrophyService.php';
 
 if (!isset($trophyId)) {
@@ -44,11 +45,11 @@ $orderId = (int) $trophy["order_id"];
 $firstAchievers = $trophyService->getFirstAchievers($npCommunicationId, $orderId);
 $latestAchievers = $trophyService->getLatestAchievers($npCommunicationId, $orderId);
 
-$metaData = new stdClass();
-$metaData->title = $trophy["trophy_name"] ." Trophy";
-$metaData->description = htmlentities($trophy["trophy_detail"], ENT_QUOTES, "UTF-8");
-$metaData->image = "https://psn100.net/img/trophy/". $trophy["trophy_icon"];
-$metaData->url = "https://psn100.net/trophy/". $trophy["trophy_id"] ."-". $utility->slugify($trophy["trophy_name"]);
+$metaData = (new PageMetaData())
+    ->setTitle($trophy["trophy_name"] . ' Trophy')
+    ->setDescription(htmlentities($trophy["trophy_detail"], ENT_QUOTES, 'UTF-8'))
+    ->setImage('https://psn100.net/img/trophy/' . $trophy["trophy_icon"])
+    ->setUrl('https://psn100.net/trophy/' . $trophy["trophy_id"] . '-' . $utility->slugify($trophy["trophy_name"]));
 
 $title = $trophy["trophy_name"] . " Trophy ~ PSN 100%";
 require_once("header.php");


### PR DESCRIPTION
## Summary
- introduce a PageMetaData value object to encapsulate metadata for page headers
- update the header and page controllers to populate metadata through the new object

## Testing
- php -l wwwroot/classes/PageMetaData.php
- php -l wwwroot/header.php
- php -l wwwroot/game.php
- php -l wwwroot/player.php
- php -l wwwroot/trophy.php

------
https://chatgpt.com/codex/tasks/task_e_68d3bbe45a08832fb13b60d02d9f4734