### PR TITLE
Refactor player random page into OOP flow

### DIFF
--- a/wwwroot/classes/PlayerRandomGamesPage.php
+++ b/wwwroot/classes/PlayerRandomGamesPage.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerRandomGamesService.php';
+require_once __DIR__ . '/PlayerRandomGamesFilter.php';
+require_once __DIR__ . '/PlayerSummary.php';
+require_once __DIR__ . '/PlayerSummaryService.php';
+
+class PlayerRandomGamesPage
+{
+    private const STATUS_FLAGGED = 1;
+    private const STATUS_PRIVATE = 3;
+
+    private PlayerRandomGamesFilter $filter;
+
+    private PlayerSummary $playerSummary;
+
+    /**
+     * @var PlayerRandomGame[]
+     */
+    private array $randomGames;
+
+    private int $playerStatus;
+
+    public function __construct(
+        PlayerRandomGamesService $randomGamesService,
+        PlayerSummaryService $summaryService,
+        PlayerRandomGamesFilter $filter,
+        int $accountId,
+        int $playerStatus
+    ) {
+        $this->filter = $filter;
+        $this->playerSummary = $summaryService->getSummary($accountId);
+        $this->playerStatus = $playerStatus;
+
+        if ($this->shouldLoadRandomGames()) {
+            $this->randomGames = $randomGamesService->getRandomGames($accountId, $filter);
+        } else {
+            $this->randomGames = [];
+        }
+    }
+
+    public function getFilter(): PlayerRandomGamesFilter
+    {
+        return $this->filter;
+    }
+
+    public function getPlayerSummary(): PlayerSummary
+    {
+        return $this->playerSummary;
+    }
+
+    /**
+     * @return PlayerRandomGame[]
+     */
+    public function getRandomGames(): array
+    {
+        return $this->randomGames;
+    }
+
+    public function shouldShowFlaggedMessage(): bool
+    {
+        return $this->playerStatus === self::STATUS_FLAGGED;
+    }
+
+    public function shouldShowPrivateMessage(): bool
+    {
+        return $this->playerStatus === self::STATUS_PRIVATE;
+    }
+
+    public function shouldShowRandomGames(): bool
+    {
+        return !$this->shouldShowFlaggedMessage() && !$this->shouldShowPrivateMessage();
+    }
+
+    private function shouldLoadRandomGames(): bool
+    {
+        return $this->shouldShowRandomGames();
+    }
+}


### PR DESCRIPTION
## Summary
- add a PlayerRandomGamesPage class to encapsulate data loading for random player games
- update the random games page to use the new object for summary, filter, and status messaging

## Testing
- php -l wwwroot/classes/PlayerRandomGamesPage.php
- php -l wwwroot/player_random.php

------
https://chatgpt.com/codex/tasks/task_e_68d4ed11d8b8832f96395f72420a120f