### PR TITLE
Fix HTML escaping for player about-me tooltip

### DIFF
--- a/wwwroot/classes/PlayerHeaderViewModel.php
+++ b/wwwroot/classes/PlayerHeaderViewModel.php
@@ -30,7 +30,9 @@ class PlayerHeaderViewModel
     {
         $aboutMe = (string) ($this->player['about_me'] ?? '');
 
-        return nl2br(htmlentities($aboutMe, ENT_QUOTES, 'UTF-8'));
+        $escapedAboutMe = htmlentities($aboutMe, ENT_QUOTES, 'UTF-8');
+
+        return str_replace(["\r\n", "\r", "\n"], '&#10;', $escapedAboutMe);
     }
 
     public function getCountryName(): string


### PR DESCRIPTION
## Summary
- escape the player "about me" tooltip text without reintroducing raw `<br>` tags
- replace newline characters with line feed entities so multi-line tooltips render correctly without breaking HTML

## Testing
- php -l wwwroot/classes/PlayerHeaderViewModel.php

------
https://chatgpt.com/codex/tasks/task_e_68dd90cd13a0832fbcd2755b25abff0e