### PR TITLE
Refactor shared search query helpers

### DIFF
--- a/wwwroot/classes/SearchQueryHelper.php
+++ b/wwwroot/classes/SearchQueryHelper.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+final class SearchQueryHelper
+{
+    /**
+     * @param array<int, string> $columns
+     * @return array<int, string>
+     */
+    public static function addFulltextSelectColumns(
+        array $columns,
+        string $column,
+        bool $includeScore,
+        string $searchTerm
+    ): array {
+        if (!$includeScore) {
+            return $columns;
+        }
+
+        $columns[] = sprintf('%s = :search AS exact_match', $column);
+
+        if ($searchTerm !== '') {
+            $columns[] = sprintf('%s LIKE :search_prefix AS prefix_match', $column);
+        } else {
+            $columns[] = '0 AS prefix_match';
+        }
+
+        $columns[] = sprintf('MATCH(%s) AGAINST (:search) AS score', $column);
+
+        return $columns;
+    }
+
+    /**
+     * @param array<int, string> $conditions
+     * @return array<int, string>
+     */
+    public static function appendFulltextCondition(
+        array $conditions,
+        bool $shouldApply,
+        string $column,
+        string $searchTerm
+    ): array {
+        if (!$shouldApply) {
+            return $conditions;
+        }
+
+        $matchCondition = sprintf('(MATCH(%s) AGAINST (:search)) > 0', $column);
+
+        if ($searchTerm !== '') {
+            $conditions[] = sprintf('(%s OR %s LIKE :search_like)', $matchCondition, $column);
+        } else {
+            $conditions[] = $matchCondition;
+        }
+
+        return $conditions;
+    }
+
+    public static function bindSearchParameters(\PDOStatement $statement, string $searchTerm, bool $bindPrefix): void
+    {
+        $statement->bindValue(':search', $searchTerm, \PDO::PARAM_STR);
+
+        if ($searchTerm === '') {
+            return;
+        }
+
+        $statement->bindValue(':search_like', self::buildSearchLikeParameter($searchTerm), \PDO::PARAM_STR);
+
+        if ($bindPrefix) {
+            $statement->bindValue(':search_prefix', self::buildSearchPrefixParameter($searchTerm), \PDO::PARAM_STR);
+        }
+    }
+
+    public static function buildSearchLikeParameter(string $search): string
+    {
+        return '%' . addcslashes($search, "\\%_") . '%';
+    }
+
+    public static function buildSearchPrefixParameter(string $search): string
+    {
+        return addcslashes($search, "\\%_") . '%';
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable SearchQueryHelper to build shared full-text select, condition, and binding logic
- update PlayerGamesService and GameListService to rely on the helper, removing duplicated SQL assembly code

## Testing
- php -l wwwroot/classes/SearchQueryHelper.php
- php -l wwwroot/classes/PlayerGamesService.php
- php -l wwwroot/classes/GameListService.php

------
https://chatgpt.com/codex/tasks/task_e_68e788a6e47c832fa1b3697f6c16230c