### PR TITLE
Refactor player queue handling to use request object

### DIFF
--- a/wwwroot/classes/PlayerQueueController.php
+++ b/wwwroot/classes/PlayerQueueController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../database.php';
 require_once __DIR__ . '/PlayerQueueService.php';
+require_once __DIR__ . '/PlayerQueueRequest.php';
 require_once __DIR__ . '/PlayerQueueHandler.php';
 
 class PlayerQueueController
@@ -25,11 +26,15 @@ class PlayerQueueController
 
     public function handleAddToQueue(array $requestData, array $serverData): string
     {
-        return $this->handler->handleAddToQueueRequest($requestData, $serverData);
+        $request = PlayerQueueRequest::fromArrays($requestData, $serverData);
+
+        return $this->handler->handleAddToQueueRequest($request);
     }
 
     public function handleQueuePosition(array $requestData, array $serverData): string
     {
-        return $this->handler->handleQueuePositionRequest($requestData, $serverData);
+        $request = PlayerQueueRequest::fromArrays($requestData, $serverData);
+
+        return $this->handler->handleQueuePositionRequest($request);
     }
 }

--- a/wwwroot/classes/PlayerQueueHandler.php
+++ b/wwwroot/classes/PlayerQueueHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/PlayerQueueRequest.php';
+
 class PlayerQueueHandler
 {
     private PlayerQueueService $service;
@@ -9,14 +11,14 @@ class PlayerQueueHandler
         $this->service = $service;
     }
 
-    public function handleAddToQueueRequest(array $requestData, array $serverData): string
+    public function handleAddToQueueRequest(PlayerQueueRequest $request): string
     {
-        $playerName = $this->service->sanitizePlayerName($requestData['q'] ?? '');
-        $ipAddress = $this->service->sanitizeIpAddress($serverData['REMOTE_ADDR'] ?? '');
-
-        if ($playerName === '') {
+        if ($request->isPlayerNameEmpty()) {
             return "PSN name can't be empty.";
         }
+
+        $playerName = $request->getPlayerName();
+        $ipAddress = $request->getIpAddress();
 
         $cheaterAccountId = $this->service->getCheaterAccountId($playerName);
         if ($cheaterAccountId !== null) {
@@ -38,14 +40,14 @@ class PlayerQueueHandler
         return $this->createSpinnerMessage("{$playerLink} is being added to the queue.");
     }
 
-    public function handleQueuePositionRequest(array $requestData, array $serverData): string
+    public function handleQueuePositionRequest(PlayerQueueRequest $request): string
     {
-        $playerName = $this->service->sanitizePlayerName($requestData['q'] ?? '');
-        $ipAddress = $this->service->sanitizeIpAddress($serverData['REMOTE_ADDR'] ?? '');
-
-        if ($playerName === '') {
+        if ($request->isPlayerNameEmpty()) {
             return "PSN name can't be empty.";
         }
+
+        $playerName = $request->getPlayerName();
+        $ipAddress = $request->getIpAddress();
 
         if ($this->service->hasReachedIpSubmissionLimit($ipAddress)) {
             return $this->createQueueLimitMessage();

--- a/wwwroot/classes/PlayerQueueRequest.php
+++ b/wwwroot/classes/PlayerQueueRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerQueueRequest
+{
+    private string $playerName;
+
+    private string $ipAddress;
+
+    private function __construct(string $playerName, string $ipAddress)
+    {
+        $this->playerName = $playerName;
+        $this->ipAddress = $ipAddress;
+    }
+
+    public static function fromArrays(array $requestData, array $serverData): self
+    {
+        $playerName = self::sanitizeValue($requestData['q'] ?? '');
+        $ipAddress = self::sanitizeValue($serverData['REMOTE_ADDR'] ?? '');
+
+        return new self($playerName, $ipAddress);
+    }
+
+    public function getPlayerName(): string
+    {
+        return $this->playerName;
+    }
+
+    public function getIpAddress(): string
+    {
+        return $this->ipAddress;
+    }
+
+    public function isPlayerNameEmpty(): bool
+    {
+        return $this->playerName === '';
+    }
+
+    private static function sanitizeValue(?string $value): string
+    {
+        return trim((string) ($value ?? ''));
+    }
+}

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -12,16 +12,6 @@ class PlayerQueueService
         $this->database = $database;
     }
 
-    public function sanitizePlayerName(?string $playerName): string
-    {
-        return trim((string) ($playerName ?? ''));
-    }
-
-    public function sanitizeIpAddress(?string $ipAddress): string
-    {
-        return trim((string) ($ipAddress ?? ''));
-    }
-
     public function getIpSubmissionCount(string $ipAddress): int
     {
         if ($ipAddress === '') {


### PR DESCRIPTION
## Summary
- introduce a `PlayerQueueRequest` value object to encapsulate sanitized queue input data
- update the queue controller and handler to work with the new request object instead of raw arrays
- simplify `PlayerQueueService` by removing now-unused sanitization helpers

## Testing
- php -l wwwroot/classes/PlayerQueueRequest.php
- php -l wwwroot/classes/PlayerQueueHandler.php
- php -l wwwroot/classes/PlayerQueueController.php
- php -l wwwroot/classes/PlayerQueueService.php

------
https://chatgpt.com/codex/tasks/task_e_68e51d815e30832faf83cdaa29bd5a33