### PR TITLE
Preserve Roman numerals during APA title casing

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1380,6 +1380,12 @@ class ThirtyMinuteCronJob implements CronJobInterface
             return true;
         }
 
+        $romanNumeral = mb_strtoupper($word, 'UTF-8');
+
+        if (preg_match('/^(?=[IVXLCDM]+$)M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$/', $romanNumeral) === 1) {
+            return true;
+        }
+
         $lower = mb_strtolower($word, 'UTF-8');
         $upper = mb_strtoupper($word, 'UTF-8');
 


### PR DESCRIPTION
## Summary
- ensure the APA-style title casing helper leaves Roman numeral words untouched by detecting them before conversion

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e82432c048832fb5ba130c6cacade4