### PR TITLE
Handle earned trophies consistently in advisor queries

### DIFF
--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -80,7 +80,7 @@ class PlayerAdvisorService
                 t.np_communication_id = te.np_communication_id
                 AND t.order_id = te.order_id
                 AND te.account_id = :account_id
-                AND te.earned = 0
+                AND (te.earned = 0 OR te.earned IS NULL)
             JOIN trophy_title_player ttp ON
                 t.np_communication_id = ttp.np_communication_id
                 AND ttp.account_id = :account_id

--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -29,14 +29,17 @@ class PlayerAdvisorService
             SELECT COUNT(*)
             FROM trophy t
             JOIN trophy_title tt USING (np_communication_id)
-            LEFT JOIN trophy_earned te ON
-                t.np_communication_id = te.np_communication_id
-                AND t.order_id = te.order_id
-                AND te.account_id = :account_id
             JOIN trophy_title_player ttp ON
                 t.np_communication_id = ttp.np_communication_id
                 AND ttp.account_id = :account_id
-            WHERE (te.earned IS NULL OR te.earned = 0)
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM trophy_earned te
+                WHERE te.np_communication_id = t.np_communication_id
+                    AND te.order_id = t.order_id
+                    AND te.account_id = :account_id
+                    AND te.earned = 1
+            )
                 AND tt.status = 0
                 AND t.status = 0
         SQL;
@@ -77,10 +80,18 @@ class PlayerAdvisorService
                 t.np_communication_id = te.np_communication_id
                 AND t.order_id = te.order_id
                 AND te.account_id = :account_id
+                AND te.earned = 0
             JOIN trophy_title_player ttp ON
                 t.np_communication_id = ttp.np_communication_id
                 AND ttp.account_id = :account_id
-            WHERE (te.earned IS NULL OR te.earned = 0)
+            WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM trophy_earned te_earned
+                    WHERE te_earned.np_communication_id = t.np_communication_id
+                        AND te_earned.order_id = t.order_id
+                        AND te_earned.account_id = :account_id
+                        AND te_earned.earned = 1
+                )
                 AND tt.status = 0
                 AND t.status = 0
         SQL;


### PR DESCRIPTION
## Summary
- filter getAdvisableTrophies() with a NOT EXISTS check to match the count query's earned trophy handling
- keep the LEFT JOIN for progress data but restrict it to unearned rows

## Testing
- not run (environment not configured)


------
https://chatgpt.com/codex/tasks/task_e_68d80975b5d0832fb5f6834e8a14df9b