### PR TITLE
Refactor router database lookups into repositories

### DIFF
--- a/wwwroot/classes/GameRepository.php
+++ b/wwwroot/classes/GameRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+class GameRepository
+{
+    private \PDO $database;
+
+    public function __construct(\PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function findIdFromSegment(?string $segment): ?int
+    {
+        if ($segment === null || $segment === '') {
+            return null;
+        }
+
+        $parts = explode('-', $segment);
+        $id = (int) $parts[0];
+
+        if ($id <= 0) {
+            return null;
+        }
+
+        return $this->findId($id);
+    }
+
+    public function findId(int $id): ?int
+    {
+        if ($id <= 0) {
+            return null;
+        }
+
+        $query = $this->database->prepare('SELECT id FROM trophy_title WHERE id = :id');
+        $query->bindValue(':id', $id, \PDO::PARAM_INT);
+        $query->execute();
+        $result = $query->fetchColumn();
+
+        if ($result === false) {
+            return null;
+        }
+
+        return (int) $result;
+    }
+}

--- a/wwwroot/classes/PlayerRepository.php
+++ b/wwwroot/classes/PlayerRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerRepository
+{
+    private \PDO $database;
+
+    public function __construct(\PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function findAccountIdByOnlineId(string $onlineId): ?int
+    {
+        $query = $this->database->prepare('SELECT account_id FROM player WHERE online_id = :online_id');
+        $query->bindValue(':online_id', $onlineId, \PDO::PARAM_STR);
+        $query->execute();
+        $accountId = $query->fetchColumn();
+
+        if ($accountId === false) {
+            return null;
+        }
+
+        return (int) $accountId;
+    }
+
+    public function fetchPlayerByAccountId(int $accountId): ?array
+    {
+        $query = $this->database->prepare('
+            SELECT
+                p.*,
+                r.ranking,
+                r.rarity_ranking,
+                r.ranking_country,
+                r.rarity_ranking_country
+            FROM
+                player p
+            LEFT JOIN player_ranking r ON p.account_id = r.account_id
+            WHERE
+                p.account_id = :account_id
+        ');
+        $query->bindValue(':account_id', $accountId, \PDO::PARAM_INT);
+        $query->execute();
+        $player = $query->fetch();
+
+        return is_array($player) ? $player : null;
+    }
+}

--- a/wwwroot/classes/TrophyRepository.php
+++ b/wwwroot/classes/TrophyRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+class TrophyRepository
+{
+    private \PDO $database;
+
+    public function __construct(\PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function findIdFromSegment(?string $segment): ?int
+    {
+        if ($segment === null || $segment === '') {
+            return null;
+        }
+
+        $parts = explode('-', $segment);
+        $id = (int) $parts[0];
+
+        if ($id <= 0) {
+            return null;
+        }
+
+        return $this->findId($id);
+    }
+
+    public function findId(int $id): ?int
+    {
+        if ($id <= 0) {
+            return null;
+        }
+
+        $query = $this->database->prepare('SELECT id FROM trophy WHERE id = :id');
+        $query->bindValue(':id', $id, \PDO::PARAM_INT);
+        $query->execute();
+        $result = $query->fetchColumn();
+
+        if ($result === false) {
+            return null;
+        }
+
+        return (int) $result;
+    }
+}

--- a/wwwroot/index.php
+++ b/wwwroot/index.php
@@ -9,7 +9,11 @@ require_once 'init.php';
 require_once 'classes/Application.php';
 require_once 'classes/HttpRequest.php';
 
-$router = new Router($database);
+$gameRepository = new GameRepository($database);
+$trophyRepository = new TrophyRepository($database);
+$playerRepository = new PlayerRepository($database);
+
+$router = new Router($gameRepository, $trophyRepository, $playerRepository);
 $request = HttpRequest::fromGlobals();
 $application = new Application($router, $request);
 $application->run();


### PR DESCRIPTION
## Summary
- extract repositories for game, trophy, and player lookups used by the router
- update the router to depend on the repositories instead of issuing queries directly
- wire the new repository classes into the application bootstrap

## Testing
- php -l wwwroot/index.php
- php -l wwwroot/classes/Router.php
- php -l wwwroot/classes/GameRepository.php
- php -l wwwroot/classes/TrophyRepository.php
- php -l wwwroot/classes/PlayerRepository.php

------
https://chatgpt.com/codex/tasks/task_e_68dd90bca5f0832fa5df0fa3f98728a9