### PR TITLE
Preserve VR acronym in trophy title formatting

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1361,6 +1361,14 @@ class ThirtyMinuteCronJob implements CronJobInterface
             return true;
         }
 
+        $acronyms = [
+            'VR',
+        ];
+
+        if (in_array($word, $acronyms, true)) {
+            return true;
+        }
+
         if (preg_match('/\d/', $word) === 1) {
             return true;
         }


### PR DESCRIPTION
## Summary
- ensure the APA title case formatter leaves the acronym "VR" untouched
- prevent new trophy titles containing "VR" from being converted to "Vr"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e61997ffd8832f9c49d70096cf95e6