### PR TITLE
Refactor player queue scripts into controller

### DIFF
--- a/wwwroot/add_to_queue.php
+++ b/wwwroot/add_to_queue.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 require_once 'init.php';
-require_once 'classes/PlayerQueueService.php';
-require_once 'classes/PlayerQueueHandler.php';
+require_once 'classes/PlayerQueueController.php';
 
-$playerQueueService = new PlayerQueueService($database);
-$playerQueueHandler = new PlayerQueueHandler($playerQueueService);
+$controller = PlayerQueueController::create($database);
 
-echo $playerQueueHandler->handleAddToQueueRequest($_REQUEST, $_SERVER);
+$requestData = $_REQUEST ?? [];
+$serverData = $_SERVER ?? [];
+
+echo $controller->handleAddToQueue($requestData, $serverData);

--- a/wwwroot/check_queue_position.php
+++ b/wwwroot/check_queue_position.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 require_once 'init.php';
-require_once 'classes/PlayerQueueService.php';
-require_once 'classes/PlayerQueueHandler.php';
+require_once 'classes/PlayerQueueController.php';
 
-$playerQueueService = new PlayerQueueService($database);
-$playerQueueHandler = new PlayerQueueHandler($playerQueueService);
+$controller = PlayerQueueController::create($database);
 
-echo $playerQueueHandler->handleQueuePositionRequest($_REQUEST, $_SERVER);
+$requestData = $_REQUEST ?? [];
+$serverData = $_SERVER ?? [];
+
+echo $controller->handleQueuePosition($requestData, $serverData);

--- a/wwwroot/classes/PlayerQueueController.php
+++ b/wwwroot/classes/PlayerQueueController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../database.php';
+require_once __DIR__ . '/PlayerQueueService.php';
+require_once __DIR__ . '/PlayerQueueHandler.php';
+
+class PlayerQueueController
+{
+    private PlayerQueueHandler $handler;
+
+    public function __construct(PlayerQueueHandler $handler)
+    {
+        $this->handler = $handler;
+    }
+
+    public static function create(Database $database): self
+    {
+        $service = new PlayerQueueService($database);
+        $handler = new PlayerQueueHandler($service);
+
+        return new self($handler);
+    }
+
+    public function handleAddToQueue(array $requestData, array $serverData): string
+    {
+        return $this->handler->handleAddToQueueRequest($requestData, $serverData);
+    }
+
+    public function handleQueuePosition(array $requestData, array $serverData): string
+    {
+        return $this->handler->handleQueuePositionRequest($requestData, $serverData);
+    }
+}


### PR DESCRIPTION
## Summary
- add a PlayerQueueController to encapsulate queue handling logic
- update the queue endpoints to delegate to the controller and enable strict types

## Testing
- php -l wwwroot/classes/PlayerQueueController.php
- php -l wwwroot/add_to_queue.php
- php -l wwwroot/check_queue_position.php

------
https://chatgpt.com/codex/tasks/task_e_68e4d644ad20832f90c41ae6a24ee141