### PR TITLE
Refactor player log to use value objects

### DIFF
--- a/wwwroot/classes/PlayerLogEntry.php
+++ b/wwwroot/classes/PlayerLogEntry.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+final class PlayerLogEntry
+{
+    private int $trophyId;
+
+    private string $trophyType;
+
+    private string $trophyName;
+
+    private string $trophyDetail;
+
+    private string $trophyIcon;
+
+    private ?string $rarityPercent;
+
+    private int $trophyStatus;
+
+    private ?int $progressTargetValue;
+
+    private ?int $progress;
+
+    private ?string $rewardName;
+
+    private ?string $rewardImageUrl;
+
+    private int $gameId;
+
+    private string $gameName;
+
+    private int $gameStatus;
+
+    private string $gameIcon;
+
+    private string $platforms;
+
+    private string $earnedDate;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        $entry = new self();
+        $entry->trophyId = isset($row['trophy_id']) ? (int) $row['trophy_id'] : 0;
+        $entry->trophyType = (string) ($row['trophy_type'] ?? '');
+        $entry->trophyName = (string) ($row['trophy_name'] ?? '');
+        $entry->trophyDetail = (string) ($row['trophy_detail'] ?? '');
+        $entry->trophyIcon = (string) ($row['trophy_icon'] ?? '');
+        $entry->rarityPercent = self::toNullableString($row['rarity_percent'] ?? null);
+        $entry->trophyStatus = isset($row['trophy_status']) ? (int) $row['trophy_status'] : 0;
+        $entry->progressTargetValue = self::toNullableInt($row['progress_target_value'] ?? null);
+        $entry->progress = self::toNullableInt($row['progress'] ?? null);
+        $entry->rewardName = self::toNullableString($row['reward_name'] ?? null);
+        $entry->rewardImageUrl = self::toNullableString($row['reward_image_url'] ?? null);
+        $entry->gameId = isset($row['game_id']) ? (int) $row['game_id'] : 0;
+        $entry->gameName = (string) ($row['game_name'] ?? '');
+        $entry->gameStatus = isset($row['game_status']) ? (int) $row['game_status'] : 0;
+        $entry->gameIcon = (string) ($row['game_icon'] ?? '');
+        $entry->platforms = (string) ($row['platform'] ?? '');
+        $entry->earnedDate = (string) ($row['earned_date'] ?? '');
+
+        return $entry;
+    }
+
+    public function getTrophyId(): int
+    {
+        return $this->trophyId;
+    }
+
+    public function getTrophyType(): string
+    {
+        return $this->trophyType;
+    }
+
+    public function getTrophyName(): string
+    {
+        return $this->trophyName;
+    }
+
+    public function getTrophyDetail(): string
+    {
+        return $this->trophyDetail;
+    }
+
+    public function getTrophyIcon(): string
+    {
+        return $this->trophyIcon;
+    }
+
+    public function getTrophyIconRelativePath(): string
+    {
+        if ($this->trophyIcon === '.png') {
+            return $this->usesPs5Assets()
+                ? '../missing-ps5-game-and-trophy.png'
+                : '../missing-ps4-trophy.png';
+        }
+
+        return $this->trophyIcon;
+    }
+
+    public function getRarityPercent(): ?string
+    {
+        return $this->rarityPercent;
+    }
+
+    public function getTrophyStatus(): int
+    {
+        return $this->trophyStatus;
+    }
+
+    public function getProgressTargetValue(): ?int
+    {
+        return $this->progressTargetValue;
+    }
+
+    public function getProgress(): ?int
+    {
+        return $this->progress;
+    }
+
+    public function getProgressDisplay(): ?string
+    {
+        if ($this->progressTargetValue === null) {
+            return null;
+        }
+
+        $progress = $this->progress ?? 0;
+
+        return $progress . '/' . $this->progressTargetValue;
+    }
+
+    public function getRewardName(): ?string
+    {
+        return $this->rewardName;
+    }
+
+    public function getRewardImageUrl(): ?string
+    {
+        return $this->rewardImageUrl;
+    }
+
+    public function getGameId(): int
+    {
+        return $this->gameId;
+    }
+
+    public function getGameName(): string
+    {
+        return $this->gameName;
+    }
+
+    public function getGameStatus(): int
+    {
+        return $this->gameStatus;
+    }
+
+    public function getGameIcon(): string
+    {
+        return $this->gameIcon;
+    }
+
+    public function getGameIconRelativePath(): string
+    {
+        if ($this->gameIcon === '.png') {
+            return $this->usesPs5Assets()
+                ? '../missing-ps5-game-and-trophy.png'
+                : '../missing-ps4-game.png';
+        }
+
+        return $this->gameIcon;
+    }
+
+    public function getPlatformString(): string
+    {
+        return $this->platforms;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPlatforms(): array
+    {
+        if ($this->platforms === '') {
+            return [];
+        }
+
+        $platforms = array_map('trim', explode(',', $this->platforms));
+        $platforms = array_filter(
+            $platforms,
+            static fn(string $value): bool => $value !== ''
+        );
+
+        return array_values($platforms);
+    }
+
+    public function requiresWarning(): bool
+    {
+        return $this->gameStatus !== 0 || $this->trophyStatus !== 0;
+    }
+
+    public function getEarnedDate(): string
+    {
+        return $this->earnedDate;
+    }
+
+    public function getEarnedBadgeElementId(): string
+    {
+        return 'trophy-earned-' . $this->trophyId;
+    }
+
+    public function getGameSlug(Utility $utility): string
+    {
+        return $this->gameId . '-' . $utility->slugify($this->gameName);
+    }
+
+    public function getTrophySlug(Utility $utility): string
+    {
+        return $this->trophyId . '-' . $utility->slugify($this->trophyName);
+    }
+
+    private static function toNullableInt(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_numeric((string) $value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+
+    private static function toNullableString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = (string) $value;
+
+        return $value === '' ? null : $value;
+    }
+
+    private function usesPs5Assets(): bool
+    {
+        $platforms = strtoupper($this->platforms);
+
+        return str_contains($platforms, 'PS5') || str_contains($platforms, 'PSVR2');
+    }
+}

--- a/wwwroot/classes/PlayerLogPage.php
+++ b/wwwroot/classes/PlayerLogPage.php
@@ -13,7 +13,7 @@ class PlayerLogPage
     private PlayerLogFilter $requestedFilter;
 
     /**
-     * @var array<int, array<string, mixed>>
+     * @var PlayerLogEntry[]
      */
     private array $trophies = [];
 
@@ -46,7 +46,7 @@ class PlayerLogPage
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return PlayerLogEntry[]
      */
     public function getTrophies(): array
     {

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerLogEntry.php';
+
 class PlayerLogService
 {
     public const PAGE_SIZE = 50;
@@ -44,7 +46,7 @@ class PlayerLogService
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return PlayerLogEntry[]
      */
     public function getTrophies(int $accountId, PlayerLogFilter $filter, int $offset, int $limit = self::PAGE_SIZE): array
     {
@@ -84,13 +86,16 @@ class PlayerLogService
         $query->bindValue(':limit', $limit, PDO::PARAM_INT);
         $query->execute();
 
-        $trophies = $query->fetchAll(PDO::FETCH_ASSOC);
+        $rows = $query->fetchAll(PDO::FETCH_ASSOC);
 
-        if (!is_array($trophies)) {
+        if (!is_array($rows) || $rows === []) {
             return [];
         }
 
-        return $trophies;
+        return array_map(
+            static fn(array $row): PlayerLogEntry => PlayerLogEntry::fromArray($row),
+            $rows
+        );
     }
 
     private function buildPlatformClause(PlayerLogFilter $filter): string

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -156,42 +156,53 @@ require_once("header.php");
                                 <?php
                             } else {
                                 foreach ($trophiesLog as $trophy) {
+                                    $rowClassAttribute = $trophy->requiresWarning() ? ' class="table-warning"' : '';
+                                    $gameSlug = $trophy->getGameSlug($utility);
+                                    $trophySlug = $trophy->getTrophySlug($utility);
+                                    $gameUrl = '/game/' . $gameSlug . '/' . $player['online_id'];
+                                    $trophyUrl = '/trophy/' . $trophySlug . '/' . $player['online_id'];
+                                    $badgeElementId = $trophy->getEarnedBadgeElementId();
+                                    $progressDisplay = $trophy->getProgressDisplay();
+                                    $rewardName = $trophy->getRewardName();
+                                    $rewardImageUrl = $trophy->getRewardImageUrl();
                                     ?>
-                                    <tr<?= (($trophy["game_status"] != 0 || $trophy["trophy_status"] != 0) ? " class='table-warning'" : ""); ?>>
+                                    <tr<?= $rowClassAttribute; ?>>
                                         <td scope="row" class="text-center align-middle">
-                                            <a href="/game/<?= $trophy["game_id"] ."-". $utility->slugify($trophy["game_name"]); ?>/<?= $player["online_id"]; ?>">
-                                                <img src="/img/title/<?= ($trophy["game_icon"] == ".png") ? ((str_contains($trophy["platform"], "PS5")) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-game.png") : $trophy["game_icon"]; ?>" alt="<?= $trophy["game_name"]; ?>" title="<?= $trophy["game_name"]; ?>" style="width: 10rem;" />
+                                            <a href="<?= htmlspecialchars($gameUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                                                <img src="/img/title/<?= htmlspecialchars($trophy->getGameIconRelativePath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 10rem;" />
                                             </a>
                                         </td>
                                         <td class="align-middle">
                                             <div class="hstack gap-3">
                                                 <div class="d-flex align-items-center justify-content-center">
-                                                    <a href="/trophy/<?= $trophy["trophy_id"] ."-". $utility->slugify($trophy["trophy_name"]); ?>/<?= $player["online_id"]; ?>">
-                                                        <img src="/img/trophy/<?= ($trophy["trophy_icon"] == ".png") ? ((str_contains($trophy["platform"], "PS5")) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-trophy.png") : $trophy["trophy_icon"]; ?>" alt="<?= $trophy["trophy_name"]; ?>" title="<?= $trophy["trophy_name"]; ?>" style="width: 5rem;" />
+                                                    <a href="<?= htmlspecialchars($trophyUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                                                        <img src="/img/trophy/<?= htmlspecialchars($trophy->getTrophyIconRelativePath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 5rem;" />
                                                     </a>
                                                 </div>
 
                                                 <div>
                                                     <div class="vstack">
                                                         <span>
-                                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/trophy/<?= $trophy["trophy_id"] ."-". $utility->slugify($trophy["trophy_name"]); ?>/<?= $player["online_id"]; ?>">
-                                                                <b><?= htmlentities($trophy["trophy_name"]); ?></b>
+                                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($trophyUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                                                                <b><?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?></b>
                                                             </a>
                                                         </span>
-                                                        <?= nl2br(htmlentities($trophy["trophy_detail"], ENT_QUOTES, "UTF-8")); ?>
+                                                        <?= nl2br(htmlentities($trophy->getTrophyDetail(), ENT_QUOTES, 'UTF-8')); ?>
                                                         <?php
-                                                        if ($trophy["progress_target_value"] != null) {
-                                                            echo "<br><b>". $trophy["progress_target_value"] ."/". $trophy["progress_target_value"] ."</b>";
+                                                        if ($progressDisplay !== null) {
+                                                            echo '<br><b>' . htmlentities($progressDisplay, ENT_QUOTES, 'UTF-8') . '</b>';
                                                         }
 
-                                                        if ($trophy["reward_name"] != null && $trophy["reward_image_url"] != null) {
-                                                            echo "<br>Reward: <a href='/img/reward/". $trophy["reward_image_url"] ."'>". $trophy["reward_name"] ."</a>";
+                                                        if ($rewardName !== null && $rewardImageUrl !== null) {
+                                                            echo "<br>Reward: <a href='/img/reward/" . htmlspecialchars($rewardImageUrl, ENT_QUOTES, 'UTF-8') . "'>"
+                                                                . htmlspecialchars($rewardName, ENT_QUOTES, 'UTF-8')
+                                                                . '</a>';
                                                         }
                                                         ?>
                                                         <div>
-                                                            <span class="badge rounded-pill text-bg-success" id="<?= $trophy["trophy_id"]; ?>"></span>
+                                                            <span class="badge rounded-pill text-bg-success" id="<?= htmlspecialchars($badgeElementId, ENT_QUOTES, 'UTF-8'); ?>"></span>
                                                             <script>
-                                                                document.getElementById("<?= $trophy["trophy_id"]; ?>").innerHTML = 'Earned ' + new Date('<?= $trophy["earned_date"]; ?> UTC').toLocaleString('sv-SE');
+                                                                document.getElementById(<?= json_encode($badgeElementId); ?>).innerHTML = 'Earned ' + new Date(<?= json_encode($trophy->getEarnedDate() . ' UTC'); ?>).toLocaleString('sv-SE');
                                                             </script>
                                                         </div>
                                                     </div>
@@ -201,15 +212,15 @@ require_once("header.php");
                                         <td class="text-center align-middle">
                                             <div class="vstack gap-1">
                                                 <?php
-                                                foreach (explode(",", $trophy["platform"]) as $platform) {
-                                                    echo "<span class=\"badge rounded-pill text-bg-primary p-2\">". $platform ."</span> ";
+                                                foreach ($trophy->getPlatforms() as $platform) {
+                                                    echo "<span class=\"badge rounded-pill text-bg-primary p-2\">" . htmlspecialchars($platform, ENT_QUOTES, 'UTF-8') . '</span> ';
                                                 }
                                                 ?>
                                             </div>
                                         </td>
                                         <td class="text-center align-middle">
                                         <?php
-                                        $trophyRarity = $trophyRarityFormatter->format($trophy["rarity_percent"], (int) $trophy["trophy_status"]);
+                                        $trophyRarity = $trophyRarityFormatter->format($trophy->getRarityPercent(), $trophy->getTrophyStatus());
 
                                         if ($trophyRarity->isUnobtainable()) {
                                             echo "<span class='badge rounded-pill text-bg-warning p-2'>" . $trophyRarity->getLabel() . '</span>';
@@ -219,7 +230,7 @@ require_once("header.php");
                                         ?>
                                         </td>
                                         <td class="text-center align-middle">
-                                            <img src="/img/trophy-<?= $trophy["trophy_type"]; ?>.svg" alt="<?= ucfirst($trophy["trophy_type"]); ?>" title="<?= ucfirst($trophy["trophy_type"]); ?>" height="50" />
+                                            <img src="/img/trophy-<?= htmlspecialchars($trophy->getTrophyType(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= htmlentities(ucfirst($trophy->getTrophyType()), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities(ucfirst($trophy->getTrophyType()), ENT_QUOTES, 'UTF-8'); ?>" height="50" />
                                         </td>
                                     </tr>
                                     <?php


### PR DESCRIPTION
## Summary
- add a PlayerLogEntry value object to encapsulate player log trophy data
- update the player log service and page classes to return typed entries
- render the player log template via the new object API with improved escaping

## Testing
- php -l wwwroot/classes/PlayerLogEntry.php
- php -l wwwroot/classes/PlayerLogService.php
- php -l wwwroot/classes/PlayerLogPage.php
- php -l wwwroot/player_log.php

------
https://chatgpt.com/codex/tasks/task_e_68e6292ee92c832f993fbfa98d9fb8cf