### PR TITLE
Refactor game pages to use GameDetails value object

### DIFF
--- a/wwwroot/classes/Game/GameDetails.php
+++ b/wwwroot/classes/Game/GameDetails.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+class GameDetails
+{
+    private int $id;
+
+    private string $name;
+
+    private string $npCommunicationId;
+
+    private ?string $parentNpCommunicationId;
+
+    private string $platform;
+
+    private string $iconUrl;
+
+    private string $setVersion;
+
+    private ?string $region;
+
+    private ?string $message;
+
+    private int $platinum;
+
+    private int $gold;
+
+    private int $silver;
+
+    private int $bronze;
+
+    private int $ownersCompleted;
+
+    private int $owners;
+
+    private string $difficulty;
+
+    private int $status;
+
+    private int $rarityPoints;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        $game = new self();
+
+        $game->id = (int) ($row['id'] ?? 0);
+        $game->name = (string) ($row['name'] ?? '');
+        $game->npCommunicationId = (string) ($row['np_communication_id'] ?? '');
+        $game->parentNpCommunicationId = isset($row['parent_np_communication_id'])
+            ? self::toNullableString($row['parent_np_communication_id'])
+            : null;
+        $game->platform = (string) ($row['platform'] ?? '');
+        $game->iconUrl = (string) ($row['icon_url'] ?? '');
+        $game->setVersion = (string) ($row['set_version'] ?? '');
+        $game->region = self::toNullableString($row['region'] ?? null);
+        $game->message = self::toNullableString($row['message'] ?? null);
+        $game->platinum = (int) ($row['platinum'] ?? 0);
+        $game->gold = (int) ($row['gold'] ?? 0);
+        $game->silver = (int) ($row['silver'] ?? 0);
+        $game->bronze = (int) ($row['bronze'] ?? 0);
+        $game->ownersCompleted = (int) ($row['owners_completed'] ?? 0);
+        $game->owners = (int) ($row['owners'] ?? 0);
+        $game->difficulty = (string) ($row['difficulty'] ?? '0');
+        $game->status = (int) ($row['status'] ?? 0);
+        $game->rarityPoints = (int) ($row['rarity_points'] ?? 0);
+
+        return $game;
+    }
+
+    private static function toNullableString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $stringValue = (string) $value;
+
+        return $stringValue === '' ? null : $stringValue;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getNpCommunicationId(): string
+    {
+        return $this->npCommunicationId;
+    }
+
+    public function getParentNpCommunicationId(): ?string
+    {
+        return $this->parentNpCommunicationId;
+    }
+
+    public function getPlatform(): string
+    {
+        return $this->platform;
+    }
+
+    public function getIconUrl(): string
+    {
+        return $this->iconUrl;
+    }
+
+    public function getSetVersion(): string
+    {
+        return $this->setVersion;
+    }
+
+    public function getRegion(): ?string
+    {
+        return $this->region;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function hasMessage(): bool
+    {
+        return $this->message !== null && $this->message !== '';
+    }
+
+    public function getPlatinum(): int
+    {
+        return $this->platinum;
+    }
+
+    public function getGold(): int
+    {
+        return $this->gold;
+    }
+
+    public function getSilver(): int
+    {
+        return $this->silver;
+    }
+
+    public function getBronze(): int
+    {
+        return $this->bronze;
+    }
+
+    public function getOwnersCompleted(): int
+    {
+        return $this->ownersCompleted;
+    }
+
+    public function getOwners(): int
+    {
+        return $this->owners;
+    }
+
+    public function getDifficulty(): string
+    {
+        return $this->difficulty;
+    }
+
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+
+    public function getRarityPoints(): int
+    {
+        return $this->rarityPoints;
+    }
+}
+

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/Game/GameHeaderData.php';
 require_once __DIR__ . '/Game/GameHeaderParent.php';
 require_once __DIR__ . '/Game/GameHeaderStack.php';
@@ -15,17 +16,14 @@ class GameHeaderService
         $this->database = $database;
     }
 
-    /**
-     * @param array<string, mixed> $game
-     */
-    public function buildHeaderData(array $game): GameHeaderData
+    public function buildHeaderData(GameDetails $game): GameHeaderData
     {
-        $status = (int) ($game['status'] ?? 0);
-        $npCommunicationId = (string) ($game['np_communication_id'] ?? '');
-        $parentNpCommunicationId = $game['parent_np_communication_id'] ?? null;
+        $status = $game->getStatus();
+        $npCommunicationId = $game->getNpCommunicationId();
+        $parentNpCommunicationId = $game->getParentNpCommunicationId();
 
         $parentGame = null;
-        if ($status === 2 && is_string($parentNpCommunicationId) && $parentNpCommunicationId !== '') {
+        if ($status === 2 && $parentNpCommunicationId !== null && $parentNpCommunicationId !== '') {
             $parentGame = $this->fetchParentGame($parentNpCommunicationId);
         }
 

--- a/wwwroot/classes/GameLeaderboardPage.php
+++ b/wwwroot/classes/GameLeaderboardPage.php
@@ -7,15 +7,13 @@ require_once __DIR__ . '/GameLeaderboardFilter.php';
 require_once __DIR__ . '/GameLeaderboardRow.php';
 require_once __DIR__ . '/GameLeaderboardService.php';
 require_once __DIR__ . '/GameHeaderService.php';
+require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/GameNotFoundException.php';
 require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
 
 class GameLeaderboardPage
 {
-    /**
-     * @var array<string, mixed>
-     */
-    private array $game;
+    private GameDetails $game;
 
     private GameHeaderData $gameHeaderData;
 
@@ -37,11 +35,10 @@ class GameLeaderboardPage
     private ?string $playerAccountId;
 
     /**
-     * @param array<string, mixed> $game
      * @param GameLeaderboardRow[] $rows
      */
     private function __construct(
-        array $game,
+        GameDetails $game,
         GameHeaderData $gameHeaderData,
         GameLeaderboardFilter $filter,
         int $totalPlayers,
@@ -85,8 +82,8 @@ class GameLeaderboardPage
             $playerAccountId = $leaderboardService->getPlayerAccountId($player);
 
             if ($playerAccountId === null) {
-                $gameIdValue = (int) ($game['id'] ?? 0);
-                $gameName = (string) ($game['name'] ?? '');
+                $gameIdValue = $game->getId();
+                $gameName = $game->getName();
 
                 throw new GameLeaderboardPlayerNotFoundException($gameIdValue, $gameName);
             }
@@ -95,12 +92,13 @@ class GameLeaderboardPage
         $filter = GameLeaderboardFilter::fromArray($queryParameters);
         $limit = GameLeaderboardService::PAGE_SIZE;
         $offset = $filter->getOffset($limit);
+        $npCommunicationId = $game->getNpCommunicationId();
         $totalPlayers = $leaderboardService->getLeaderboardPlayerCount(
-            (string) $game['np_communication_id'],
+            $npCommunicationId,
             $filter
         );
         $rows = $leaderboardService->getLeaderboardRows(
-            (string) $game['np_communication_id'],
+            $npCommunicationId,
             $filter,
             $limit
         );
@@ -121,10 +119,7 @@ class GameLeaderboardPage
         );
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getGame(): array
+    public function getGame(): GameDetails
     {
         return $this->game;
     }

--- a/wwwroot/classes/GameLeaderboardService.php
+++ b/wwwroot/classes/GameLeaderboardService.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/GameLeaderboardRow.php';
 
 class GameLeaderboardService
@@ -15,7 +16,7 @@ class GameLeaderboardService
         $this->database = $database;
     }
 
-    public function getGame(int $gameId): ?array
+    public function getGame(int $gameId): ?GameDetails
     {
         $query = $this->database->prepare(
             <<<'SQL'
@@ -32,7 +33,11 @@ class GameLeaderboardService
 
         $game = $query->fetch(PDO::FETCH_ASSOC);
 
-        return is_array($game) ? $game : null;
+        if (!is_array($game)) {
+            return null;
+        }
+
+        return GameDetails::fromArray($game);
     }
 
     public function getPlayerAccountId(string $onlineId): ?string

--- a/wwwroot/classes/GamePage.php
+++ b/wwwroot/classes/GamePage.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/GameService.php';
 require_once __DIR__ . '/GameHeaderService.php';
 require_once __DIR__ . '/GameNotFoundException.php';
 require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
+require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/Game/GameHeaderData.php';
 require_once __DIR__ . '/PageMetaData.php';
 require_once __DIR__ . '/Utility.php';
@@ -18,10 +19,7 @@ class GamePage
 
     private Utility $utility;
 
-    /**
-     * @var array<string, mixed>
-     */
-    private array $game;
+    private GameDetails $game;
 
     private GameHeaderData $headerData;
 
@@ -72,14 +70,11 @@ class GamePage
         $this->sort = $this->gameService->resolveSort($queryParameters);
         $this->playerAccountId = $this->resolvePlayerAccountId();
         $this->gamePlayer = $this->playerAccountId !== null
-            ? $this->gameService->getGamePlayer($this->game['np_communication_id'], $this->playerAccountId)
+            ? $this->gameService->getGamePlayer($this->game->getNpCommunicationId(), $this->playerAccountId)
             : null;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    private function loadGame(int $gameId): array
+    private function loadGame(int $gameId): GameDetails
     {
         $game = $this->gameService->getGame($gameId);
 
@@ -100,18 +95,15 @@ class GamePage
 
         if ($accountId === null) {
             throw new GameLeaderboardPlayerNotFoundException(
-                (int) $this->game['id'],
-                (string) $this->game['name']
+                $this->game->getId(),
+                $this->game->getName()
             );
         }
 
         return $accountId;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getGame(): array
+    public function getGame(): GameDetails
     {
         return $this->game;
     }
@@ -145,7 +137,7 @@ class GamePage
     public function getTrophyGroups(): array
     {
         if ($this->trophyGroups === []) {
-            $this->trophyGroups = $this->gameService->getTrophyGroups($this->game['np_communication_id']);
+            $this->trophyGroups = $this->gameService->getTrophyGroups($this->game->getNpCommunicationId());
         }
 
         return $this->trophyGroups;
@@ -162,7 +154,7 @@ class GamePage
 
         if (!array_key_exists($groupId, $this->trophyGroupPlayers)) {
             $this->trophyGroupPlayers[$groupId] = $this->gameService->getTrophyGroupPlayer(
-                $this->game['np_communication_id'],
+                $this->game->getNpCommunicationId(),
                 $groupId,
                 $this->playerAccountId
             );
@@ -178,7 +170,7 @@ class GamePage
     {
         if (!array_key_exists($groupId, $this->trophiesByGroup)) {
             $this->trophiesByGroup[$groupId] = $this->gameService->getTrophies(
-                $this->game['np_communication_id'],
+                $this->game->getNpCommunicationId(),
                 $groupId,
                 $this->playerAccountId,
                 $this->sort
@@ -191,24 +183,24 @@ class GamePage
     public function createMetaData(): PageMetaData
     {
         return (new PageMetaData())
-            ->setTitle($this->game['name'] . ' Trophies')
+            ->setTitle($this->game->getName() . ' Trophies')
             ->setDescription(
-                $this->game['bronze'] . ' Bronze ~ '
-                . $this->game['silver'] . ' Silver ~ '
-                . $this->game['gold'] . ' Gold ~ '
-                . $this->game['platinum'] . ' Platinum'
+                $this->game->getBronze() . ' Bronze ~ '
+                . $this->game->getSilver() . ' Silver ~ '
+                . $this->game->getGold() . ' Gold ~ '
+                . $this->game->getPlatinum() . ' Platinum'
             )
-            ->setImage('https://psn100.net/img/title/' . $this->game['icon_url'])
-            ->setUrl('https://psn100.net/game/' . $this->game['id'] . '-' . $this->getGameSlug());
+            ->setImage('https://psn100.net/img/title/' . $this->game->getIconUrl())
+            ->setUrl('https://psn100.net/game/' . $this->game->getId() . '-' . $this->getGameSlug());
     }
 
     public function getPageTitle(): string
     {
-        return $this->game['name'] . ' Trophies ~ PSN 100%';
+        return $this->game->getName() . ' Trophies ~ PSN 100%';
     }
 
     public function getGameSlug(): string
     {
-        return $this->utility->slugify((string) $this->game['name']);
+        return $this->utility->slugify($this->game->getName());
     }
 }

--- a/wwwroot/classes/GameRecentPlayersPage.php
+++ b/wwwroot/classes/GameRecentPlayersPage.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 require_once __DIR__ . '/GamePlayerFilter.php';
 require_once __DIR__ . '/GameRecentPlayersService.php';
 require_once __DIR__ . '/GameHeaderService.php';
+require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/GameNotFoundException.php';
 require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
 require_once __DIR__ . '/Utility.php';
 
 class GameRecentPlayersPage
 {
-    /**
-     * @var array<string, mixed>
-     */
-    private array $game;
+    private GameDetails $game;
 
     private GameHeaderData $gameHeaderData;
 
@@ -33,12 +31,11 @@ class GameRecentPlayersPage
     private ?array $gamePlayer;
 
     /**
-     * @param array<string, mixed> $game
      * @param GameRecentPlayer[] $recentPlayers
      * @param array<string, mixed>|null $gamePlayer
      */
     private function __construct(
-        array $game,
+        GameDetails $game,
         GameHeaderData $gameHeaderData,
         GamePlayerFilter $filter,
         array $recentPlayers,
@@ -79,20 +76,20 @@ class GameRecentPlayersPage
             $playerAccountId = $recentPlayersService->getPlayerAccountId($player);
 
             if ($playerAccountId === null) {
-                $gameIdValue = (int) ($game['id'] ?? 0);
-                $gameName = (string) ($game['name'] ?? '');
+                $gameIdValue = $game->getId();
+                $gameName = $game->getName();
 
                 throw new GameLeaderboardPlayerNotFoundException($gameIdValue, $gameName);
             }
 
             $gamePlayer = $recentPlayersService->getGamePlayer(
-                (string) $game['np_communication_id'],
+                $game->getNpCommunicationId(),
                 $playerAccountId
             );
         }
 
         $recentPlayers = $recentPlayersService->getRecentPlayers(
-            (string) $game['np_communication_id'],
+            $game->getNpCommunicationId(),
             $filter
         );
 
@@ -108,10 +105,7 @@ class GameRecentPlayersPage
         );
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getGame(): array
+    public function getGame(): GameDetails
     {
         return $this->game;
     }
@@ -149,16 +143,11 @@ class GameRecentPlayersPage
 
     public function getGameSlug(Utility $utility): string
     {
-        $gameId = (int) ($this->game['id'] ?? 0);
-        $gameName = (string) ($this->game['name'] ?? '');
-
-        return $gameId . '-' . $utility->slugify($gameName);
+        return $this->game->getId() . '-' . $utility->slugify($this->game->getName());
     }
 
     public function getPageTitle(): string
     {
-        $gameName = (string) ($this->game['name'] ?? '');
-
-        return $gameName . ' Recent Players ~ PSN 100%';
+        return $this->game->getName() . ' Recent Players ~ PSN 100%';
     }
 }

--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/GameRecentPlayer.php';
 
 class GameRecentPlayersService
@@ -15,7 +16,7 @@ class GameRecentPlayersService
         $this->database = $database;
     }
 
-    public function getGame(int $gameId): ?array
+    public function getGame(int $gameId): ?GameDetails
     {
         $query = $this->database->prepare(
             <<<'SQL'
@@ -32,7 +33,11 @@ class GameRecentPlayersService
 
         $game = $query->fetch(PDO::FETCH_ASSOC);
 
-        return is_array($game) ? $game : null;
+        if (!is_array($game)) {
+            return null;
+        }
+
+        return GameDetails::fromArray($game);
     }
 
     public function getPlayerAccountId(string $onlineId): ?string

--- a/wwwroot/classes/GameService.php
+++ b/wwwroot/classes/GameService.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Game/GameDetails.php';
+
 class GameService
 {
     private PDO $database;
@@ -11,7 +13,7 @@ class GameService
         $this->database = $database;
     }
 
-    public function getGame(int $gameId): ?array
+    public function getGame(int $gameId): ?GameDetails
     {
         $query = $this->database->prepare(
             <<<'SQL'
@@ -28,7 +30,11 @@ class GameService
 
         $game = $query->fetch(PDO::FETCH_ASSOC);
 
-        return is_array($game) ? $game : null;
+        if (!is_array($game)) {
+            return null;
+        }
+
+        return GameDetails::fromArray($game);
     }
 
     /**

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -53,9 +53,9 @@ require_once("header.php");
 
             <div class="col-12 col-lg-6 mb-3 text-center">
                 <div class="btn-group">
-                    <a class="btn btn-primary active" href="/game/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?><?= (isset($player) ? "/".$player : "") ?>">Trophies</a>
-                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?><?= (isset($player) ? "/".$player : "") ?>">Leaderboard</a>
-                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?><?= (isset($player) ? "/".$player : "") ?>">Recent Players</a>
+                    <a class="btn btn-primary active" href="/game/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Trophies</a>
+                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Leaderboard</a>
+                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Recent Players</a>
                 </div>
             </div>
 
@@ -122,7 +122,7 @@ require_once("header.php");
                                     <th scope="col" colspan="4" class="bg-dark-subtle">
                                         <div class="hstack gap-3">
                                             <div>
-                                                <img class="card-img object-fit-cover" style="height: 7rem;" src="/img/group/<?= ($trophyGroup["icon_url"] == ".png") ? ((str_contains($game["platform"], "PS5") || str_contains($game["platform"], "PSVR2")) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-game.png") : $trophyGroup["icon_url"]; ?>" alt="<?= htmlentities($trophyGroup["name"]); ?>">
+                                                <img class="card-img object-fit-cover" style="height: 7rem;" src="/img/group/<?= ($trophyGroup["icon_url"] == ".png") ? ((str_contains($game->getPlatform(), "PS5") || str_contains($game->getPlatform(), "PSVR2")) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-game.png") : $trophyGroup["icon_url"]; ?>" alt="<?= htmlentities($trophyGroup["name"]); ?>">
                                             </div>
                                             
                                             <div>
@@ -207,7 +207,7 @@ require_once("header.php");
                                         ?>
                                         <td style="width: 5rem;">
                                             <div>
-                                                <img class="card-img object-fit-scale" style="height: 5rem;" src="/img/trophy/<?= ($trophy["icon_url"] == ".png") ? ((str_contains($game["platform"], "PS5") || str_contains($game["platform"], "PSVR2")) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-trophy.png") : $trophy["icon_url"]; ?>" alt="<?= htmlentities($trophy["name"]); ?>">
+                                                <img class="card-img object-fit-scale" style="height: 5rem;" src="/img/trophy/<?= ($trophy["icon_url"] == ".png") ? ((str_contains($game->getPlatform(), "PS5") || str_contains($game->getPlatform(), "PSVR2")) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-trophy.png") : $trophy["icon_url"]; ?>" alt="<?= htmlentities($trophy["name"]); ?>">
                                             </div>
                                         </td>
 

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+/** @var GameDetails $game */
 /** @var GameHeaderData $gameHeaderData */
 ?>
 <div class="row">
@@ -33,11 +34,11 @@ declare(strict_types=1);
         <?php
     }
 
-    if (!empty($game['message'])) {
+    if ($game->hasMessage()) {
         ?>
         <div class="col-12">
             <div class="alert alert-warning" role="alert">
-                <?= $game['message']; ?>
+                <?= $game->getMessage(); ?>
             </div>
         </div>
         <?php
@@ -48,14 +49,23 @@ declare(strict_types=1);
 <div class="bg-body-tertiary p-3 rounded mb-3">
     <div class="row">
         <div class="col-12 col-lg-2">
-            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= ($game['icon_url'] == '.png') ? ((str_contains($game['platform'], 'PS5') || str_contains($game['platform'], 'PSVR2')) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-game.png") : $game['icon_url']; ?>" alt="<?= htmlentities($game['name']); ?>">
+            <?php
+            $gameIconUrl = $game->getIconUrl();
+            $gamePlatform = $game->getPlatform();
+            $iconPath = ($gameIconUrl === '.png')
+                ? ((str_contains($gamePlatform, 'PS5') || str_contains($gamePlatform, 'PSVR2'))
+                    ? '../missing-ps5-game-and-trophy.png'
+                    : '../missing-ps4-game.png')
+                : $gameIconUrl;
+            ?>
+            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= $iconPath; ?>" alt="<?= htmlentities($game->getName()); ?>">
         </div>
 
         <div class="col-12 col-lg-6">
             <div class="vstack gap-3">
                 <div class="hstack">
                     <div>
-                        <h1><?= htmlentities($game['name']); ?></h1>
+                        <h1><?= htmlentities($game->getName()); ?></h1>
                     </div>
 
                     <?php
@@ -102,14 +112,15 @@ declare(strict_types=1);
 
                 <div>
                     <?php
-                    foreach (explode(',', $game['platform']) as $platform) {
+                    foreach (explode(',', $gamePlatform) as $platform) {
                         echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">" . $platform . "</span> ";
                     }
                     ?>
                 </div>
 
                 <div>
-                    Version: <?= $game['set_version']; ?><?= (is_null($game['region']) ? '' : " <span class=\"badge rounded-pill text-bg-primary\">" . $game['region'] . '</span>') ?>
+                    <?php $region = $game->getRegion(); ?>
+                    Version: <?= $game->getSetVersion(); ?><?= ($region === null ? '' : " <span class=\"badge rounded-pill text-bg-primary\">" . $region . '</span>') ?>
                 </div>
 
                 <div>
@@ -130,11 +141,11 @@ declare(strict_types=1);
                     <?php
                     if (isset($gamePlayer)) {
                         ?>
-                        <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $gamePlayer['platinum'] ?? '0'; ?>/<?= $game['platinum']; ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $gamePlayer['gold'] ?? '0'; ?>/<?= $game['gold']; ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $gamePlayer['silver'] ?? '0'; ?>/<?= $game['silver']; ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $gamePlayer['bronze'] ?? '0'; ?>/<?= $game['bronze']; ?></span>
+                        <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $gamePlayer['platinum'] ?? '0'; ?>/<?= $game->getPlatinum(); ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $gamePlayer['gold'] ?? '0'; ?>/<?= $game->getGold(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $gamePlayer['silver'] ?? '0'; ?>/<?= $game->getSilver(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $gamePlayer['bronze'] ?? '0'; ?>/<?= $game->getBronze(); ?></span>
                         <?php
                     } else {
                         ?>
-                        <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $game['platinum']; ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $game['gold']; ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $game['silver']; ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $game['bronze']; ?></span>
+                        <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $game->getPlatinum(); ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $game->getGold(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $game->getSilver(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $game->getBronze(); ?></span>
                         <?php
                     }
                     ?>
@@ -153,18 +164,19 @@ declare(strict_types=1);
                 ?>
 
                 <div>
-                    <?= number_format($game['owners_completed']); ?> of <?= number_format($game['owners']); ?> players (<?= $game['difficulty']; ?>%) have 100% this game.
+                    <?= number_format($game->getOwnersCompleted()); ?> of <?= number_format($game->getOwners()); ?> players (<?= $game->getDifficulty(); ?>%) have 100% this game.
                 </div>
 
                 <div>
                     <?php
-                    if ($game['status'] == 0) {
-                        echo number_format($game['rarity_points']) . ' Rarity Points';
-                    } elseif ($game['status'] == 1) {
+                    $status = $game->getStatus();
+                    if ($status === 0) {
+                        echo number_format($game->getRarityPoints()) . ' Rarity Points';
+                    } elseif ($status === 1) {
                         echo "<span class='badge rounded-pill text-bg-warning' title='This game is delisted, no trophies will be accounted for on any leaderboard.'>Delisted</span>";
-                    } elseif ($game['status'] == 3) {
+                    } elseif ($status === 3) {
                         echo "<span class='badge rounded-pill text-bg-warning' title='This game is obsolete, no trophies will be accounted for on any leaderboard.'>Obsolete</span>";
-                    } elseif ($game['status'] == 4) {
+                    } elseif ($status === 4) {
                         echo "<span class='badge rounded-pill text-bg-warning' title='This game is delisted &amp; obsolete, no trophies will be accounted for on any leaderboard.'>Delisted &amp; Obsolete</span>";
                     }
 

--- a/wwwroot/game_leaderboard.php
+++ b/wwwroot/game_leaderboard.php
@@ -39,7 +39,7 @@ $totalPagesCount = $gameLeaderboardPage->getTotalPagesCount();
 $rows = $gameLeaderboardPage->getRows();
 $accountId = $gameLeaderboardPage->getPlayerAccountId();
 
-$title = $game["name"] ." Leaderboard ~ PSN 100%";
+$title = $game->getName() . " Leaderboard ~ PSN 100%";
 require_once("header.php");
 ?>
 
@@ -55,9 +55,9 @@ require_once("header.php");
 
             <div class="col-6 text-center">
                 <div class="btn-group">
-                    <a class="btn btn-outline-primary" href="/game/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?><?= (isset($player) ? "/".$player : "") ?>">Trophies</a>
-                    <a class="btn btn-primary active" href="/game-leaderboard/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?><?= (isset($player) ? "/".$player : "") ?>">Leaderboard</a>
-                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?><?= (isset($player) ? "/".$player : "") ?>">Recent Players</a>
+                    <a class="btn btn-outline-primary" href="/game/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Trophies</a>
+                    <a class="btn btn-primary active" href="/game-leaderboard/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Leaderboard</a>
+                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Recent Players</a>
                 </div>
             </div>
 
@@ -88,7 +88,7 @@ require_once("header.php");
                                 $paramsAvatar = $row->getAvatarQueryParameters($filter);
                                 $paramsCountry = $row->getCountryQueryParameters($filter);
                                 $playerName = $row->getOnlineId();
-                                $playerUrl = '/game/' . $game["id"] . '-' . $utility->slugify($game["name"]) . '/' . rawurlencode($playerName);
+                                $playerUrl = '/game/' . $game->getId() . '-' . $utility->slugify($game->getName()) . '/' . rawurlencode($playerName);
                                 ?>
                                 <tr<?= $row->matchesAccountId($accountId) ? " class='table-primary'" : ""; ?>>
                                     <th class="align-middle" style="width: 2rem;" scope="row"><?= ++$rank; ?></th>

--- a/wwwroot/game_recent_players.php
+++ b/wwwroot/game_recent_players.php
@@ -53,9 +53,9 @@ require_once("header.php");
 
             <div class="col-6 text-center">
                 <div class="btn-group">
-                    <a class="btn btn-outline-primary" href="/game/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?><?= (isset($player) ? "/".$player : "") ?>">Trophies</a>
-                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?><?= (isset($player) ? "/".$player : "") ?>">Leaderboard</a>
-                    <a class="btn btn-primary active" href="/game-recent-players/<?= $game["id"] ."-". $utility->slugify($game["name"]); ?><?= (isset($player) ? "/".$player : "") ?>">Recent Players</a>
+                    <a class="btn btn-outline-primary" href="/game/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Trophies</a>
+                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Leaderboard</a>
+                    <a class="btn btn-primary active" href="/game-recent-players/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Recent Players</a>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- add a GameDetails value object and update the game data services to return it
- refactor the GamePage, GameLeaderboardPage, and GameRecentPlayersPage workflows to consume the new object
- adjust the game-related templates to reference the new getters instead of array offsets

## Testing
- php -l wwwroot/classes/Game/GameDetails.php
- php -l wwwroot/classes/GameService.php
- php -l wwwroot/classes/GamePage.php
- php -l wwwroot/classes/GameHeaderService.php
- php -l wwwroot/classes/GameLeaderboardService.php
- php -l wwwroot/classes/GameLeaderboardPage.php
- php -l wwwroot/classes/GameRecentPlayersService.php
- php -l wwwroot/classes/GameRecentPlayersPage.php
- php -l wwwroot/game.php
- php -l wwwroot/game_header.php
- php -l wwwroot/game_leaderboard.php
- php -l wwwroot/game_recent_players.php

------
https://chatgpt.com/codex/tasks/task_e_68e371ea6720832f99c8d7db923b9c04