### PR TITLE
Refactor router to use handler classes

### DIFF
--- a/wwwroot/classes/Router.php
+++ b/wwwroot/classes/Router.php
@@ -6,23 +6,40 @@ require_once __DIR__ . '/RouteResult.php';
 require_once __DIR__ . '/GameRepository.php';
 require_once __DIR__ . '/TrophyRepository.php';
 require_once __DIR__ . '/PlayerRepository.php';
+require_once __DIR__ . '/Routing/RouteHandlerInterface.php';
+require_once __DIR__ . '/Routing/HomeRouteHandler.php';
+require_once __DIR__ . '/Routing/SimpleRouteHandler.php';
+require_once __DIR__ . '/Routing/GameRouteHandler.php';
+require_once __DIR__ . '/Routing/LeaderboardRouteHandler.php';
+require_once __DIR__ . '/Routing/PlayerRouteHandler.php';
+require_once __DIR__ . '/Routing/TrophyRouteHandler.php';
 
 class Router
 {
-    private GameRepository $gameRepository;
+    private RouteHandlerInterface $defaultHandler;
 
-    private TrophyRepository $trophyRepository;
-
-    private PlayerRepository $playerRepository;
+    /**
+     * @var array<string, RouteHandlerInterface>
+     */
+    private array $routeHandlers;
 
     public function __construct(
         GameRepository $gameRepository,
         TrophyRepository $trophyRepository,
         PlayerRepository $playerRepository
     ) {
-        $this->gameRepository = $gameRepository;
-        $this->trophyRepository = $trophyRepository;
-        $this->playerRepository = $playerRepository;
+        $this->defaultHandler = new HomeRouteHandler('home.php');
+        $this->routeHandlers = [
+            'about' => new SimpleRouteHandler('about.php', '/about/'),
+            'avatar' => new SimpleRouteHandler('avatars.php', '/avatar/'),
+            'changelog' => new SimpleRouteHandler('changelog.php', '/changelog/'),
+            'game' => new GameRouteHandler($gameRepository, 'game.php', '/game/', 'games.php'),
+            'game-leaderboard' => new GameRouteHandler($gameRepository, 'game_leaderboard.php', '/game/'),
+            'game-recent-players' => new GameRouteHandler($gameRepository, 'game_recent_players.php', '/game/'),
+            'leaderboard' => new LeaderboardRouteHandler(),
+            'player' => new PlayerRouteHandler($playerRepository),
+            'trophy' => new TrophyRouteHandler($trophyRepository),
+        ];
     }
 
     public function dispatch(string $requestUri): RouteResult
@@ -34,204 +51,17 @@ class Router
         $segments = $path === '' ? [] : explode('/', $path);
 
         if ($segments === [] || $segments[0] === '') {
-            return RouteResult::include('home.php');
+            return $this->defaultHandler->handle([]);
         }
 
         $route = array_shift($segments);
 
-        switch ($route) {
-            case 'about':
-                return $this->handleSimpleRoute($segments, 'about.php', '/about/');
-            case 'avatar':
-                return $this->handleSimpleRoute($segments, 'avatars.php', '/avatar/');
-            case 'changelog':
-                return $this->handleSimpleRoute($segments, 'changelog.php', '/changelog/');
-            case 'game':
-                return $this->handleGame($segments);
-            case 'game-leaderboard':
-                return $this->handleGameLeaderboard($segments);
-            case 'game-recent-players':
-                return $this->handleGameRecentPlayers($segments);
-            case 'leaderboard':
-                return $this->handleLeaderboard($segments);
-            case 'player':
-                return $this->handlePlayer($segments);
-            case 'trophy':
-                return $this->handleTrophy($segments);
-            default:
-                return RouteResult::notFound();
+        $handler = $route !== null ? ($this->routeHandlers[$route] ?? null) : null;
+
+        if (!$handler instanceof RouteHandlerInterface) {
+            return RouteResult::notFound();
         }
+
+        return $handler->handle($segments);
     }
-
-    private function handleSimpleRoute(array $segments, string $file, string $redirect): RouteResult
-    {
-        if ($this->hasAdditionalSegments($segments)) {
-            return RouteResult::redirect($redirect);
-        }
-
-        return RouteResult::include($file);
-    }
-
-    private function handleGame(array $segments): RouteResult
-    {
-        if ($this->isFirstSegmentMissing($segments)) {
-            return RouteResult::include('games.php');
-        }
-
-        $gameSegment = array_shift($segments);
-        $gameId = $this->gameRepository->findIdFromSegment($gameSegment);
-
-        if ($gameId === null) {
-            return RouteResult::redirect('/game/');
-        }
-
-        $player = $segments[0] ?? null;
-
-        return RouteResult::include('game.php', [
-            'gameId' => $gameId,
-            'player' => $player,
-        ]);
-    }
-
-    private function handleGameLeaderboard(array $segments): RouteResult
-    {
-        if ($this->isFirstSegmentMissing($segments)) {
-            return RouteResult::redirect('/game/');
-        }
-
-        $gameSegment = array_shift($segments);
-        $gameId = $this->gameRepository->findIdFromSegment($gameSegment);
-
-        if ($gameId === null) {
-            return RouteResult::redirect('/game/');
-        }
-
-        $player = $segments[0] ?? null;
-
-        return RouteResult::include('game_leaderboard.php', [
-            'gameId' => $gameId,
-            'player' => $player,
-        ]);
-    }
-
-    private function handleGameRecentPlayers(array $segments): RouteResult
-    {
-        if ($this->isFirstSegmentMissing($segments)) {
-            return RouteResult::redirect('/game/');
-        }
-
-        $gameSegment = array_shift($segments);
-        $gameId = $this->gameRepository->findIdFromSegment($gameSegment);
-
-        if ($gameId === null) {
-            return RouteResult::redirect('/game/');
-        }
-
-        $player = $segments[0] ?? null;
-
-        return RouteResult::include('game_recent_players.php', [
-            'gameId' => $gameId,
-            'player' => $player,
-        ]);
-    }
-
-    private function handleLeaderboard(array $segments): RouteResult
-    {
-        if ($this->isFirstSegmentMissing($segments)) {
-            return RouteResult::redirect('/leaderboard/trophy');
-        }
-
-        $view = $segments !== [] ? array_shift($segments) : '';
-
-        switch ($view) {
-            case 'main':
-            case 'trophy':
-                return RouteResult::include('leaderboard_main.php');
-            case 'rarity':
-                return RouteResult::include('leaderboard_rarity.php');
-            default:
-                return RouteResult::redirect('/leaderboard/trophy');
-        }
-    }
-
-    private function handlePlayer(array $segments): RouteResult
-    {
-        if ($this->isFirstSegmentMissing($segments)) {
-            return RouteResult::redirect('/leaderboard/trophy');
-        }
-
-        $onlineId = array_shift($segments);
-        $accountId = $this->playerRepository->findAccountIdByOnlineId($onlineId);
-
-        if ($accountId === null) {
-            return RouteResult::redirect('/player/');
-        }
-
-        $player = $this->playerRepository->fetchPlayerByAccountId($accountId);
-
-        if (!is_array($player) || $player === []) {
-            return RouteResult::redirect('/player/');
-        }
-
-        $view = $segments !== [] ? (string) array_shift($segments) : '';
-
-        $variables = [
-            'accountId' => $accountId,
-            'player' => $player,
-            'onlineId' => $onlineId,
-        ];
-
-        switch ($view) {
-            case '':
-                return RouteResult::include('player.php', $variables);
-            case 'advisor':
-                return RouteResult::include('player_advisor.php', $variables);
-            case 'log':
-                return RouteResult::include('player_log.php', $variables);
-            case 'random':
-                return RouteResult::include('player_random.php', $variables);
-            case 'report':
-                return RouteResult::include('player_report.php', $variables);
-            default:
-                return RouteResult::redirect('/player/' . $onlineId);
-        }
-    }
-
-    private function handleTrophy(array $segments): RouteResult
-    {
-        if ($this->isFirstSegmentMissing($segments)) {
-            return RouteResult::include('trophies.php');
-        }
-
-        $trophySegment = array_shift($segments);
-        $trophyId = $this->trophyRepository->findIdFromSegment($trophySegment);
-
-        if ($trophyId === null) {
-            return RouteResult::redirect('/trophy/');
-        }
-
-        $player = $segments[0] ?? null;
-
-        return RouteResult::include('trophy.php', [
-            'trophyId' => $trophyId,
-            'player' => $player,
-        ]);
-    }
-
-    private function hasAdditionalSegments(array $segments): bool
-    {
-        foreach ($segments as $segment) {
-            if ($segment !== '') {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function isFirstSegmentMissing(array $segments): bool
-    {
-        return !isset($segments[0]) || $segments[0] === '';
-    }
-
 }

--- a/wwwroot/classes/Routing/GameRouteHandler.php
+++ b/wwwroot/classes/Routing/GameRouteHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../GameRepository.php';
+require_once __DIR__ . '/RouteHandlerInterface.php';
+
+class GameRouteHandler implements RouteHandlerInterface
+{
+    private GameRepository $gameRepository;
+
+    private string $includeFile;
+
+    private string $redirectPath;
+
+    private ?string $missingSegmentInclude;
+
+    public function __construct(
+        GameRepository $gameRepository,
+        string $includeFile,
+        string $redirectPath,
+        ?string $missingSegmentInclude = null
+    ) {
+        $this->gameRepository = $gameRepository;
+        $this->includeFile = $includeFile;
+        $this->redirectPath = $redirectPath;
+        $this->missingSegmentInclude = $missingSegmentInclude;
+    }
+
+    /**
+     * @param list<string> $segments
+     */
+    public function handle(array $segments): RouteResult
+    {
+        if (!isset($segments[0]) || $segments[0] === '') {
+            if ($this->missingSegmentInclude !== null) {
+                return RouteResult::include($this->missingSegmentInclude);
+            }
+
+            return RouteResult::redirect($this->redirectPath);
+        }
+
+        $gameSegment = array_shift($segments);
+        $gameId = $this->gameRepository->findIdFromSegment($gameSegment);
+
+        if ($gameId === null) {
+            return RouteResult::redirect($this->redirectPath);
+        }
+
+        $player = $segments[0] ?? null;
+
+        return RouteResult::include(
+            $this->includeFile,
+            [
+                'gameId' => $gameId,
+                'player' => $player,
+            ]
+        );
+    }
+}

--- a/wwwroot/classes/Routing/HomeRouteHandler.php
+++ b/wwwroot/classes/Routing/HomeRouteHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/RouteHandlerInterface.php';
+
+class HomeRouteHandler implements RouteHandlerInterface
+{
+    private string $includeFile;
+
+    public function __construct(string $includeFile = 'home.php')
+    {
+        $this->includeFile = $includeFile;
+    }
+
+    /**
+     * @param list<string> $segments
+     */
+    public function handle(array $segments): RouteResult
+    {
+        return RouteResult::include($this->includeFile);
+    }
+}

--- a/wwwroot/classes/Routing/LeaderboardRouteHandler.php
+++ b/wwwroot/classes/Routing/LeaderboardRouteHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/RouteHandlerInterface.php';
+
+class LeaderboardRouteHandler implements RouteHandlerInterface
+{
+    private const DEFAULT_REDIRECT = '/leaderboard/trophy';
+
+    /**
+     * @param list<string> $segments
+     */
+    public function handle(array $segments): RouteResult
+    {
+        if (!isset($segments[0]) || $segments[0] === '') {
+            return RouteResult::redirect(self::DEFAULT_REDIRECT);
+        }
+
+        $view = array_shift($segments) ?? '';
+
+        switch ($view) {
+            case 'main':
+            case 'trophy':
+                return RouteResult::include('leaderboard_main.php');
+            case 'rarity':
+                return RouteResult::include('leaderboard_rarity.php');
+            default:
+                return RouteResult::redirect(self::DEFAULT_REDIRECT);
+        }
+    }
+}

--- a/wwwroot/classes/Routing/PlayerRouteHandler.php
+++ b/wwwroot/classes/Routing/PlayerRouteHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../PlayerRepository.php';
+require_once __DIR__ . '/RouteHandlerInterface.php';
+
+class PlayerRouteHandler implements RouteHandlerInterface
+{
+    private PlayerRepository $playerRepository;
+
+    public function __construct(PlayerRepository $playerRepository)
+    {
+        $this->playerRepository = $playerRepository;
+    }
+
+    /**
+     * @param list<string> $segments
+     */
+    public function handle(array $segments): RouteResult
+    {
+        if (!isset($segments[0]) || $segments[0] === '') {
+            return RouteResult::redirect('/leaderboard/trophy');
+        }
+
+        $onlineId = array_shift($segments) ?? '';
+        $accountId = $this->playerRepository->findAccountIdByOnlineId($onlineId);
+
+        if ($accountId === null) {
+            return RouteResult::redirect('/player/');
+        }
+
+        $player = $this->playerRepository->fetchPlayerByAccountId($accountId);
+
+        if (!is_array($player) || $player === []) {
+            return RouteResult::redirect('/player/');
+        }
+
+        $view = $segments !== [] ? (string) array_shift($segments) : '';
+
+        $variables = [
+            'accountId' => $accountId,
+            'player' => $player,
+            'onlineId' => $onlineId,
+        ];
+
+        switch ($view) {
+            case '':
+                return RouteResult::include('player.php', $variables);
+            case 'advisor':
+                return RouteResult::include('player_advisor.php', $variables);
+            case 'log':
+                return RouteResult::include('player_log.php', $variables);
+            case 'random':
+                return RouteResult::include('player_random.php', $variables);
+            case 'report':
+                return RouteResult::include('player_report.php', $variables);
+            default:
+                return RouteResult::redirect('/player/' . $onlineId);
+        }
+    }
+}

--- a/wwwroot/classes/Routing/RouteHandlerInterface.php
+++ b/wwwroot/classes/Routing/RouteHandlerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../RouteResult.php';
+
+interface RouteHandlerInterface
+{
+    /**
+     * @param list<string> $segments
+     */
+    public function handle(array $segments): RouteResult;
+}

--- a/wwwroot/classes/Routing/SimpleRouteHandler.php
+++ b/wwwroot/classes/Routing/SimpleRouteHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/RouteHandlerInterface.php';
+
+class SimpleRouteHandler implements RouteHandlerInterface
+{
+    private string $includeFile;
+
+    private string $redirectPath;
+
+    public function __construct(string $includeFile, string $redirectPath)
+    {
+        $this->includeFile = $includeFile;
+        $this->redirectPath = $redirectPath;
+    }
+
+    /**
+     * @param list<string> $segments
+     */
+    public function handle(array $segments): RouteResult
+    {
+        if ($this->hasAdditionalSegments($segments)) {
+            return RouteResult::redirect($this->redirectPath);
+        }
+
+        return RouteResult::include($this->includeFile);
+    }
+
+    /**
+     * @param list<string> $segments
+     */
+    private function hasAdditionalSegments(array $segments): bool
+    {
+        foreach ($segments as $segment) {
+            if ($segment !== '') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/wwwroot/classes/Routing/TrophyRouteHandler.php
+++ b/wwwroot/classes/Routing/TrophyRouteHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TrophyRepository.php';
+require_once __DIR__ . '/RouteHandlerInterface.php';
+
+class TrophyRouteHandler implements RouteHandlerInterface
+{
+    private TrophyRepository $trophyRepository;
+
+    public function __construct(TrophyRepository $trophyRepository)
+    {
+        $this->trophyRepository = $trophyRepository;
+    }
+
+    /**
+     * @param list<string> $segments
+     */
+    public function handle(array $segments): RouteResult
+    {
+        if (!isset($segments[0]) || $segments[0] === '') {
+            return RouteResult::include('trophies.php');
+        }
+
+        $trophySegment = array_shift($segments);
+        $trophyId = $this->trophyRepository->findIdFromSegment($trophySegment);
+
+        if ($trophyId === null) {
+            return RouteResult::redirect('/trophy/');
+        }
+
+        $player = $segments[0] ?? null;
+
+        return RouteResult::include(
+            'trophy.php',
+            [
+                'trophyId' => $trophyId,
+                'player' => $player,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a route handler interface and concrete handler classes for home, simple, game, leaderboard, player, and trophy routes
- update the Router to delegate dispatching to the new handler objects while keeping the existing routing behaviour intact

## Testing
- for file in wwwroot/classes/Routing/*.php wwwroot/classes/Router.php; do php -l $file; done

------
https://chatgpt.com/codex/tasks/task_e_68e4d644ad20832f90c41ae6a24ee141