### PR TITLE
Refactor admin possible cheater page to view models

### DIFF
--- a/wwwroot/admin/possible.php
+++ b/wwwroot/admin/possible.php
@@ -2,11 +2,12 @@
 declare(strict_types=1);
 
 require_once '../init.php';
+require_once '../classes/Admin/PossibleCheaterPage.php';
 require_once '../classes/Admin/PossibleCheaterService.php';
 
 $possibleCheaterService = new PossibleCheaterService($database);
-$generalCheaters = $possibleCheaterService->getGeneralPossibleCheaters();
-$sections = $possibleCheaterService->getSectionResults();
+$possibleCheaterPage = new PossibleCheaterPage($possibleCheaterService);
+$possibleCheaterReport = $possibleCheaterPage->getReport();
 ?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">
@@ -20,18 +21,18 @@ $sections = $possibleCheaterService->getSectionResults();
     <body>
         <div class="p-4">
             <a href="/admin/">Back</a><br><br>
-            <?php foreach ($generalCheaters as $possibleCheater): ?>
-                <a href="/game/<?= (int) $possibleCheater['game_id']; ?>-<?= htmlspecialchars($utility->slugify($possibleCheater['game_name']), ENT_QUOTES, 'UTF-8'); ?>/<?= rawurlencode($possibleCheater['player_name']); ?>">
-                    <?= htmlspecialchars($possibleCheater['player_name'], ENT_QUOTES, 'UTF-8'); ?> (<?= $possibleCheater['account_id']; ?>)
+            <?php foreach ($possibleCheaterReport->getGeneralCheaters() as $possibleCheater): ?>
+                <a href="<?= htmlspecialchars($possibleCheater->getProfileUrl($utility), ENT_QUOTES, 'UTF-8'); ?>">
+                    <?= htmlspecialchars($possibleCheater->getPlayerName(), ENT_QUOTES, 'UTF-8'); ?> (<?= $possibleCheater->getAccountId(); ?>)
                 </a><br>
             <?php endforeach; ?>
 
-            <?php foreach ($sections as $section): ?>
+            <?php foreach ($possibleCheaterReport->getSections() as $section): ?>
                 <br>
-                <?= htmlspecialchars($section['title'], ENT_QUOTES, 'UTF-8'); ?><br>
-                <?php foreach ($section['entries'] as $entry): ?>
-                    <a href="<?= htmlspecialchars($entry['url'], ENT_QUOTES, 'UTF-8'); ?>">
-                        <?= htmlspecialchars($entry['online_id'], ENT_QUOTES, 'UTF-8'); ?> (<?= $entry['account_id']; ?>)
+                <?= htmlspecialchars($section->getTitle(), ENT_QUOTES, 'UTF-8'); ?><br>
+                <?php foreach ($section->getEntries() as $entry): ?>
+                    <a href="<?= htmlspecialchars($entry->getUrl(), ENT_QUOTES, 'UTF-8'); ?>">
+                        <?= htmlspecialchars($entry->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?> (<?= $entry->getAccountId(); ?>)
                     </a><br>
                 <?php endforeach; ?>
             <?php endforeach; ?>

--- a/wwwroot/classes/Admin/PossibleCheaterPage.php
+++ b/wwwroot/classes/Admin/PossibleCheaterPage.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PossibleCheaterReport.php';
+require_once __DIR__ . '/PossibleCheaterService.php';
+
+class PossibleCheaterPage
+{
+    private PossibleCheaterReport $report;
+
+    public function __construct(PossibleCheaterService $service)
+    {
+        $generalCheaters = array_map(
+            static fn(array $cheater): PossibleCheaterReportEntry => PossibleCheaterReportEntry::fromArray($cheater),
+            $service->getGeneralPossibleCheaters()
+        );
+
+        $sections = array_map(
+            static fn(array $section): PossibleCheaterReportSection => PossibleCheaterReportSection::fromArray($section),
+            $service->getSectionResults()
+        );
+
+        $this->report = new PossibleCheaterReport($generalCheaters, $sections);
+    }
+
+    public function getReport(): PossibleCheaterReport
+    {
+        return $this->report;
+    }
+}

--- a/wwwroot/classes/Admin/PossibleCheaterReport.php
+++ b/wwwroot/classes/Admin/PossibleCheaterReport.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../Utility.php';
+
+class PossibleCheaterReport
+{
+    /**
+     * @param PossibleCheaterReportEntry[] $generalCheaters
+     * @param PossibleCheaterReportSection[] $sections
+     */
+    public function __construct(
+        private array $generalCheaters,
+        private array $sections
+    ) {
+    }
+
+    /**
+     * @return PossibleCheaterReportEntry[]
+     */
+    public function getGeneralCheaters(): array
+    {
+        return $this->generalCheaters;
+    }
+
+    /**
+     * @return PossibleCheaterReportSection[]
+     */
+    public function getSections(): array
+    {
+        return $this->sections;
+    }
+}
+
+class PossibleCheaterReportEntry
+{
+    public function __construct(
+        private int $gameId,
+        private string $gameName,
+        private string $playerName,
+        private int $accountId
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (int) ($data['game_id'] ?? 0),
+            (string) ($data['game_name'] ?? ''),
+            (string) ($data['player_name'] ?? ''),
+            (int) ($data['account_id'] ?? 0)
+        );
+    }
+
+    public function getPlayerName(): string
+    {
+        return $this->playerName;
+    }
+
+    public function getAccountId(): int
+    {
+        return $this->accountId;
+    }
+
+    public function getProfileUrl(Utility $utility): string
+    {
+        $slug = $utility->slugify($this->gameName);
+        $player = rawurlencode($this->playerName);
+
+        return sprintf('/game/%d-%s/%s', $this->gameId, $slug, $player);
+    }
+}
+
+class PossibleCheaterReportSection
+{
+    /**
+     * @param PossibleCheaterReportSectionEntry[] $entries
+     */
+    public function __construct(
+        private string $title,
+        private array $entries
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $title = (string) ($data['title'] ?? '');
+        $entryData = is_array($data['entries'] ?? null) ? $data['entries'] : [];
+
+        $entries = array_map(
+            static fn(array $entry): PossibleCheaterReportSectionEntry => PossibleCheaterReportSectionEntry::fromArray($entry),
+            $entryData
+        );
+
+        return new self($title, $entries);
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return PossibleCheaterReportSectionEntry[]
+     */
+    public function getEntries(): array
+    {
+        return $this->entries;
+    }
+}
+
+class PossibleCheaterReportSectionEntry
+{
+    public function __construct(
+        private string $url,
+        private string $onlineId,
+        private int $accountId
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (string) ($data['url'] ?? ''),
+            (string) ($data['online_id'] ?? ''),
+            (int) ($data['account_id'] ?? 0)
+        );
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getOnlineId(): string
+    {
+        return $this->onlineId;
+    }
+
+    public function getAccountId(): int
+    {
+        return $this->accountId;
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated report, entry, and section classes for the possible cheater admin view
- introduce a page object to build the report from the service
- update the admin possible cheater page to render using the new OOP abstractions

## Testing
- php -l wwwroot/classes/Admin/PossibleCheaterReport.php
- php -l wwwroot/classes/Admin/PossibleCheaterPage.php
- php -l wwwroot/admin/possible.php

------
https://chatgpt.com/codex/tasks/task_e_68d9006f31b0832f9cb2b5a6123c7354