### PR TITLE
Refactor trophy list to use objects

### DIFF
--- a/wwwroot/classes/TrophyListItem.php
+++ b/wwwroot/classes/TrophyListItem.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Utility.php';
+
+class TrophyListItem
+{
+    private const PLATFORM_SEPARATOR = ',';
+    private const MISSING_PS5_ICON = '../missing-ps5-game-and-trophy.png';
+    private const MISSING_PS4_GAME_ICON = '../missing-ps4-game.png';
+    private const MISSING_PS4_TROPHY_ICON = '../missing-ps4-trophy.png';
+
+    private int $trophyId;
+
+    private string $trophyType;
+
+    private string $trophyName;
+
+    private string $trophyDetail;
+
+    private string $trophyIcon;
+
+    private float $rarityPercent;
+
+    private ?int $progressTargetValue;
+
+    private ?string $rewardName;
+
+    private ?string $rewardImageUrl;
+
+    private int $gameId;
+
+    private string $gameName;
+
+    private string $gameIcon;
+
+    private string $platform;
+
+    public function __construct(
+        int $trophyId,
+        string $trophyType,
+        string $trophyName,
+        string $trophyDetail,
+        string $trophyIcon,
+        float $rarityPercent,
+        ?int $progressTargetValue,
+        ?string $rewardName,
+        ?string $rewardImageUrl,
+        int $gameId,
+        string $gameName,
+        string $gameIcon,
+        string $platform
+    ) {
+        $this->trophyId = $trophyId;
+        $this->trophyType = $trophyType;
+        $this->trophyName = $trophyName;
+        $this->trophyDetail = $trophyDetail;
+        $this->trophyIcon = $trophyIcon;
+        $this->rarityPercent = $rarityPercent;
+        $this->progressTargetValue = $progressTargetValue;
+        $this->rewardName = $rewardName;
+        $this->rewardImageUrl = $rewardImageUrl;
+        $this->gameId = $gameId;
+        $this->gameName = $gameName;
+        $this->gameIcon = $gameIcon;
+        $this->platform = $platform;
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (int) ($data['trophy_id'] ?? 0),
+            (string) ($data['trophy_type'] ?? ''),
+            (string) ($data['trophy_name'] ?? ''),
+            (string) ($data['trophy_detail'] ?? ''),
+            (string) ($data['trophy_icon'] ?? ''),
+            (float) ($data['rarity_percent'] ?? 0.0),
+            isset($data['progress_target_value']) ? (int) $data['progress_target_value'] : null,
+            isset($data['reward_name']) ? (string) $data['reward_name'] : null,
+            isset($data['reward_image_url']) ? (string) $data['reward_image_url'] : null,
+            (int) ($data['game_id'] ?? 0),
+            (string) ($data['game_name'] ?? ''),
+            (string) ($data['game_icon'] ?? ''),
+            (string) ($data['platform'] ?? '')
+        );
+    }
+
+    public function getTrophyId(): int
+    {
+        return $this->trophyId;
+    }
+
+    public function getTrophyType(): string
+    {
+        return $this->trophyType;
+    }
+
+    public function getTrophyName(): string
+    {
+        return $this->trophyName;
+    }
+
+    public function getTrophyDetail(): string
+    {
+        return $this->trophyDetail;
+    }
+
+    public function getTrophyIcon(): string
+    {
+        return $this->trophyIcon;
+    }
+
+    public function getTrophyIconPath(): string
+    {
+        if ($this->trophyIcon === '.png') {
+            return $this->usesPlayStation5Assets()
+                ? self::MISSING_PS5_ICON
+                : self::MISSING_PS4_TROPHY_ICON;
+        }
+
+        return $this->trophyIcon;
+    }
+
+    public function getRarityPercent(): float
+    {
+        return $this->rarityPercent;
+    }
+
+    public function getProgressTargetValue(): ?int
+    {
+        return $this->progressTargetValue;
+    }
+
+    public function getRewardName(): ?string
+    {
+        return $this->rewardName;
+    }
+
+    public function getRewardImageUrl(): ?string
+    {
+        return $this->rewardImageUrl;
+    }
+
+    public function getGameId(): int
+    {
+        return $this->gameId;
+    }
+
+    public function getGameName(): string
+    {
+        return $this->gameName;
+    }
+
+    public function getGameIcon(): string
+    {
+        return $this->gameIcon;
+    }
+
+    public function getGameIconPath(): string
+    {
+        if ($this->gameIcon === '.png') {
+            return $this->usesPlayStation5Assets()
+                ? self::MISSING_PS5_ICON
+                : self::MISSING_PS4_GAME_ICON;
+        }
+
+        return $this->gameIcon;
+    }
+
+    public function getPlatform(): string
+    {
+        return $this->platform;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPlatforms(): array
+    {
+        $platforms = array_map('trim', explode(self::PLATFORM_SEPARATOR, $this->platform));
+
+        return array_values(array_filter($platforms, static fn (string $platform): bool => $platform !== ''));
+    }
+
+    public function getGameUrl(Utility $utility): string
+    {
+        return '/game/' . $this->gameId . '-' . $utility->slugify($this->gameName);
+    }
+
+    public function getTrophyUrl(Utility $utility): string
+    {
+        return '/trophy/' . $this->trophyId . '-' . $utility->slugify($this->trophyName);
+    }
+
+    private function usesPlayStation5Assets(): bool
+    {
+        return str_contains($this->platform, 'PS5');
+    }
+}

--- a/wwwroot/classes/TrophyListPage.php
+++ b/wwwroot/classes/TrophyListPage.php
@@ -13,7 +13,7 @@ class TrophyListPage
     private ChangelogPaginator $paginator;
 
     /**
-     * @var array<int, array<string, mixed>>
+     * @var TrophyListItem[]
      */
     private array $trophies;
 
@@ -35,7 +35,7 @@ class TrophyListPage
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return TrophyListItem[]
      */
     public function getTrophies(): array
     {

--- a/wwwroot/classes/TrophyListService.php
+++ b/wwwroot/classes/TrophyListService.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/TrophyListItem.php';
+
 class TrophyListService
 {
     public const PAGE_SIZE = 50;
@@ -29,7 +31,7 @@ class TrophyListService
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return TrophyListItem[]
      */
     public function getTrophies(int $offset, int $limit = self::PAGE_SIZE): array
     {
@@ -65,7 +67,10 @@ class TrophyListService
         /** @var array<int, array<string, mixed>> $trophies */
         $trophies = $query->fetchAll(PDO::FETCH_ASSOC);
 
-        return $trophies;
+        return array_map(
+            static fn (array $trophy): TrophyListItem => TrophyListItem::fromArray($trophy),
+            $trophies
+        );
     }
 }
 

--- a/wwwroot/trophies.php
+++ b/wwwroot/trophies.php
@@ -41,36 +41,41 @@ require_once('header.php');
                         <tbody>
                             <?php
                             foreach ($trophyListPage->getTrophies() as $trophy) {
+                                $gameUrl = $trophy->getGameUrl($utility);
+                                $trophyUrl = $trophy->getTrophyUrl($utility);
                                 ?>
                                 <tr>
                                     <td scope="row" class="text-center align-middle">
-                                        <a href="/game/<?= $trophy['game_id'] . '-' . $utility->slugify($trophy['game_name']); ?>">
-                                            <img src="/img/title/<?= ($trophy['game_icon'] == '.png') ? ((str_contains($trophy['platform'], 'PS5')) ? '../missing-ps5-game-and-trophy.png' : '../missing-ps4-game.png') : $trophy['game_icon']; ?>" alt="<?= htmlentities($trophy['game_name'], ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy['game_name'], ENT_QUOTES, 'UTF-8'); ?>" style="width: 10rem;" />
+                                        <a href="<?= $gameUrl; ?>">
+                                            <img src="/img/title/<?= $trophy->getGameIconPath(); ?>" alt="<?= htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 10rem;" />
                                         </a>
                                     </td>
                                     <td class="align-middle">
                                         <div class="hstack gap-3">
                                             <div class="d-flex align-items-center justify-content-center">
-                                                <a href="/trophy/<?= $trophy['trophy_id'] . '-' . $utility->slugify($trophy['trophy_name']); ?>">
-                                                    <img src="/img/trophy/<?= ($trophy['trophy_icon'] == '.png') ? ((str_contains($trophy['platform'], 'PS5')) ? '../missing-ps5-game-and-trophy.png' : '../missing-ps4-trophy.png') : $trophy['trophy_icon']; ?>" alt="<?= htmlentities($trophy['trophy_name'], ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy['trophy_name'], ENT_QUOTES, 'UTF-8'); ?>" style="width: 5rem;" />
+                                                <a href="<?= $trophyUrl; ?>">
+                                                    <img src="/img/trophy/<?= $trophy->getTrophyIconPath(); ?>" alt="<?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 5rem;" />
                                                 </a>
                                             </div>
 
                                             <div>
                                                 <div class="vstack">
                                                     <span>
-                                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/trophy/<?= $trophy['trophy_id'] . '-' . $utility->slugify($trophy['trophy_name']); ?>">
-                                                            <b><?= htmlentities($trophy['trophy_name']); ?></b>
+                                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= $trophyUrl; ?>">
+                                                            <b><?= htmlentities($trophy->getTrophyName()); ?></b>
                                                         </a>
                                                     </span>
-                                                    <?= nl2br(htmlentities($trophy['trophy_detail'], ENT_QUOTES, 'UTF-8')); ?>
+                                                    <?= nl2br(htmlentities($trophy->getTrophyDetail(), ENT_QUOTES, 'UTF-8')); ?>
                                                     <?php
-                                                    if ($trophy['progress_target_value'] != null) {
-                                                        echo '<br><b>0/' . $trophy['progress_target_value'] . '</b>';
+                                                    $progressTargetValue = $trophy->getProgressTargetValue();
+                                                    if ($progressTargetValue !== null) {
+                                                        echo '<br><b>0/' . $progressTargetValue . '</b>';
                                                     }
 
-                                                    if ($trophy['reward_name'] != null && $trophy['reward_image_url'] != null) {
-                                                        echo "<br>Reward: <a href='/img/reward/" . $trophy['reward_image_url'] . "'>" . $trophy['reward_name'] . '</a>';
+                                                    $rewardName = $trophy->getRewardName();
+                                                    $rewardImageUrl = $trophy->getRewardImageUrl();
+                                                    if ($rewardName !== null && $rewardImageUrl !== null) {
+                                                        echo "<br>Reward: <a href='/img/reward/" . $rewardImageUrl . "'>" . $rewardName . '</a>';
                                                     }
                                                     ?>
                                                 </div>
@@ -80,7 +85,7 @@ require_once('header.php');
                                     <td class="text-center align-middle">
                                         <div class="vstack gap-1">
                                             <?php
-                                            foreach (explode(',', $trophy['platform']) as $platform) {
+                                            foreach ($trophy->getPlatforms() as $platform) {
                                                 echo "<span class=\"badge rounded-pill text-bg-primary p-2\">" . $platform . '</span> ';
                                             }
                                             ?>
@@ -88,12 +93,12 @@ require_once('header.php');
                                     </td>
                                     <td class="text-center align-middle">
                                         <?php
-                                        $trophyRarity = $trophyRarityFormatter->format($trophy['rarity_percent']);
+                                        $trophyRarity = $trophyRarityFormatter->format($trophy->getRarityPercent());
                                         echo $trophyRarity->renderSpan();
                                         ?>
                                     </td>
                                     <td class="text-center align-middle">
-                                        <img src="/img/trophy-<?= $trophy['trophy_type']; ?>.svg" alt="<?= ucfirst($trophy['trophy_type']); ?>" title="<?= ucfirst($trophy['trophy_type']); ?>" height="50" />
+                                        <img src="/img/trophy-<?= $trophy->getTrophyType(); ?>.svg" alt="<?= ucfirst($trophy->getTrophyType()); ?>" title="<?= ucfirst($trophy->getTrophyType()); ?>" height="50" />
                                     </td>
                                 </tr>
                                 <?php


### PR DESCRIPTION
## Summary
- add a TrophyListItem model that encapsulates trophy metadata and computed helpers
- update the trophy list service/page to return typed TrophyListItem objects
- adjust the trophies listing view to consume the new object-oriented API

## Testing
- php -l wwwroot/classes/TrophyListItem.php
- php -l wwwroot/classes/TrophyListService.php
- php -l wwwroot/classes/TrophyListPage.php
- php -l wwwroot/trophies.php

------
https://chatgpt.com/codex/tasks/task_e_68e36da5f68c832f948dbaa0e55dd2c8