### PR TITLE
Fix player log count to ignore unearned trophies

### DIFF
--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -31,6 +31,7 @@ class PlayerLogService
             JOIN trophy_title tt USING (np_communication_id)
             WHERE tt.status != 2
                 AND te.account_id = :account_id
+                AND te.earned = 1
         SQL;
 
         $sql .= $this->buildPlatformClause($filter);


### PR DESCRIPTION
## Summary
- ensure the player log count query filters out unearned trophies so pagination totals match the visible list

## Testing
- php -l wwwroot/classes/PlayerLogService.php

------
https://chatgpt.com/codex/tasks/task_e_68e37c866104832f81c4564b141c1ec4