### PR TITLE
Refactor homepage data loading into OOP page classes

### DIFF
--- a/wwwroot/classes/HomepagePage.php
+++ b/wwwroot/classes/HomepagePage.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/HomepageContentService.php';
+require_once __DIR__ . '/HomepageViewModel.php';
+
+class HomepagePage
+{
+    private const DEFAULT_TITLE = 'PSN 100% ~ PlayStation Leaderboards & Trophies';
+
+    private HomepageContentService $contentService;
+
+    private string $title = self::DEFAULT_TITLE;
+
+    private ?int $newGamesLimit = null;
+
+    private ?int $newDlcsLimit = null;
+
+    private ?int $popularGamesLimit = null;
+
+    public function __construct(HomepageContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function setNewGamesLimit(int $limit): self
+    {
+        $this->assertPositiveLimit($limit);
+        $this->newGamesLimit = $limit;
+
+        return $this;
+    }
+
+    public function setNewDlcsLimit(int $limit): self
+    {
+        $this->assertPositiveLimit($limit);
+        $this->newDlcsLimit = $limit;
+
+        return $this;
+    }
+
+    public function setPopularGamesLimit(int $limit): self
+    {
+        $this->assertPositiveLimit($limit);
+        $this->popularGamesLimit = $limit;
+
+        return $this;
+    }
+
+    public function buildViewModel(): HomepageViewModel
+    {
+        $newGames = $this->newGamesLimit === null
+            ? $this->contentService->getNewGames()
+            : $this->contentService->getNewGames($this->newGamesLimit);
+
+        $newDlcs = $this->newDlcsLimit === null
+            ? $this->contentService->getNewDlcs()
+            : $this->contentService->getNewDlcs($this->newDlcsLimit);
+
+        $popularGames = $this->popularGamesLimit === null
+            ? $this->contentService->getPopularGames()
+            : $this->contentService->getPopularGames($this->popularGamesLimit);
+
+        return new HomepageViewModel($this->title, $newGames, $newDlcs, $popularGames);
+    }
+
+    private function assertPositiveLimit(int $limit): void
+    {
+        if ($limit < 1) {
+            throw new InvalidArgumentException('Limit must be greater than or equal to 1.');
+        }
+    }
+}

--- a/wwwroot/classes/HomepageViewModel.php
+++ b/wwwroot/classes/HomepageViewModel.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Homepage/HomepageNewGame.php';
+require_once __DIR__ . '/Homepage/HomepageDlc.php';
+require_once __DIR__ . '/Homepage/HomepagePopularGame.php';
+
+class HomepageViewModel
+{
+    private string $title;
+
+    /**
+     * @var HomepageNewGame[]
+     */
+    private array $newGames;
+
+    /**
+     * @var HomepageDlc[]
+     */
+    private array $newDlcs;
+
+    /**
+     * @var HomepagePopularGame[]
+     */
+    private array $popularGames;
+
+    /**
+     * @param HomepageNewGame[] $newGames
+     * @param HomepageDlc[] $newDlcs
+     * @param HomepagePopularGame[] $popularGames
+     */
+    public function __construct(string $title, array $newGames, array $newDlcs, array $popularGames)
+    {
+        $this->title = $title;
+        $this->newGames = $newGames;
+        $this->newDlcs = $newDlcs;
+        $this->popularGames = $popularGames;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return HomepageNewGame[]
+     */
+    public function getNewGames(): array
+    {
+        return $this->newGames;
+    }
+
+    /**
+     * @return HomepageDlc[]
+     */
+    public function getNewDlcs(): array
+    {
+        return $this->newDlcs;
+    }
+
+    /**
+     * @return HomepagePopularGame[]
+     */
+    public function getPopularGames(): array
+    {
+        return $this->popularGames;
+    }
+}

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -1,11 +1,14 @@
 <?php
-require_once 'classes/HomepageContentService.php';
+require_once 'classes/HomepagePage.php';
 
-$title = "PSN 100% ~ PlayStation Leaderboards & Trophies";
 $homepageContentService = new HomepageContentService($database);
-$newGames = $homepageContentService->getNewGames();
-$newDlcs = $homepageContentService->getNewDlcs();
-$popularGames = $homepageContentService->getPopularGames();
+$homepagePage = new HomepagePage($homepageContentService);
+$homepageViewModel = $homepagePage->buildViewModel();
+
+$title = $homepageViewModel->getTitle();
+$newGames = $homepageViewModel->getNewGames();
+$newDlcs = $homepageViewModel->getNewDlcs();
+$popularGames = $homepageViewModel->getPopularGames();
 require_once("header.php");
 ?>
 


### PR DESCRIPTION
## Summary
- encapsulate homepage content retrieval inside new `HomepagePage` and `HomepageViewModel` classes
- update `home.php` to build and use the view model instead of fetching arrays directly

## Testing
- php -l wwwroot/classes/HomepageViewModel.php
- php -l wwwroot/classes/HomepagePage.php
- php -l wwwroot/home.php

------
https://chatgpt.com/codex/tasks/task_e_68d63fb83ef8832fbdae86da9e5ce3f7