### PR TITLE
Improve rescan progress streaming reliability

### DIFF
--- a/wwwroot/admin/rescan.php
+++ b/wwwroot/admin/rescan.php
@@ -186,7 +186,18 @@ require_once("../init.php");
                         }
 
                         if (payload.type === 'progress') {
-                            const progressValue = typeof payload.progress === 'number' ? payload.progress : 0;
+                            let progressValue = 0;
+
+                            if (typeof payload.progress === 'number' && Number.isFinite(payload.progress)) {
+                                progressValue = payload.progress;
+                            } else if (typeof payload.progress === 'string') {
+                                const parsedProgress = Number(payload.progress.trim());
+
+                                if (Number.isFinite(parsedProgress)) {
+                                    progressValue = parsedProgress;
+                                }
+                            }
+
                             this.updateProgress(progressValue, payload.message ?? null);
 
                             return;
@@ -283,10 +294,13 @@ require_once("../init.php");
                         return;
                     }
 
-                    const clampedValue = Math.min(100, Math.max(0, Math.round(value)));
+                    const numericValue = Number.isFinite(value) ? value : Number(value);
+                    const clampedValue = Math.min(100, Math.max(0, typeof numericValue === 'number' && Number.isFinite(numericValue) ? numericValue : 0));
+                    const displayValue = Math.round(clampedValue);
+
                     this.progressBar.style.width = `${clampedValue}%`;
-                    this.progressBar.setAttribute('aria-valuenow', String(clampedValue));
-                    this.progressBar.textContent = `${clampedValue}%`;
+                    this.progressBar.setAttribute('aria-valuenow', String(displayValue));
+                    this.progressBar.textContent = `${displayValue}%`;
 
                     if (message !== null && this.progressMessage) {
                         this.progressMessage.textContent = message;

--- a/wwwroot/classes/Admin/GameRescanRequestHandler.php
+++ b/wwwroot/classes/Admin/GameRescanRequestHandler.php
@@ -105,6 +105,11 @@ class GameRescanRequestHandler
     {
         echo json_encode($payload, JSON_UNESCAPED_UNICODE), "\n";
 
+        // Ensure enough data is flushed to the client for intermediaries that buffer
+        // small chunks (for example, when using FastCGI). The extra whitespace is
+        // ignored by the client, but it helps deliver each progress update promptly.
+        echo str_repeat(' ', 2048), "\n";
+
         if (function_exists('ob_flush')) {
             @ob_flush();
         }


### PR DESCRIPTION
## Summary
- ensure streamed rescan progress events include enough data to bypass FastCGI buffering so intermediate updates arrive promptly
- tolerate numeric progress values delivered as strings when updating the admin rescan progress bar

## Testing
- php -l wwwroot/classes/Admin/GameRescanRequestHandler.php
- php -l wwwroot/admin/rescan.php

------
https://chatgpt.com/codex/tasks/task_e_68dd64ffa84c832fb0c2f69398828215