### PR TITLE
Refactor game player progress handling

### DIFF
--- a/wwwroot/classes/Game/GamePlayerProgress.php
+++ b/wwwroot/classes/Game/GamePlayerProgress.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+class GamePlayerProgress
+{
+    private string $npCommunicationId;
+
+    private string $accountId;
+
+    private int $bronze;
+
+    private int $silver;
+
+    private int $gold;
+
+    private int $platinum;
+
+    private int $progress;
+
+    private function __construct()
+    {
+        $this->npCommunicationId = '';
+        $this->accountId = '';
+        $this->bronze = 0;
+        $this->silver = 0;
+        $this->gold = 0;
+        $this->platinum = 0;
+        $this->progress = 0;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        $player = new self();
+        $player->npCommunicationId = (string) ($row['np_communication_id'] ?? '');
+        $player->accountId = (string) ($row['account_id'] ?? '');
+        $player->bronze = (int) ($row['bronze'] ?? 0);
+        $player->silver = (int) ($row['silver'] ?? 0);
+        $player->gold = (int) ($row['gold'] ?? 0);
+        $player->platinum = (int) ($row['platinum'] ?? 0);
+        $player->progress = (int) ($row['progress'] ?? 0);
+
+        return $player;
+    }
+
+    public function getNpCommunicationId(): string
+    {
+        return $this->npCommunicationId;
+    }
+
+    public function getAccountId(): string
+    {
+        return $this->accountId;
+    }
+
+    public function getBronzeCount(): int
+    {
+        return $this->bronze;
+    }
+
+    public function getSilverCount(): int
+    {
+        return $this->silver;
+    }
+
+    public function getGoldCount(): int
+    {
+        return $this->gold;
+    }
+
+    public function getPlatinumCount(): int
+    {
+        return $this->platinum;
+    }
+
+    public function getProgress(): int
+    {
+        return $this->progress;
+    }
+
+    public function isCompleted(): bool
+    {
+        return $this->progress >= 100;
+    }
+}

--- a/wwwroot/classes/GamePage.php
+++ b/wwwroot/classes/GamePage.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/GameHeaderService.php';
 require_once __DIR__ . '/GameNotFoundException.php';
 require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
 require_once __DIR__ . '/Game/GameDetails.php';
+require_once __DIR__ . '/Game/GamePlayerProgress.php';
 require_once __DIR__ . '/Game/GameHeaderData.php';
 require_once __DIR__ . '/PageMetaData.php';
 require_once __DIR__ . '/Utility.php';
@@ -27,10 +28,7 @@ class GamePage
 
     private ?int $playerAccountId;
 
-    /**
-     * @var array<string, mixed>|null
-     */
-    private ?array $gamePlayer;
+    private ?GamePlayerProgress $gamePlayer;
 
     /**
      * @var array<int, array<string, mixed>>
@@ -123,10 +121,7 @@ class GamePage
         return $this->playerAccountId;
     }
 
-    /**
-     * @return array<string, mixed>|null
-     */
-    public function getGamePlayer(): ?array
+    public function getGamePlayer(): ?GamePlayerProgress
     {
         return $this->gamePlayer;
     }

--- a/wwwroot/classes/GameRecentPlayersPage.php
+++ b/wwwroot/classes/GameRecentPlayersPage.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/GamePlayerFilter.php';
 require_once __DIR__ . '/GameRecentPlayersService.php';
 require_once __DIR__ . '/GameHeaderService.php';
 require_once __DIR__ . '/Game/GameDetails.php';
+require_once __DIR__ . '/Game/GamePlayerProgress.php';
 require_once __DIR__ . '/GameNotFoundException.php';
 require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
 require_once __DIR__ . '/Utility.php';
@@ -25,14 +26,11 @@ class GameRecentPlayersPage
 
     private ?string $playerAccountId;
 
-    /**
-     * @var array<string, mixed>|null
-     */
-    private ?array $gamePlayer;
+    private ?GamePlayerProgress $gamePlayer;
 
     /**
      * @param GameRecentPlayer[] $recentPlayers
-     * @param array<string, mixed>|null $gamePlayer
+     * @param GamePlayerProgress|null $gamePlayer
      */
     private function __construct(
         GameDetails $game,
@@ -40,7 +38,7 @@ class GameRecentPlayersPage
         GamePlayerFilter $filter,
         array $recentPlayers,
         ?string $playerAccountId,
-        ?array $gamePlayer
+        ?GamePlayerProgress $gamePlayer
     ) {
         $this->game = $game;
         $this->gameHeaderData = $gameHeaderData;
@@ -134,9 +132,9 @@ class GameRecentPlayersPage
     }
 
     /**
-     * @return array<string, mixed>|null
+     * @return GamePlayerProgress|null
      */
-    public function getGamePlayer(): ?array
+    public function getGamePlayer(): ?GamePlayerProgress
     {
         return $this->gamePlayer;
     }

--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Game/GameDetails.php';
+require_once __DIR__ . '/Game/GamePlayerProgress.php';
 require_once __DIR__ . '/GameRecentPlayer.php';
 
 class GameRecentPlayersService
@@ -70,7 +71,7 @@ class GameRecentPlayersService
         return (string) $accountId;
     }
 
-    public function getGamePlayer(string $npCommunicationId, string $accountId): ?array
+    public function getGamePlayer(string $npCommunicationId, string $accountId): ?GamePlayerProgress
     {
         $query = $this->database->prepare(
             <<<'SQL'
@@ -91,7 +92,11 @@ class GameRecentPlayersService
 
         $gamePlayer = $query->fetch(PDO::FETCH_ASSOC);
 
-        return is_array($gamePlayer) ? $gamePlayer : null;
+        if (!is_array($gamePlayer)) {
+            return null;
+        }
+
+        return GamePlayerProgress::fromArray($gamePlayer);
     }
 
     /**

--- a/wwwroot/classes/GameService.php
+++ b/wwwroot/classes/GameService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Game/GameDetails.php';
+require_once __DIR__ . '/Game/GamePlayerProgress.php';
 
 class GameService
 {
@@ -80,7 +81,7 @@ class GameService
         return (int) $accountId;
     }
 
-    public function getGamePlayer(string $npCommunicationId, int $accountId): ?array
+    public function getGamePlayer(string $npCommunicationId, int $accountId): ?GamePlayerProgress
     {
         $query = $this->database->prepare(
             <<<'SQL'
@@ -99,7 +100,11 @@ class GameService
 
         $gamePlayer = $query->fetch(PDO::FETCH_ASSOC);
 
-        return is_array($gamePlayer) ? $gamePlayer : null;
+        if (!is_array($gamePlayer)) {
+            return null;
+        }
+
+        return GamePlayerProgress::fromArray($gamePlayer);
     }
 
     /**

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 /** @var GameDetails $game */
 /** @var GameHeaderData $gameHeaderData */
+/** @var GamePlayerProgress|null $gamePlayer */
 ?>
 <div class="row">
     <?php
@@ -139,9 +140,9 @@ declare(strict_types=1);
             <div class="vstack gap-3 bg-dark-subtle rounded p-3 h-100">
                 <div class="text-center">
                     <?php
-                    if (isset($gamePlayer)) {
+                    if (isset($gamePlayer) && $gamePlayer instanceof GamePlayerProgress) {
                         ?>
-                        <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $gamePlayer['platinum'] ?? '0'; ?>/<?= $game->getPlatinum(); ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $gamePlayer['gold'] ?? '0'; ?>/<?= $game->getGold(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $gamePlayer['silver'] ?? '0'; ?>/<?= $game->getSilver(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $gamePlayer['bronze'] ?? '0'; ?>/<?= $game->getBronze(); ?></span>
+                        <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $gamePlayer->getPlatinumCount(); ?>/<?= $game->getPlatinum(); ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $gamePlayer->getGoldCount(); ?>/<?= $game->getGold(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $gamePlayer->getSilverCount(); ?>/<?= $game->getSilver(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $gamePlayer->getBronzeCount(); ?>/<?= $game->getBronze(); ?></span>
                         <?php
                     } else {
                         ?>
@@ -152,11 +153,11 @@ declare(strict_types=1);
                 </div>
 
                 <?php
-                if (isset($gamePlayer)) {
+                if (isset($gamePlayer) && $gamePlayer instanceof GamePlayerProgress) {
                     ?>
                     <div>
-                        <div class="progress" role="progressbar" aria-label="Player trophy progress" aria-valuenow="<?= $gamePlayer['progress'] ?? '0'; ?>" aria-valuemin="0" aria-valuemax="100">
-                            <div class="progress-bar" style="width: <?= $gamePlayer['progress'] ?? '0'; ?>%"><?= $gamePlayer['progress'] ?? '0'; ?>%</div>
+                        <div class="progress" role="progressbar" aria-label="Player trophy progress" aria-valuenow="<?= $gamePlayer->getProgress(); ?>" aria-valuemin="0" aria-valuemax="100">
+                            <div class="progress-bar" style="width: <?= $gamePlayer->getProgress(); ?>%"><?= $gamePlayer->getProgress(); ?>%</div>
                         </div>
                     </div>
                     <?php
@@ -180,10 +181,8 @@ declare(strict_types=1);
                         echo "<span class='badge rounded-pill text-bg-warning' title='This game is delisted &amp; obsolete, no trophies will be accounted for on any leaderboard.'>Delisted &amp; Obsolete</span>";
                     }
 
-                    if (isset($gamePlayer) && $gamePlayer != false) {
-                        if ($gamePlayer['progress'] == 100) {
-                            echo " <span class='badge rounded-pill text-bg-success' title='Player has completed this game to 100%!'>Completed!</span>";
-                        }
+                    if (isset($gamePlayer) && $gamePlayer instanceof GamePlayerProgress && $gamePlayer->isCompleted()) {
+                        echo " <span class='badge rounded-pill text-bg-success' title='Player has completed this game to 100%!'>Completed!</span>";
                     }
                     ?>
                 </div>


### PR DESCRIPTION
## Summary
- add a dedicated `GamePlayerProgress` value object to represent an individual's trophy counts and completion state
- update the game and recent-player services/pages to return the new object instead of raw arrays
- adjust the shared game header template to render trophy progress through the object-oriented API

## Testing
- php -l wwwroot/classes/Game/GamePlayerProgress.php
- php -l wwwroot/game_header.php
- php -l wwwroot/classes/GameRecentPlayersPage.php
- php -l wwwroot/classes/GamePage.php

------
https://chatgpt.com/codex/tasks/task_e_68e6292ee92c832f993fbfa98d9fb8cf