### PR TITLE
Refactor leaderboard pages to use row objects

### DIFF
--- a/wwwroot/classes/Leaderboard/AbstractLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/AbstractLeaderboardRow.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../PlayerLeaderboardFilter.php';
+require_once __DIR__ . '/../Utility.php';
+
+abstract class AbstractLeaderboardRow
+{
+    private const NEW_PLAYER_RANK_VALUE = 16777215;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $player;
+
+    private PlayerLeaderboardFilter $filter;
+
+    private Utility $utility;
+
+    private ?string $highlightedPlayerId;
+
+    /**
+     * @var array<string, int|string>
+     */
+    private array $filterParameters;
+
+    private string $rankingField;
+
+    private string $rankingLastWeekField;
+
+    private string $countryRankingField;
+
+    private string $countryRankingLastWeekField;
+
+    /**
+     * @param array<string, mixed> $player
+     * @param array<string, int|string> $filterParameters
+     */
+    public function __construct(
+        array $player,
+        PlayerLeaderboardFilter $filter,
+        Utility $utility,
+        ?string $highlightedPlayerId,
+        array $filterParameters,
+        string $rankingField,
+        string $rankingLastWeekField,
+        string $countryRankingField,
+        string $countryRankingLastWeekField
+    ) {
+        $this->player = $player;
+        $this->filter = $filter;
+        $this->utility = $utility;
+        $this->highlightedPlayerId = $highlightedPlayerId !== null ? trim($highlightedPlayerId) : null;
+        $this->filterParameters = $filterParameters;
+        $this->rankingField = $rankingField;
+        $this->rankingLastWeekField = $rankingLastWeekField;
+        $this->countryRankingField = $countryRankingField;
+        $this->countryRankingLastWeekField = $countryRankingLastWeekField;
+    }
+
+    public function getRowId(): string
+    {
+        return (string) ($this->player['online_id'] ?? '');
+    }
+
+    public function getRowCssClass(): string
+    {
+        return $this->isHighlighted() ? 'table-primary' : '';
+    }
+
+    public function getOnlineId(): string
+    {
+        return (string) ($this->player['online_id'] ?? '');
+    }
+
+    public function getAvatarUrl(): string
+    {
+        return (string) ($this->player['avatar_url'] ?? '');
+    }
+
+    public function getCountryCode(): string
+    {
+        return (string) ($this->player['country'] ?? '');
+    }
+
+    public function getCountryName(): string
+    {
+        return $this->utility->getCountryName($this->getCountryCode());
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    public function getAvatarQueryParameters(): array
+    {
+        $parameters = $this->filterParameters;
+        $parameters['avatar'] = $this->getAvatarUrl();
+
+        return $parameters;
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    public function getCountryQueryParameters(): array
+    {
+        $parameters = $this->filterParameters;
+        $parameters['country'] = $this->getCountryCode();
+
+        return $parameters;
+    }
+
+    public function getLevel(): int
+    {
+        return (int) ($this->player['level'] ?? 0);
+    }
+
+    public function getProgress(): int
+    {
+        return (int) ($this->player['progress'] ?? 0);
+    }
+
+    public function getRankCellHtml(): string
+    {
+        if ($this->filter->hasCountry()) {
+            return $this->renderRankCell(
+                (int) ($this->player[$this->countryRankingField] ?? 0),
+                (int) ($this->player[$this->countryRankingLastWeekField] ?? 0)
+            );
+        }
+
+        return $this->renderRankCell(
+            (int) ($this->player[$this->rankingField] ?? 0),
+            (int) ($this->player[$this->rankingLastWeekField] ?? 0)
+        );
+    }
+
+    public function hasHiddenTrophies(): bool
+    {
+        return (int) ($this->player['trophy_count_npwr'] ?? 0) < (int) ($this->player['trophy_count_sony'] ?? 0);
+    }
+
+    public function getHiddenIndicatorHtml(): string
+    {
+        if (!$this->hasHiddenTrophies()) {
+            return '';
+        }
+
+        return " <span style='color: #9d9d9d;'>(H)</span>";
+    }
+
+    protected function getInt(string $key): int
+    {
+        return (int) ($this->player[$key] ?? 0);
+    }
+
+    private function renderRankCell(int $currentRank, int $previousRank): string
+    {
+        if ($previousRank === 0 || $previousRank === self::NEW_PLAYER_RANK_VALUE) {
+            return 'New!' . $this->getHiddenIndicatorHtml();
+        }
+
+        $delta = $previousRank - $currentRank;
+        $parts = ["<div class='vstack'>"];
+
+        if ($delta > 0) {
+            $parts[] = "<span style='color: #0bd413; cursor: default;' title='+" . $delta . "'>&#9650;</span>";
+        }
+
+        $parts[] = (string) $currentRank . $this->getHiddenIndicatorHtml();
+
+        if ($delta < 0) {
+            $parts[] = "<span style='color: #d40b0b; cursor: default;' title='" . $delta . "'>&#9660;</span>";
+        }
+
+        $parts[] = '</div>';
+
+        return implode('', $parts);
+    }
+
+    private function isHighlighted(): bool
+    {
+        $onlineId = $this->getOnlineId();
+
+        if ($onlineId === '') {
+            return false;
+        }
+
+        return $this->highlightedPlayerId !== null && strcasecmp($this->highlightedPlayerId, $onlineId) === 0;
+    }
+}

--- a/wwwroot/classes/Leaderboard/RarityLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/RarityLeaderboardRow.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/AbstractLeaderboardRow.php';
+
+class RarityLeaderboardRow extends AbstractLeaderboardRow
+{
+    /**
+     * @param array<string, mixed> $player
+     * @param array<string, int|string> $filterParameters
+     */
+    public function __construct(
+        array $player,
+        PlayerLeaderboardFilter $filter,
+        Utility $utility,
+        ?string $highlightedPlayerId,
+        array $filterParameters
+    ) {
+        parent::__construct(
+            $player,
+            $filter,
+            $utility,
+            $highlightedPlayerId,
+            $filterParameters,
+            'ranking',
+            'rarity_rank_last_week',
+            'ranking_country',
+            'rarity_rank_country_last_week'
+        );
+    }
+
+    public function getLegendaryCount(): int
+    {
+        return $this->getInt('legendary');
+    }
+
+    public function getEpicCount(): int
+    {
+        return $this->getInt('epic');
+    }
+
+    public function getRareCount(): int
+    {
+        return $this->getInt('rare');
+    }
+
+    public function getUncommonCount(): int
+    {
+        return $this->getInt('uncommon');
+    }
+
+    public function getCommonCount(): int
+    {
+        return $this->getInt('common');
+    }
+
+    public function getRarityPoints(): int
+    {
+        return $this->getInt('rarity_points');
+    }
+}

--- a/wwwroot/classes/Leaderboard/TrophyLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/TrophyLeaderboardRow.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/AbstractLeaderboardRow.php';
+
+class TrophyLeaderboardRow extends AbstractLeaderboardRow
+{
+    /**
+     * @param array<string, mixed> $player
+     * @param array<string, int|string> $filterParameters
+     */
+    public function __construct(
+        array $player,
+        PlayerLeaderboardFilter $filter,
+        Utility $utility,
+        ?string $highlightedPlayerId,
+        array $filterParameters
+    ) {
+        parent::__construct(
+            $player,
+            $filter,
+            $utility,
+            $highlightedPlayerId,
+            $filterParameters,
+            'ranking',
+            'rank_last_week',
+            'ranking_country',
+            'rank_country_last_week'
+        );
+    }
+
+    public function getPlatinumCount(): int
+    {
+        return $this->getInt('platinum');
+    }
+
+    public function getGoldCount(): int
+    {
+        return $this->getInt('gold');
+    }
+
+    public function getSilverCount(): int
+    {
+        return $this->getInt('silver');
+    }
+
+    public function getBronzeCount(): int
+    {
+        return $this->getInt('bronze');
+    }
+
+    public function getTotalTrophies(): int
+    {
+        return $this->getPlatinumCount()
+            + $this->getGoldCount()
+            + $this->getSilverCount()
+            + $this->getBronzeCount();
+    }
+
+    public function getPoints(): int
+    {
+        return $this->getInt('points');
+    }
+}

--- a/wwwroot/leaderboard_main.php
+++ b/wwwroot/leaderboard_main.php
@@ -2,6 +2,7 @@
 require_once 'classes/PlayerLeaderboardFilter.php';
 require_once 'classes/PlayerLeaderboardService.php';
 require_once 'classes/PlayerLeaderboardPage.php';
+require_once 'classes/Leaderboard/TrophyLeaderboardRow.php';
 
 $title = "PSN Trophy Leaderboard ~ PSN 100%";
 require_once("header.php");
@@ -13,6 +14,18 @@ $playerLeaderboardPage = new PlayerLeaderboardPage($playerLeaderboardService, $p
 $players = $playerLeaderboardPage->getPlayers();
 $filterParameters = $playerLeaderboardPage->getFilterParameters();
 $pageParameters = $playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getCurrentPage());
+$highlightedPlayerId = isset($_GET['player']) ? (string) $_GET['player'] : null;
+
+$rows = array_map(
+    static fn(array $player) => new TrophyLeaderboardRow(
+        $player,
+        $playerLeaderboardFilter,
+        $utility,
+        $highlightedPlayerId,
+        $filterParameters
+    ),
+    $players
+);
 ?>
 
 <main class="container">
@@ -60,109 +73,45 @@ $pageParameters = $playerLeaderboardPage->getPageQueryParameters($playerLeaderbo
                         </thead>
 
                         <tbody>
-                            <?php
-                            foreach ($players as $player) {
-                                $trophies = $player["bronze"] + $player["silver"] + $player["gold"] + $player["platinum"];
-                                $countryName = $utility->getCountryName($player["country"]);
-                                if (isset($_GET["player"]) && $_GET["player"] == $player["online_id"]) {
-                                    echo "<tr id=\"". $player["online_id"] ."\" class=\"table-primary\">";
-                                } else {
-                                    echo "<tr id=\"". $player["online_id"] ."\">";
-                                }
+                            <?php foreach ($rows as $row) { ?>
+                                <tr id="<?= htmlspecialchars($row->getRowId(), ENT_QUOTES, 'UTF-8'); ?>"<?= $row->getRowCssClass() !== '' ? ' class="' . $row->getRowCssClass() . '"' : ''; ?>>
+                                    <th scope="row" class="text-center align-middle">
+                                        <?= $row->getRankCellHtml(); ?>
+                                    </th>
+                                    <td class="align-middle">
+                                        <div class="hstack gap-3">
+                                            <div>
+                                                <a href="?<?= http_build_query($row->getAvatarQueryParameters()); ?>">
+                                                    <img src="/img/avatar/<?= htmlspecialchars($row->getAvatarUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="" height="50" width="50" />
+                                                </a>
+                                            </div>
 
-                                $paramsAvatar = $filterParameters;
-                                $paramsAvatar["avatar"] = $player["avatar_url"];
-                                $paramsCountry = $filterParameters;
-                                $paramsCountry["country"] = $player["country"];
-                                ?>
-                                <th scope="row" class="text-center align-middle">
-                                    <?php
-                                    if ($playerLeaderboardFilter->hasCountry()) {
-                                        if ($player["rank_country_last_week"] == 0 || $player["rank_country_last_week"] == 16777215) {
-                                            echo "New!";
-                                            if ($player["trophy_count_npwr"] < $player["trophy_count_sony"]) {
-                                                echo " <span style='color: #9d9d9d;'>(H)</span>";
-                                            }
-                                        } else {
-                                            $delta = $player["rank_country_last_week"] - $player["ranking_country"];
+                                            <div>
+                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/player/<?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
+                                            </div>
 
-                                            echo "<div class='vstack'>";
-                                            if ($delta > 0) {
-                                                echo "<span style='color: #0bd413; cursor: default;' title='+". $delta ."'>&#9650;</span>";
-                                            }
-                                            
-                                            echo $player["ranking_country"];
-                                            if ($player["trophy_count_npwr"] < $player["trophy_count_sony"]) {
-                                                echo " <span style='color: #9d9d9d;'>(H)</span>";
-                                            }
-
-                                            if ($delta < 0) {
-                                                echo "<span style='color: #d40b0b; cursor: default;' title='". $delta ."'>&#9660;</span>";
-                                            } 
-                                            echo "</div>";
-                                        }
-                                    } else {
-                                        if ($player["rank_last_week"] == 0 || $player["rank_last_week"] == 16777215) {
-                                            echo "New!";
-                                            if ($player["trophy_count_npwr"] < $player["trophy_count_sony"]) {
-                                                echo " <span style='color: #9d9d9d;'>(H)</span>";
-                                            }
-                                        } else {
-                                            $delta = $player["rank_last_week"] - $player["ranking"];
-            
-                                            echo "<div class='vstack'>";
-                                            if ($delta > 0) {
-                                                echo "<span style='color: #0bd413; cursor: default;' title='+". $delta ."'>&#9650;</span>";
-                                            }
-                                            
-                                            echo $player["ranking"];
-                                            if ($player["trophy_count_npwr"] < $player["trophy_count_sony"]) {
-                                                echo " <span style='color: #9d9d9d;'>(H)</span>";
-                                            }
-
-                                            if ($delta < 0) {
-                                                echo "<span style='color: #d40b0b; cursor: default;' title='". $delta ."'>&#9660;</span>";
-                                            } 
-                                            echo "</div>";
-                                        }
-                                    }
-                                    ?>
-                                </th>
-                                <td class="align-middle">
-                                    <div class="hstack gap-3">
-                                        <div>
-                                            <a href="?<?= http_build_query($paramsAvatar); ?>">
-                                                <img src="/img/avatar/<?= $player["avatar_url"]; ?>" alt="" height="50" width="50" />
-                                            </a>
+                                            <div class="ms-auto">
+                                                <a href="?<?= http_build_query($row->getCountryQueryParameters()); ?>">
+                                                    <?php $countryName = htmlspecialchars($row->getCountryName(), ENT_QUOTES, 'UTF-8'); ?>
+                                                    <img src="/img/country/<?= htmlspecialchars($row->getCountryCode(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
+                                                </a>
+                                            </div>
                                         </div>
-
-                                        <div>
-                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/player/<?= $player["online_id"]; ?>"><?= $player["online_id"]; ?></a>
+                                    </td>
+                                    <td class="text-center">
+                                        <img src="/img/star.svg" class="mb-1" alt="Level" title="Level" height="18" /> <?= number_format($row->getLevel()); ?>
+                                        <div class="progress" title="<?= $row->getProgress(); ?>%">
+                                            <div class="progress-bar bg-primary" role="progressbar" style="width: <?= $row->getProgress(); ?>%" aria-valuenow="<?= $row->getProgress(); ?>" aria-valuemin="0" aria-valuemax="100"></div>
                                         </div>
-
-                                        <div class="ms-auto">
-                                            <a href="?<?= http_build_query($paramsCountry); ?>">
-                                                <img src="/img/country/<?= $player["country"]; ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
-                                            </a>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="text-center">
-                                    <img src="/img/star.svg" class="mb-1" alt="Level" title="Level" height="18" /> <?= number_format($player["level"]); ?>
-                                    <div class="progress" title="<?= $player["progress"]; ?>%">
-                                        <div class="progress-bar bg-primary" role="progressbar" style="width: <?= $player["progress"]; ?>%" aria-valuenow="<?= $player["progress"]; ?>" aria-valuemin="0" aria-valuemax="100"></div>
-                                    </div>
-                                </td>
-                                <td class="text-center align-middle"><img src="/img/trophy-platinum.svg" alt="Platinum" height="18" /> <span class="trophy-platinum"><?= number_format($player["platinum"]); ?></span></td>
-                                <td class="text-center align-middle"><img src="/img/trophy-gold.svg" alt="Gold" height="18" /> <span class="trophy-gold"><?= number_format($player["gold"]); ?></span></td>
-                                <td class="text-center align-middle"><img src="/img/trophy-silver.svg" alt="Silver" height="18" /> <span class="trophy-silver"><?= number_format($player["silver"]); ?></span></td>
-                                <td class="text-center align-middle"><img src="/img/trophy-bronze.svg" alt="Bronze" height="18" /> <span class="trophy-bronze"><?= number_format($player["bronze"]); ?></span></td>
-                                <td class="text-center align-middle"><?= number_format($trophies); ?></td>
-                                <td class="text-center align-middle"><?= number_format($player["points"]); ?></td>
-                                <?php
-                                echo "</tr>";
-                            }
-                            ?>
+                                    </td>
+                                    <td class="text-center align-middle"><img src="/img/trophy-platinum.svg" alt="Platinum" height="18" /> <span class="trophy-platinum"><?= number_format($row->getPlatinumCount()); ?></span></td>
+                                    <td class="text-center align-middle"><img src="/img/trophy-gold.svg" alt="Gold" height="18" /> <span class="trophy-gold"><?= number_format($row->getGoldCount()); ?></span></td>
+                                    <td class="text-center align-middle"><img src="/img/trophy-silver.svg" alt="Silver" height="18" /> <span class="trophy-silver"><?= number_format($row->getSilverCount()); ?></span></td>
+                                    <td class="text-center align-middle"><img src="/img/trophy-bronze.svg" alt="Bronze" height="18" /> <span class="trophy-bronze"><?= number_format($row->getBronzeCount()); ?></span></td>
+                                    <td class="text-center align-middle"><?= number_format($row->getTotalTrophies()); ?></td>
+                                    <td class="text-center align-middle"><?= number_format($row->getPoints()); ?></td>
+                                </tr>
+                            <?php } ?>
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
## Summary
- add reusable leaderboard row classes to encapsulate ranking display logic
- update trophy and rarity leaderboard pages to render via row objects and reuse formatting helpers

## Testing
- php -l wwwroot/classes/Leaderboard/AbstractLeaderboardRow.php
- php -l wwwroot/classes/Leaderboard/TrophyLeaderboardRow.php
- php -l wwwroot/classes/Leaderboard/RarityLeaderboardRow.php
- php -l wwwroot/leaderboard_main.php
- php -l wwwroot/leaderboard_rarity.php

------
https://chatgpt.com/codex/tasks/task_e_68d46150d480832fb453df7bf0e4d4b2