### PR TITLE
Handle missing players in queue position responses

### DIFF
--- a/wwwroot/classes/PlayerQueueHandler.php
+++ b/wwwroot/classes/PlayerQueueHandler.php
@@ -61,7 +61,7 @@ class PlayerQueueHandler
         }
 
         $playerData = $this->service->getPlayerStatusData($playerName);
-        if ($this->service->isCheaterStatus($playerData['status'])) {
+        if ($playerData !== null && $this->service->isCheaterStatus($playerData['status'])) {
             return $this->responseFactory->createCheaterResponse($playerName, $playerData['account_id']);
         }
 
@@ -72,6 +72,10 @@ class PlayerQueueHandler
         $position = $this->service->getQueuePosition($playerName);
         if ($position !== null) {
             return $this->responseFactory->createQueuePositionResponse($playerName, $position);
+        }
+
+        if ($playerData === null) {
+            return $this->responseFactory->createPlayerNotFoundResponse($playerName);
         }
 
         return $this->responseFactory->createQueueCompleteResponse($playerName);

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -69,6 +69,13 @@ final class PlayerQueueResponseFactory
         return PlayerQueueResponse::complete($playerLink . ' has been updated!');
     }
 
+    public function createPlayerNotFoundResponse(string $playerName): PlayerQueueResponse
+    {
+        $playerLink = $this->createPlayerLink($playerName);
+
+        return PlayerQueueResponse::error($playerLink . ' was not found. Please check the spelling and try again.');
+    }
+
     private function createQueuedResponse(string $message): PlayerQueueResponse
     {
         return PlayerQueueResponse::queued($this->createSpinnerMessage($message));

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -139,7 +139,10 @@ class PlayerQueueService
         return $position === false ? null : (int) $position;
     }
 
-    public function getPlayerStatusData(string $playerName): array
+    /**
+     * @return array{account_id: string|null, status: int|null}|null
+     */
+    public function getPlayerStatusData(string $playerName): ?array
     {
         $query = $this->database->prepare(
             <<<'SQL'
@@ -158,10 +161,7 @@ class PlayerQueueService
         $result = $query->fetch(PDO::FETCH_ASSOC);
 
         if (!is_array($result)) {
-            return [
-                'account_id' => null,
-                'status' => null,
-            ];
+            return null;
         }
 
         return [


### PR DESCRIPTION
## Summary
- return a clear error message when a queue position check is made for a player that does not exist
- ensure queue checks still respect cheater, scanning, and queued states
- update the player lookup service to signal when no database record is found

## Testing
- php -l wwwroot/classes/PlayerQueueHandler.php
- php -l wwwroot/classes/PlayerQueueResponseFactory.php
- php -l wwwroot/classes/PlayerQueueService.php

------
https://chatgpt.com/codex/tasks/task_e_68ece1e50434832fb7a6ac7410d0793a