### PR TITLE
Refactor admin game reset handling

### DIFF
--- a/wwwroot/admin/reset.php
+++ b/wwwroot/admin/reset.php
@@ -1,21 +1,20 @@
 <?php
-require_once("../init.php");
-require_once("../classes/GameResetService.php");
+
+declare(strict_types=1);
+
+require_once '../init.php';
+require_once '../classes/GameResetService.php';
+require_once '../classes/Admin/GameResetRequestHandler.php';
 
 $gameResetService = new GameResetService($database);
-$success = null;
+$requestHandler = new GameResetRequestHandler($gameResetService);
 
-if (isset($_POST["game"]) && ctype_digit((string) $_POST["game"])) {
-    $gameId = (int) $_POST["game"];
-    $status = isset($_POST["status"]) ? (int) $_POST["status"] : 0;
+$requestMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$postData = $_POST ?? [];
 
-    try {
-        $message = $gameResetService->process($gameId, $status);
-        $success = "<p>{$message}</p>";
-    } catch (InvalidArgumentException $exception) {
-        $success = $exception->getMessage();
-    }
-}
+$result = $requestHandler->handleRequest($requestMethod, $postData);
+$success = $result->getSuccessMessage();
+$error = $result->getErrorMessage();
 
 ?>
 <!doctype html>
@@ -42,6 +41,10 @@ if (isset($_POST["game"]) && ctype_digit((string) $_POST["game"])) {
             </form>
 
             <?php
+            if ($error !== null) {
+                echo $error;
+            }
+
             if ($success !== null) {
                 echo $success;
             }

--- a/wwwroot/classes/Admin/GameResetRequestHandler.php
+++ b/wwwroot/classes/Admin/GameResetRequestHandler.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/GameResetRequestResult.php';
+require_once __DIR__ . '/../GameResetService.php';
+
+class GameResetRequestHandler
+{
+    private GameResetService $gameResetService;
+
+    public function __construct(GameResetService $gameResetService)
+    {
+        $this->gameResetService = $gameResetService;
+    }
+
+    /**
+     * @param array<string, mixed> $postData
+     */
+    public function handleRequest(string $requestMethod, array $postData): GameResetRequestResult
+    {
+        if (strtoupper($requestMethod) !== 'POST') {
+            return GameResetRequestResult::empty();
+        }
+
+        $gameId = $this->parsePositiveInt($postData['game'] ?? null);
+        if ($gameId === null) {
+            return GameResetRequestResult::error('<p>Please provide a valid game ID.</p>');
+        }
+
+        $action = $this->parseAction($postData['status'] ?? null);
+        if ($action === null) {
+            return GameResetRequestResult::error('<p>Please choose a valid action.</p>');
+        }
+
+        try {
+            $message = $this->gameResetService->process($gameId, $action);
+
+            return GameResetRequestResult::success('<p>' . $this->escape($message) . '</p>');
+        } catch (InvalidArgumentException $exception) {
+            $message = $this->escape($exception->getMessage());
+
+            return GameResetRequestResult::error('<p>' . $message . '</p>');
+        } catch (Throwable $exception) {
+            return GameResetRequestResult::error('<p>Failed to process the request. Please try again.</p>');
+        }
+    }
+
+    private function parsePositiveInt(mixed $value): ?int
+    {
+        if (!is_scalar($value)) {
+            return null;
+        }
+
+        $filtered = filter_var($value, FILTER_VALIDATE_INT);
+        if ($filtered === false) {
+            return null;
+        }
+
+        $number = (int) $filtered;
+        if ($number <= 0) {
+            return null;
+        }
+
+        return $number;
+    }
+
+    private function parseAction(mixed $value): ?int
+    {
+        if (!is_scalar($value)) {
+            return null;
+        }
+
+        $filtered = filter_var($value, FILTER_VALIDATE_INT);
+        if ($filtered === false) {
+            return null;
+        }
+
+        $action = (int) $filtered;
+        if (!in_array($action, [0, 1], true)) {
+            return null;
+        }
+
+        return $action;
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/wwwroot/classes/Admin/GameResetRequestResult.php
+++ b/wwwroot/classes/Admin/GameResetRequestResult.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+class GameResetRequestResult
+{
+    private ?string $successMessage;
+
+    private ?string $errorMessage;
+
+    private function __construct(?string $successMessage, ?string $errorMessage)
+    {
+        $this->successMessage = $successMessage;
+        $this->errorMessage = $errorMessage;
+    }
+
+    public static function success(string $message): self
+    {
+        return new self($message, null);
+    }
+
+    public static function error(string $message): self
+    {
+        return new self(null, $message);
+    }
+
+    public static function empty(): self
+    {
+        return new self(null, null);
+    }
+
+    public function getSuccessMessage(): ?string
+    {
+        return $this->successMessage;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `GameResetRequestHandler` and `GameResetRequestResult` classes to encapsulate admin reset processing
- update `admin/reset.php` to delegate request handling to the new OOP flow and keep responses sanitized

## Testing
- php -l wwwroot/classes/Admin/GameResetRequestHandler.php
- php -l wwwroot/classes/Admin/GameResetRequestResult.php
- php -l wwwroot/admin/reset.php

------
https://chatgpt.com/codex/tasks/task_e_68d4e4e3c688832fa3505ead3aeb824b