### PR TITLE
Refactor navigation menu rendering to object-oriented components

### DIFF
--- a/wwwroot/classes/NavigationMenu.php
+++ b/wwwroot/classes/NavigationMenu.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/NavigationState.php';
+
+final class NavigationMenu
+{
+    /**
+     * @var NavigationMenuItem[]
+     */
+    private array $items;
+
+    /**
+     * @param NavigationMenuItem[] $items
+     */
+    private function __construct(array $items)
+    {
+        $this->items = $items;
+    }
+
+    public static function createDefault(NavigationState $state): self
+    {
+        $items = [
+            new NavigationMenuItem('Home', '/', $state->isSectionActive('home')),
+            new NavigationMenuItem('Leaderboards', '/leaderboard/trophy', $state->isSectionActive('leaderboard')),
+            new NavigationMenuItem('Games', '/game', $state->isSectionActive('game')),
+            new NavigationMenuItem('Trophies', '/trophy', $state->isSectionActive('trophy')),
+            new NavigationMenuItem('Avatars', '/avatar', $state->isSectionActive('avatar')),
+            new NavigationMenuItem('About', '/about', $state->isSectionActive('about')),
+        ];
+
+        return new self($items);
+    }
+
+    /**
+     * @return NavigationMenuItem[]
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+}
+
+final class NavigationMenuItem
+{
+    private string $label;
+
+    private string $href;
+
+    private bool $active;
+
+    public function __construct(string $label, string $href, bool $active)
+    {
+        $this->label = $label;
+        $this->href = $href;
+        $this->active = $active;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getHref(): string
+    {
+        return $this->href;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function getLinkCssClass(): string
+    {
+        return 'nav-link' . ($this->active ? ' active' : '');
+    }
+
+    public function getAriaCurrentValue(): ?string
+    {
+        return $this->active ? 'page' : null;
+    }
+}

--- a/wwwroot/classes/NavigationState.php
+++ b/wwwroot/classes/NavigationState.php
@@ -82,6 +82,11 @@ final class NavigationState
         return $this->getActiveClass('about');
     }
 
+    public function isSectionActive(string $section): bool
+    {
+        return $this->getActiveClass($section) === self::ACTIVE_SUFFIX;
+    }
+
     private function getActiveClass(string $section): string
     {
         return $this->activeClasses[$section] ?? '';

--- a/wwwroot/nav.php
+++ b/wwwroot/nav.php
@@ -1,7 +1,9 @@
 <?php
 require_once __DIR__ . '/classes/NavigationState.php';
+require_once __DIR__ . '/classes/NavigationMenu.php';
 
 $navigationState = NavigationState::fromGlobals($_SERVER, $_GET);
+$navigationMenu = NavigationMenu::createDefault($navigationState);
 ?>
 
 <nav class="navbar navbar-expand-md navbar-dark bg-dark mb-2">
@@ -23,24 +25,21 @@ $navigationState = NavigationState::fromGlobals($_SERVER, $_GET);
             </form>
 
             <ul class="navbar-nav ms-auto mb-2 mb-md-0">
-                <li class="nav-item">
-                    <a class="nav-link<?= $navigationState->getHomeClass(); ?>" href="/">Home</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link<?= $navigationState->getLeaderboardClass(); ?>" href="/leaderboard/trophy">Leaderboards</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link<?= $navigationState->getGameClass(); ?>" href="/game">Games</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link<?= $navigationState->getTrophyClass(); ?>" href="/trophy">Trophies</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link<?= $navigationState->getAvatarClass(); ?>" href="/avatar">Avatars</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link<?= $navigationState->getAboutClass(); ?>" href="/about">About</a>
-                </li>
+                <?php foreach ($navigationMenu->getItems() as $item) { ?>
+                    <?php
+                    $linkClass = htmlspecialchars($item->getLinkCssClass(), ENT_QUOTES, 'UTF-8');
+                    $href = htmlspecialchars($item->getHref(), ENT_QUOTES, 'UTF-8');
+                    $ariaCurrent = $item->getAriaCurrentValue();
+                    $ariaAttribute = $ariaCurrent !== null
+                        ? ' aria-current="' . htmlspecialchars($ariaCurrent, ENT_QUOTES, 'UTF-8') . '"'
+                        : '';
+                    ?>
+                    <li class="nav-item">
+                        <a class="<?= $linkClass; ?>" href="<?= $href; ?>"<?= $ariaAttribute; ?>>
+                            <?= htmlspecialchars($item->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
+                        </a>
+                    </li>
+                <?php } ?>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add NavigationMenu and NavigationMenuItem classes to encapsulate building navigation links
- expose an `isSectionActive` helper on `NavigationState` and update the navbar template to render via the new menu objects

## Testing
- php -l wwwroot/classes/NavigationMenu.php
- php -l wwwroot/nav.php
- php -l wwwroot/classes/NavigationState.php

------
https://chatgpt.com/codex/tasks/task_e_68eacca989dc832fa9ba7664453573ae