### PR TITLE
Refactor application rendering to use a template renderer

### DIFF
--- a/wwwroot/classes/ApplicationContainer.php
+++ b/wwwroot/classes/ApplicationContainer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../database.php';
 require_once __DIR__ . '/Utility.php';
 require_once __DIR__ . '/PaginationRenderer.php';
+require_once __DIR__ . '/TemplateRenderer.php';
 require_once __DIR__ . '/Application.php';
 
 class ApplicationContainer
@@ -22,6 +23,8 @@ class ApplicationContainer
     private ?PlayerRepository $playerRepository = null;
 
     private ?Router $router = null;
+
+    private ?TemplateRenderer $templateRenderer = null;
 
     public function __construct(
         ?Database $database = null,
@@ -93,9 +96,26 @@ class ApplicationContainer
         return $this->router;
     }
 
+    public function getTemplateRenderer(): TemplateRenderer
+    {
+        if ($this->templateRenderer === null) {
+            $this->templateRenderer = new TemplateRenderer(
+                $this->getDatabase(),
+                $this->getUtility(),
+                $this->getPaginationRenderer()
+            );
+        }
+
+        return $this->templateRenderer;
+    }
+
     public function createApplication(HttpRequest $request): Application
     {
-        return new Application($this->getRouter(), $request);
+        return new Application(
+            $this->getRouter(),
+            $request,
+            $this->getTemplateRenderer()
+        );
     }
 
     public function createRequestFromGlobals(): HttpRequest

--- a/wwwroot/classes/TemplateRenderer.php
+++ b/wwwroot/classes/TemplateRenderer.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../database.php';
+require_once __DIR__ . '/Utility.php';
+require_once __DIR__ . '/PaginationRenderer.php';
+
+class TemplateRenderer
+{
+    private Database $database;
+
+    private Utility $utility;
+
+    private PaginationRenderer $paginationRenderer;
+
+    public function __construct(Database $database, Utility $utility, PaginationRenderer $paginationRenderer)
+    {
+        $this->database = $database;
+        $this->utility = $utility;
+        $this->paginationRenderer = $paginationRenderer;
+    }
+
+    /**
+     * @param array<string, mixed> $variables
+     */
+    public function render(string $templatePath, array $variables = []): void
+    {
+        if ($variables !== []) {
+            extract($variables, EXTR_SKIP);
+        }
+
+        $database = $this->database;
+        $utility = $this->utility;
+        $paginationRenderer = $this->paginationRenderer;
+
+        require_once $templatePath;
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated TemplateRenderer to provide shared dependencies to templates
- update the application bootstrap to use the renderer for normal and 404 responses

## Testing
- php -l wwwroot/classes/Application.php
- php -l wwwroot/classes/ApplicationContainer.php
- php -l wwwroot/classes/TemplateRenderer.php

------
https://chatgpt.com/codex/tasks/task_e_68eacca989dc832fa9ba7664453573ae