### PR TITLE
Refactor trophy rarity rendering

### DIFF
--- a/wwwroot/classes/TrophyRarity.php
+++ b/wwwroot/classes/TrophyRarity.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+class TrophyRarity
+{
+    private ?string $percentage;
+
+    private string $label;
+
+    private ?string $cssClass;
+
+    private bool $unobtainable;
+
+    public function __construct(?string $percentage, string $label, ?string $cssClass, bool $unobtainable)
+    {
+        $this->percentage = $percentage;
+        $this->label = $label;
+        $this->cssClass = $cssClass;
+        $this->unobtainable = $unobtainable;
+    }
+
+    public function getPercentage(): ?string
+    {
+        return $this->percentage;
+    }
+
+    public function hasPercentage(): bool
+    {
+        return $this->percentage !== null && $this->percentage !== '';
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getCssClass(): ?string
+    {
+        return $this->cssClass;
+    }
+
+    public function isUnobtainable(): bool
+    {
+        return $this->unobtainable;
+    }
+
+    public function renderSpan(string $separator = '<br>', bool $includePercentWhenUnobtainable = false): string
+    {
+        $parts = [];
+
+        if (!$this->unobtainable || $includePercentWhenUnobtainable) {
+            if ($this->hasPercentage()) {
+                $parts[] = $this->percentage . '%';
+            }
+        }
+
+        $parts[] = $this->label;
+
+        $classAttribute = '';
+        if ($this->cssClass !== null && $this->cssClass !== '') {
+            $classAttribute = ' class="' . $this->cssClass . '"';
+        }
+
+        return '<span' . $classAttribute . '>' . implode($separator, $parts) . '</span>';
+    }
+}

--- a/wwwroot/classes/TrophyRarityFormatter.php
+++ b/wwwroot/classes/TrophyRarityFormatter.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TrophyRarity.php';
+
+class TrophyRarityFormatter
+{
+    /**
+     * @param float|int|string|null $rarityPercent
+     */
+    public function format($rarityPercent, int $status = 0): TrophyRarity
+    {
+        $percentageString = $this->normalizePercentage($rarityPercent);
+
+        if ($status === 1) {
+            return new TrophyRarity($percentageString, 'Unobtainable', null, true);
+        }
+
+        $value = $this->toFloat($rarityPercent);
+
+        if ($value !== null) {
+            if ($value <= 0.02) {
+                return new TrophyRarity($percentageString, 'Legendary', 'trophy-legendary', false);
+            }
+
+            if ($value <= 0.2) {
+                return new TrophyRarity($percentageString, 'Epic', 'trophy-epic', false);
+            }
+
+            if ($value <= 2) {
+                return new TrophyRarity($percentageString, 'Rare', 'trophy-rare', false);
+            }
+
+            if ($value <= 10) {
+                return new TrophyRarity($percentageString, 'Uncommon', 'trophy-uncommon', false);
+            }
+        }
+
+        return new TrophyRarity($percentageString, 'Common', 'trophy-common', false);
+    }
+
+    /**
+     * @param float|int|string|null $rarityPercent
+     */
+    private function normalizePercentage($rarityPercent): ?string
+    {
+        if ($rarityPercent === null) {
+            return null;
+        }
+
+        if (is_string($rarityPercent)) {
+            return trim($rarityPercent);
+        }
+
+        if (is_int($rarityPercent) || is_float($rarityPercent)) {
+            return (string) $rarityPercent;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param float|int|string|null $rarityPercent
+     */
+    private function toFloat($rarityPercent): ?float
+    {
+        if ($rarityPercent === null) {
+            return null;
+        }
+
+        if (is_string($rarityPercent)) {
+            $rarityPercent = trim($rarityPercent);
+
+            if ($rarityPercent === '') {
+                return null;
+            }
+        }
+
+        if (is_numeric($rarityPercent)) {
+            return (float) $rarityPercent;
+        }
+
+        return null;
+    }
+}

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/classes/GamePage.php';
+require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
 
 if (!isset($gameId)) {
     header("Location: /game/", true, 303);
@@ -36,6 +37,7 @@ $accountId = $gamePage->getPlayerAccountId();
 $gamePlayer = $gamePage->getGamePlayer();
 $metaData = $gamePage->createMetaData();
 $title = $gamePage->getPageTitle();
+$trophyRarityFormatter = new TrophyRarityFormatter();
 require_once("header.php");
 ?>
 
@@ -288,18 +290,12 @@ require_once("header.php");
 
                                         <td style="width: 5rem; background: linear-gradient(to top right, var(--bs-table-bg), var(--bs-table-bg), var(--bs-table-bg), <?= $trophyColor; ?>);" class="text-center align-middle">
                                             <?php
-                                            if ($trophy["status"] == 1) {
-                                                echo "<span>". $trophy["rarity_percent"] ."%<br>Unobtainable</span>";
-                                            } elseif ($trophy["rarity_percent"] <= 0.02) {
-                                                echo "<span class='trophy-legendary'>". $trophy["rarity_percent"] ."%<br>Legendary</span>";
-                                            } elseif ($trophy["rarity_percent"] <= 0.2) {
-                                                echo "<span class='trophy-epic'>". $trophy["rarity_percent"] ."%<br>Epic</span>";
-                                            } elseif ($trophy["rarity_percent"] <= 2) {
-                                                echo "<span class='trophy-rare'>". $trophy["rarity_percent"] ."%<br>Rare</span>";
-                                            } elseif ($trophy["rarity_percent"] <= 10) {
-                                                echo "<span class='trophy-uncommon'>". $trophy["rarity_percent"] ."%<br>Uncommon</span>";
+                                            $trophyRarity = $trophyRarityFormatter->format($trophy["rarity_percent"], (int) $trophy["status"]);
+
+                                            if ($trophyRarity->isUnobtainable()) {
+                                                echo $trophyRarity->renderSpan('<br>', true);
                                             } else {
-                                                echo "<span class='trophy-common'>". $trophy["rarity_percent"] ."%<br>Common</span>";
+                                                echo $trophyRarity->renderSpan();
                                             }
                                             ?>
                                         </td>

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/classes/PlayerAdvisorService.php';
 require_once __DIR__ . '/classes/PlayerAdvisorPage.php';
 require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
+require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
 
 if (!isset($accountId)) {
     header("Location: /player/", true, 303);
@@ -32,6 +33,7 @@ $advisableTrophies = $playerAdvisorPage->getAdvisableTrophies();
 $totalPages = $playerAdvisorPage->getTotalPages();
 $filterParameters = $playerAdvisorPage->getFilterParameters();
 $shouldDisplayAdvisor = $playerAdvisorPage->shouldDisplayAdvisor();
+$trophyRarityFormatter = new TrophyRarityFormatter();
 
 $title = $player["online_id"] . "'s Trophy Advisor ~ PSN 100%";
 require_once("header.php");
@@ -205,19 +207,10 @@ require_once("header.php");
                                             </div>
                                         </td>
                                         <td class="text-center align-middle">
-                                            <?php
-                                            if ($trophy["rarity_percent"] <= 0.02) {
-                                                echo "<span class='trophy-legendary'>". $trophy["rarity_percent"] ."%<br>Legendary</span>";
-                                            } elseif ($trophy["rarity_percent"] <= 0.2) {
-                                                echo "<span class='trophy-epic'>". $trophy["rarity_percent"] ."%<br>Epic</span>";
-                                            } elseif ($trophy["rarity_percent"] <= 2) {
-                                                echo "<span class='trophy-rare'>". $trophy["rarity_percent"] ."%<br>Rare</span>";
-                                            } elseif ($trophy["rarity_percent"] <= 10) {
-                                                echo "<span class='trophy-uncommon'>". $trophy["rarity_percent"] ."%<br>Uncommon</span>";
-                                            } else {
-                                                echo "<span class='trophy-common'>". $trophy["rarity_percent"] ."%<br>Common</span>";
-                                            }
-                                            ?>
+                                        <?php
+                                        $trophyRarity = $trophyRarityFormatter->format($trophy["rarity_percent"]);
+                                        echo $trophyRarity->renderSpan();
+                                        ?>
                                         </td>
                                         <td class="text-center align-middle">
                                             <img src="/img/trophy-<?= $trophy["trophy_type"]; ?>.svg" alt="<?= ucfirst($trophy["trophy_type"]); ?>" title="<?= ucfirst($trophy["trophy_type"]); ?>" height="50" />

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/classes/PlayerLogService.php';
 require_once __DIR__ . '/classes/PlayerLogPage.php';
 require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
+require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
 
 if (!isset($accountId)) {
     header("Location: /player/", true, 303);
@@ -23,6 +24,7 @@ $playerLogPage = new PlayerLogPage(
     (int) $player['status']
 );
 $trophiesLog = $playerLogPage->getTrophies();
+$trophyRarityFormatter = new TrophyRarityFormatter();
 
 $title = $player["online_id"] . "'s Trophy Log ~ PSN 100%";
 require_once("header.php");
@@ -206,21 +208,15 @@ require_once("header.php");
                                             </div>
                                         </td>
                                         <td class="text-center align-middle">
-                                            <?php
-                                            if ($trophy["trophy_status"] == 1) {
-                                                echo "<span class='badge rounded-pill text-bg-warning p-2'>Unobtainable</span>";
-                                            } elseif ($trophy["rarity_percent"] <= 0.02) {
-                                                echo "<span class='trophy-legendary'>". $trophy["rarity_percent"] ."%<br>Legendary</span>";
-                                            } elseif ($trophy["rarity_percent"] <= 0.2) {
-                                                echo "<span class='trophy-epic'>". $trophy["rarity_percent"] ."%<br>Epic</span>";
-                                            } elseif ($trophy["rarity_percent"] <= 2) {
-                                                echo "<span class='trophy-rare'>". $trophy["rarity_percent"] ."%<br>Rare</span>";
-                                            } elseif ($trophy["rarity_percent"] <= 10) {
-                                                echo "<span class='trophy-uncommon'>". $trophy["rarity_percent"] ."%<br>Uncommon</span>";
-                                            } else {
-                                                echo "<span class='trophy-common'>". $trophy["rarity_percent"] ."%<br>Common</span>";
-                                            }
-                                            ?>
+                                        <?php
+                                        $trophyRarity = $trophyRarityFormatter->format($trophy["rarity_percent"], (int) $trophy["trophy_status"]);
+
+                                        if ($trophyRarity->isUnobtainable()) {
+                                            echo "<span class='badge rounded-pill text-bg-warning p-2'>" . $trophyRarity->getLabel() . '</span>';
+                                        } else {
+                                            echo $trophyRarity->renderSpan();
+                                        }
+                                        ?>
                                         </td>
                                         <td class="text-center align-middle">
                                             <img src="/img/trophy-<?= $trophy["trophy_type"]; ?>.svg" alt="<?= ucfirst($trophy["trophy_type"]); ?>" title="<?= ucfirst($trophy["trophy_type"]); ?>" height="50" />

--- a/wwwroot/trophies.php
+++ b/wwwroot/trophies.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 require_once __DIR__ . '/classes/TrophyListFilter.php';
 require_once __DIR__ . '/classes/TrophyListPage.php';
 require_once __DIR__ . '/classes/TrophyListService.php';
+require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
 
 $trophyListFilter = TrophyListFilter::fromArray($_GET ?? []);
 $trophyListService = new TrophyListService($database);
 $trophyListPage = new TrophyListPage($trophyListService, $trophyListFilter);
+$trophyRarityFormatter = new TrophyRarityFormatter();
 
 $title = "Trophies ~ PSN 100%";
 require_once('header.php');
@@ -86,17 +88,8 @@ require_once('header.php');
                                     </td>
                                     <td class="text-center align-middle">
                                         <?php
-                                        if ($trophy['rarity_percent'] <= 0.02) {
-                                            echo "<span class='trophy-legendary'>" . $trophy['rarity_percent'] . "%<br>Legendary</span>";
-                                        } elseif ($trophy['rarity_percent'] <= 0.2) {
-                                            echo "<span class='trophy-epic'>" . $trophy['rarity_percent'] . "%<br>Epic</span>";
-                                        } elseif ($trophy['rarity_percent'] <= 2) {
-                                            echo "<span class='trophy-rare'>" . $trophy['rarity_percent'] . "%<br>Rare</span>";
-                                        } elseif ($trophy['rarity_percent'] <= 10) {
-                                            echo "<span class='trophy-uncommon'>" . $trophy['rarity_percent'] . "%<br>Uncommon</span>";
-                                        } else {
-                                            echo "<span class='trophy-common'>" . $trophy['rarity_percent'] . "%<br>Common</span>";
-                                        }
+                                        $trophyRarity = $trophyRarityFormatter->format($trophy['rarity_percent']);
+                                        echo $trophyRarity->renderSpan();
                                         ?>
                                     </td>
                                     <td class="text-center align-middle">

--- a/wwwroot/trophy.php
+++ b/wwwroot/trophy.php
@@ -2,6 +2,7 @@
 
 require_once 'classes/PageMetaData.php';
 require_once 'classes/TrophyService.php';
+require_once 'classes/TrophyRarityFormatter.php';
 
 if (!isset($trophyId)) {
     header("Location: /trophy/", true, 303);
@@ -9,6 +10,7 @@ if (!isset($trophyId)) {
 }
 
 $trophyService = new TrophyService($database);
+$trophyRarityFormatter = new TrophyRarityFormatter();
 $trophy = $trophyService->getTrophyById((int) $trophyId);
 
 if ($trophy === null) {
@@ -142,18 +144,12 @@ require_once("header.php");
                                 
                                 <div class="col-2 text-center align-self-center">
                                     <?php
-                                    if ($trophy["status"] == 1) {
-                                        echo "Unobtainable";
-                                    } elseif ($trophy["rarity_percent"] <= 0.02) {
-                                        echo "<span class='trophy-legendary'>". $trophy["rarity_percent"] ."%<br>Legendary</span>";
-                                    } elseif ($trophy["rarity_percent"] <= 0.2) {
-                                        echo "<span class='trophy-epic'>". $trophy["rarity_percent"] ."%<br>Epic</span>";
-                                    } elseif ($trophy["rarity_percent"] <= 2) {
-                                        echo "<span class='trophy-rare'>". $trophy["rarity_percent"] ."%<br>Rare</span>";
-                                    } elseif ($trophy["rarity_percent"] <= 10) {
-                                        echo "<span class='trophy-uncommon'>". $trophy["rarity_percent"] ."%<br>Uncommon</span>";
+                                    $trophyRarity = $trophyRarityFormatter->format($trophy["rarity_percent"], (int) $trophy["status"]);
+
+                                    if ($trophyRarity->isUnobtainable()) {
+                                        echo $trophyRarity->getLabel();
                                     } else {
-                                        echo "<span class='trophy-common'>". $trophy["rarity_percent"] ."%<br>Common</span>";
+                                        echo $trophyRarity->renderSpan();
                                     }
                                     ?>
                                 </div>


### PR DESCRIPTION
## Summary
- add a TrophyRarity value object and TrophyRarityFormatter to centralize rarity classification and rendering
- update game, trophy, player log, player advisor, and trophies pages to use the formatter and handle unobtainable trophies consistently

## Testing
- `for file in wwwroot/classes/TrophyRarity.php wwwroot/classes/TrophyRarityFormatter.php wwwroot/trophy.php wwwroot/game.php wwwroot/player_log.php wwwroot/player_advisor.php wwwroot/trophies.php; do php -l $file; done`

------
https://chatgpt.com/codex/tasks/task_e_68d6492d3e14832fb2a1fed4d0369f72