### PR TITLE
Prevent extra alerts for cheater-tagged players

### DIFF
--- a/wwwroot/classes/PlayerHeaderViewModel.php
+++ b/wwwroot/classes/PlayerHeaderViewModel.php
@@ -111,6 +111,10 @@ class PlayerHeaderViewModel
                 break;
         }
 
+        if ($status === 1) {
+            return $alerts;
+        }
+
         if ($this->isUnranked()) {
             $alerts[] = "This player isn't ranked within the top 10000 and will not have their trophies contributed to the site statistics.";
         }


### PR DESCRIPTION
## Summary
- return early from the player header alert builder when a player is flagged as a cheater
- suppress unranked and hidden trophy alerts so only the cheater notice is shown

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68edf20b8738832fae5e7360d9292272