### PR TITLE
Refactor player header view to use view model

### DIFF
--- a/wwwroot/classes/PlayerHeaderViewModel.php
+++ b/wwwroot/classes/PlayerHeaderViewModel.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerSummary.php';
+require_once __DIR__ . '/Utility.php';
+
+class PlayerHeaderViewModel
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $player;
+
+    private PlayerSummary $playerSummary;
+
+    private Utility $utility;
+
+    /**
+     * @param array<string, mixed> $player
+     */
+    public function __construct(array $player, PlayerSummary $playerSummary, Utility $utility)
+    {
+        $this->player = $player;
+        $this->playerSummary = $playerSummary;
+        $this->utility = $utility;
+    }
+
+    public function getAboutMe(): string
+    {
+        $aboutMe = (string) ($this->player['about_me'] ?? '');
+
+        return nl2br(htmlentities($aboutMe, ENT_QUOTES, 'UTF-8'));
+    }
+
+    public function getCountryName(): string
+    {
+        return $this->utility->getCountryName($this->player['country'] ?? null);
+    }
+
+    public function getTotalTrophies(): int
+    {
+        return (int) ($this->player['bronze'] ?? 0)
+            + (int) ($this->player['silver'] ?? 0)
+            + (int) ($this->player['gold'] ?? 0)
+            + (int) ($this->player['platinum'] ?? 0);
+    }
+
+    public function getNumberOfGames(): int
+    {
+        return $this->playerSummary->getNumberOfGames();
+    }
+
+    public function getNumberOfCompletedGames(): int
+    {
+        return $this->playerSummary->getNumberOfCompletedGames();
+    }
+
+    public function getAverageProgress(): ?float
+    {
+        $averageProgress = $this->playerSummary->getAverageProgress();
+
+        return $averageProgress !== null ? (float) $averageProgress : null;
+    }
+
+    public function getUnearnedTrophies(): int
+    {
+        return $this->playerSummary->getUnearnedTrophies();
+    }
+
+    public function canShowPlayerStats(): bool
+    {
+        $status = $this->getStatus();
+
+        return $status !== 1 && $status !== 3;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAlerts(): array
+    {
+        $alerts = [];
+        $status = $this->getStatus();
+        $onlineId = $this->getOnlineId();
+        $accountId = $this->getAccountId();
+
+        switch ($status) {
+            case 1:
+                $alerts[] = sprintf(
+                    "This player has some funny looking trophy data. This doesn't necessarily mean cheating, but all data from this player will be excluded from site statistics and leaderboards. <a href=\"https://github.com/Ragowit/psn100/issues?q=label%%3Acheater+%s+OR+%d\">Dispute</a>?",
+                    rawurlencode($onlineId),
+                    $accountId
+                );
+                break;
+            case 3:
+                $alerts[] = "This player seems to have a <a class=\"link-underline link-underline-opacity-0 link-underline-opacity-100-hover\" href=\"https://www.playstation.com/en-us/support/account/privacy-settings-psn/\">private</a> profile. Make sure this player is no longer private, and then issue a new scan of the profile on the front page.";
+                break;
+            case 4:
+                $alerts[] = 'This player has not played a game in over a year and is considered inactive by this site. All data from this player will be excluded from site statistics and leaderboards.';
+                break;
+            case 5:
+                $alerts[] = 'This player seems to no longer be available from Sony, maybe removed for some reason. We will recheck after 24h and if this player is still not available it will be removed from here as well.';
+                break;
+            case 99:
+                $alerts[] = 'This is a new player currently being scanned for the first time. Rank and stats will be done once the scan is complete.';
+                break;
+        }
+
+        if ($this->isUnranked()) {
+            $alerts[] = "This player isn't ranked within the top 10000 and will not have their trophies contributed to the site statistics.";
+        }
+
+        if ($this->hasHiddenTrophies()) {
+            $alerts[] = sprintf(
+                'This player has <a href="https://www.playstation.com/en-us/support/games/hide-games-playstation-library/">hidden %s of their trophies</a>.',
+                number_format($this->getHiddenTrophyCount())
+            );
+        }
+
+        return $alerts;
+    }
+
+    public function hasLastUpdatedDate(): bool
+    {
+        $lastUpdated = $this->player['last_updated_date'] ?? null;
+
+        return is_string($lastUpdated) && $lastUpdated !== '';
+    }
+
+    public function getLastUpdatedDate(): ?string
+    {
+        if (!$this->hasLastUpdatedDate()) {
+            return null;
+        }
+
+        return (string) $this->player['last_updated_date'];
+    }
+
+    public function getCountryCode(): string
+    {
+        return (string) ($this->player['country'] ?? '');
+    }
+
+    public function getOnlineId(): string
+    {
+        return (string) ($this->player['online_id'] ?? '');
+    }
+
+    private function getAccountId(): int
+    {
+        return (int) ($this->player['account_id'] ?? 0);
+    }
+
+    private function getStatus(): int
+    {
+        return (int) ($this->player['status'] ?? 0);
+    }
+
+    private function hasHiddenTrophies(): bool
+    {
+        if ($this->getStatus() === 3) {
+            return false;
+        }
+
+        return $this->getHiddenTrophyCount() > 0;
+    }
+
+    private function getHiddenTrophyCount(): int
+    {
+        $sonyCount = (int) ($this->player['trophy_count_sony'] ?? 0);
+        $npwrCount = (int) ($this->player['trophy_count_npwr'] ?? 0);
+
+        return max(0, $sonyCount - $npwrCount);
+    }
+
+    private function isUnranked(): bool
+    {
+        return (int) ($this->player['ranking'] ?? 0) > 10000;
+    }
+}
+

--- a/wwwroot/player_header.php
+++ b/wwwroot/player_header.php
@@ -1,81 +1,25 @@
 <?php
-$aboutMe = nl2br(htmlentities($player["about_me"], ENT_QUOTES, 'UTF-8'));
-$countryName = $utility->getCountryName($player["country"]);
-$trophies = $player["bronze"] + $player["silver"] + $player["gold"] + $player["platinum"];
-$numberOfGames = $playerSummary->getNumberOfGames();
-$numberOfCompletedGames = $playerSummary->getNumberOfCompletedGames();
-$averageProgress = $playerSummary->getAverageProgress();
-$unearnedTrophies = $playerSummary->getUnearnedTrophies();
+require_once __DIR__ . '/classes/PlayerHeaderViewModel.php';
+
+$playerHeaderViewModel = new PlayerHeaderViewModel($player, $playerSummary, $utility);
+$alerts = $playerHeaderViewModel->getAlerts();
 ?>
 
 <div class="row">
-    <?php
-    if ($player["status"] == 1) {
-        ?>
+    <?php foreach ($alerts as $alert) { ?>
         <div class="col-12">
             <div class="alert alert-warning" role="alert">
-                This player has some funny looking trophy data. This doesn't necessarily mean cheating, but all data from this player will be excluded from site statistics and leaderboards. <a href="https://github.com/Ragowit/psn100/issues?q=label%3Acheater+<?= $player["online_id"]; ?>+OR+<?= $player["account_id"]; ?>">Dispute</a>?
+                <?= $alert; ?>
             </div>
         </div>
-        <?php
-    } elseif ($player["status"] == 3) {
-        ?>
-        <div class="col-12">
-            <div class="alert alert-warning" role="alert">
-                This player seems to have a <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="https://www.playstation.com/en-us/support/account/privacy-settings-psn/">private</a> profile. Make sure this player is no longer private, and then issue a new scan of the profile on the front page.
-            </div>
-        </div>
-        <?php
-    } elseif ($player["status"] == 4) {
-        ?>
-        <div class="col-12">
-            <div class="alert alert-warning" role="alert">
-                This player has not played a game in over a year and is considered inactive by this site. All data from this player will be excluded from site statistics and leaderboards.
-            </div>
-        </div>
-        <?php
-    } elseif ($player["status"] == 5) {
-        ?>
-        <div class="col-12">
-            <div class="alert alert-warning" role="alert">
-                This player seems to no longer be available from Sony, maybe removed for some reason. We will recheck after 24h and if this player is still not available it will be removed from here as well.
-            </div>
-        </div>
-        <?php
-    }  elseif ($player["status"] == 99) {
-        ?>
-        <div class="col-12">
-            <div class="alert alert-warning" role="alert">
-                This is a new player currently being scanned for the first time. Rank and stats will be done once the scan is complete.
-            </div>
-        </div>
-        <?php
-    } elseif ($player["ranking"] > 10000) {
-        ?>
-        <div class="col-12">
-            <div class="alert alert-warning" role="alert">
-                This player isn't ranked within the top 10000 and will not have their trophies contributed to the site statistics.
-            </div>
-        </div>
-        <?php
-    }
-    if ($player["trophy_count_npwr"] < $player["trophy_count_sony"] && $player["status"] !== 3) {
-        ?>
-        <div class="col-12">
-            <div class="alert alert-warning" role="alert">
-                This player has <a href="https://www.playstation.com/en-us/support/games/hide-games-playstation-library/">hidden <?= ($player["trophy_count_sony"] - $player["trophy_count_npwr"]); ?> of their trophies</a>.
-            </div>
-        </div>
-        <?php
-    }
-    ?>
+    <?php } ?>
 </div>
 
 <div class="row">
     <div class="col-12 col-lg-4 mb-3">
         <div class="vstack gap-1 bg-body-tertiary p-3 rounded">
             <div>
-                <h1 title="<?= $aboutMe; ?>"><?= $player["online_id"] ?></h1>
+                <h1 title="<?= $playerHeaderViewModel->getAboutMe(); ?>"><?= $player["online_id"] ?></h1>
             </div>
 
             <div class="hstack gap-3">
@@ -87,7 +31,7 @@ $unearnedTrophies = $playerSummary->getUnearnedTrophies();
                     <div class="hstack">
                         <div class="vstack">
                             <?php
-                            if ($player["status"] == 1 || $player["status"] == 3) {
+                            if (!$playerHeaderViewModel->canShowPlayerStats()) {
                                 echo "N/A";
                             } else {
                                 ?>
@@ -108,17 +52,19 @@ $unearnedTrophies = $playerSummary->getUnearnedTrophies();
                         </div>
 
                         <div class="ms-auto">
-                            <img src="/img/country/<?= $player["country"]; ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName ?>" height="50" width="50" style="border-radius: 50%;" />
+                            <?php $countryName = htmlentities($playerHeaderViewModel->getCountryName(), ENT_QUOTES, 'UTF-8'); ?>
+                            <img src="/img/country/<?= $playerHeaderViewModel->getCountryCode(); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
                         </div>
                     </div>
 
                     <div>
                         <small>Last Updated: <span id="lastUpdate"></span></small>
                         <?php
-                        if (!is_null($player["last_updated_date"])) {
+                        if ($playerHeaderViewModel->hasLastUpdatedDate()) {
+                            $lastUpdatedDate = $playerHeaderViewModel->getLastUpdatedDate();
                             ?>
                             <script>
-                                document.getElementById("lastUpdate").innerHTML = new Date('<?= $player["last_updated_date"]; ?> UTC').toLocaleString('sv-SE');
+                                document.getElementById("lastUpdate").innerHTML = new Date('<?= $lastUpdatedDate; ?> UTC').toLocaleString('sv-SE');
                             </script>
                             <?php
                         }
@@ -129,11 +75,11 @@ $unearnedTrophies = $playerSummary->getUnearnedTrophies();
 
             <div class="text-center bg-dark-subtle p-3 rounded">
                 <?php
-                if ($player["status"] == 1 || $player["status"] == 3) {
+                if (!$playerHeaderViewModel->canShowPlayerStats()) {
                     echo "N/A";
                 } else {
                     ?>
-                    <?= number_format($trophies); ?> Trophies<br>
+                    <?= number_format($playerHeaderViewModel->getTotalTrophies()); ?> Trophies<br>
                     <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= number_format($player["platinum"]); ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= number_format($player["gold"]); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= number_format($player["silver"]); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= number_format($player["bronze"]); ?></span><br>
                     <span class="trophy-legendary" title="Legendary"><?= number_format($player["legendary"]); ?></span> &bull; <span class="trophy-epic" title="Epic"><?= number_format($player["epic"]); ?></span> &bull; <span class="trophy-rare" title="Rare"><?= number_format($player["rare"]); ?></span> &bull; <span class="trophy-uncommon" title="Uncommon"><?= number_format($player["uncommon"]); ?></span> &bull; <span class="trophy-common" title="Common"><?= number_format($player["common"]); ?></span>
                     <?php
@@ -150,11 +96,11 @@ $unearnedTrophies = $playerSummary->getUnearnedTrophies();
                     Games
                     <hr class="m-2">
                     <?php
-                    if ($player["status"] == 1 || $player["status"] == 3) {
+                    if (!$playerHeaderViewModel->canShowPlayerStats()) {
                         echo "N/A";
                     } else {
                         ?>
-                        <h2><?= number_format($numberOfGames); ?></h2>
+                        <h2><?= number_format($playerHeaderViewModel->getNumberOfGames()); ?></h2>
                         <?php
                     }
                     ?>
@@ -164,11 +110,11 @@ $unearnedTrophies = $playerSummary->getUnearnedTrophies();
                     100% Completion
                     <hr class="m-2">
                     <?php
-                    if ($player["status"] == 1 || $player["status"] == 3) {
+                    if (!$playerHeaderViewModel->canShowPlayerStats()) {
                         echo "N/A";
                     } else {
                         ?>
-                        <h2><?= number_format($numberOfCompletedGames); ?></h2>
+                        <h2><?= number_format($playerHeaderViewModel->getNumberOfCompletedGames()); ?></h2>
                         <?php
                     }
                     ?>
@@ -268,11 +214,11 @@ $unearnedTrophies = $playerSummary->getUnearnedTrophies();
                     Average Progress
                     <hr class="m-2">
                     <?php
-                    if ($player["status"] == 1 || $player["status"] == 3) {
+                    if (!$playerHeaderViewModel->canShowPlayerStats()) {
                         echo "N/A";
                     } else {
                         ?>
-                        <h2><?= number_format($averageProgress ?? 0.0, 2); ?>%</h2>
+                        <h2><?= number_format($playerHeaderViewModel->getAverageProgress() ?? 0.0, 2); ?>%</h2>
                         <?php
                     }
                     ?>
@@ -282,11 +228,11 @@ $unearnedTrophies = $playerSummary->getUnearnedTrophies();
                     Unearned Trophies
                     <hr class="m-2">
                     <?php
-                    if ($player["status"] == 1 || $player["status"] == 3) {
+                    if (!$playerHeaderViewModel->canShowPlayerStats()) {
                         echo "N/A";
                     } else {
                         ?>
-                        <h2><?= number_format($unearnedTrophies); ?></h2>
+                        <h2><?= number_format($playerHeaderViewModel->getUnearnedTrophies()); ?></h2>
                         <?php
                     }
                     ?>


### PR DESCRIPTION
## Summary
- introduce PlayerHeaderViewModel to encapsulate player header calculations and alerts
- update player_header.php to consume the new view model for status alerts and statistics display

## Testing
- php -l wwwroot/classes/PlayerHeaderViewModel.php
- php -l wwwroot/player_header.php

------
https://chatgpt.com/codex/tasks/task_e_68d4510bb494832fac0733de35121374