### PR TITLE
Refactor reported players admin page

### DIFF
--- a/wwwroot/admin/report.php
+++ b/wwwroot/admin/report.php
@@ -3,14 +3,15 @@ declare(strict_types=1);
 
 require_once '../init.php';
 require_once '../classes/Admin/PlayerReportAdminService.php';
+require_once '../classes/Admin/PlayerReportAdminPage.php';
 
 $playerReportAdminService = new PlayerReportAdminService($database);
+$playerReportAdminPage = new PlayerReportAdminPage($playerReportAdminService);
+$pageResult = $playerReportAdminPage->handle($_GET ?? []);
 
-if (isset($_GET['delete']) && ctype_digit((string) $_GET['delete'])) {
-    $playerReportAdminService->deleteReportById((int) $_GET['delete']);
-}
-
-$reportedPlayers = $playerReportAdminService->getReportedPlayers();
+$reportedPlayers = $pageResult->getReportedPlayers();
+$successMessage = $pageResult->getSuccessMessage();
+$errorMessage = $pageResult->getErrorMessage();
 ?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">
@@ -24,6 +25,16 @@ $reportedPlayers = $playerReportAdminService->getReportedPlayers();
     <body>
         <div class="p-4">
             <a href="/admin/">Back</a><br><br>
+            <?php if ($successMessage !== null) { ?>
+                <div class="alert alert-success" role="alert">
+                    <?= htmlentities($successMessage, ENT_QUOTES, 'UTF-8'); ?>
+                </div>
+            <?php } ?>
+            <?php if ($errorMessage !== null) { ?>
+                <div class="alert alert-warning" role="alert">
+                    <?= htmlentities($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
+                </div>
+            <?php } ?>
             <?php foreach ($reportedPlayers as $reportedPlayer) { ?>
                 <div class="mb-3">
                     <a href="/player/<?= htmlentities($reportedPlayer->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>">

--- a/wwwroot/classes/Admin/PlayerReportAdminPage.php
+++ b/wwwroot/classes/Admin/PlayerReportAdminPage.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerReportAdminService.php';
+require_once __DIR__ . '/PlayerReportAdminPageResult.php';
+
+class PlayerReportAdminPage
+{
+    private PlayerReportAdminService $playerReportAdminService;
+
+    public function __construct(PlayerReportAdminService $playerReportAdminService)
+    {
+        $this->playerReportAdminService = $playerReportAdminService;
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public function handle(array $queryParameters): PlayerReportAdminPageResult
+    {
+        $successMessage = null;
+        $errorMessage = null;
+
+        if (array_key_exists('delete', $queryParameters)) {
+            $deleteId = $this->parseDeleteId($queryParameters['delete']);
+
+            if ($deleteId === null) {
+                $errorMessage = 'Please provide a valid report ID to delete.';
+            } else {
+                $this->playerReportAdminService->deleteReportById($deleteId);
+                $successMessage = sprintf('Report %d deleted successfully.', $deleteId);
+            }
+        }
+
+        $reportedPlayers = $this->playerReportAdminService->getReportedPlayers();
+
+        return new PlayerReportAdminPageResult($reportedPlayers, $successMessage, $errorMessage);
+    }
+
+    private function parseDeleteId(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value > 0 ? $value : null;
+        }
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmedValue = trim($value);
+        if ($trimmedValue === '') {
+            return null;
+        }
+
+        if (!ctype_digit($trimmedValue)) {
+            return null;
+        }
+
+        $deleteId = (int) $trimmedValue;
+
+        return $deleteId > 0 ? $deleteId : null;
+    }
+}

--- a/wwwroot/classes/Admin/PlayerReportAdminPageResult.php
+++ b/wwwroot/classes/Admin/PlayerReportAdminPageResult.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/ReportedPlayer.php';
+
+class PlayerReportAdminPageResult
+{
+    /**
+     * @var ReportedPlayer[]
+     */
+    private array $reportedPlayers;
+
+    private ?string $successMessage;
+
+    private ?string $errorMessage;
+
+    /**
+     * @param ReportedPlayer[] $reportedPlayers
+     */
+    public function __construct(array $reportedPlayers, ?string $successMessage = null, ?string $errorMessage = null)
+    {
+        $this->reportedPlayers = $reportedPlayers;
+        $this->successMessage = $successMessage;
+        $this->errorMessage = $errorMessage;
+    }
+
+    /**
+     * @return ReportedPlayer[]
+     */
+    public function getReportedPlayers(): array
+    {
+        return $this->reportedPlayers;
+    }
+
+    public function getSuccessMessage(): ?string
+    {
+        return $this->successMessage;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+}


### PR DESCRIPTION
## Summary
- wrap the reported players admin logic in an object-oriented page handler
- add a result object to expose reported players and any status messages to the view
- show success and error alerts when deletions are processed

## Testing
- php -l wwwroot/classes/Admin/PlayerReportAdminPage.php
- php -l wwwroot/classes/Admin/PlayerReportAdminPageResult.php
- php -l wwwroot/admin/report.php

------
https://chatgpt.com/codex/tasks/task_e_68d976a7c298832fb2723d5ab8ccc817