### PR TITLE
Refactor player report handling into page object

### DIFF
--- a/wwwroot/classes/PlayerReportPage.php
+++ b/wwwroot/classes/PlayerReportPage.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerReportHandler.php';
+require_once __DIR__ . '/PlayerReportResult.php';
+require_once __DIR__ . '/PlayerSummary.php';
+require_once __DIR__ . '/PlayerSummaryService.php';
+
+class PlayerReportPage
+{
+    private PlayerReportHandler $playerReportHandler;
+
+    private PlayerSummaryService $playerSummaryService;
+
+    private int $accountId;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $queryParameters;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $serverParameters;
+
+    private PlayerSummary $playerSummary;
+
+    private string $explanation;
+
+    private bool $explanationSubmitted;
+
+    private PlayerReportResult $reportResult;
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     * @param array<string, mixed> $serverParameters
+     */
+    public function __construct(
+        PlayerReportHandler $playerReportHandler,
+        PlayerSummaryService $playerSummaryService,
+        int $accountId,
+        array $queryParameters,
+        array $serverParameters
+    ) {
+        $this->playerReportHandler = $playerReportHandler;
+        $this->playerSummaryService = $playerSummaryService;
+        $this->accountId = $accountId;
+        $this->queryParameters = $queryParameters;
+        $this->serverParameters = $serverParameters;
+
+        $this->initialize();
+    }
+
+    private function initialize(): void
+    {
+        $this->playerSummary = $this->playerSummaryService->getSummary($this->accountId);
+        $this->explanation = $this->playerReportHandler->getExplanation($this->queryParameters);
+        $this->explanationSubmitted = array_key_exists('explanation', $this->queryParameters);
+        $this->reportResult = $this->playerReportHandler->handleReportRequest(
+            $this->accountId,
+            $this->explanation,
+            $this->explanationSubmitted,
+            $this->serverParameters
+        );
+    }
+
+    public function getPlayerSummary(): PlayerSummary
+    {
+        return $this->playerSummary;
+    }
+
+    public function getExplanation(): string
+    {
+        return $this->explanation;
+    }
+
+    public function wasExplanationSubmitted(): bool
+    {
+        return $this->explanationSubmitted;
+    }
+
+    public function getReportResult(): PlayerReportResult
+    {
+        return $this->reportResult;
+    }
+}
+

--- a/wwwroot/player_report.php
+++ b/wwwroot/player_report.php
@@ -5,6 +5,7 @@ if (!isset($accountId)) {
 }
 
 require_once __DIR__ . '/classes/PlayerReportHandler.php';
+require_once __DIR__ . '/classes/PlayerReportPage.php';
 require_once __DIR__ . '/classes/PlayerReportService.php';
 require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
@@ -12,17 +13,17 @@ require_once __DIR__ . '/classes/PlayerSummaryService.php';
 $playerReportService = new PlayerReportService($database);
 $playerReportHandler = new PlayerReportHandler($playerReportService);
 $playerSummaryService = new PlayerSummaryService($database);
-$playerSummary = $playerSummaryService->getSummary((int) $accountId);
-
-$queryParameters = $_GET ?? [];
-$explanation = $playerReportHandler->getExplanation($queryParameters);
-$explanationSubmitted = array_key_exists('explanation', $queryParameters);
-$reportResult = $playerReportHandler->handleReportRequest(
+$playerReportPage = new PlayerReportPage(
+    $playerReportHandler,
+    $playerSummaryService,
     (int) $accountId,
-    $explanation,
-    $explanationSubmitted,
+    $_GET ?? [],
     $_SERVER ?? []
 );
+
+$playerSummary = $playerReportPage->getPlayerSummary();
+$explanation = $playerReportPage->getExplanation();
+$reportResult = $playerReportPage->getReportResult();
 
 $title = $player["online_id"] . "'s Report ~ PSN 100%";
 require_once("header.php");


### PR DESCRIPTION
## Summary
- add a PlayerReportPage class that encapsulates fetching player summaries, explanations, and report results
- update player_report.php to build the new page object and consume its getters instead of duplicating logic

## Testing
- php -l wwwroot/classes/PlayerReportPage.php
- php -l wwwroot/player_report.php

------
https://chatgpt.com/codex/tasks/task_e_68e4d644ad20832f90c41ae6a24ee141