### PR TITLE
Refactor cron scripts to use CronJobApplication helper

### DIFF
--- a/wwwroot/classes/Cron/CronJobApplication.php
+++ b/wwwroot/classes/Cron/CronJobApplication.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/CronJobInterface.php';
+require_once __DIR__ . '/CronJobRunner.php';
+
+/**
+ * Small helper that encapsulates the procedural bootstrap that each cron
+ * entrypoint previously performed. By funnelling the work through this class
+ * the scripts become easier to read and are now focused solely on describing
+ * which job to execute.
+ */
+final class CronJobApplication
+{
+    private CronJobRunner $runner;
+
+    private function __construct(CronJobRunner $runner)
+    {
+        $this->runner = $runner;
+    }
+
+    public static function create(?CronJobRunner $runner = null): self
+    {
+        return new self($runner ?? CronJobRunner::create());
+    }
+
+    public function configureEnvironment(): void
+    {
+        $this->runner->configureEnvironment();
+    }
+
+    /**
+     * @param callable():CronJobInterface $jobFactory
+     */
+    public function run(callable $jobFactory): void
+    {
+        $job = $jobFactory();
+
+        if (!$job instanceof CronJobInterface) {
+            throw new InvalidArgumentException('Cron job factory must return a CronJobInterface instance.');
+        }
+
+        $this->runner->run($job);
+    }
+}

--- a/wwwroot/cron/30th_minute.php
+++ b/wwwroot/cron/30th_minute.php
@@ -3,21 +3,23 @@
 declare(strict_types=1);
 
 require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobApplication.php';
 require_once dirname(__DIR__) . '/classes/Cron/CronJobCliArguments.php';
 
-$cronJobRunner = CronJobRunner::create();
-$cronJobRunner->configureEnvironment();
+$application = CronJobApplication::create();
+$application->configureEnvironment();
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 require_once dirname(__DIR__) . '/init.php';
 require_once dirname(__DIR__) . '/classes/TrophyCalculator.php';
 require_once dirname(__DIR__) . '/classes/Cron/ThirtyMinuteCronJob.php';
 
-$cliArguments = CronJobCliArguments::fromArgv($_SERVER['argv'] ?? []);
-$workerId = $cliArguments->getWorkerId();
+$application->run(static function () use ($database): CronJobInterface {
+    $cliArguments = CronJobCliArguments::fromArgv($_SERVER['argv'] ?? []);
+    $workerId = $cliArguments->getWorkerId();
 
-$trophyCalculator = new TrophyCalculator($database);
-$logger = new Psn100Logger($database);
+    $trophyCalculator = new TrophyCalculator($database);
+    $logger = new Psn100Logger($database);
 
-$cronJob = new ThirtyMinuteCronJob($database, $trophyCalculator, $logger, $workerId);
-$cronJobRunner->run($cronJob);
+    return new ThirtyMinuteCronJob($database, $trophyCalculator, $logger, $workerId);
+});

--- a/wwwroot/cron/5th_minute.php
+++ b/wwwroot/cron/5th_minute.php
@@ -3,13 +3,16 @@
 declare(strict_types=1);
 
 require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobApplication.php';
 
-$cronJobRunner = CronJobRunner::create();
-$cronJobRunner->configureEnvironment();
+$application = CronJobApplication::create();
+$application->configureEnvironment();
 
 require_once dirname(__DIR__) . '/init.php';
 require_once dirname(__DIR__) . '/classes/Cron/PlayerRankingCronJob.php';
 
-$playerRankingUpdater = new PlayerRankingUpdater($database);
-$playerRankingCronJob = new PlayerRankingCronJob($playerRankingUpdater);
-$cronJobRunner->run($playerRankingCronJob);
+$application->run(static function () use ($database): CronJobInterface {
+    $playerRankingUpdater = new PlayerRankingUpdater($database);
+
+    return new PlayerRankingCronJob($playerRankingUpdater);
+});

--- a/wwwroot/cron/daily.php
+++ b/wwwroot/cron/daily.php
@@ -3,12 +3,12 @@
 declare(strict_types=1);
 
 require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobApplication.php';
 
-$cronJobRunner = CronJobRunner::create();
-$cronJobRunner->configureEnvironment();
+$application = CronJobApplication::create();
+$application->configureEnvironment();
 
 require_once dirname(__DIR__) . '/init.php';
 require_once dirname(__DIR__) . '/classes/Cron/DailyCronJob.php';
 
-$dailyCronJob = new DailyCronJob($database);
-$cronJobRunner->run($dailyCronJob);
+$application->run(static fn (): CronJobInterface => new DailyCronJob($database));

--- a/wwwroot/cron/hourly.php
+++ b/wwwroot/cron/hourly.php
@@ -3,12 +3,12 @@
 declare(strict_types=1);
 
 require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobApplication.php';
 
-$cronJobRunner = CronJobRunner::create();
-$cronJobRunner->configureEnvironment();
+$application = CronJobApplication::create();
+$application->configureEnvironment();
 
 require_once dirname(__DIR__) . '/init.php';
 require_once dirname(__DIR__) . '/classes/Cron/HourlyCronJob.php';
 
-$hourlyCronJob = new HourlyCronJob($database);
-$cronJobRunner->run($hourlyCronJob);
+$application->run(static fn (): CronJobInterface => new HourlyCronJob($database));

--- a/wwwroot/cron/weekly.php
+++ b/wwwroot/cron/weekly.php
@@ -3,12 +3,12 @@
 declare(strict_types=1);
 
 require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobApplication.php';
 
-$cronJobRunner = CronJobRunner::create();
-$cronJobRunner->configureEnvironment();
+$application = CronJobApplication::create();
+$application->configureEnvironment();
 
 require_once dirname(__DIR__) . '/init.php';
 require_once dirname(__DIR__) . '/classes/Cron/WeeklyCronJob.php';
 
-$weeklyCronJob = new WeeklyCronJob($database);
-$cronJobRunner->run($weeklyCronJob);
+$application->run(static fn (): CronJobInterface => new WeeklyCronJob($database));


### PR DESCRIPTION
## Summary
- add a CronJobApplication helper that encapsulates the cron bootstrap workflow
- update each cron entrypoint to build jobs through the new helper class

## Testing
- php -l wwwroot/cron/30th_minute.php wwwroot/cron/5th_minute.php wwwroot/cron/daily.php wwwroot/cron/hourly.php wwwroot/cron/weekly.php wwwroot/classes/Cron/CronJobApplication.php

------
https://chatgpt.com/codex/tasks/task_e_68ec17605988832fae454c3734ab5ab2