### PR TITLE
Refactor meta tag generation into renderer class

### DIFF
--- a/wwwroot/classes/PageMetaDataRenderer.php
+++ b/wwwroot/classes/PageMetaDataRenderer.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PageMetaData.php';
+
+class PageMetaDataRenderer
+{
+    private const OG_SITE_NAME = 'PSN 100%';
+    private const TWITTER_CARD = 'summary_large_image';
+
+    public function render(PageMetaData $metaData): string
+    {
+        if ($metaData->isEmpty()) {
+            return '';
+        }
+
+        $tags = [];
+
+        $canonicalUrl = $this->escape($metaData->getUrl());
+        if ($canonicalUrl !== null) {
+            $tags[] = sprintf('<link rel="canonical" href="%s" />', $canonicalUrl);
+            $tags[] = sprintf('<meta property="og:url" content="%s">', $canonicalUrl);
+        }
+
+        $description = $this->escape($metaData->getDescription());
+        if ($description !== null) {
+            $tags[] = sprintf('<meta property="og:description" content="%s">', $description);
+        }
+
+        $image = $this->escape($metaData->getImage());
+        if ($image !== null) {
+            $tags[] = sprintf('<meta property="og:image" content="%s">', $image);
+        }
+
+        $title = $this->escape($metaData->getTitle());
+        if ($title !== null) {
+            $tags[] = sprintf('<meta property="og:title" content="%s">', $title);
+            $tags[] = sprintf('<meta name="twitter:image:alt" content="%s">', $title);
+        }
+
+        $tags[] = sprintf('<meta property="og:site_name" content="%s">', self::OG_SITE_NAME);
+        $tags[] = '<meta property="og:type" content="article">';
+        $tags[] = sprintf('<meta name="twitter:card" content="%s">', self::TWITTER_CARD);
+
+        return implode(PHP_EOL, $tags);
+    }
+
+    private function escape(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/wwwroot/header.php
+++ b/wwwroot/header.php
@@ -1,4 +1,13 @@
-<?php require_once __DIR__ . '/classes/PageMetaData.php'; ?>
+<?php
+require_once __DIR__ . '/classes/PageMetaData.php';
+require_once __DIR__ . '/classes/PageMetaDataRenderer.php';
+
+$metaTagHtml = '';
+if (isset($metaData) && $metaData instanceof PageMetaData) {
+    $renderer = new PageMetaDataRenderer();
+    $metaTagHtml = $renderer->render($metaData);
+}
+?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">
     <head>
@@ -10,24 +19,7 @@
         <meta name="description" content="Check your leaderboard position against other PlayStation trophy hunters!">
         <meta name="author" content="Markus 'Ragowit' Persson, and other contributors via GitHub project">
 
-        <?php
-        if (isset($metaData) && $metaData instanceof PageMetaData && !$metaData->isEmpty()) {
-            $canonicalUrl = htmlspecialchars($metaData->getUrl() ?? '', ENT_QUOTES, 'UTF-8');
-            $description = htmlspecialchars($metaData->getDescription() ?? '', ENT_QUOTES, 'UTF-8');
-            $image = htmlspecialchars($metaData->getImage() ?? '', ENT_QUOTES, 'UTF-8');
-            $titleMeta = htmlspecialchars($metaData->getTitle() ?? '', ENT_QUOTES, 'UTF-8');
-
-            echo "<link rel=\"canonical\" href=\"" . $canonicalUrl . "\" />";
-            echo "<meta property=\"og:description\" content=\"" . $description . "\">";
-            echo "<meta property=\"og:image\" content=\"" . $image . "\">";
-            echo "<meta property=\"og:site_name\" content=\"PSN 100%\">";
-            echo "<meta property=\"og:title\" content=\"" . $titleMeta . "\">";
-            echo "<meta property=\"og:type\" content=\"article\">";
-            echo "<meta property=\"og:url\" content=\"" . $canonicalUrl . "\">";
-            echo "<meta name=\"twitter:card\" content=\"summary_large_image\">";
-            echo "<meta name=\"twitter:image:alt\" content=\"" . $titleMeta . "\">";
-        }
-        ?>
+        <?= $metaTagHtml; ?>
 
         <link rel="apple-touch-icon" sizes="180x180" href="/img/apple-touch-icon.png">
         <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon-32x32.png">


### PR DESCRIPTION
## Summary
- introduce a PageMetaDataRenderer class to encapsulate building social meta tags
- update the shared header template to rely on the renderer when page meta data is present

## Testing
- php -l wwwroot/header.php
- php -l wwwroot/classes/PageMetaDataRenderer.php

------
https://chatgpt.com/codex/tasks/task_e_68da2ed337c4832fb0a5f3dded14f160