### PR TITLE
Adjust APA title casing to capitalize “with”

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1238,7 +1238,6 @@ class ThirtyMinuteCronJob implements CronJobInterface
             'into',
             'onto',
             'upon',
-            'with',
             'without',
             'within',
             'over',


### PR DESCRIPTION
## Summary
- remove "with" from the list of words that stay lowercase in APA title casing so it is capitalized

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e81a787164832fb46f1218779d7584