### PR TITLE
Refactor homepage bootstrap into controller

### DIFF
--- a/wwwroot/classes/HomepageController.php
+++ b/wwwroot/classes/HomepageController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/HomepageContentService.php';
+require_once __DIR__ . '/HomepagePage.php';
+require_once __DIR__ . '/HomepageViewModel.php';
+
+final class HomepageController
+{
+    private HomepagePage $homepagePage;
+
+    public function __construct(HomepagePage $homepagePage)
+    {
+        $this->homepagePage = $homepagePage;
+    }
+
+    public static function fromDatabase(PDO $database): self
+    {
+        $contentService = new HomepageContentService($database);
+        $homepagePage = new HomepagePage($contentService);
+
+        return new self($homepagePage);
+    }
+
+    public function withTitle(string $title): self
+    {
+        $this->homepagePage->setTitle($title);
+
+        return $this;
+    }
+
+    public function withNewGamesLimit(int $limit): self
+    {
+        $this->homepagePage->setNewGamesLimit($limit);
+
+        return $this;
+    }
+
+    public function withNewDlcsLimit(int $limit): self
+    {
+        $this->homepagePage->setNewDlcsLimit($limit);
+
+        return $this;
+    }
+
+    public function withPopularGamesLimit(int $limit): self
+    {
+        $this->homepagePage->setPopularGamesLimit($limit);
+
+        return $this;
+    }
+
+    public function getViewModel(): HomepageViewModel
+    {
+        return $this->homepagePage->buildViewModel();
+    }
+}

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -1,9 +1,8 @@
 <?php
-require_once 'classes/HomepagePage.php';
+require_once 'classes/HomepageController.php';
 
-$homepageContentService = new HomepageContentService($database);
-$homepagePage = new HomepagePage($homepageContentService);
-$homepageViewModel = $homepagePage->buildViewModel();
+$homepageController = HomepageController::fromDatabase($database);
+$homepageViewModel = $homepageController->getViewModel();
 
 $title = $homepageViewModel->getTitle();
 $newGames = $homepageViewModel->getNewGames();


### PR DESCRIPTION
## Summary
- add a dedicated `HomepageController` to encapsulate homepage data retrieval in an OO-friendly way
- update `home.php` to consume the controller instead of manually wiring the services

## Testing
- php -l wwwroot/classes/HomepageController.php
- php -l wwwroot/home.php

------
https://chatgpt.com/codex/tasks/task_e_68ec17605988832fae454c3734ab5ab2