### PR TITLE
Refactor rarity leaderboard setup into context class

### DIFF
--- a/wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../PlayerLeaderboardFilter.php';
+require_once __DIR__ . '/../PlayerRarityLeaderboardService.php';
+require_once __DIR__ . '/../PlayerLeaderboardPage.php';
+require_once __DIR__ . '/../Utility.php';
+require_once __DIR__ . '/RarityLeaderboardRow.php';
+
+class RarityLeaderboardPageContext
+{
+    private const TITLE = 'PSN Rarity Leaderboard ~ PSN 100%';
+
+    private PlayerLeaderboardPage $leaderboardPage;
+
+    private PlayerLeaderboardFilter $filter;
+
+    private Utility $utility;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $filterParameters;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $currentPageParameters;
+
+    private ?string $highlightedPlayerId;
+
+    /**
+     * @var RarityLeaderboardRow[]
+     */
+    private array $rows;
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    private function __construct(
+        PlayerLeaderboardPage $leaderboardPage,
+        PlayerLeaderboardFilter $filter,
+        Utility $utility,
+        array $queryParameters
+    ) {
+        $this->leaderboardPage = $leaderboardPage;
+        $this->filter = $filter;
+        $this->utility = $utility;
+        $this->filterParameters = $leaderboardPage->getFilterParameters();
+        $this->currentPageParameters = $leaderboardPage->getPageQueryParameters($leaderboardPage->getCurrentPage());
+        $this->highlightedPlayerId = $this->resolveHighlightedPlayerId($queryParameters);
+        $this->rows = $this->buildRows();
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public static function fromGlobals(PDO $database, Utility $utility, array $queryParameters): self
+    {
+        $playerLeaderboardService = new PlayerRarityLeaderboardService($database);
+        $playerLeaderboardFilter = PlayerLeaderboardFilter::fromArray($queryParameters);
+        $playerLeaderboardPage = new PlayerLeaderboardPage($playerLeaderboardService, $playerLeaderboardFilter);
+
+        return new self($playerLeaderboardPage, $playerLeaderboardFilter, $utility, $queryParameters);
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    private function resolveHighlightedPlayerId(array $queryParameters): ?string
+    {
+        $highlightedPlayer = $queryParameters['player'] ?? null;
+
+        if ($highlightedPlayer === null) {
+            return null;
+        }
+
+        $highlightedPlayer = trim((string) $highlightedPlayer);
+
+        return $highlightedPlayer !== '' ? $highlightedPlayer : null;
+    }
+
+    /**
+     * @return RarityLeaderboardRow[]
+     */
+    private function buildRows(): array
+    {
+        $players = $this->leaderboardPage->getPlayers();
+
+        return array_map(
+            fn(array $player): RarityLeaderboardRow => new RarityLeaderboardRow(
+                $player,
+                $this->filter,
+                $this->utility,
+                $this->highlightedPlayerId,
+                $this->filterParameters
+            ),
+            $players
+        );
+    }
+
+    public function getTitle(): string
+    {
+        return self::TITLE;
+    }
+
+    /**
+     * @return RarityLeaderboardRow[]
+     */
+    public function getRows(): array
+    {
+        return $this->rows;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getFilterQueryParameters(): array
+    {
+        return $this->filterParameters;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getCurrentPageQueryParameters(): array
+    {
+        return $this->currentPageParameters;
+    }
+
+    public function shouldShowCountryRank(): bool
+    {
+        return $this->filter->hasCountry();
+    }
+
+    public function getLeaderboardPage(): PlayerLeaderboardPage
+    {
+        return $this->leaderboardPage;
+    }
+}

--- a/wwwroot/leaderboard_rarity.php
+++ b/wwwroot/leaderboard_rarity.php
@@ -1,30 +1,14 @@
 <?php
-require_once 'classes/PlayerLeaderboardFilter.php';
-require_once 'classes/PlayerRarityLeaderboardService.php';
-require_once 'classes/PlayerLeaderboardPage.php';
-require_once 'classes/Leaderboard/RarityLeaderboardRow.php';
+require_once 'classes/Leaderboard/RarityLeaderboardPageContext.php';
 
-$title = "PSN Rarity Leaderboard ~ PSN 100%";
+$rarityLeaderboardPageContext = RarityLeaderboardPageContext::fromGlobals($database, $utility, $_GET ?? []);
+$title = $rarityLeaderboardPageContext->getTitle();
 require_once("header.php");
 
-$playerLeaderboardFilter = PlayerLeaderboardFilter::fromArray($_GET ?? []);
-$playerLeaderboardService = new PlayerRarityLeaderboardService($database);
-$playerLeaderboardPage = new PlayerLeaderboardPage($playerLeaderboardService, $playerLeaderboardFilter);
-
-$players = $playerLeaderboardPage->getPlayers();
-$filterParameters = $playerLeaderboardPage->getFilterParameters();
-$highlightedPlayerId = isset($_GET['player']) ? (string) $_GET['player'] : null;
-
-$rows = array_map(
-    static fn(array $player) => new RarityLeaderboardRow(
-        $player,
-        $playerLeaderboardFilter,
-        $utility,
-        $highlightedPlayerId,
-        $filterParameters
-    ),
-    $players
-);
+$playerLeaderboardPage = $rarityLeaderboardPageContext->getLeaderboardPage();
+$rows = $rarityLeaderboardPageContext->getRows();
+$filterParameters = $rarityLeaderboardPageContext->getFilterQueryParameters();
+$shouldShowCountryRank = $rarityLeaderboardPageContext->shouldShowCountryRank();
 ?>
 
 <main class="container">
@@ -49,17 +33,11 @@ $rows = array_map(
                     <table class="table">
                         <thead>
                             <tr class="text-uppercase">
-                                <?php
-                                if ($playerLeaderboardFilter->hasCountry()) {
-                                    ?>
+                                <?php if ($shouldShowCountryRank) { ?>
                                     <th scope="col" class="text-center">Country<br>Rank</th>
-                                    <?php
-                                } else {
-                                    ?>
+                                <?php } else { ?>
                                     <th scope="col" class="text-center">Rank</th>
-                                    <?php
-                                }
-                                ?>
+                                <?php } ?>
                                 <th scope="col">User</th>
                                 <th scope="col" class="text-center">Level</th>
                                 <th scope="col" class="text-center">Legendary</th>


### PR DESCRIPTION
## Summary
- extract the rarity leaderboard preparation logic into a dedicated `RarityLeaderboardPageContext`
- update `leaderboard_rarity.php` to rely on the new context and streamline the view logic

## Testing
- php -l wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
- php -l wwwroot/leaderboard_rarity.php

------
https://chatgpt.com/codex/tasks/task_e_68e580387200832fb4865894af5fa624