### PR TITLE
Refactor player header leaderboard display into view models

### DIFF
--- a/wwwroot/classes/PlayerHeaderViewModel.php
+++ b/wwwroot/classes/PlayerHeaderViewModel.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/Utility.php';
+require_once __DIR__ . '/PlayerLeaderboardRank.php';
+require_once __DIR__ . '/PlayerLeaderboardRankChange.php';
 
 class PlayerHeaderViewModel
 {
@@ -123,6 +125,54 @@ class PlayerHeaderViewModel
         return $alerts;
     }
 
+    /**
+     * @return PlayerLeaderboardRank[]
+     */
+    public function getTrophyLeaderboardRanks(): array
+    {
+        return [
+            PlayerLeaderboardRank::createWorldRank(
+                '/leaderboard/trophy',
+                $this->getOnlineId(),
+                (int) ($this->player['ranking'] ?? 0),
+                (int) ($this->player['rank_last_week'] ?? 0),
+                $this->isLeaderboardRankAvailable()
+            ),
+            PlayerLeaderboardRank::createCountryRank(
+                '/leaderboard/trophy',
+                $this->getOnlineId(),
+                $this->getCountryCode(),
+                (int) ($this->player['ranking_country'] ?? 0),
+                (int) ($this->player['rank_country_last_week'] ?? 0),
+                $this->isLeaderboardRankAvailable()
+            ),
+        ];
+    }
+
+    /**
+     * @return PlayerLeaderboardRank[]
+     */
+    public function getRarityLeaderboardRanks(): array
+    {
+        return [
+            PlayerLeaderboardRank::createWorldRank(
+                '/leaderboard/rarity',
+                $this->getOnlineId(),
+                (int) ($this->player['rarity_ranking'] ?? 0),
+                (int) ($this->player['rarity_rank_last_week'] ?? 0),
+                $this->isLeaderboardRankAvailable()
+            ),
+            PlayerLeaderboardRank::createCountryRank(
+                '/leaderboard/rarity',
+                $this->getOnlineId(),
+                $this->getCountryCode(),
+                (int) ($this->player['rarity_ranking_country'] ?? 0),
+                (int) ($this->player['rarity_rank_country_last_week'] ?? 0),
+                $this->isLeaderboardRankAvailable()
+            ),
+        ];
+    }
+
     public function hasLastUpdatedDate(): bool
     {
         $lastUpdated = $this->player['last_updated_date'] ?? null;
@@ -179,6 +229,11 @@ class PlayerHeaderViewModel
     private function isUnranked(): bool
     {
         return (int) ($this->player['ranking'] ?? 0) > 10000;
+    }
+
+    private function isLeaderboardRankAvailable(): bool
+    {
+        return (int) ($this->player['status'] ?? 0) === 0;
     }
 }
 

--- a/wwwroot/classes/PlayerLeaderboardRank.php
+++ b/wwwroot/classes/PlayerLeaderboardRank.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerLeaderboardRankChange.php';
+
+class PlayerLeaderboardRank
+{
+    private const PAGE_SIZE = 50;
+
+    private string $label;
+
+    private string $basePath;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $additionalQueryParameters;
+
+    private string $onlineId;
+
+    private int $rank;
+
+    private int $previousRank;
+
+    private bool $isActive;
+
+    /**
+     * @param array<string, string> $additionalQueryParameters
+     */
+    private function __construct(
+        string $label,
+        string $basePath,
+        array $additionalQueryParameters,
+        string $onlineId,
+        int $rank,
+        int $previousRank,
+        bool $isActive
+    ) {
+        $this->label = $label;
+        $this->basePath = $basePath;
+        $this->additionalQueryParameters = $additionalQueryParameters;
+        $this->onlineId = $onlineId;
+        $this->rank = max(0, $rank);
+        $this->previousRank = max(0, $previousRank);
+        $this->isActive = $isActive;
+    }
+
+    public static function createWorldRank(
+        string $basePath,
+        string $onlineId,
+        int $rank,
+        int $previousRank,
+        bool $isActive
+    ): self {
+        return new self('World Rank', $basePath, [], $onlineId, $rank, $previousRank, $isActive);
+    }
+
+    public static function createCountryRank(
+        string $basePath,
+        string $onlineId,
+        string $countryCode,
+        int $rank,
+        int $previousRank,
+        bool $isActive
+    ): self {
+        return new self('Country Rank', $basePath, ['country' => $countryCode], $onlineId, $rank, $previousRank, $isActive);
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->isActive && $this->rank > 0;
+    }
+
+    public function getRank(): ?int
+    {
+        if (!$this->isAvailable()) {
+            return null;
+        }
+
+        return $this->rank;
+    }
+
+    public function getUrl(): ?string
+    {
+        if (!$this->isAvailable()) {
+            return null;
+        }
+
+        $page = max(1, (int) ceil($this->rank / self::PAGE_SIZE));
+
+        $queryParameters = array_merge(
+            $this->additionalQueryParameters,
+            [
+                'page' => (string) $page,
+                'player' => $this->onlineId,
+            ]
+        );
+
+        return $this->basePath . '?' . http_build_query($queryParameters) . '#' . rawurlencode($this->onlineId);
+    }
+
+    public function getChange(): ?PlayerLeaderboardRankChange
+    {
+        if (!$this->isAvailable()) {
+            return null;
+        }
+
+        return PlayerLeaderboardRankChange::fromRanks($this->rank, $this->previousRank);
+    }
+}
+

--- a/wwwroot/classes/PlayerLeaderboardRankChange.php
+++ b/wwwroot/classes/PlayerLeaderboardRankChange.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerLeaderboardRankChange
+{
+    private const NEW_RANK_SENTINEL = 16777215;
+
+    private ?int $delta;
+
+    private bool $isNew;
+
+    private function __construct(?int $delta, bool $isNew)
+    {
+        $this->delta = $delta;
+        $this->isNew = $isNew;
+    }
+
+    public static function fromRanks(int $currentRank, int $previousRank): self
+    {
+        if ($previousRank === 0 || $previousRank === self::NEW_RANK_SENTINEL) {
+            return new self(null, true);
+        }
+
+        return new self($previousRank - $currentRank, false);
+    }
+
+    public function isNew(): bool
+    {
+        return $this->isNew;
+    }
+
+    public function shouldDisplay(): bool
+    {
+        if ($this->isNew) {
+            return true;
+        }
+
+        return $this->delta !== null;
+    }
+
+    public function getDisplayText(): string
+    {
+        if ($this->isNew) {
+            return '(New!)';
+        }
+
+        if ($this->delta === null) {
+            return '';
+        }
+
+        if ($this->delta > 0) {
+            return '(+' . $this->delta . ')';
+        }
+
+        if ($this->delta < 0) {
+            return '(' . $this->delta . ')';
+        }
+
+        return '(=)';
+    }
+
+    public function getColor(): ?string
+    {
+        if ($this->isNew || $this->delta === null) {
+            return null;
+        }
+
+        if ($this->delta > 0) {
+            return '#0bd413';
+        }
+
+        if ($this->delta < 0) {
+            return '#d40b0b';
+        }
+
+        return '#0070d1';
+    }
+}
+

--- a/wwwroot/player_header.php
+++ b/wwwroot/player_header.php
@@ -3,6 +3,8 @@ require_once __DIR__ . '/classes/PlayerHeaderViewModel.php';
 
 $playerHeaderViewModel = new PlayerHeaderViewModel($player, $playerSummary, $utility);
 $alerts = $playerHeaderViewModel->getAlerts();
+$trophyLeaderboardRanks = $playerHeaderViewModel->getTrophyLeaderboardRanks();
+$rarityLeaderboardRanks = $playerHeaderViewModel->getRarityLeaderboardRanks();
 ?>
 
 <div class="row">
@@ -133,74 +135,39 @@ $alerts = $playerHeaderViewModel->getAlerts();
                     </div>
 
                     <div class="hstack gap-3">
-                        <div class="w-50">
-                            World Rank<br>
-                            <?php
-                            // World Rank
-                            if ($player["status"] == 0) {
-                                ?>
-                                <h3>
-                                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/leaderboard/trophy?page=<?= ceil($player["ranking"] / 50); ?>&player=<?= $player["online_id"]; ?>#<?= $player["online_id"]; ?>"><?= $player["ranking"]; ?></a>
-                                    <?php
-                                    if ($player["rank_last_week"] == 0 || $player["rank_last_week"] == 16777215) {
-                                        echo "<span class='fs-6'>(New!)</span>";
-                                    } else {
-                                        $delta = $player["rank_last_week"] - $player["ranking"];
+                        <?php foreach ($trophyLeaderboardRanks as $index => $rank) { ?>
+                            <?php if ($index > 0) { ?>
+                                <div class="vr"></div>
+                            <?php } ?>
 
-                                        if ($delta < 0) {
-                                            echo "<span class='fs-6' style='color: #d40b0b;'>(". $delta .")</span>";
-                                        } elseif ($delta > 0) {
-                                            echo "<span class='fs-6' style='color: #0bd413;'>(+". $delta .")</span>";
-                                        } else {
-                                            echo "<span class='fs-6' style='color: #0070d1;'>(=)</span>";
-                                        }
-                                    }
-                                    ?>
-                                </h3>
-                                <?php
-                            } else {
-                                ?>
-                                <h3>N/A</h3>
-                                <?php
-                            }
-                            ?>
-                        </div>
-
-                        <div class="vr">
-                        </div>
-
-                        <div class="w-50">
-                            Country Rank<br>
-                            <?php
-                            // Country Rank
-                            if ($player["status"] == 0) {
-                                ?>
-                                <h3>
-                                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/leaderboard/trophy?country=<?= $player["country"]; ?>&page=<?= ceil($player["ranking_country"] / 50); ?>&player=<?= $player["online_id"]; ?>#<?= $player["online_id"]; ?>"><?= $player["ranking_country"]; ?></a>
-                                    <?php
-                                    if ($player["rank_country_last_week"] == 0 || $player["rank_country_last_week"] == 16777215) {
-                                        echo "<span class='fs-6'>(New!)</span>";
-                                    } else {
-                                        $delta = $player["rank_country_last_week"] - $player["ranking_country"];
-
-                                        if ($delta < 0) {
-                                            echo "<span class='fs-6' style='color: #d40b0b;'>(". $delta .")</span>";
-                                        } elseif ($delta > 0) {
-                                            echo "<span class='fs-6' style='color: #0bd413;'>(+". $delta .")</span>";
-                                        } else {
-                                            echo "<span class='fs-6' style='color: #0070d1;'>(=)</span>";
-                                        }
-                                    }
-                                    ?>
-                                </h3>
-                                <?php
-                            } else {
-                                ?>
-                                <h3>N/A</h3>
-                                <?php
-                            }
-                            ?>
-                        </div>
+                            <div class="w-50">
+                                <?= htmlspecialchars($rank->getLabel(), ENT_QUOTES, 'UTF-8'); ?><br>
+                                <?php if ($rank->isAvailable()) { ?>
+                                    <h3>
+                                        <?php $rankUrl = $rank->getUrl(); ?>
+                                        <?php if ($rankUrl !== null) { ?>
+                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($rankUrl, ENT_QUOTES, 'UTF-8'); ?>"><?= $rank->getRank(); ?></a>
+                                        <?php } else { ?>
+                                            <?= $rank->getRank(); ?>
+                                        <?php } ?>
+                                        <?php $change = $rank->getChange(); ?>
+                                        <?php if ($change !== null && $change->shouldDisplay()) { ?>
+                                            <?php $displayText = $change->getDisplayText(); ?>
+                                            <?php if ($change->isNew()) { ?>
+                                                <span class="fs-6"><?= htmlspecialchars($displayText, ENT_QUOTES, 'UTF-8'); ?></span>
+                                            <?php } else { ?>
+                                                <?php $color = $change->getColor(); ?>
+                                                <span class="fs-6"<?php if ($color !== null) { ?> style="color: <?= htmlspecialchars($color, ENT_QUOTES, 'UTF-8'); ?>;"<?php } ?>>
+                                                    <?= htmlspecialchars($displayText, ENT_QUOTES, 'UTF-8'); ?>
+                                                </span>
+                                            <?php } ?>
+                                        <?php } ?>
+                                    </h3>
+                                <?php } else { ?>
+                                    <h3>N/A</h3>
+                                <?php } ?>
+                            </div>
+                        <?php } ?>
                     </div>
                 </div>
             </div>
@@ -251,74 +218,39 @@ $alerts = $playerHeaderViewModel->getAlerts();
                     </div>
 
                     <div class="hstack gap-3">
-                        <div class="w-50">
-                            World Rank<br>
-                            <?php
-                            // World Rank
-                            if ($player["status"] == 0) {
-                                ?>
-                                <h3>
-                                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/leaderboard/rarity?page=<?= ceil($player["rarity_ranking"] / 50); ?>&player=<?= $player["online_id"]; ?>#<?= $player["online_id"]; ?>"><?= $player["rarity_ranking"]; ?></a>
-                                    <?php
-                                    if ($player["rarity_rank_last_week"] == 0 || $player["rarity_rank_last_week"] == 16777215) {
-                                        echo "<span class='fs-6'>(New!)</span>";
-                                    } else {
-                                        $delta = $player["rarity_rank_last_week"] - $player["rarity_ranking"];
+                        <?php foreach ($rarityLeaderboardRanks as $index => $rank) { ?>
+                            <?php if ($index > 0) { ?>
+                                <div class="vr"></div>
+                            <?php } ?>
 
-                                        if ($delta < 0) {
-                                            echo "<span class='fs-6' style='color: #d40b0b;'>(". $delta .")</span>";
-                                        } elseif ($delta > 0) {
-                                            echo "<span class='fs-6' style='color: #0bd413;'>(+". $delta .")</span>";
-                                        } else {
-                                            echo "<span class='fs-6' style='color: #0070d1;'>(=)</span>";
-                                        }    
-                                    }
-                                    ?>
-                                </h3>
-                                <?php
-                            } else {
-                                ?>
-                                <h3>N/A</h3>
-                                <?php
-                            }
-                            ?>
-                        </div>
-
-                        <div class="vr">
-                        </div>
-
-                        <div class="w-50">
-                            Country Rank<br>
-                            <?php
-                            // Country Rank
-                            if ($player["status"] == 0) {
-                                ?>
-                                <h3>
-                                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/leaderboard/rarity?country=<?= $player["country"]; ?>&page=<?= ceil($player["rarity_ranking_country"] / 50); ?>&player=<?= $player["online_id"]; ?>#<?= $player["online_id"]; ?>"><?= $player["rarity_ranking_country"]; ?></a>
-                                    <?php
-                                    if ($player["rarity_rank_country_last_week"] == 0 || $player["rarity_rank_country_last_week"] == 16777215) {
-                                        echo "<span class='fs-6'>(New!)</span>";
-                                    } else {
-                                        $delta = $player["rarity_rank_country_last_week"] - $player["rarity_ranking_country"];
-
-                                        if ($delta < 0) {
-                                            echo "<span class='fs-6' style='color: #d40b0b;'>(". $delta .")</span>";
-                                        } elseif ($delta > 0) {
-                                            echo "<span class='fs-6' style='color: #0bd413;'>(+". $delta .")</span>";
-                                        } else {
-                                            echo "<span class='fs-6' style='color: #0070d1;'>(=)</span>";
-                                        }
-                                    }
-                                    ?>
-                                </h3>
-                                <?php
-                            } else {
-                                ?>
-                                <h3>N/A</h3>
-                                <?php
-                            }
-                            ?>
-                        </div>
+                            <div class="w-50">
+                                <?= htmlspecialchars($rank->getLabel(), ENT_QUOTES, 'UTF-8'); ?><br>
+                                <?php if ($rank->isAvailable()) { ?>
+                                    <h3>
+                                        <?php $rankUrl = $rank->getUrl(); ?>
+                                        <?php if ($rankUrl !== null) { ?>
+                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($rankUrl, ENT_QUOTES, 'UTF-8'); ?>"><?= $rank->getRank(); ?></a>
+                                        <?php } else { ?>
+                                            <?= $rank->getRank(); ?>
+                                        <?php } ?>
+                                        <?php $change = $rank->getChange(); ?>
+                                        <?php if ($change !== null && $change->shouldDisplay()) { ?>
+                                            <?php $displayText = $change->getDisplayText(); ?>
+                                            <?php if ($change->isNew()) { ?>
+                                                <span class="fs-6"><?= htmlspecialchars($displayText, ENT_QUOTES, 'UTF-8'); ?></span>
+                                            <?php } else { ?>
+                                                <?php $color = $change->getColor(); ?>
+                                                <span class="fs-6"<?php if ($color !== null) { ?> style="color: <?= htmlspecialchars($color, ENT_QUOTES, 'UTF-8'); ?>;"<?php } ?>>
+                                                    <?= htmlspecialchars($displayText, ENT_QUOTES, 'UTF-8'); ?>
+                                                </span>
+                                            <?php } ?>
+                                        <?php } ?>
+                                    </h3>
+                                <?php } else { ?>
+                                    <h3>N/A</h3>
+                                <?php } ?>
+                            </div>
+                        <?php } ?>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- introduce PlayerLeaderboardRank and PlayerLeaderboardRankChange classes to encapsulate leaderboard metadata
- expose trophy and rarity rank collections from PlayerHeaderViewModel
- update the player header template to render leaderboard ranks via the new view models

## Testing
- php -l wwwroot/classes/PlayerHeaderViewModel.php
- php -l wwwroot/classes/PlayerLeaderboardRank.php
- php -l wwwroot/classes/PlayerLeaderboardRankChange.php
- php -l wwwroot/player_header.php

------
https://chatgpt.com/codex/tasks/task_e_68de18eaa180832fae5f5e08df1b68f7