### PR TITLE
Refactor changelog rendering to presenter

### DIFF
--- a/wwwroot/changelog.php
+++ b/wwwroot/changelog.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once 'classes/ChangelogEntry.php';
+require_once 'classes/ChangelogEntryPresenter.php';
 require_once 'classes/ChangelogPaginator.php';
 require_once 'classes/ChangelogService.php';
 
@@ -12,6 +13,10 @@ $requestedPage = isset($_GET['page']) && is_numeric((string) $_GET['page']) ? (i
 $totalChanges = $changelogService->getTotalChangeCount();
 $paginator = new ChangelogPaginator($requestedPage, $totalChanges, ChangelogService::PAGE_SIZE);
 $changes = $changelogService->getChanges($paginator);
+$presenters = array_map(
+    static fn(ChangelogEntry $change): ChangelogEntryPresenter => new ChangelogEntryPresenter($change, $utility),
+    $changes
+);
 
 require_once("header.php");
 ?>
@@ -27,10 +32,9 @@ require_once("header.php");
         <div class="row">
             <?php
             $currentDate = '';
-            /** @var ChangelogEntry $change */
-            foreach ($changes as $change) {
-                $time = $change->getTime();
-                $changeDate = $time->format('Y-m-d');
+            /** @var ChangelogEntryPresenter $presenter */
+            foreach ($presenters as $presenter) {
+                $changeDate = $presenter->getDateLabel();
 
                 if ($currentDate !== $changeDate) {
                     ?>
@@ -41,147 +45,12 @@ require_once("header.php");
                     $currentDate = $changeDate;
                 }
 
-                $param1Platforms = $change->getParam1Platforms();
-                $param1PlatformBadges = '';
-
-                if ($param1Platforms !== []) {
-                    $param1PlatformBadges = implode(
-                        ' ',
-                        array_map(
-                            static fn(string $platform): string => '<span class="badge rounded-pill text-bg-primary">' . htmlentities($platform, ENT_QUOTES, 'UTF-8') . '</span>',
-                            $param1Platforms
-                        )
-                    );
-                }
-
-                $param2Platforms = $change->getParam2Platforms();
-                $param2PlatformBadges = '';
-
-                if ($param2Platforms !== []) {
-                    $param2PlatformBadges = implode(
-                        ' ',
-                        array_map(
-                            static fn(string $platform): string => '<span class="badge rounded-pill text-bg-primary">' . htmlentities($platform, ENT_QUOTES, 'UTF-8') . '</span>',
-                            $param2Platforms
-                        )
-                    );
-                }
-
-                $param1Region = $change->getParam1Region();
-                $param1RegionBadge = $param1Region !== null && $param1Region !== ''
-                    ? ' <span class="badge rounded-pill text-bg-primary">' . htmlentities($param1Region, ENT_QUOTES, 'UTF-8') . '</span>'
-                    : '';
-
-                $param2Region = $change->getParam2Region();
-                $param2RegionBadge = $param2Region !== null && $param2Region !== ''
-                    ? ' <span class="badge rounded-pill text-bg-primary">' . htmlentities($param2Region, ENT_QUOTES, 'UTF-8') . '</span>'
-                    : '';
                 ?>
                 <div class="col-1">
-                    <?= $time->format('H:i:s'); ?>
+                    <?= $presenter->getTimeLabel(); ?>
                 </div>
                 <div class="col-11">
-                    <?php
-                    $param1Id = (string) ($change->getParam1Id() ?? '');
-                    $param1Name = $change->getParam1Name() ?? '';
-                    $param1Url = '/game/' . $param1Id . '-' . $utility->slugify((string) $param1Name);
-
-                    $param2Id = (string) ($change->getParam2Id() ?? '');
-                    $param2Name = $change->getParam2Name() ?? '';
-                    $param2Url = '/game/' . $param2Id . '-' . $utility->slugify((string) $param2Name);
-
-                    switch ($change->getChangeType()) {
-                        case ChangelogEntry::TYPE_GAME_CLONE:
-                            ?>
-                            <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a> (<?= $param1PlatformBadges; ?>) was cloned: <a href="<?= $param2Url; ?>"><?= htmlentities($param2Name, ENT_QUOTES, 'UTF-8'); ?></a> (<?= $param2PlatformBadges; ?>)
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_COPY:
-                            ?>
-                            Copied trophy data from <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a><?= $param1RegionBadge; ?> (<?= $param1PlatformBadges; ?>) into <a href="<?= $param2Url; ?>"><?= htmlentities($param2Name, ENT_QUOTES, 'UTF-8'); ?></a> (<?= $param2PlatformBadges; ?>).
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_DELETE:
-                            ?>
-                            The merged game entry for '<?= htmlentities($change->getExtra() ?? '', ENT_QUOTES, 'UTF-8'); ?>' have been deleted.
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_DELISTED:
-                            ?>
-                            <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a> (<?= $param1PlatformBadges; ?>) status was set to delisted.
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_DELISTED_AND_OBSOLETE:
-                            ?>
-                            <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a> (<?= $param1PlatformBadges; ?>) status was set to delisted &amp; obsolete.
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_MERGE:
-                            ?>
-                            <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a><?= $param1RegionBadge; ?> (<?= $param1PlatformBadges; ?>) was merged into <a href="<?= $param2Url; ?>"><?= htmlentities($param2Name, ENT_QUOTES, 'UTF-8'); ?></a> (<?= $param2PlatformBadges; ?>)
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_NORMAL:
-                            ?>
-                            <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a> (<?= $param1PlatformBadges; ?>) status was set to normal.
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_OBSOLETE:
-                            ?>
-                            <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a> (<?= $param1PlatformBadges; ?>) status was set to obsolete.
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_OBTAINABLE:
-                            ?>
-                            Trophies have been tagged as obtainable for <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a><?= $param1RegionBadge; ?> (<?= $param1PlatformBadges; ?>).
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_RESCAN:
-                            ?>
-                            The game <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a><?= $param1RegionBadge; ?> (<?= $param1PlatformBadges; ?>) have been rescanned for updated/new trophy data and game details.
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_RESET:
-                            ?>
-                            Merged trophies have been reset for <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a> (<?= $param1PlatformBadges; ?>).
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_UNOBTAINABLE:
-                            ?>
-                            Trophies have been tagged as unobtainable for <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a><?= $param1RegionBadge; ?> (<?= $param1PlatformBadges; ?>).
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_UPDATE:
-                            ?>
-                            <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a><?= $param1RegionBadge; ?> (<?= $param1PlatformBadges; ?>) was updated.
-                            <?php
-                            break;
-
-                        case ChangelogEntry::TYPE_GAME_VERSION:
-                            ?>
-                            <a href="<?= $param1Url; ?>"><?= htmlentities($param1Name, ENT_QUOTES, 'UTF-8'); ?></a><?= $param1RegionBadge; ?> (<?= $param1PlatformBadges; ?>) has a new version.
-                            <?php
-                            break;
-
-                        default:
-                            ?>
-                            Unknown type: <?= htmlentities($change->getChangeType(), ENT_QUOTES, 'UTF-8'); ?>
-                            <?php
-                            break;
-                    }
-                    ?>
+                    <?= $presenter->getMessage(); ?>
                 </div>
                 <?php
             }

--- a/wwwroot/classes/ChangelogEntryPresenter.php
+++ b/wwwroot/classes/ChangelogEntryPresenter.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/ChangelogEntry.php';
+require_once __DIR__ . '/Utility.php';
+
+class ChangelogEntryPresenter
+{
+    private ChangelogEntry $entry;
+    private Utility $utility;
+
+    public function __construct(ChangelogEntry $entry, Utility $utility)
+    {
+        $this->entry = $entry;
+        $this->utility = $utility;
+    }
+
+    public function getDateLabel(): string
+    {
+        return $this->entry->getTime()->format('Y-m-d');
+    }
+
+    public function getTimeLabel(): string
+    {
+        return $this->entry->getTime()->format('H:i:s');
+    }
+
+    public function getMessage(): string
+    {
+        $param1Link = $this->buildGameLink($this->entry->getParam1Id(), $this->entry->getParam1Name());
+        $param1RegionBadge = $this->buildRegionBadge($this->entry->getParam1Region());
+        $param1PlatformBadges = $this->buildPlatformBadges($this->entry->getParam1Platforms());
+
+        $param2Link = $this->buildGameLink($this->entry->getParam2Id(), $this->entry->getParam2Name());
+        $param2PlatformBadges = $this->buildPlatformBadges($this->entry->getParam2Platforms());
+
+        $extra = $this->escape($this->entry->getExtra());
+
+        switch ($this->entry->getChangeType()) {
+            case ChangelogEntry::TYPE_GAME_CLONE:
+                return sprintf(
+                    '%s was cloned: %s',
+                    $this->formatGameReference($param1Link, '', $param1PlatformBadges),
+                    $this->formatGameReference($param2Link, '', $param2PlatformBadges)
+                );
+            case ChangelogEntry::TYPE_GAME_COPY:
+                return sprintf(
+                    'Copied trophy data from %s into %s.',
+                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges),
+                    $this->formatGameReference($param2Link, '', $param2PlatformBadges)
+                );
+            case ChangelogEntry::TYPE_GAME_DELETE:
+                return sprintf(
+                    "The merged game entry for '%s' have been deleted.",
+                    $extra
+                );
+            case ChangelogEntry::TYPE_GAME_DELISTED:
+                return sprintf(
+                    '%s status was set to delisted.',
+                    $this->formatGameReference($param1Link, '', $param1PlatformBadges)
+                );
+            case ChangelogEntry::TYPE_GAME_DELISTED_AND_OBSOLETE:
+                return sprintf(
+                    '%s status was set to delisted &amp; obsolete.',
+                    $this->formatGameReference($param1Link, '', $param1PlatformBadges)
+                );
+            case ChangelogEntry::TYPE_GAME_MERGE:
+                return sprintf(
+                    '%s was merged into %s',
+                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges),
+                    $this->formatGameReference($param2Link, '', $param2PlatformBadges)
+                );
+            case ChangelogEntry::TYPE_GAME_NORMAL:
+                return sprintf(
+                    '%s status was set to normal.',
+                    $this->formatGameReference($param1Link, '', $param1PlatformBadges)
+                );
+            case ChangelogEntry::TYPE_GAME_OBSOLETE:
+                return sprintf(
+                    '%s status was set to obsolete.',
+                    $this->formatGameReference($param1Link, '', $param1PlatformBadges)
+                );
+            case ChangelogEntry::TYPE_GAME_OBTAINABLE:
+                return sprintf(
+                    'Trophies have been tagged as obtainable for %s.',
+                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
+                );
+            case ChangelogEntry::TYPE_GAME_RESCAN:
+                return sprintf(
+                    'The game %s have been rescanned for updated/new trophy data and game details.',
+                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
+                );
+            case ChangelogEntry::TYPE_GAME_RESET:
+                return sprintf(
+                    'Merged trophies have been reset for %s.',
+                    $this->formatGameReference($param1Link, '', $param1PlatformBadges)
+                );
+            case ChangelogEntry::TYPE_GAME_UNOBTAINABLE:
+                return sprintf(
+                    'Trophies have been tagged as unobtainable for %s.',
+                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
+                );
+            case ChangelogEntry::TYPE_GAME_UPDATE:
+                return sprintf(
+                    '%s was updated.',
+                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
+                );
+            case ChangelogEntry::TYPE_GAME_VERSION:
+                return sprintf(
+                    '%s has a new version.',
+                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
+                );
+            default:
+                return sprintf(
+                    'Unknown type: %s',
+                    $this->escape($this->entry->getChangeType())
+                );
+        }
+    }
+
+    /**
+     * @param array<int, string> $platforms
+     */
+    private function buildPlatformBadges(array $platforms): string
+    {
+        if ($platforms === []) {
+            return '';
+        }
+
+        $badges = array_map(
+            static fn(string $platform): string => sprintf(
+                '<span class="badge rounded-pill text-bg-primary">%s</span>',
+                htmlentities($platform, ENT_QUOTES, 'UTF-8')
+            ),
+            $platforms
+        );
+
+        return implode(' ', $badges);
+    }
+
+    private function buildRegionBadge(?string $region): string
+    {
+        if ($region === null || $region === '') {
+            return '';
+        }
+
+        return sprintf(
+            ' <span class="badge rounded-pill text-bg-primary">%s</span>',
+            htmlentities($region, ENT_QUOTES, 'UTF-8')
+        );
+    }
+
+    private function buildGameLink(?int $id, ?string $name): string
+    {
+        $idPart = $id !== null ? (string) $id : '';
+        $name = $name ?? '';
+        $url = '/game/' . $idPart . '-' . $this->utility->slugify($name);
+
+        return sprintf(
+            '<a href="%s">%s</a>',
+            htmlentities($url, ENT_QUOTES, 'UTF-8'),
+            htmlentities($name, ENT_QUOTES, 'UTF-8')
+        );
+    }
+
+    private function formatGameReference(string $link, string $regionBadge, string $platformBadges): string
+    {
+        return sprintf(
+            '%s%s %s',
+            $link,
+            $regionBadge,
+            $this->wrapWithParentheses($platformBadges)
+        );
+    }
+
+    private function wrapWithParentheses(string $content): string
+    {
+        return sprintf('(%s)', $content);
+    }
+
+    private function escape(?string $value): string
+    {
+        return htmlentities($value ?? '', ENT_QUOTES, 'UTF-8');
+    }
+}


### PR DESCRIPTION
## Summary
- extract changelog presentation logic into a new `ChangelogEntryPresenter` class to encapsulate formatting concerns
- update `changelog.php` to build presenter objects and render entries through them for a cleaner OOP flow

## Testing
- php -l wwwroot/classes/ChangelogEntryPresenter.php
- php -l wwwroot/changelog.php

------
https://chatgpt.com/codex/tasks/task_e_68d5b1d82a70832fa24a6c23448b4710