### PR TITLE
Refactor 30-minute cron job to use CronJobRunner

### DIFF
--- a/wwwroot/classes/Cron/CronJobCliArguments.php
+++ b/wwwroot/classes/Cron/CronJobCliArguments.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+final class CronJobCliArguments
+{
+    private array $arguments;
+
+    private function __construct(array $arguments)
+    {
+        $this->arguments = $arguments;
+    }
+
+    public static function fromArgv(array $argv): self
+    {
+        $arguments = [];
+
+        if (count($argv) > 1) {
+            parse_str(implode('&', array_slice($argv, 1)), $arguments);
+
+            if (!is_array($arguments)) {
+                $arguments = [];
+            }
+        }
+
+        return new self($arguments);
+    }
+
+    public function getWorkerId(): int
+    {
+        return $this->getIntArgument('worker');
+    }
+
+    private function getIntArgument(string $key, int $default = 0): int
+    {
+        if (!array_key_exists($key, $this->arguments)) {
+            return $default;
+        }
+
+        $value = $this->arguments[$key];
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        if (is_string($value)) {
+            $filteredValue = filter_var($value, FILTER_VALIDATE_INT);
+            if ($filteredValue !== false && $filteredValue !== null) {
+                return (int) $filteredValue;
+            }
+        }
+
+        return $default;
+    }
+}

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CronJobInterface.php';
+
 use Tustin\PlayStation\Client;
 
-class ThirtyMinuteCronJob
+class ThirtyMinuteCronJob implements CronJobInterface
 {
     private PDO $database;
 
@@ -12,14 +14,17 @@ class ThirtyMinuteCronJob
 
     private Psn100Logger $logger;
 
-    public function __construct(PDO $database, TrophyCalculator $trophyCalculator, Psn100Logger $logger)
+    private int $workerId;
+
+    public function __construct(PDO $database, TrophyCalculator $trophyCalculator, Psn100Logger $logger, int $workerId)
     {
         $this->database = $database;
         $this->trophyCalculator = $trophyCalculator;
         $this->logger = $logger;
+        $this->workerId = $workerId;
     }
 
-    public function run(int $workerId): void
+    public function run(): void
     {
         $recheck = "";
 
@@ -35,7 +40,7 @@ class ThirtyMinuteCronJob
                         setting
                     WHERE
                         id = :id");
-                $query->bindValue(":id", $workerId, PDO::PARAM_INT);
+                $query->bindValue(":id", $this->workerId, PDO::PARAM_INT);
                 $query->execute();
                 $worker = $query->fetch();
 

--- a/wwwroot/cron/30th_minute.php
+++ b/wwwroot/cron/30th_minute.php
@@ -2,20 +2,22 @@
 
 declare(strict_types=1);
 
-parse_str(implode('&', array_slice($argv, 1)), $arguments);
+require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobCliArguments.php';
 
-//ini_set("max_execution_time", "0");
-//ini_set("mysql.connect_timeout", "0");
-//set_time_limit(0);
+$cronJobRunner = CronJobRunner::create();
+$cronJobRunner->configureEnvironment();
+
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 require_once dirname(__DIR__) . '/init.php';
 require_once dirname(__DIR__) . '/classes/TrophyCalculator.php';
 require_once dirname(__DIR__) . '/classes/Cron/ThirtyMinuteCronJob.php';
 
+$cliArguments = CronJobCliArguments::fromArgv($_SERVER['argv'] ?? []);
+$workerId = $cliArguments->getWorkerId();
+
 $trophyCalculator = new TrophyCalculator($database);
 $logger = new Psn100Logger($database);
 
-$workerId = isset($arguments['worker']) ? (int) $arguments['worker'] : 0;
-
-$cronJob = new ThirtyMinuteCronJob($database, $trophyCalculator, $logger);
-$cronJob->run($workerId);
+$cronJob = new ThirtyMinuteCronJob($database, $trophyCalculator, $logger, $workerId);
+$cronJobRunner->run($cronJob);


### PR DESCRIPTION
## Summary
- add a small CLI argument parser for cron scripts to convert argv into typed values
- refactor the 30-minute cron entry point to use CronJobRunner and dependency injection for the worker id
- update ThirtyMinuteCronJob to implement CronJobInterface and store the worker id on construction

## Testing
- php -l wwwroot/cron/30th_minute.php
- php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php
- php -l wwwroot/classes/Cron/CronJobCliArguments.php

------
https://chatgpt.com/codex/tasks/task_e_68e57768fb78832fa8260f4d780b2997