### PR TITLE
Refactor possible cheater rules into objects

### DIFF
--- a/wwwroot/classes/Admin/PossibleCheaterRuleGroup.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleGroup.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+final class PossibleCheaterRule
+{
+    public function __construct(private string $condition)
+    {
+    }
+
+    public static function fromString(string $condition): self
+    {
+        return new self($condition);
+    }
+
+    public function getCondition(): string
+    {
+        return $this->condition;
+    }
+}
+
+final class PossibleCheaterRuleGroup
+{
+    /**
+     * @param PossibleCheaterRule[] $rules
+     */
+    public function __construct(private string $label, private array $rules)
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $label = (string) ($data['label'] ?? '');
+        $conditions = is_array($data['conditions'] ?? null) ? $data['conditions'] : [];
+
+        $rules = [];
+        foreach ($conditions as $condition) {
+            $rules[] = PossibleCheaterRule::fromString((string) $condition);
+        }
+
+        return new self($label, $rules);
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    /**
+     * @return PossibleCheaterRule[]
+     */
+    public function getRules(): array
+    {
+        return $this->rules;
+    }
+}

--- a/wwwroot/classes/Admin/PossibleCheaterSectionDefinition.php
+++ b/wwwroot/classes/Admin/PossibleCheaterSectionDefinition.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+final class PossibleCheaterSectionDefinition
+{
+    public function __construct(
+        private string $title,
+        private string $query,
+        private string $linkPattern
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (string) ($data['title'] ?? ''),
+            (string) ($data['query'] ?? ''),
+            (string) ($data['linkPattern'] ?? '')
+        );
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+
+    public function buildLink(string $onlineId): string
+    {
+        return sprintf($this->linkPattern, rawurlencode($onlineId));
+    }
+}


### PR DESCRIPTION
## Summary
- wrap possible cheater rule definitions in dedicated value objects
- update PossibleCheaterService to consume the new rule and section definitions

## Testing
- php -l wwwroot/classes/Admin/PossibleCheaterRuleGroup.php
- php -l wwwroot/classes/Admin/PossibleCheaterSectionDefinition.php
- php -l wwwroot/classes/Admin/PossibleCheaterService.php

------
https://chatgpt.com/codex/tasks/task_e_68e57768fb78832fa8260f4d780b2997