### PR TITLE
Refactor leaderboard code to object-oriented row model

### DIFF
--- a/wwwroot/classes/GameLeaderboardPage.php
+++ b/wwwroot/classes/GameLeaderboardPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/GamePlayerFilter.php';
 require_once __DIR__ . '/GameLeaderboardFilter.php';
+require_once __DIR__ . '/GameLeaderboardRow.php';
 require_once __DIR__ . '/GameLeaderboardService.php';
 require_once __DIR__ . '/GameHeaderService.php';
 require_once __DIR__ . '/GameNotFoundException.php';
@@ -29,7 +30,7 @@ class GameLeaderboardPage
     private int $totalPagesCount;
 
     /**
-     * @var array<int, array<string, mixed>>
+     * @var GameLeaderboardRow[]
      */
     private array $rows;
 
@@ -37,7 +38,7 @@ class GameLeaderboardPage
 
     /**
      * @param array<string, mixed> $game
-     * @param array<int, array<string, mixed>> $rows
+     * @param GameLeaderboardRow[] $rows
      */
     private function __construct(
         array $game,
@@ -159,7 +160,7 @@ class GameLeaderboardPage
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return GameLeaderboardRow[]
      */
     public function getRows(): array
     {

--- a/wwwroot/classes/GameLeaderboardRow.php
+++ b/wwwroot/classes/GameLeaderboardRow.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/GamePlayerFilter.php';
+require_once __DIR__ . '/Utility.php';
+
+class GameLeaderboardRow
+{
+    private string $accountId;
+
+    private string $avatarUrl;
+
+    private string $countryCode;
+
+    private string $onlineId;
+
+    private int $trophyCountNpwr;
+
+    private int $trophyCountSony;
+
+    private int $bronzeCount;
+
+    private int $silverCount;
+
+    private int $goldCount;
+
+    private int $platinumCount;
+
+    private int $progress;
+
+    private string $lastKnownDate;
+
+    private function __construct(
+        string $accountId,
+        string $avatarUrl,
+        string $countryCode,
+        string $onlineId,
+        int $trophyCountNpwr,
+        int $trophyCountSony,
+        int $bronzeCount,
+        int $silverCount,
+        int $goldCount,
+        int $platinumCount,
+        int $progress,
+        string $lastKnownDate
+    ) {
+        $this->accountId = $accountId;
+        $this->avatarUrl = $avatarUrl;
+        $this->countryCode = $countryCode;
+        $this->onlineId = $onlineId;
+        $this->trophyCountNpwr = $trophyCountNpwr;
+        $this->trophyCountSony = $trophyCountSony;
+        $this->bronzeCount = $bronzeCount;
+        $this->silverCount = $silverCount;
+        $this->goldCount = $goldCount;
+        $this->platinumCount = $platinumCount;
+        $this->progress = $progress;
+        $this->lastKnownDate = $lastKnownDate;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        return new self(
+            isset($row['account_id']) ? (string) $row['account_id'] : '',
+            (string) ($row['avatar_url'] ?? ''),
+            (string) ($row['country'] ?? ''),
+            (string) ($row['name'] ?? ''),
+            isset($row['trophy_count_npwr']) ? (int) $row['trophy_count_npwr'] : 0,
+            isset($row['trophy_count_sony']) ? (int) $row['trophy_count_sony'] : 0,
+            isset($row['bronze']) ? (int) $row['bronze'] : 0,
+            isset($row['silver']) ? (int) $row['silver'] : 0,
+            isset($row['gold']) ? (int) $row['gold'] : 0,
+            isset($row['platinum']) ? (int) $row['platinum'] : 0,
+            isset($row['progress']) ? (int) $row['progress'] : 0,
+            (string) ($row['last_known_date'] ?? '')
+        );
+    }
+
+    public function matchesAccountId(?string $accountId): bool
+    {
+        if ($accountId === null || $accountId === '') {
+            return false;
+        }
+
+        return $this->accountId !== '' && $this->accountId === $accountId;
+    }
+
+    public function getAvatarUrl(): string
+    {
+        return $this->avatarUrl;
+    }
+
+    public function getCountryCode(): string
+    {
+        return $this->countryCode;
+    }
+
+    public function getCountryName(Utility $utility): string
+    {
+        return $utility->getCountryName($this->countryCode);
+    }
+
+    public function getOnlineId(): string
+    {
+        return $this->onlineId;
+    }
+
+    public function getBronzeCount(): int
+    {
+        return $this->bronzeCount;
+    }
+
+    public function getSilverCount(): int
+    {
+        return $this->silverCount;
+    }
+
+    public function getGoldCount(): int
+    {
+        return $this->goldCount;
+    }
+
+    public function getPlatinumCount(): int
+    {
+        return $this->platinumCount;
+    }
+
+    public function getProgress(): int
+    {
+        return $this->progress;
+    }
+
+    public function getLastKnownDate(): string
+    {
+        return $this->lastKnownDate;
+    }
+
+    public function hasHiddenTrophies(): bool
+    {
+        return $this->trophyCountNpwr < $this->trophyCountSony;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAvatarQueryParameters(GamePlayerFilter $filter): array
+    {
+        return $filter->withAvatar($this->avatarUrl);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getCountryQueryParameters(GamePlayerFilter $filter): array
+    {
+        return $filter->withCountry($this->countryCode);
+    }
+}

--- a/wwwroot/classes/GameLeaderboardService.php
+++ b/wwwroot/classes/GameLeaderboardService.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/GameLeaderboardRow.php';
+
 class GameLeaderboardService
 {
     public const PAGE_SIZE = 50;
@@ -89,7 +91,7 @@ class GameLeaderboardService
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return GameLeaderboardRow[]
      */
     public function getLeaderboardRows(string $npCommunicationId, GameLeaderboardFilter $filter, int $limit): array
     {
@@ -143,14 +145,10 @@ class GameLeaderboardService
             return [];
         }
 
-        foreach ($rows as &$row) {
-            if (isset($row['account_id'])) {
-                $row['account_id'] = (string) $row['account_id'];
-            }
-        }
-        unset($row);
-
-        return $rows;
+        return array_map(
+            static fn(array $row): GameLeaderboardRow => GameLeaderboardRow::fromArray($row),
+            $rows
+        );
     }
 
     private function buildFilterSql(GamePlayerFilter $filter): string

--- a/wwwroot/game_leaderboard.php
+++ b/wwwroot/game_leaderboard.php
@@ -84,33 +84,35 @@ require_once("header.php");
                             <?php
                             $rank = $offset;
                             foreach ($rows as $row) {
-                                $countryName = $utility->getCountryName($row["country"]);
-                                $paramsAvatar = $filter->withAvatar($row["avatar_url"]);
-                                $paramsCountry = $filter->withCountry($row["country"]);
+                                $countryName = $row->getCountryName($utility);
+                                $paramsAvatar = $row->getAvatarQueryParameters($filter);
+                                $paramsCountry = $row->getCountryQueryParameters($filter);
+                                $playerName = $row->getOnlineId();
+                                $playerUrl = '/game/' . $game["id"] . '-' . $utility->slugify($game["name"]) . '/' . rawurlencode($playerName);
                                 ?>
-                                <tr<?= ($accountId !== null && $row["account_id"] === $accountId) ? " class='table-primary'" : ""; ?>>
+                                <tr<?= $row->matchesAccountId($accountId) ? " class='table-primary'" : ""; ?>>
                                     <th class="align-middle" style="width: 2rem;" scope="row"><?= ++$rank; ?></th>
 
                                     <td>
                                         <div class="hstack gap-3">
                                             <div>
                                                 <a href="?<?= http_build_query($paramsAvatar); ?>">
-                                                    <img src="/img/avatar/<?= $row["avatar_url"]; ?>" alt="" height="50" width="50" />
+                                                    <img src="/img/avatar/<?= htmlspecialchars($row->getAvatarUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="" height="50" width="50" />
                                                 </a>
                                             </div>
 
                                             <div>
-                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?>/<?= $row["name"]; ?>"><?= $row["name"]; ?></a>
-                                                <?php
-                                                if ($row["trophy_count_npwr"] < $row["trophy_count_sony"]) {
-                                                    echo " <span style='color: #9d9d9d; font-weight: bold;'>(H)</span>";
-                                                }
-                                                ?>
+                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= $playerUrl; ?>">
+                                                    <?= htmlspecialchars($playerName, ENT_QUOTES, 'UTF-8'); ?>
+                                                </a>
+                                                <?php if ($row->hasHiddenTrophies()) { ?>
+                                                    <span style='color: #9d9d9d; font-weight: bold;'>(H)</span>
+                                                <?php } ?>
                                             </div>
 
                                             <div class="ms-auto">
                                                 <a href="?<?= http_build_query($paramsCountry); ?>">
-                                                    <img src="/img/country/<?= $row["country"]; ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
+                                                    <img src="/img/country/<?= htmlspecialchars($row->getCountryCode(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
                                                 </a>
                                             </div>
                                         </div>
@@ -119,19 +121,21 @@ require_once("header.php");
                                     <td class="align-middle text-center" style="white-space: nowrap; width: 5rem;">
                                         <span id="date<?= $rank; ?>"></span>
                                         <script>
-                                            document.getElementById("date<?= $rank; ?>").innerHTML = new Date('<?= $row["last_known_date"]; ?> UTC').toLocaleString('sv-SE').replace(' ', '<br>');
+                                            document.getElementById("date<?= $rank; ?>").innerHTML = new Date(<?= json_encode($row->getLastKnownDate() . ' UTC'); ?>).toLocaleString('sv-SE').replace(' ', '<br>');
                                         </script>
                                     </td>
 
                                     <td class="align-middle text-center" style="white-space: nowrap; width: 10rem;">
                                         <div class="vstack gap-1">
                                             <div>
-                                                <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $row["platinum"]; ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $row["gold"]; ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $row["silver"]; ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $row["bronze"]; ?></span>
+                                                <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $row->getPlatinumCount(); ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $row->getGoldCount(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $row->getSilverCount(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $row->getBronzeCount(); ?></span>
                                             </div>
 
                                             <div>
-                                                <div class="progress" role="progressbar" aria-label="Player game progress" aria-valuenow="<?= $row["progress"]; ?>" aria-valuemin="0" aria-valuemax="100">
-                                                    <div class="progress-bar" style="width: <?= $row["progress"]; ?>%"><?= $row["progress"]; ?>%</div>
+                                                <div class="progress" role="progressbar" aria-label="Player game progress" aria-valuenow="<?= $row->getProgress(); ?>" aria-valuemin="0" aria-valuemax="100">
+                                                    <div class="progress-bar" style="width: <?= $row->getProgress(); ?>%">
+                                                        <?= $row->getProgress(); ?>%
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
## Summary
- add a `GameLeaderboardRow` value object to model leaderboard entries and helper behaviour
- update the leaderboard service/page to return the new row objects instead of associative arrays
- adjust the game leaderboard template to render using the new object API with improved escaping

## Testing
- php -l wwwroot/classes/GameLeaderboardRow.php
- php -l wwwroot/classes/GameLeaderboardService.php
- php -l wwwroot/classes/GameLeaderboardPage.php
- php -l wwwroot/game_leaderboard.php

------
https://chatgpt.com/codex/tasks/task_e_68d82d6fe3c8832f86ceef3670f50bc3