### PR TITLE
Refactor player queue endpoints to return typed responses

### DIFF
--- a/wwwroot/add_to_queue.php
+++ b/wwwroot/add_to_queue.php
@@ -10,4 +10,17 @@ $controller = PlayerQueueController::create($database);
 $requestData = $_REQUEST ?? [];
 $serverData = $_SERVER ?? [];
 
-echo $controller->handleAddToQueue($requestData, $serverData);
+$response = $controller->handleAddToQueue($requestData, $serverData);
+
+header('Content-Type: application/json');
+
+try {
+    echo json_encode($response->toArray(), JSON_THROW_ON_ERROR);
+} catch (JsonException) {
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'An unexpected error occurred while encoding the response.',
+        'shouldPoll' => false,
+    ]);
+}

--- a/wwwroot/check_queue_position.php
+++ b/wwwroot/check_queue_position.php
@@ -10,4 +10,17 @@ $controller = PlayerQueueController::create($database);
 $requestData = $_REQUEST ?? [];
 $serverData = $_SERVER ?? [];
 
-echo $controller->handleQueuePosition($requestData, $serverData);
+$response = $controller->handleQueuePosition($requestData, $serverData);
+
+header('Content-Type: application/json');
+
+try {
+    echo json_encode($response->toArray(), JSON_THROW_ON_ERROR);
+} catch (JsonException) {
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'An unexpected error occurred while encoding the response.',
+        'shouldPoll' => false,
+    ]);
+}

--- a/wwwroot/classes/PlayerQueueController.php
+++ b/wwwroot/classes/PlayerQueueController.php
@@ -24,14 +24,14 @@ class PlayerQueueController
         return new self($handler);
     }
 
-    public function handleAddToQueue(array $requestData, array $serverData): string
+    public function handleAddToQueue(array $requestData, array $serverData): PlayerQueueResponse
     {
         $request = PlayerQueueRequest::fromArrays($requestData, $serverData);
 
         return $this->handler->handleAddToQueueRequest($request);
     }
 
-    public function handleQueuePosition(array $requestData, array $serverData): string
+    public function handleQueuePosition(array $requestData, array $serverData): PlayerQueueResponse
     {
         $request = PlayerQueueRequest::fromArrays($requestData, $serverData);
 

--- a/wwwroot/classes/PlayerQueueResponse.php
+++ b/wwwroot/classes/PlayerQueueResponse.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+class PlayerQueueResponse
+{
+    private const STATUS_QUEUED = 'queued';
+    private const STATUS_COMPLETE = 'complete';
+    private const STATUS_ERROR = 'error';
+
+    private string $status;
+
+    private string $message;
+
+    private function __construct(string $status, string $message)
+    {
+        $this->status = $status;
+        $this->message = $message;
+    }
+
+    public static function queued(string $message): self
+    {
+        return new self(self::STATUS_QUEUED, $message);
+    }
+
+    public static function complete(string $message): self
+    {
+        return new self(self::STATUS_COMPLETE, $message);
+    }
+
+    public static function error(string $message): self
+    {
+        return new self(self::STATUS_ERROR, $message);
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function shouldPoll(): bool
+    {
+        return $this->status === self::STATUS_QUEUED;
+    }
+
+    /**
+     * @return array<string, string|bool>
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->getStatus(),
+            'message' => $this->getMessage(),
+            'shouldPoll' => $this->shouldPoll(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a `PlayerQueueResponse` value object and use it throughout the queue handler and controller
- emit JSON responses from the add-to-queue and queue-position endpoints with basic error handling
- update the home page queue manager JavaScript to consume structured responses and decide whether to continue polling

## Testing
- php -l wwwroot/classes/PlayerQueueResponse.php
- php -l wwwroot/classes/PlayerQueueHandler.php
- php -l wwwroot/classes/PlayerQueueController.php
- php -l wwwroot/add_to_queue.php
- php -l wwwroot/check_queue_position.php
- php -l wwwroot/home.php

------
https://chatgpt.com/codex/tasks/task_e_68e57768fb78832fa8260f4d780b2997