### PR TITLE
Prioritize exact matches in game search results

### DIFF
--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -161,6 +161,7 @@ class GameListService
         ];
 
         if ($filter->shouldApplySearch()) {
+            $columns[] = 'tt.name = :search AS exact_match';
             $columns[] = 'MATCH(tt.name) AGAINST (:search) AS score';
         }
 
@@ -240,7 +241,7 @@ class GameListService
             GameListFilter::SORT_COMPLETION => 'ORDER BY difficulty DESC, owners DESC, `name`',
             GameListFilter::SORT_OWNERS => 'ORDER BY owners DESC, `name`',
             GameListFilter::SORT_RARITY => 'ORDER BY rarity_points DESC, owners DESC, `name`',
-            GameListFilter::SORT_SEARCH => 'ORDER BY score DESC',
+            GameListFilter::SORT_SEARCH => 'ORDER BY exact_match DESC, score DESC, `name`',
             default => 'ORDER BY id DESC',
         };
     }

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -67,6 +67,7 @@ class PlayerGamesService
         ];
 
         if ($filter->shouldIncludeScoreColumn()) {
+            $columns[] = 'tt.name = :search AS exact_match';
             $columns[] = 'MATCH(tt.name) AGAINST (:search) AS score';
         }
 
@@ -159,7 +160,7 @@ class PlayerGamesService
             PlayerGamesFilter::SORT_MAX_RARITY => 'ORDER BY max_rarity_points DESC, `name`',
             PlayerGamesFilter::SORT_NAME => 'ORDER BY `name`',
             PlayerGamesFilter::SORT_RARITY => 'ORDER BY rarity_points DESC, `name`',
-            PlayerGamesFilter::SORT_SEARCH => 'ORDER BY score DESC',
+            PlayerGamesFilter::SORT_SEARCH => 'ORDER BY exact_match DESC, score DESC, `name`',
             default => 'ORDER BY last_updated_date DESC',
         };
     }


### PR DESCRIPTION
## Summary
- add an exact match flag to game search queries so titles that exactly match the search term are ordered first
- apply the same ordering improvement to player-specific game searches for consistency

## Testing
- php -l wwwroot/classes/GameListService.php
- php -l wwwroot/classes/PlayerGamesService.php

------
https://chatgpt.com/codex/tasks/task_e_68e7803162bc832fac319cf52b6bd935