### PR TITLE
Extract shared pagination renderer

### DIFF
--- a/wwwroot/avatars.php
+++ b/wwwroot/avatars.php
@@ -35,63 +35,12 @@ require_once("header.php");
 
     <div class="row">
         <div class="col-12">
-            <nav aria-label="Avatars page navigation">
-                <ul class="pagination justify-content-center">
-                    <?php
-                    if ($avatarPage->hasPreviousPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $avatarPage->getPreviousPage(); ?>" aria-label="Previous">&lt;</a></li>
-                        <?php
-                    }
-
-                    if ($avatarPage->shouldShowFirstPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $avatarPage->getFirstPage(); ?>"><?= $avatarPage->getFirstPage(); ?></a></li>
-                        <?php
-                    }
-
-                    if ($avatarPage->shouldShowLeadingEllipsis()) {
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <?php
-                    }
-
-                    foreach ($avatarPage->getPreviousPages() as $previousPage) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $previousPage; ?>"><?= $previousPage; ?></a></li>
-                        <?php
-                    }
-                    ?>
-
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?page=<?= $avatarPage->getCurrentPage(); ?>"><?= $avatarPage->getCurrentPage(); ?></a></li>
-
-                    <?php
-                    foreach ($avatarPage->getNextPages() as $nextPage) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $nextPage; ?>"><?= $nextPage; ?></a></li>
-                        <?php
-                    }
-
-                    if ($avatarPage->shouldShowTrailingEllipsis()) {
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <?php
-                    }
-
-                    if ($avatarPage->shouldShowLastPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $avatarPage->getLastPage(); ?>"><?= $avatarPage->getLastPage(); ?></a></li>
-                        <?php
-                    }
-
-                    if ($avatarPage->hasNextPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $avatarPage->getNextPage(); ?>" aria-label="Next">&gt;</a></li>
-                        <?php
-                    }
-                    ?>
-                </ul>
-            </nav>
+            <?php renderPagination(
+                $avatarPage->getCurrentPage(),
+                $avatarPage->getLastPage(),
+                static fn (int $pageNumber): array => ['page' => (string) $pageNumber],
+                'Avatars page navigation'
+            ); ?>
         </div>
     </div>
 </main>

--- a/wwwroot/changelog.php
+++ b/wwwroot/changelog.php
@@ -44,73 +44,12 @@ require_once("header.php");
             </p>
         </div>
         <div class="col-12">
-            <nav aria-label="Page navigation">
-                <ul class="pagination justify-content-center">
-                    <?php
-                    $currentPage = $changelogPage->getCurrentPage();
-                    $totalPages = $changelogPage->getTotalPages();
-                    $lastPageNumber = $changelogPage->getLastPageNumber();
-
-                    if ($changelogPage->hasPreviousPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $changelogPage->getPreviousPage(); ?>">Prev</a></li>
-                        <?php
-                    }
-
-                    if ($currentPage > 3) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=1">1</a></li>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">~</a></li>
-                        <?php
-                    }
-
-                    if ($currentPage - 2 > 0) {
-                        $pageNumber = $currentPage - 2;
-                        if ($pageNumber >= 1) {
-                            ?>
-                            <li class="page-item"><a class="page-link" href="?page=<?= $pageNumber; ?>"><?= $pageNumber; ?></a></li>
-                            <?php
-                        }
-                    }
-
-                    if ($currentPage - 1 > 0) {
-                        $pageNumber = $currentPage - 1;
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $pageNumber; ?>"><?= $pageNumber; ?></a></li>
-                        <?php
-                    }
-                    ?>
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?page=<?= $currentPage; ?>"><?= $currentPage; ?></a></li>
-                    <?php
-                    if ($currentPage + 1 <= $lastPageNumber) {
-                        $pageNumber = $currentPage + 1;
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $pageNumber; ?>"><?= $pageNumber; ?></a></li>
-                        <?php
-                    }
-
-                    if ($currentPage + 2 <= $lastPageNumber) {
-                        $pageNumber = $currentPage + 2;
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $pageNumber; ?>"><?= $pageNumber; ?></a></li>
-                        <?php
-                    }
-
-                    if ($totalPages > 0 && $currentPage < $totalPages - 2) {
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">~</a></li>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $totalPages; ?>"><?= $totalPages; ?></a></li>
-                        <?php
-                    }
-
-                    if ($currentPage < $totalPages) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?page=<?= $changelogPage->getNextPage(); ?>">Next</a></li>
-                        <?php
-                    }
-                    ?>
-                </ul>
-            </nav>
+            <?php renderPagination(
+                $changelogPage->getCurrentPage(),
+                $changelogPage->getLastPageNumber(),
+                static fn (int $pageNumber): array => ['page' => (string) $pageNumber],
+                'Changelog page navigation'
+            ); ?>
         </div>
     </div>
 </main>

--- a/wwwroot/game_leaderboard.php
+++ b/wwwroot/game_leaderboard.php
@@ -158,76 +158,12 @@ require_once("header.php");
             </p>
         </div>
         <div class="col-12">
-            <nav aria-label="Game Leaderboard page navigation">
-                <ul class="pagination justify-content-center">
-                    <?php
-                    if ($page > 1) {
-                        $previousParams = $filter->withPage($page - 1);
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($previousParams); ?>" aria-label="Previous">&lt;</a></li>
-                        <?php
-                    }
-
-                    if ($page > 3) {
-                        $firstPageParams = $filter->withPage(1);
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($firstPageParams); ?>">1</a></li>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <?php
-                    }
-
-                    if ($page-2 > 0) {
-                        $twoBackParams = $filter->withPage($page - 2);
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($twoBackParams); ?>"><?= $page-2; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page-1 > 0) {
-                        $oneBackParams = $filter->withPage($page - 1);
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($oneBackParams); ?>"><?= $page-1; ?></a></li>
-                        <?php
-                    }
-                    ?>
-
-                    <?php
-                    $currentPageParams = $filter->withPage($page);
-                    ?>
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($currentPageParams); ?>"><?= $page; ?></a></li>
-
-                    <?php
-                    if ($page + 1 <= $totalPagesCount) {
-                        $oneAheadParams = $filter->withPage($page + 1);
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($oneAheadParams); ?>"><?= $page+1; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page + 2 <= $totalPagesCount) {
-                        $twoAheadParams = $filter->withPage($page + 2);
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($twoAheadParams); ?>"><?= $page+2; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page < $totalPagesCount - 2) {
-                        $lastPageParams = $filter->withPage($totalPagesCount);
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($lastPageParams); ?>"><?= $totalPagesCount; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page < $totalPagesCount) {
-                        $nextParams = $filter->withPage($page + 1);
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($nextParams); ?>" aria-label="Next">&gt;</a></li>
-                        <?php
-                    }
-                    ?>
-                </ul>
-            </nav>
+            <?php renderPagination(
+                $page,
+                $totalPagesCount,
+                static fn (int $pageNumber): array => $filter->withPage($pageNumber),
+                'Game Leaderboard page navigation'
+            ); ?>
         </div>
     </div>
 </main>

--- a/wwwroot/games.php
+++ b/wwwroot/games.php
@@ -215,70 +215,12 @@ require_once("header.php");
             </p>
         </div>
         <div class="col-12">
-            <nav aria-label="Games page navigation">
-                <ul class="pagination justify-content-center">
-                    <?php
-                    if ($gameListPage->hasPreviousPage()) {
-                        $previousParameters = $gameListPage->getPageQueryParameters($gameListPage->getPreviousPage());
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($previousParameters); ?>" aria-label="Previous">&lt;</a></li>
-                        <?php
-                    }
-
-                    if ($gameListPage->shouldShowFirstPage()) {
-                        $firstParameters = $gameListPage->getPageQueryParameters($gameListPage->getFirstPage());
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($firstParameters); ?>">1</a></li>
-                        <?php
-                    }
-
-                    if ($gameListPage->shouldShowLeadingEllipsis()) {
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <?php
-                    }
-
-                    foreach ($gameListPage->getPreviousPages() as $previousPage) {
-                        $params = $gameListPage->getPageQueryParameters($previousPage);
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= $previousPage; ?></a></li>
-                        <?php
-                    }
-
-                    $currentParameters = $gameListPage->getCurrentPageParameters();
-                    ?>
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($currentParameters); ?>"><?= $gameListPage->getCurrentPage(); ?></a></li>
-
-                    <?php
-                    foreach ($gameListPage->getNextPages() as $nextPage) {
-                        $params = $gameListPage->getPageQueryParameters($nextPage);
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($params); ?>"><?= $nextPage; ?></a></li>
-                        <?php
-                    }
-
-                    if ($gameListPage->shouldShowTrailingEllipsis()) {
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <?php
-                    }
-
-                    if ($gameListPage->shouldShowLastPage()) {
-                        $lastParameters = $gameListPage->getLastPageParameters();
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($lastParameters); ?>"><?= $gameListPage->getLastPage(); ?></a></li>
-                        <?php
-                    }
-
-                    if ($gameListPage->hasNextPage()) {
-                        $nextParameters = $gameListPage->getPageQueryParameters($gameListPage->getNextPage());
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($nextParameters); ?>" aria-label="Next">&gt;</a></li>
-                        <?php
-                    }
-                    ?>
-                </ul>
-            </nav>
+            <?php renderPagination(
+                $gameListPage->getCurrentPage(),
+                $gameListPage->getLastPage(),
+                static fn (int $pageNumber): array => $gameListPage->getPageQueryParameters($pageNumber),
+                'Games page navigation'
+            ); ?>
         </div>
     </div>
 </main>

--- a/wwwroot/header.php
+++ b/wwwroot/header.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/classes/PageMetaData.php';
 require_once __DIR__ . '/classes/PageMetaDataRenderer.php';
+require_once __DIR__ . '/pagination.php';
 
 $metaTagHtml = '';
 if (isset($metaData) && $metaData instanceof PageMetaData) {

--- a/wwwroot/leaderboard_main.php
+++ b/wwwroot/leaderboard_main.php
@@ -8,7 +8,6 @@ require_once("header.php");
 $playerLeaderboardPage = $trophyLeaderboardPageContext->getLeaderboardPage();
 $rows = $trophyLeaderboardPageContext->getRows();
 $filterParameters = $trophyLeaderboardPageContext->getFilterQueryParameters();
-$pageParameters = $trophyLeaderboardPageContext->getCurrentPageQueryParameters();
 ?>
 
 <main class="container">
@@ -109,63 +108,12 @@ $pageParameters = $trophyLeaderboardPageContext->getCurrentPageQueryParameters()
             </p>
         </div>
         <div class="col-12">
-            <nav aria-label="Leaderboard page navigation">
-                <ul class="pagination justify-content-center">
-                    <?php
-                    if ($playerLeaderboardPage->hasPreviousPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getPreviousPage())); ?>">&lt;</a></li>
-                        <?php
-                    }
-
-                    if ($playerLeaderboardPage->shouldShowFirstPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getFirstPage())); ?>"><?= $playerLeaderboardPage->getFirstPage(); ?></a></li>
-                        <?php
-                    }
-
-                    if ($playerLeaderboardPage->shouldShowLeadingEllipsis()) {
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <?php
-                    }
-
-                    foreach ($playerLeaderboardPage->getPreviousPages() as $previousPage) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($previousPage)); ?>"><?= $previousPage; ?></a></li>
-                        <?php
-                    }
-                    ?>
-
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($pageParameters); ?>"><?= $playerLeaderboardPage->getCurrentPage(); ?></a></li>
-
-                    <?php
-                    foreach ($playerLeaderboardPage->getNextPages() as $nextPage) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($nextPage)); ?>"><?= $nextPage; ?></a></li>
-                        <?php
-                    }
-
-                    if ($playerLeaderboardPage->shouldShowTrailingEllipsis()) {
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <?php
-                    }
-
-                    if ($playerLeaderboardPage->shouldShowLastPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getLastPage())); ?>"><?= $playerLeaderboardPage->getLastPage(); ?></a></li>
-                        <?php
-                    }
-
-                    if ($playerLeaderboardPage->hasNextPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getNextPage())); ?>">&gt;</a></li>
-                        <?php
-                    }
-                    ?>
-                </ul>
-            </nav>
+            <?php renderPagination(
+                $playerLeaderboardPage->getCurrentPage(),
+                $playerLeaderboardPage->getLastPage(),
+                static fn (int $pageNumber): array => $playerLeaderboardPage->getPageQueryParameters($pageNumber),
+                'Leaderboard page navigation'
+            ); ?>
         </div>
     </div>
 </main>

--- a/wwwroot/leaderboard_rarity.php
+++ b/wwwroot/leaderboard_rarity.php
@@ -13,7 +13,6 @@ $playerLeaderboardPage = new PlayerLeaderboardPage($playerLeaderboardService, $p
 
 $players = $playerLeaderboardPage->getPlayers();
 $filterParameters = $playerLeaderboardPage->getFilterParameters();
-$pageParameters = $playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getCurrentPage());
 $highlightedPlayerId = isset($_GET['player']) ? (string) $_GET['player'] : null;
 
 $rows = array_map(
@@ -126,63 +125,12 @@ $rows = array_map(
             </p>
         </div>
         <div class="col-12">
-            <nav aria-label="Leaderboard page navigation">
-                <ul class="pagination justify-content-center">
-                    <?php
-                    if ($playerLeaderboardPage->hasPreviousPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getPreviousPage())); ?>">&lt;</a></li>
-                        <?php
-                    }
-
-                    if ($playerLeaderboardPage->shouldShowFirstPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getFirstPage())); ?>"><?= $playerLeaderboardPage->getFirstPage(); ?></a></li>
-                        <?php
-                    }
-
-                    if ($playerLeaderboardPage->shouldShowLeadingEllipsis()) {
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <?php
-                    }
-
-                    foreach ($playerLeaderboardPage->getPreviousPages() as $previousPage) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($previousPage)); ?>"><?= $previousPage; ?></a></li>
-                        <?php
-                    }
-                    ?>
-
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($pageParameters); ?>"><?= $playerLeaderboardPage->getCurrentPage(); ?></a></li>
-
-                    <?php
-                    foreach ($playerLeaderboardPage->getNextPages() as $nextPage) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($nextPage)); ?>"><?= $nextPage; ?></a></li>
-                        <?php
-                    }
-
-                    if ($playerLeaderboardPage->shouldShowTrailingEllipsis()) {
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <?php
-                    }
-
-                    if ($playerLeaderboardPage->shouldShowLastPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getLastPage())); ?>"><?= $playerLeaderboardPage->getLastPage(); ?></a></li>
-                        <?php
-                    }
-
-                    if ($playerLeaderboardPage->hasNextPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerLeaderboardPage->getPageQueryParameters($playerLeaderboardPage->getNextPage())); ?>">&gt;</a></li>
-                        <?php
-                    }
-                    ?>
-                </ul>
-            </nav>
+            <?php renderPagination(
+                $playerLeaderboardPage->getCurrentPage(),
+                $playerLeaderboardPage->getLastPage(),
+                static fn (int $pageNumber): array => $playerLeaderboardPage->getPageQueryParameters($pageNumber),
+                'Leaderboard page navigation'
+            ); ?>
         </div>
     </div>
 </main>

--- a/wwwroot/pagination.php
+++ b/wwwroot/pagination.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Render Bootstrap pagination links that match the site's existing style.
+ *
+ * @param callable(int):array<string, string> $queryParametersFactory
+ */
+function renderPagination(
+    int $currentPage,
+    int $totalPages,
+    callable $queryParametersFactory,
+    ?string $ariaLabel = null
+): void {
+    $totalPages = max(1, $totalPages);
+    $navAttributes = '';
+
+    if ($ariaLabel !== null && $ariaLabel !== '') {
+        $navAttributes = ' aria-label="' . htmlspecialchars($ariaLabel, ENT_QUOTES, 'UTF-8') . '"';
+    }
+
+    $buildUrl = static function (int $page) use ($queryParametersFactory): string {
+        $parameters = $queryParametersFactory($page);
+
+        if (!is_array($parameters)) {
+            throw new \InvalidArgumentException('Pagination parameter factory must return an array.');
+        }
+
+        return '?' . http_build_query($parameters);
+    };
+    ?>
+    <nav<?= $navAttributes; ?>>
+        <ul class="pagination justify-content-center">
+            <?php if ($currentPage > 1) { ?>
+                <li class="page-item"><a class="page-link" href="<?= $buildUrl($currentPage - 1); ?>" aria-label="Previous">&lt;</a></li>
+            <?php } ?>
+
+            <?php if ($currentPage > 3) { ?>
+                <li class="page-item"><a class="page-link" href="<?= $buildUrl(1); ?>">1</a></li>
+                <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
+            <?php } ?>
+
+            <?php for ($i = 2; $i >= 1; $i--) {
+                $previousPage = $currentPage - $i;
+
+                if ($previousPage > 0) {
+                    ?>
+                    <li class="page-item"><a class="page-link" href="<?= $buildUrl($previousPage); ?>"><?= $previousPage; ?></a></li>
+                    <?php
+                }
+            } ?>
+
+            <li class="page-item active" aria-current="page"><a class="page-link" href="<?= $buildUrl($currentPage); ?>"><?= $currentPage; ?></a></li>
+
+            <?php for ($i = 1; $i <= 2; $i++) {
+                $nextPage = $currentPage + $i;
+
+                if ($nextPage <= $totalPages) {
+                    ?>
+                    <li class="page-item"><a class="page-link" href="<?= $buildUrl($nextPage); ?>"><?= $nextPage; ?></a></li>
+                    <?php
+                }
+            } ?>
+
+            <?php if ($currentPage < $totalPages - 2) { ?>
+                <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
+                <li class="page-item"><a class="page-link" href="<?= $buildUrl($totalPages); ?>"><?= $totalPages; ?></a></li>
+            <?php } ?>
+
+            <?php if ($currentPage < $totalPages) { ?>
+                <li class="page-item"><a class="page-link" href="<?= $buildUrl($currentPage + 1); ?>" aria-label="Next">&gt;</a></li>
+            <?php } ?>
+        </ul>
+    </nav>
+    <?php
+}

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -308,62 +308,12 @@ require_once("header.php");
             </p>
         </div>
         <div class="col-12">
-            <nav aria-label="Player games navigation">
-                <ul class="pagination justify-content-center">
-                    <?php
-                    if ($playerGamesPage->hasPreviousPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerGamesPage->getPageQueryParameters($playerGamesPage->getPreviousPage())); ?>" aria-label="Previous">&lt;</a></li>
-                        <?php
-                    }
-
-                    if ($playerGamesPage->shouldShowFirstPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerGamesPage->getPageQueryParameters($playerGamesPage->getFirstPage())); ?>">1</a></li>
-                        <?php
-                        if ($playerGamesPage->shouldShowLeadingEllipsis()) {
-                            ?>
-                            <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                            <?php
-                        }
-                    }
-
-                    foreach ($playerGamesPage->getPreviousPages() as $previousPage) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerGamesPage->getPageQueryParameters($previousPage)); ?>"><?= $previousPage; ?></a></li>
-                        <?php
-                    }
-                    ?>
-
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($playerGamesPage->getPageQueryParameters($playerGamesPage->getCurrentPage())); ?>"><?= $playerGamesPage->getCurrentPage(); ?></a></li>
-
-                    <?php
-                    foreach ($playerGamesPage->getNextPages() as $nextPage) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerGamesPage->getPageQueryParameters($nextPage)); ?>"><?= $nextPage; ?></a></li>
-                        <?php
-                    }
-
-                    if ($playerGamesPage->shouldShowTrailingEllipsis()) {
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <?php
-                    }
-
-                    if ($playerGamesPage->shouldShowLastPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerGamesPage->getPageQueryParameters($playerGamesPage->getLastPage())); ?>"><?= $playerGamesPage->getLastPage(); ?></a></li>
-                        <?php
-                    }
-
-                    if ($playerGamesPage->hasNextPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($playerGamesPage->getPageQueryParameters($playerGamesPage->getNextPage())); ?>" aria-label="Next">&gt;</a></li>
-                        <?php
-                    }
-                    ?>
-                </ul>
-            </nav>
+            <?php renderPagination(
+                $playerGamesPage->getCurrentPage(),
+                $playerGamesPage->getLastPage(),
+                static fn (int $pageNumber): array => $playerGamesPage->getPageQueryParameters($pageNumber),
+                'Player games navigation'
+            ); ?>
         </div>
     </div>
 </main>

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -234,87 +234,15 @@ require_once("header.php");
             </p>
         </div>
         <div class="col-12">
-            <nav aria-label="Player log navigation">
-                <ul class="pagination justify-content-center">
-                    <?php
-                    $baseParameters = $filterParameters;
-
-                    if ($page > 1) {
-                        $previousParameters = $baseParameters;
-                        $previousParameters['page'] = $page - 1;
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($previousParameters); ?>" aria-label="Previous">&lt;</a></li>
-                        <?php
-                    }
-
-                    if ($page > 3) {
-                        $firstPageParameters = $baseParameters;
-                        $firstPageParameters['page'] = 1;
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($firstPageParameters); ?>">1</a></li>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <?php
-                    }
-
-                    if ($page-2 > 0) {
-                        $twoBeforeParameters = $baseParameters;
-                        $twoBeforeParameters['page'] = $page - 2;
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($twoBeforeParameters); ?>"><?= $page-2; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page-1 > 0) {
-                        $oneBeforeParameters = $baseParameters;
-                        $oneBeforeParameters['page'] = $page - 1;
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($oneBeforeParameters); ?>"><?= $page-1; ?></a></li>
-                        <?php
-                    }
-                    ?>
-
-                    <?php
-                    $currentParameters = $baseParameters;
-                    $currentParameters['page'] = $page;
-                    ?>
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($currentParameters); ?>"><?= $page; ?></a></li>
-
-                    <?php
-                    if ($page + 1 <= $totalPages) {
-                        $oneAfterParameters = $baseParameters;
-                        $oneAfterParameters['page'] = $page + 1;
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($oneAfterParameters); ?>"><?= $page+1; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page + 2 <= $totalPages) {
-                        $twoAfterParameters = $baseParameters;
-                        $twoAfterParameters['page'] = $page + 2;
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($twoAfterParameters); ?>"><?= $page+2; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page < $totalPages - 2) {
-                        $lastPageParameters = $baseParameters;
-                        $lastPageParameters['page'] = $totalPages;
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($lastPageParameters); ?>"><?= $totalPages; ?></a></li>
-                        <?php
-                    }
-
-                    if ($page < $totalPages) {
-                        $nextParameters = $baseParameters;
-                        $nextParameters['page'] = $page + 1;
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($nextParameters); ?>" aria-label="Next">&gt;</a></li>
-                        <?php
-                    }
-                    ?>
-                </ul>
-            </nav>
+            <?php renderPagination(
+                $page,
+                $totalPages,
+                static fn (int $pageNumber): array => array_merge(
+                    $filterParameters,
+                    ['page' => (string) $pageNumber]
+                ),
+                'Player log navigation'
+            ); ?>
         </div>
     </div>
 </main>

--- a/wwwroot/trophies.php
+++ b/wwwroot/trophies.php
@@ -113,63 +113,12 @@ require_once('header.php');
             </p>
         </div>
         <div class="col-12">
-            <nav aria-label="Trophies page navigation">
-                <ul class="pagination justify-content-center">
-                    <?php
-                    if ($trophyListPage->hasPreviousPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($trophyListPage->getPreviousPage())); ?>">&lt;</a></li>
-                        <?php
-                    }
-
-                    if ($trophyListPage->shouldShowFirstPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($trophyListPage->getFirstPage())); ?>"><?= $trophyListPage->getFirstPage(); ?></a></li>
-                        <?php
-
-                        if ($trophyListPage->shouldShowLeadingEllipsis()) {
-                            ?>
-                            <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                            <?php
-                        }
-                    }
-
-                    foreach ($trophyListPage->getPreviousPages() as $previousPage) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($previousPage)); ?>"><?= $previousPage; ?></a></li>
-                        <?php
-                    }
-                    ?>
-
-                    <li class="page-item active" aria-current="page"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($trophyListPage->getCurrentPage())); ?>"><?= $trophyListPage->getCurrentPage(); ?></a></li>
-
-                    <?php
-                    foreach ($trophyListPage->getNextPages() as $nextPage) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($nextPage)); ?>"><?= $nextPage; ?></a></li>
-                        <?php
-                    }
-
-                    if ($trophyListPage->shouldShowTrailingEllipsis()) {
-                        ?>
-                        <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>
-                        <?php
-                    }
-
-                    if ($trophyListPage->shouldShowLastPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($trophyListPage->getLastPage())); ?>"><?= $trophyListPage->getLastPage(); ?></a></li>
-                        <?php
-                    }
-
-                    if ($trophyListPage->hasNextPage()) {
-                        ?>
-                        <li class="page-item"><a class="page-link" href="?<?= http_build_query($trophyListPage->getPageQueryParameters($trophyListPage->getNextPage())); ?>">&gt;</a></li>
-                        <?php
-                    }
-                    ?>
-                </ul>
-            </nav>
+            <?php renderPagination(
+                $trophyListPage->getCurrentPage(),
+                $trophyListPage->getLastPage(),
+                static fn (int $pageNumber): array => $trophyListPage->getPageQueryParameters($pageNumber),
+                'Trophies page navigation'
+            ); ?>
         </div>
     </div>
 </main>


### PR DESCRIPTION
## Summary
- add a reusable pagination renderer that encapsulates the shared HTML fragment
- load the helper from the header and replace duplicated pagination markup across affected pages

## Testing
- for file in wwwroot/pagination.php wwwroot/header.php wwwroot/game_leaderboard.php wwwroot/player_advisor.php wwwroot/leaderboard_main.php wwwroot/leaderboard_rarity.php wwwroot/changelog.php wwwroot/player.php wwwroot/avatars.php wwwroot/trophies.php wwwroot/games.php; do php -l "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68da315f2868832fa85e7c2c15692096