### PR TITLE
Refactor trophy filtering into dedicated class

### DIFF
--- a/wwwroot/classes/GameTrophyFilter.php
+++ b/wwwroot/classes/GameTrophyFilter.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+class GameTrophyFilter
+{
+    private bool $unearnedOnly;
+
+    private function __construct(bool $unearnedOnly)
+    {
+        $this->unearnedOnly = $unearnedOnly;
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public static function fromQueryParameters(array $queryParameters, bool $allowUnearnedFilter): self
+    {
+        if (!$allowUnearnedFilter) {
+            return new self(false);
+        }
+
+        $unearnedOnly = self::resolveBoolean($queryParameters['unearned'] ?? null);
+
+        return new self($unearnedOnly);
+    }
+
+    public function shouldShowUnearnedOnly(): bool
+    {
+        return $this->unearnedOnly;
+    }
+
+    /**
+     * @param array<string, mixed>|null $trophyGroupPlayer
+     */
+    public function shouldDisplayGroup(?array $trophyGroupPlayer): bool
+    {
+        if (!$this->unearnedOnly || $trophyGroupPlayer === null) {
+            return true;
+        }
+
+        $progress = isset($trophyGroupPlayer['progress']) ? (int) $trophyGroupPlayer['progress'] : 0;
+
+        return $progress < 100;
+    }
+
+    /**
+     * @param array<string, mixed> $trophy
+     */
+    public function shouldDisplayTrophy(array $trophy): bool
+    {
+        if (!$this->unearnedOnly) {
+            return true;
+        }
+
+        $earned = isset($trophy['earned']) ? (int) $trophy['earned'] : 0;
+
+        return $earned !== 1;
+    }
+
+    private static function resolveBoolean(mixed $value): bool
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value !== 0;
+        }
+
+        if (is_string($value)) {
+            $normalized = strtolower(trim($value));
+
+            if ($normalized === '' || in_array($normalized, ['0', 'false', 'off', 'no'], true)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        return true;
+    }
+}

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/classes/GamePage.php';
+require_once __DIR__ . '/classes/GameTrophyFilter.php';
 require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
 
 if (!isset($gameId)) {
@@ -35,6 +36,7 @@ $gameHeaderData = $gamePage->getGameHeaderData();
 $sort = $gamePage->getSort();
 $accountId = $gamePage->getPlayerAccountId();
 $gamePlayer = $gamePage->getGamePlayer();
+$gameTrophyFilter = GameTrophyFilter::fromQueryParameters($_GET ?? [], $accountId !== null);
 $metaData = $gamePage->createMetaData();
 $title = $gamePage->getPageTitle();
 $trophyRarityFormatter = new TrophyRarityFormatter();
@@ -69,7 +71,7 @@ require_once("header.php");
                             <ul class="dropdown-menu p-2">
                                 <li>
                                     <div class="form-check">
-                                        <input class="form-check-input" type="checkbox"<?= (!empty($_GET["unearned"]) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterUnearnedTrophies" name="unearned">
+                                        <input class="form-check-input" type="checkbox"<?= ($gameTrophyFilter->shouldShowUnearnedOnly() ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterUnearnedTrophies" name="unearned">
                                         <label class="form-check-label" for="filterUnearnedTrophies">
                                             Unearned Trophies
                                         </label>
@@ -108,10 +110,7 @@ require_once("header.php");
 
                     $previousTimeStamp = null;
 
-                    if ($accountId !== null
-                        && $trophyGroupPlayer !== null
-                        && ($trophyGroupPlayer["progress"] ?? null) == 100
-                        && !empty($_GET["unearned"])) {
+                    if (!$gameTrophyFilter->shouldDisplayGroup($trophyGroupPlayer)) {
                         continue;
                     }
                     ?>
@@ -172,7 +171,7 @@ require_once("header.php");
                                 $trophies = $gamePage->getTrophies($trophyGroupId);
 
                                 foreach ($trophies as $trophy) {
-                                    if ($accountId !== null && ($trophy["earned"] ?? null) == 1 && !empty($_GET["unearned"])) {
+                                    if (!$gameTrophyFilter->shouldDisplayTrophy($trophy)) {
                                         continue;
                                     }
 


### PR DESCRIPTION
## Summary
- add a `GameTrophyFilter` value object to encapsulate the unearned trophy filter state
- update `game.php` to use the new filter object instead of directly reading `$_GET`

## Testing
- php -l wwwroot/classes/GameTrophyFilter.php
- php -l wwwroot/game.php

------
https://chatgpt.com/codex/tasks/task_e_68e6292ee92c832f993fbfa98d9fb8cf