### PR TITLE
Refactor recent players listing to use objects

### DIFF
--- a/wwwroot/classes/GameRecentPlayer.php
+++ b/wwwroot/classes/GameRecentPlayer.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/GamePlayerFilter.php';
+require_once __DIR__ . '/Utility.php';
+
+class GameRecentPlayer
+{
+    private string $accountId;
+
+    private string $avatarUrl;
+
+    private string $countryCode;
+
+    private string $onlineId;
+
+    private int $trophyCountNpwr;
+
+    private int $trophyCountSony;
+
+    private int $bronzeCount;
+
+    private int $silverCount;
+
+    private int $goldCount;
+
+    private int $platinumCount;
+
+    private int $progress;
+
+    private string $lastKnownDate;
+
+    private function __construct(
+        string $accountId,
+        string $avatarUrl,
+        string $countryCode,
+        string $onlineId,
+        int $trophyCountNpwr,
+        int $trophyCountSony,
+        int $bronzeCount,
+        int $silverCount,
+        int $goldCount,
+        int $platinumCount,
+        int $progress,
+        string $lastKnownDate
+    ) {
+        $this->accountId = $accountId;
+        $this->avatarUrl = $avatarUrl;
+        $this->countryCode = $countryCode;
+        $this->onlineId = $onlineId;
+        $this->trophyCountNpwr = $trophyCountNpwr;
+        $this->trophyCountSony = $trophyCountSony;
+        $this->bronzeCount = $bronzeCount;
+        $this->silverCount = $silverCount;
+        $this->goldCount = $goldCount;
+        $this->platinumCount = $platinumCount;
+        $this->progress = $progress;
+        $this->lastKnownDate = $lastKnownDate;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        return new self(
+            isset($row['account_id']) ? (string) $row['account_id'] : '',
+            (string) ($row['avatar_url'] ?? ''),
+            (string) ($row['country'] ?? ''),
+            (string) ($row['name'] ?? ''),
+            isset($row['trophy_count_npwr']) ? (int) $row['trophy_count_npwr'] : 0,
+            isset($row['trophy_count_sony']) ? (int) $row['trophy_count_sony'] : 0,
+            isset($row['bronze']) ? (int) $row['bronze'] : 0,
+            isset($row['silver']) ? (int) $row['silver'] : 0,
+            isset($row['gold']) ? (int) $row['gold'] : 0,
+            isset($row['platinum']) ? (int) $row['platinum'] : 0,
+            isset($row['progress']) ? (int) $row['progress'] : 0,
+            (string) ($row['last_known_date'] ?? '')
+        );
+    }
+
+    public function getAccountId(): string
+    {
+        return $this->accountId;
+    }
+
+    public function matchesAccountId(?string $accountId): bool
+    {
+        if ($accountId === null || $accountId === '') {
+            return false;
+        }
+
+        return $this->accountId !== '' && $this->accountId === $accountId;
+    }
+
+    public function getAvatarUrl(): string
+    {
+        return $this->avatarUrl;
+    }
+
+    public function getCountryCode(): string
+    {
+        return $this->countryCode;
+    }
+
+    public function getCountryName(Utility $utility): string
+    {
+        return $utility->getCountryName($this->countryCode);
+    }
+
+    public function getOnlineId(): string
+    {
+        return $this->onlineId;
+    }
+
+    public function getBronzeCount(): int
+    {
+        return $this->bronzeCount;
+    }
+
+    public function getSilverCount(): int
+    {
+        return $this->silverCount;
+    }
+
+    public function getGoldCount(): int
+    {
+        return $this->goldCount;
+    }
+
+    public function getPlatinumCount(): int
+    {
+        return $this->platinumCount;
+    }
+
+    public function getProgress(): int
+    {
+        return $this->progress;
+    }
+
+    public function getLastKnownDate(): string
+    {
+        return $this->lastKnownDate;
+    }
+
+    public function hasHiddenTrophies(): bool
+    {
+        return $this->trophyCountNpwr < $this->trophyCountSony;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAvatarQueryParameters(GamePlayerFilter $filter): array
+    {
+        return $filter->withAvatar($this->avatarUrl);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getCountryQueryParameters(GamePlayerFilter $filter): array
+    {
+        return $filter->withCountry($this->countryCode);
+    }
+}

--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/GameRecentPlayer.php';
+
 class GameRecentPlayersService
 {
     public const RECENT_PLAYERS_LIMIT = 10;
@@ -86,7 +88,7 @@ class GameRecentPlayersService
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return GameRecentPlayer[]
      */
     public function getRecentPlayers(string $npCommunicationId, GamePlayerFilter $filter): array
     {
@@ -134,14 +136,10 @@ class GameRecentPlayersService
             return [];
         }
 
-        foreach ($rows as &$row) {
-            if (isset($row['account_id'])) {
-                $row['account_id'] = (string) $row['account_id'];
-            }
-        }
-        unset($row);
-
-        return $rows;
+        return array_map(
+            static fn(array $row): GameRecentPlayer => GameRecentPlayer::fromArray($row),
+            $rows
+        );
     }
 
     private function buildFilterSql(GamePlayerFilter $filter): string

--- a/wwwroot/game_recent_players.php
+++ b/wwwroot/game_recent_players.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/classes/GameHeaderService.php';
 require_once __DIR__ . '/classes/GamePlayerFilter.php';
 require_once __DIR__ . '/classes/GameRecentPlayersService.php';
+require_once __DIR__ . '/classes/GameRecentPlayer.php';
 
 if (!isset($gameId)) {
     header("Location: /game/", true, 303);
@@ -35,7 +36,9 @@ if (isset($player)) {
 }
 
 $filter = GamePlayerFilter::fromArray($_GET ?? []);
-$rows = $gameRecentPlayersService->getRecentPlayers($game["np_communication_id"], $filter);
+$recentPlayers = $gameRecentPlayersService->getRecentPlayers($game["np_communication_id"], $filter);
+
+$gameSlug = $game["id"] . "-" . $utility->slugify($game["name"]);
 
 $title = $game["name"] ." Recent Players ~ PSN 100%";
 require_once("header.php");
@@ -81,35 +84,33 @@ require_once("header.php");
 
                         <tbody>
                             <?php
-                            $rank = 0;
-                            foreach ($rows as $row) {
-                                $countryName = $utility->getCountryName($row["country"]);
-                                $paramsAvatar = $filter->withAvatar($row["avatar_url"]);
-                                $paramsCountry = $filter->withCountry($row["country"]);
+                            foreach ($recentPlayers as $index => $recentPlayer) {
+                                $rank = $index + 1;
+                                $countryName = $recentPlayer->getCountryName($utility);
+                                $paramsAvatar = $recentPlayer->getAvatarQueryParameters($filter);
+                                $paramsCountry = $recentPlayer->getCountryQueryParameters($filter);
                                 ?>
-                                <tr<?= ($accountId !== null && $row["account_id"] === $accountId) ? " class='table-primary'" : ""; ?>>
-                                    <th class="align-middle" style="width: 2rem;" scope="row"><?= ++$rank; ?></th>
+                                <tr<?= $recentPlayer->matchesAccountId($accountId) ? " class='table-primary'" : ""; ?>>
+                                    <th class="align-middle" style="width: 2rem;" scope="row"><?= $rank; ?></th>
 
                                     <td>
                                         <div class="hstack gap-3">
                                             <div>
                                                 <a href="?<?= http_build_query($paramsAvatar); ?>">
-                                                    <img src="/img/avatar/<?= $row["avatar_url"]; ?>" alt="" height="50" width="50" />
+                                                    <img src="/img/avatar/<?= htmlspecialchars($recentPlayer->getAvatarUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="" height="50" width="50" />
                                                 </a>
                                             </div>
 
                                             <div>
-                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?>/<?= $row["name"]; ?>"><?= $row["name"]; ?></a>
-                                                <?php
-                                                if ($row["trophy_count_npwr"] < $row["trophy_count_sony"]) {
-                                                    echo " <span style='color: #9d9d9d; font-weight: bold;'>(H)</span>";
-                                                }
-                                                ?>
+                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= $gameSlug; ?>/<?= rawurlencode($recentPlayer->getOnlineId()); ?>"><?= htmlspecialchars($recentPlayer->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
+                                                <?php if ($recentPlayer->hasHiddenTrophies()) { ?>
+                                                    <span style='color: #9d9d9d; font-weight: bold;'>(H)</span>
+                                                <?php } ?>
                                             </div>
 
                                             <div class="ms-auto">
                                                 <a href="?<?= http_build_query($paramsCountry); ?>">
-                                                    <img src="/img/country/<?= $row["country"]; ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
+                                                    <img src="/img/country/<?= htmlspecialchars($recentPlayer->getCountryCode(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
                                                 </a>
                                             </div>
                                         </div>
@@ -118,19 +119,19 @@ require_once("header.php");
                                     <td class="align-middle text-center" style="white-space: nowrap; width: 5rem;">
                                         <span id="date<?= $rank; ?>"></span>
                                         <script>
-                                            document.getElementById("date<?= $rank; ?>").innerHTML = new Date('<?= $row["last_known_date"]; ?> UTC').toLocaleString('sv-SE').replace(' ', '<br>');
+                                            document.getElementById("date<?= $rank; ?>").innerHTML = new Date(<?= json_encode($recentPlayer->getLastKnownDate() . ' UTC'); ?>).toLocaleString('sv-SE').replace(' ', '<br>');
                                         </script>
                                     </td>
 
                                     <td class="align-middle text-center" style="white-space: nowrap; width: 10rem;">
                                         <div class="vstack gap-1">
                                             <div>
-                                                <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $row["platinum"]; ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $row["gold"]; ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $row["silver"]; ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $row["bronze"]; ?></span>
+                                                <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $recentPlayer->getPlatinumCount(); ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $recentPlayer->getGoldCount(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $recentPlayer->getSilverCount(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $recentPlayer->getBronzeCount(); ?></span>
                                             </div>
 
                                             <div>
-                                                <div class="progress" role="progressbar" aria-label="Player game progress" aria-valuenow="<?= $row["progress"]; ?>" aria-valuemin="0" aria-valuemax="100">
-                                                    <div class="progress-bar" style="width: <?= $row["progress"]; ?>%"><?= $row["progress"]; ?>%</div>
+                                                <div class="progress" role="progressbar" aria-label="Player game progress" aria-valuenow="<?= $recentPlayer->getProgress(); ?>" aria-valuemin="0" aria-valuemax="100">
+                                                    <div class="progress-bar" style="width: <?= $recentPlayer->getProgress(); ?>%"><?= $recentPlayer->getProgress(); ?>%</div>
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
## Summary
- add a `GameRecentPlayer` value object to encapsulate recent player data and helpers
- update `GameRecentPlayersService` to hydrate and return the new object
- refactor the recent players template to rely on the object API and clean up rendering logic

## Testing
- php -l wwwroot/classes/GameRecentPlayer.php
- php -l wwwroot/classes/GameRecentPlayersService.php
- php -l wwwroot/game_recent_players.php

------
https://chatgpt.com/codex/tasks/task_e_68d5b880d9d4832f9d976d12879f2a89