### PR TITLE
Fix account ID truncation in recent players lookup

### DIFF
--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -84,7 +84,9 @@ class GameRecentPlayersService
             SQL
         );
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->bindValue(':account_id', (int) $accountId, PDO::PARAM_INT);
+        // Account IDs are stored as BIGINT UNSIGNED. Bind as string to avoid
+        // truncating larger values when PHP integers overflow.
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
 
         $gamePlayer = $query->fetch(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- avoid casting BIGINT account IDs to integers when loading a game's recent player record so large values remain intact

## Testing
- php -l wwwroot/classes/GameRecentPlayersService.php

------
https://chatgpt.com/codex/tasks/task_e_68e4d63917a8832f9a0c55c5592fcee9