### PR TITLE
Fix unranked player detection in header alerts

### DIFF
--- a/wwwroot/classes/PlayerHeaderViewModel.php
+++ b/wwwroot/classes/PlayerHeaderViewModel.php
@@ -228,7 +228,9 @@ class PlayerHeaderViewModel
 
     private function isUnranked(): bool
     {
-        return (int) ($this->player['ranking'] ?? 0) > 10000;
+        $ranking = (int) ($this->player['ranking'] ?? 0);
+
+        return $ranking === 0 || $ranking > 10000;
     }
 
     private function isLeaderboardRankAvailable(): bool


### PR DESCRIPTION
## Summary
- treat a ranking value of 0 as unranked when building player header alerts

## Testing
- php -l wwwroot/classes/PlayerHeaderViewModel.php

------
https://chatgpt.com/codex/tasks/task_e_68e37c866104832f81c4564b141c1ec4