### PR TITLE
Refactor admin utilities to share environment configuration

### DIFF
--- a/wwwroot/admin/merge.php
+++ b/wwwroot/admin/merge.php
@@ -1,10 +1,14 @@
 <?php
 declare(strict_types=1);
 
-ini_set("max_execution_time", "0");
-ini_set("max_input_time", "0");
-ini_set("mysql.connect_timeout", "0");
-set_time_limit(0);
+require_once __DIR__ . '/../classes/ExecutionEnvironmentConfigurator.php';
+
+ExecutionEnvironmentConfigurator::create()
+    ->addIniSetting('max_execution_time', '0')
+    ->addIniSetting('max_input_time', '0')
+    ->addIniSetting('mysql.connect_timeout', '0')
+    ->enableUnlimitedExecution()
+    ->configure();
 
 require_once("../init.php");
 require_once("../classes/TrophyMergeService.php");

--- a/wwwroot/admin/unobtainable.php
+++ b/wwwroot/admin/unobtainable.php
@@ -1,10 +1,14 @@
 <?php
 declare(strict_types=1);
 
-ini_set("max_execution_time", "0");
-ini_set("mysql.connect_timeout", "0");
-ini_set("default_socket_timeout", "6000");
-set_time_limit(0);
+require_once __DIR__ . '/../classes/ExecutionEnvironmentConfigurator.php';
+
+ExecutionEnvironmentConfigurator::create()
+    ->addIniSetting('max_execution_time', '0')
+    ->addIniSetting('mysql.connect_timeout', '0')
+    ->addIniSetting('default_socket_timeout', '6000')
+    ->enableUnlimitedExecution()
+    ->configure();
 
 require_once("../init.php");
 require_once("../classes/Admin/TrophyStatusService.php");

--- a/wwwroot/classes/Admin/GameRescanRequestHandler.php
+++ b/wwwroot/classes/Admin/GameRescanRequestHandler.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../ExecutionEnvironmentConfigurator.php';
+
 class GameRescanRequestHandler
 {
     private GameRescanService $gameRescanService;
@@ -119,8 +121,10 @@ class GameRescanRequestHandler
 
     private function prepareStreamResponse(): void
     {
-        set_time_limit(0);
-        ignore_user_abort(true);
+        ExecutionEnvironmentConfigurator::create()
+            ->enableUnlimitedExecution()
+            ->enableIgnoreUserAbort()
+            ->configure();
 
         header('Content-Type: application/x-ndjson; charset=utf-8');
         header('Cache-Control: no-cache');

--- a/wwwroot/classes/ExecutionEnvironmentConfigurator.php
+++ b/wwwroot/classes/ExecutionEnvironmentConfigurator.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+final class ExecutionEnvironmentConfigurator
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $iniSettings = [];
+
+    private bool $unlimitedExecution = false;
+
+    private bool $shouldIgnoreUserAbort = false;
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function addIniSetting(string $option, string $value): self
+    {
+        $this->iniSettings[$option] = $value;
+
+        return $this;
+    }
+
+    public function enableUnlimitedExecution(): self
+    {
+        $this->unlimitedExecution = true;
+
+        return $this;
+    }
+
+    public function enableIgnoreUserAbort(): self
+    {
+        $this->shouldIgnoreUserAbort = true;
+
+        return $this;
+    }
+
+    public function configure(): void
+    {
+        $this->applyIniSettings();
+
+        if ($this->unlimitedExecution) {
+            $this->removeExecutionTimeLimit();
+        }
+
+        if ($this->shouldIgnoreUserAbort) {
+            $this->configureIgnoreUserAbort();
+        }
+    }
+
+    private function applyIniSettings(): void
+    {
+        if (!function_exists('ini_set')) {
+            return;
+        }
+
+        foreach ($this->iniSettings as $option => $value) {
+            @ini_set($option, $value);
+        }
+    }
+
+    private function removeExecutionTimeLimit(): void
+    {
+        if (function_exists('set_time_limit')) {
+            @set_time_limit(0);
+        }
+    }
+
+    private function configureIgnoreUserAbort(): void
+    {
+        if (function_exists('ignore_user_abort')) {
+            @ignore_user_abort(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an ExecutionEnvironmentConfigurator helper to encapsulate ini and execution tuning for long-running tasks
- adopt the configurator in admin merge and unobtainable trophy scripts to replace procedural setup
- reuse the configurator within the game rescan request handler to centralize stream configuration

## Testing
- php -l wwwroot/classes/ExecutionEnvironmentConfigurator.php
- php -l wwwroot/admin/merge.php
- php -l wwwroot/admin/unobtainable.php
- php -l wwwroot/classes/Admin/GameRescanRequestHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68e78ca5edd0832f9ecdbd7b4af0a418