### PR TITLE
Refactor footer rendering to use a view model

### DIFF
--- a/wwwroot/classes/FooterViewModel.php
+++ b/wwwroot/classes/FooterViewModel.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+final class FooterViewModel
+{
+    private int $startYear;
+
+    private int $currentYear;
+
+    private string $versionLabel;
+
+    private string $releaseUrl;
+
+    private string $changelogUrl;
+
+    private string $issuesUrl;
+
+    private string $creatorName;
+
+    private string $creatorProfileUrl;
+
+    private string $contributorsUrl;
+
+    public function __construct(
+        int $startYear,
+        int $currentYear,
+        string $versionLabel,
+        string $releaseUrl,
+        string $changelogUrl,
+        string $issuesUrl,
+        string $creatorName,
+        string $creatorProfileUrl,
+        string $contributorsUrl
+    ) {
+        $this->startYear = $startYear;
+        $this->currentYear = $currentYear;
+        $this->versionLabel = $versionLabel;
+        $this->releaseUrl = $releaseUrl;
+        $this->changelogUrl = $changelogUrl;
+        $this->issuesUrl = $issuesUrl;
+        $this->creatorName = $creatorName;
+        $this->creatorProfileUrl = $creatorProfileUrl;
+        $this->contributorsUrl = $contributorsUrl;
+    }
+
+    public static function createDefault(): self
+    {
+        $currentYear = (int) date('Y');
+
+        return new self(
+            2019,
+            $currentYear,
+            'v7.37',
+            'https://github.com/Ragowit/psn100/releases',
+            '/changelog',
+            'https://github.com/Ragowit/psn100/issues',
+            'Ragowit',
+            '/player/Ragowit',
+            'https://github.com/ragowit/psn100/graphs/contributors'
+        );
+    }
+
+    public function getYearRangeLabel(): string
+    {
+        if ($this->startYear >= $this->currentYear) {
+            return (string) $this->startYear;
+        }
+
+        return $this->startYear . '-' . $this->currentYear;
+    }
+
+    public function getVersionLabel(): string
+    {
+        return $this->versionLabel;
+    }
+
+    public function getReleaseUrl(): string
+    {
+        return $this->releaseUrl;
+    }
+
+    public function getChangelogUrl(): string
+    {
+        return $this->changelogUrl;
+    }
+
+    public function getIssuesUrl(): string
+    {
+        return $this->issuesUrl;
+    }
+
+    public function getCreatorName(): string
+    {
+        return $this->creatorName;
+    }
+
+    public function getCreatorProfileUrl(): string
+    {
+        return $this->creatorProfileUrl;
+    }
+
+    public function getContributorsUrl(): string
+    {
+        return $this->contributorsUrl;
+    }
+}

--- a/wwwroot/footer.php
+++ b/wwwroot/footer.php
@@ -1,17 +1,30 @@
+        <?php
+        require_once __DIR__ . '/classes/FooterViewModel.php';
+
+        $footerViewModel = FooterViewModel::createDefault();
+        ?>
         <footer class="container">
             <hr>
             <div class="row">
                 <div class="col-3">
-                    &copy; 2019-<?= date("Y"); ?><br>
-                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="https://github.com/Ragowit/psn100/releases">v7.37</a> - <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/changelog">Changelog</a>
+                    &copy; <?= htmlspecialchars($footerViewModel->getYearRangeLabel(), ENT_QUOTES, 'UTF-8'); ?><br>
+                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($footerViewModel->getReleaseUrl(), ENT_QUOTES, 'UTF-8'); ?>">
+                        <?= htmlspecialchars($footerViewModel->getVersionLabel(), ENT_QUOTES, 'UTF-8'); ?>
+                    </a>
+                    -
+                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($footerViewModel->getChangelogUrl(), ENT_QUOTES, 'UTF-8'); ?>">Changelog</a>
                 </div>
                 <div class="col-6 text-center">
                     PSN100 is not affiliated with Sony or PlayStation in any way.<br>
-                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="https://github.com/Ragowit/psn100/issues">Issues</a>
+                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($footerViewModel->getIssuesUrl(), ENT_QUOTES, 'UTF-8'); ?>">Issues</a>
                 </div>
                 <div class="col-3 text-end">
-                    Created and maintained by <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/player/Ragowit">Ragowit</a>.<br>
-                    Development by <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="https://github.com/ragowit/psn100/graphs/contributors">PSN100 Contributors</a>.
+                    Created and maintained by
+                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($footerViewModel->getCreatorProfileUrl(), ENT_QUOTES, 'UTF-8'); ?>">
+                        <?= htmlspecialchars($footerViewModel->getCreatorName(), ENT_QUOTES, 'UTF-8'); ?>
+                    </a>.<br>
+                    Development by
+                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($footerViewModel->getContributorsUrl(), ENT_QUOTES, 'UTF-8'); ?>">PSN100 Contributors</a>.
                 </div>
             </div>
         </footer>


### PR DESCRIPTION
## Summary
- add a FooterViewModel class to encapsulate footer metadata and links
- update the footer template to render details through the new view model for improved OOP structure

## Testing
- php -l wwwroot/classes/FooterViewModel.php
- php -l wwwroot/footer.php

------
https://chatgpt.com/codex/tasks/task_e_68e78ca5edd0832f9ecdbd7b4af0a418