### PR TITLE
Refactor player queue endpoints to reusable endpoint class

### DIFF
--- a/wwwroot/add_to_queue.php
+++ b/wwwroot/add_to_queue.php
@@ -3,24 +3,7 @@
 declare(strict_types=1);
 
 require_once 'init.php';
-require_once 'classes/PlayerQueueController.php';
+require_once 'classes/PlayerQueueEndpoint.php';
 
-$controller = PlayerQueueController::create($database);
-
-$requestData = $_REQUEST ?? [];
-$serverData = $_SERVER ?? [];
-
-$response = $controller->handleAddToQueue($requestData, $serverData);
-
-header('Content-Type: application/json');
-
-try {
-    echo json_encode($response->toArray(), JSON_THROW_ON_ERROR);
-} catch (JsonException) {
-    http_response_code(500);
-    echo json_encode([
-        'status' => 'error',
-        'message' => 'An unexpected error occurred while encoding the response.',
-        'shouldPoll' => false,
-    ]);
-}
+$endpoint = PlayerQueueEndpoint::fromDatabase($database);
+$endpoint->handleAddToQueue($_REQUEST ?? [], $_SERVER ?? []);

--- a/wwwroot/check_queue_position.php
+++ b/wwwroot/check_queue_position.php
@@ -3,24 +3,7 @@
 declare(strict_types=1);
 
 require_once 'init.php';
-require_once 'classes/PlayerQueueController.php';
+require_once 'classes/PlayerQueueEndpoint.php';
 
-$controller = PlayerQueueController::create($database);
-
-$requestData = $_REQUEST ?? [];
-$serverData = $_SERVER ?? [];
-
-$response = $controller->handleQueuePosition($requestData, $serverData);
-
-header('Content-Type: application/json');
-
-try {
-    echo json_encode($response->toArray(), JSON_THROW_ON_ERROR);
-} catch (JsonException) {
-    http_response_code(500);
-    echo json_encode([
-        'status' => 'error',
-        'message' => 'An unexpected error occurred while encoding the response.',
-        'shouldPoll' => false,
-    ]);
-}
+$endpoint = PlayerQueueEndpoint::fromDatabase($database);
+$endpoint->handleQueuePosition($_REQUEST ?? [], $_SERVER ?? []);

--- a/wwwroot/classes/PlayerQueueEndpoint.php
+++ b/wwwroot/classes/PlayerQueueEndpoint.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../database.php';
+require_once __DIR__ . '/PlayerQueueController.php';
+require_once __DIR__ . '/PlayerQueueResponse.php';
+
+class PlayerQueueEndpoint
+{
+    private PlayerQueueController $controller;
+
+    private function __construct(PlayerQueueController $controller)
+    {
+        $this->controller = $controller;
+    }
+
+    public static function fromDatabase(Database $database): self
+    {
+        $controller = PlayerQueueController::create($database);
+
+        return new self($controller);
+    }
+
+    public function handleAddToQueue(array $requestData, array $serverData): void
+    {
+        $response = $this->controller->handleAddToQueue($requestData, $serverData);
+
+        $this->sendJsonResponse($response);
+    }
+
+    public function handleQueuePosition(array $requestData, array $serverData): void
+    {
+        $response = $this->controller->handleQueuePosition($requestData, $serverData);
+
+        $this->sendJsonResponse($response);
+    }
+
+    private function sendJsonResponse(PlayerQueueResponse $response): void
+    {
+        header('Content-Type: application/json');
+
+        try {
+            echo json_encode($response->toArray(), JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            $this->renderEncodingError();
+        }
+    }
+
+    private function renderEncodingError(): void
+    {
+        http_response_code(500);
+
+        $fallbackPayload = [
+            'status' => 'error',
+            'message' => 'An unexpected error occurred while encoding the response.',
+            'shouldPoll' => false,
+        ];
+
+        $encodedFallback = json_encode($fallbackPayload);
+        if ($encodedFallback === false) {
+            echo '{"status":"error","message":"An unexpected error occurred while encoding the response.","shouldPoll":false}';
+
+            return;
+        }
+
+        echo $encodedFallback;
+    }
+}


### PR DESCRIPTION
## Summary
- add a PlayerQueueEndpoint class to encapsulate queue request handling and JSON responses
- update the queue endpoints to delegate to the new object-oriented handler

## Testing
- php -l wwwroot/classes/PlayerQueueEndpoint.php
- php -l wwwroot/add_to_queue.php
- php -l wwwroot/check_queue_position.php

------
https://chatgpt.com/codex/tasks/task_e_68e580387200832fb4865894af5fa624