### PR TITLE
Refactor game leaderboard assembly into page object

### DIFF
--- a/wwwroot/classes/GameLeaderboardPage.php
+++ b/wwwroot/classes/GameLeaderboardPage.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/GamePlayerFilter.php';
+require_once __DIR__ . '/GameLeaderboardFilter.php';
+require_once __DIR__ . '/GameLeaderboardService.php';
+require_once __DIR__ . '/GameHeaderService.php';
+require_once __DIR__ . '/GameNotFoundException.php';
+require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
+
+class GameLeaderboardPage
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $game;
+
+    private GameHeaderData $gameHeaderData;
+
+    private GameLeaderboardFilter $filter;
+
+    private int $totalPlayers;
+
+    private int $limit;
+
+    private int $offset;
+
+    private int $totalPagesCount;
+
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private array $rows;
+
+    private ?string $playerAccountId;
+
+    /**
+     * @param array<string, mixed> $game
+     * @param array<int, array<string, mixed>> $rows
+     */
+    private function __construct(
+        array $game,
+        GameHeaderData $gameHeaderData,
+        GameLeaderboardFilter $filter,
+        int $totalPlayers,
+        int $limit,
+        int $offset,
+        int $totalPagesCount,
+        array $rows,
+        ?string $playerAccountId
+    ) {
+        $this->game = $game;
+        $this->gameHeaderData = $gameHeaderData;
+        $this->filter = $filter;
+        $this->totalPlayers = $totalPlayers;
+        $this->limit = $limit;
+        $this->offset = $offset;
+        $this->totalPagesCount = $totalPagesCount;
+        $this->rows = $rows;
+        $this->playerAccountId = $playerAccountId;
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     *
+     * @throws GameNotFoundException
+     * @throws GameLeaderboardPlayerNotFoundException
+     */
+    public static function create(
+        GameLeaderboardService $leaderboardService,
+        GameHeaderService $headerService,
+        int $gameId,
+        ?string $player,
+        array $queryParameters
+    ): self {
+        $game = $leaderboardService->getGame($gameId);
+        if ($game === null) {
+            throw new GameNotFoundException('Game not found.');
+        }
+
+        $playerAccountId = null;
+        if ($player !== null) {
+            $playerAccountId = $leaderboardService->getPlayerAccountId($player);
+
+            if ($playerAccountId === null) {
+                $gameIdValue = (int) ($game['id'] ?? 0);
+                $gameName = (string) ($game['name'] ?? '');
+
+                throw new GameLeaderboardPlayerNotFoundException($gameIdValue, $gameName);
+            }
+        }
+
+        $filter = GameLeaderboardFilter::fromArray($queryParameters);
+        $limit = GameLeaderboardService::PAGE_SIZE;
+        $offset = $filter->getOffset($limit);
+        $totalPlayers = $leaderboardService->getLeaderboardPlayerCount(
+            (string) $game['np_communication_id'],
+            $filter
+        );
+        $rows = $leaderboardService->getLeaderboardRows(
+            (string) $game['np_communication_id'],
+            $filter,
+            $limit
+        );
+        $totalPagesCount = $limit > 0 ? (int) ceil($totalPlayers / $limit) : 0;
+
+        $gameHeaderData = $headerService->buildHeaderData($game);
+
+        return new self(
+            $game,
+            $gameHeaderData,
+            $filter,
+            $totalPlayers,
+            $limit,
+            $offset,
+            $totalPagesCount,
+            $rows,
+            $playerAccountId
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getGame(): array
+    {
+        return $this->game;
+    }
+
+    public function getGameHeaderData(): GameHeaderData
+    {
+        return $this->gameHeaderData;
+    }
+
+    public function getFilter(): GameLeaderboardFilter
+    {
+        return $this->filter;
+    }
+
+    public function getTotalPlayers(): int
+    {
+        return $this->totalPlayers;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function getTotalPagesCount(): int
+    {
+        return $this->totalPagesCount;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getRows(): array
+    {
+        return $this->rows;
+    }
+
+    public function getPlayerAccountId(): ?string
+    {
+        return $this->playerAccountId;
+    }
+
+    public function getPage(): int
+    {
+        return $this->filter->getPage();
+    }
+}

--- a/wwwroot/classes/GameLeaderboardPlayerNotFoundException.php
+++ b/wwwroot/classes/GameLeaderboardPlayerNotFoundException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+class GameLeaderboardPlayerNotFoundException extends RuntimeException
+{
+    private int $gameId;
+
+    private string $gameName;
+
+    public function __construct(int $gameId, string $gameName, string $message = 'Player not found for game')
+    {
+        parent::__construct($message);
+        $this->gameId = $gameId;
+        $this->gameName = $gameName;
+    }
+
+    public function getGameId(): int
+    {
+        return $this->gameId;
+    }
+
+    public function getGameName(): string
+    {
+        return $this->gameName;
+    }
+}

--- a/wwwroot/classes/GameNotFoundException.php
+++ b/wwwroot/classes/GameNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+class GameNotFoundException extends RuntimeException
+{
+}


### PR DESCRIPTION
## Summary
- extract a `GameLeaderboardPage` object that encapsulates lookup, filtering, and pagination for game leaderboards
- add dedicated exceptions for missing games and invalid player slugs to drive controller redirects
- update `game_leaderboard.php` to delegate to the new page object and keep the view layer focused on rendering

## Testing
- php -l wwwroot/classes/GameNotFoundException.php
- php -l wwwroot/classes/GameLeaderboardPlayerNotFoundException.php
- php -l wwwroot/classes/GameLeaderboardPage.php
- php -l wwwroot/game_leaderboard.php

------
https://chatgpt.com/codex/tasks/task_e_68d4e745b0cc832f8476a35ad7dab59a