### PR TITLE
Prevent conflicting completion filters from cancelling results

### DIFF
--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -83,6 +83,12 @@ class PlayerGamesFilter
 
         $filter->completed = !empty($parameters['completed']);
         $filter->uncompleted = !empty($parameters['uncompleted']);
+
+        if ($filter->completed && $filter->uncompleted) {
+            // Selecting both checkboxes should behave like no completion filter at all.
+            $filter->completed = false;
+            $filter->uncompleted = false;
+        }
         $filter->base = !empty($parameters['base']);
 
         foreach (self::PLATFORM_KEYS as $platformKey) {


### PR DESCRIPTION
## Summary
- ignore mutually exclusive completion filters in PlayerGamesFilter so selecting both checkboxes returns all games

## Testing
- php -l wwwroot/classes/PlayerGamesFilter.php

------
https://chatgpt.com/codex/tasks/task_e_68da36fa8134832fa70b66d14f10dbf9