### PR TITLE
Refactor cron scripts to shared OOP runner

### DIFF
--- a/wwwroot/classes/Cron/CronJobInterface.php
+++ b/wwwroot/classes/Cron/CronJobInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+interface CronJobInterface
+{
+    public function run(): void;
+}

--- a/wwwroot/classes/Cron/CronJobRunner.php
+++ b/wwwroot/classes/Cron/CronJobRunner.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/CronJobInterface.php';
+
+final class CronJobRunner
+{
+    private bool $environmentConfigured = false;
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function run(CronJobInterface $job): void
+    {
+        $this->configureEnvironment();
+        $job->run();
+    }
+
+    private function configureEnvironment(): void
+    {
+        if ($this->environmentConfigured) {
+            return;
+        }
+
+        $this->applyIniSetting('max_execution_time', '0');
+        $this->applyIniSetting('mysql.connect_timeout', '0');
+
+        if (function_exists('set_time_limit')) {
+            @set_time_limit(0);
+        }
+
+        $this->environmentConfigured = true;
+    }
+
+    private function applyIniSetting(string $option, string $value): void
+    {
+        if (function_exists('ini_set')) {
+            @ini_set($option, $value);
+        }
+    }
+}

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class DailyCronJob
+require_once __DIR__ . '/CronJobInterface.php';
+
+class DailyCronJob implements CronJobInterface
 {
     private PDO $database;
 

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class HourlyCronJob
+require_once __DIR__ . '/CronJobInterface.php';
+
+class HourlyCronJob implements CronJobInterface
 {
     private const STATISTICS_UPDATE_QUERY = <<<'SQL'
         WITH game AS (

--- a/wwwroot/classes/Cron/PlayerRankingCronJob.php
+++ b/wwwroot/classes/Cron/PlayerRankingCronJob.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/CronJobInterface.php';
+require_once __DIR__ . '/PlayerRankingUpdater.php';
+
+final class PlayerRankingCronJob implements CronJobInterface
+{
+    private PlayerRankingUpdater $playerRankingUpdater;
+
+    public function __construct(PlayerRankingUpdater $playerRankingUpdater)
+    {
+        $this->playerRankingUpdater = $playerRankingUpdater;
+    }
+
+    public function run(): void
+    {
+        $this->playerRankingUpdater->recalculate();
+    }
+}

--- a/wwwroot/classes/Cron/WeeklyCronJob.php
+++ b/wwwroot/classes/Cron/WeeklyCronJob.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class WeeklyCronJob
+require_once __DIR__ . '/CronJobInterface.php';
+
+class WeeklyCronJob implements CronJobInterface
 {
     private const UPDATE_PLAYER_RANKINGS_QUERY = <<<'SQL'
         UPDATE player p

--- a/wwwroot/cron/5th_minute.php
+++ b/wwwroot/cron/5th_minute.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-ini_set("max_execution_time", "0");
-ini_set("mysql.connect_timeout", "0");
-set_time_limit(0);
-
 require_once dirname(__DIR__) . '/init.php';
-require_once dirname(__DIR__) . '/classes/Cron/PlayerRankingUpdater.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
+require_once dirname(__DIR__) . '/classes/Cron/PlayerRankingCronJob.php';
 
-$updater = new PlayerRankingUpdater($database);
-$updater->recalculate();
+$cronJobRunner = CronJobRunner::create();
+$playerRankingUpdater = new PlayerRankingUpdater($database);
+$playerRankingCronJob = new PlayerRankingCronJob($playerRankingUpdater);
+$cronJobRunner->run($playerRankingCronJob);

--- a/wwwroot/cron/daily.php
+++ b/wwwroot/cron/daily.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-ini_set("max_execution_time", "0");
-ini_set("mysql.connect_timeout", "0");
-set_time_limit(0);
-
 require_once dirname(__DIR__) . '/init.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
 require_once dirname(__DIR__) . '/classes/Cron/DailyCronJob.php';
 
+$cronJobRunner = CronJobRunner::create();
 $dailyCronJob = new DailyCronJob($database);
-$dailyCronJob->run();
+$cronJobRunner->run($dailyCronJob);

--- a/wwwroot/cron/hourly.php
+++ b/wwwroot/cron/hourly.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-ini_set("max_execution_time", "0");
-ini_set("mysql.connect_timeout", "0");
-set_time_limit(0);
-
 require_once dirname(__DIR__) . '/init.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
 require_once dirname(__DIR__) . '/classes/Cron/HourlyCronJob.php';
 
+$cronJobRunner = CronJobRunner::create();
 $hourlyCronJob = new HourlyCronJob($database);
-$hourlyCronJob->run();
+$cronJobRunner->run($hourlyCronJob);

--- a/wwwroot/cron/weekly.php
+++ b/wwwroot/cron/weekly.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-ini_set("max_execution_time", "0");
-ini_set("mysql.connect_timeout", "0");
-set_time_limit(0);
-
 require_once dirname(__DIR__) . '/init.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
 require_once dirname(__DIR__) . '/classes/Cron/WeeklyCronJob.php';
 
+$cronJobRunner = CronJobRunner::create();
 $weeklyCronJob = new WeeklyCronJob($database);
-$weeklyCronJob->run();
+$cronJobRunner->run($weeklyCronJob);


### PR DESCRIPTION
## Summary
- introduce a CronJobInterface and CronJobRunner to encapsulate environment setup for cron jobs
- implement the interface in existing cron job classes and add a wrapper for the player ranking updater
- refactor cron entry scripts to execute jobs via the shared runner for consistent OOP structure

## Testing
- php -l wwwroot/classes/Cron/CronJobRunner.php
- php -l wwwroot/classes/Cron/CronJobInterface.php
- php -l wwwroot/classes/Cron/PlayerRankingCronJob.php
- php -l wwwroot/classes/Cron/DailyCronJob.php
- php -l wwwroot/classes/Cron/HourlyCronJob.php
- php -l wwwroot/classes/Cron/WeeklyCronJob.php

------
https://chatgpt.com/codex/tasks/task_e_68e51d815e30832faf83cdaa29bd5a33