### PR TITLE
Refactor admin navigation to object

### DIFF
--- a/wwwroot/admin/index.php
+++ b/wwwroot/admin/index.php
@@ -1,3 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+require_once '../classes/Admin/AdminNavigation.php';
+
+$navigation = new AdminNavigation();
+$navigationItems = $navigation->getItems();
+?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">
     <head>
@@ -10,17 +19,13 @@
     <body>
         <div class="p-4">
             <ul>
-                <li><a href="/admin/cheater.php">Cheater</a></li>
-                <li><a href="/admin/copy.php">Copy group and trophy data</a></li>
-                <li><a href="/admin/detail.php">Game Details</a></li>
-                <li><a href="/admin/merge.php">Game Merge</a></li>
-                <li><a href="/admin/status.php">Game Status</a></li>
-                <li><a href="/admin/possible.php">Possible Cheaters</a></li>
-                <li><a href="/admin/psnp-plus.php">PSNP+</a></li>
-                <li><a href="/admin/report.php">Reported Players</a></li>
-                <li><a href="/admin/rescan.php">Rescan Game</a></li>
-                <li><a href="/admin/reset.php">Reset Trophy Data or Delete Merged Game</a></li>
-                <li><a href="/admin/unobtainable.php">Unobtainable trophy</a></li>
+                <?php foreach ($navigationItems as $item) { ?>
+                    <li>
+                        <a href="<?= htmlspecialchars($item->getHref(), ENT_QUOTES, 'UTF-8'); ?>">
+                            <?= htmlspecialchars($item->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
+                        </a>
+                    </li>
+                <?php } ?>
             </ul>
         </div>
     </body>

--- a/wwwroot/classes/Admin/AdminNavigation.php
+++ b/wwwroot/classes/Admin/AdminNavigation.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+class AdminNavigationItem
+{
+    private string $label;
+
+    private string $href;
+
+    public function __construct(string $label, string $href)
+    {
+        $this->label = $label;
+        $this->href = $href;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getHref(): string
+    {
+        return $this->href;
+    }
+}
+
+class AdminNavigation
+{
+    /**
+     * @var AdminNavigationItem[]
+     */
+    private array $items;
+
+    /**
+     * @param AdminNavigationItem[] $items
+     */
+    public function __construct(array $items = [])
+    {
+        if ($items === []) {
+            $items = $this->createDefaultItems();
+        }
+
+        $this->items = $items;
+    }
+
+    public function addItem(AdminNavigationItem $item): void
+    {
+        $this->items[] = $item;
+    }
+
+    /**
+     * @return AdminNavigationItem[]
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * @return AdminNavigationItem[]
+     */
+    private function createDefaultItems(): array
+    {
+        return [
+            new AdminNavigationItem('Cheater', '/admin/cheater.php'),
+            new AdminNavigationItem('Copy group and trophy data', '/admin/copy.php'),
+            new AdminNavigationItem('Game Details', '/admin/detail.php'),
+            new AdminNavigationItem('Game Merge', '/admin/merge.php'),
+            new AdminNavigationItem('Game Status', '/admin/status.php'),
+            new AdminNavigationItem('Possible Cheaters', '/admin/possible.php'),
+            new AdminNavigationItem('PSNP+', '/admin/psnp-plus.php'),
+            new AdminNavigationItem('Reported Players', '/admin/report.php'),
+            new AdminNavigationItem('Rescan Game', '/admin/rescan.php'),
+            new AdminNavigationItem('Reset Trophy Data or Delete Merged Game', '/admin/reset.php'),
+            new AdminNavigationItem('Unobtainable trophy', '/admin/unobtainable.php'),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- introduce AdminNavigation and AdminNavigationItem classes to encapsulate admin menu links
- update the admin index page to render its navigation list via the new object model

## Testing
- php -l wwwroot/classes/Admin/AdminNavigation.php
- php -l wwwroot/admin/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d63a367c78832fb44f7b0a5dc24aca