### PR TITLE
Refactor pagination rendering into object-oriented components

### DIFF
--- a/wwwroot/classes/Pagination.php
+++ b/wwwroot/classes/Pagination.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PaginationItem.php';
+
+final class Pagination
+{
+    private int $currentPage;
+
+    private int $totalPages;
+
+    public function __construct(int $currentPage, int $totalPages)
+    {
+        $this->totalPages = max(1, $totalPages);
+        $normalizedCurrentPage = max(1, $currentPage);
+        $this->currentPage = min($normalizedCurrentPage, $this->totalPages);
+    }
+
+    public static function create(int $currentPage, int $totalPages): self
+    {
+        return new self($currentPage, $totalPages);
+    }
+
+    /**
+     * @return list<PaginationItem>
+     */
+    public function buildItems(): array
+    {
+        $items = [];
+
+        if ($this->currentPage > 1) {
+            $items[] = PaginationItem::forPage($this->currentPage - 1, '<')
+                ->setAriaLabel('Previous');
+        }
+
+        if ($this->currentPage > 3) {
+            $items[] = PaginationItem::forPage(1, '1');
+            $items[] = PaginationItem::ellipsis();
+        }
+
+        for ($i = 2; $i >= 1; $i--) {
+            $previousPage = $this->currentPage - $i;
+
+            if ($previousPage > 0) {
+                $items[] = PaginationItem::forPage($previousPage, (string) $previousPage);
+            }
+        }
+
+        $items[] = PaginationItem::forPage($this->currentPage, (string) $this->currentPage)
+            ->markAsActive();
+
+        for ($i = 1; $i <= 2; $i++) {
+            $nextPage = $this->currentPage + $i;
+
+            if ($nextPage <= $this->totalPages) {
+                $items[] = PaginationItem::forPage($nextPage, (string) $nextPage);
+            }
+        }
+
+        if ($this->currentPage < $this->totalPages - 2) {
+            $items[] = PaginationItem::ellipsis();
+            $items[] = PaginationItem::forPage($this->totalPages, (string) $this->totalPages);
+        }
+
+        if ($this->currentPage < $this->totalPages) {
+            $items[] = PaginationItem::forPage($this->currentPage + 1, '>')
+                ->setAriaLabel('Next');
+        }
+
+        return $items;
+    }
+}
+

--- a/wwwroot/classes/PaginationItem.php
+++ b/wwwroot/classes/PaginationItem.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+final class PaginationItem
+{
+    private ?int $page;
+
+    private string $label;
+
+    private bool $active = false;
+
+    private bool $disabled = false;
+
+    private ?string $ariaLabel = null;
+
+    private function __construct(?int $page, string $label)
+    {
+        $this->page = $page;
+        $this->label = $label;
+    }
+
+    public static function forPage(int $page, string $label): self
+    {
+        return new self($page, $label);
+    }
+
+    public static function ellipsis(): self
+    {
+        return (new self(null, '...'))->markAsDisabled();
+    }
+
+    public function markAsActive(): self
+    {
+        $this->active = true;
+
+        return $this;
+    }
+
+    public function markAsDisabled(): self
+    {
+        $this->disabled = true;
+
+        return $this;
+    }
+
+    public function setAriaLabel(?string $ariaLabel): self
+    {
+        $this->ariaLabel = $ariaLabel;
+
+        return $this;
+    }
+
+    /**
+     * @param callable(int):string $urlBuilder
+     */
+    public function render(callable $urlBuilder): string
+    {
+        $classNames = ['page-item'];
+
+        if ($this->active) {
+            $classNames[] = 'active';
+        }
+
+        if ($this->disabled) {
+            $classNames[] = 'disabled';
+        }
+
+        $href = '#';
+
+        if (!$this->disabled && $this->page !== null) {
+            $href = (string) $urlBuilder($this->page);
+        }
+
+        $attributes = [];
+
+        if ($this->active) {
+            $attributes[] = 'aria-current="page"';
+        }
+
+        if ($this->ariaLabel !== null && $this->ariaLabel !== '') {
+            $attributes[] = 'aria-label="' . htmlspecialchars($this->ariaLabel, ENT_QUOTES, 'UTF-8') . '"';
+        }
+
+        if ($this->disabled) {
+            $attributes[] = 'tabindex="-1"';
+            $attributes[] = 'aria-disabled="true"';
+        }
+
+        $attributesString = $attributes === []
+            ? ''
+            : ' ' . implode(' ', $attributes);
+
+        $label = htmlspecialchars($this->label, ENT_QUOTES, 'UTF-8');
+        $href = htmlspecialchars($href, ENT_QUOTES, 'UTF-8');
+        $classAttribute = htmlspecialchars(implode(' ', $classNames), ENT_QUOTES, 'UTF-8');
+
+        return '<li class="' . $classAttribute . '"><a class="page-link" href="' . $href . '"'
+            . $attributesString . '>' . $label . '</a></li>';
+    }
+}
+

--- a/wwwroot/classes/PaginationRenderer.php
+++ b/wwwroot/classes/PaginationRenderer.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Pagination.php';
+
 /**
  * Responsible for rendering Bootstrap pagination controls that match the site's
  * existing style. The renderer generates the HTML as a string so that templates
@@ -18,7 +20,7 @@ class PaginationRenderer
         callable $queryParametersFactory,
         ?string $ariaLabel = null
     ): string {
-        $totalPages = max(1, $totalPages);
+        $pagination = Pagination::create($currentPage, $totalPages);
         $navAttributes = '';
 
         if ($ariaLabel !== null && $ariaLabel !== '') {
@@ -38,47 +40,8 @@ class PaginationRenderer
         $html = '<nav' . $navAttributes . '>';
         $html .= '<ul class="pagination justify-content-center">';
 
-        if ($currentPage > 1) {
-            $previousUrl = $buildUrl($currentPage - 1);
-            $html .= '<li class="page-item"><a class="page-link" href="' . htmlspecialchars($previousUrl, ENT_QUOTES, 'UTF-8') . '" aria-label="Previous">&lt;</a></li>';
-        }
-
-        if ($currentPage > 3) {
-            $firstPageUrl = $buildUrl(1);
-            $html .= '<li class="page-item"><a class="page-link" href="' . htmlspecialchars($firstPageUrl, ENT_QUOTES, 'UTF-8') . '">1</a></li>';
-            $html .= '<li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>';
-        }
-
-        for ($i = 2; $i >= 1; $i--) {
-            $previousPage = $currentPage - $i;
-
-            if ($previousPage > 0) {
-                $pageUrl = $buildUrl($previousPage);
-                $html .= '<li class="page-item"><a class="page-link" href="' . htmlspecialchars($pageUrl, ENT_QUOTES, 'UTF-8') . '">' . $previousPage . '</a></li>';
-            }
-        }
-
-        $currentUrl = $buildUrl($currentPage);
-        $html .= '<li class="page-item active" aria-current="page"><a class="page-link" href="' . htmlspecialchars($currentUrl, ENT_QUOTES, 'UTF-8') . '">' . $currentPage . '</a></li>';
-
-        for ($i = 1; $i <= 2; $i++) {
-            $nextPage = $currentPage + $i;
-
-            if ($nextPage <= $totalPages) {
-                $pageUrl = $buildUrl($nextPage);
-                $html .= '<li class="page-item"><a class="page-link" href="' . htmlspecialchars($pageUrl, ENT_QUOTES, 'UTF-8') . '">' . $nextPage . '</a></li>';
-            }
-        }
-
-        if ($currentPage < $totalPages - 2) {
-            $lastPageUrl = $buildUrl($totalPages);
-            $html .= '<li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>';
-            $html .= '<li class="page-item"><a class="page-link" href="' . htmlspecialchars($lastPageUrl, ENT_QUOTES, 'UTF-8') . '">' . $totalPages . '</a></li>';
-        }
-
-        if ($currentPage < $totalPages) {
-            $nextUrl = $buildUrl($currentPage + 1);
-            $html .= '<li class="page-item"><a class="page-link" href="' . htmlspecialchars($nextUrl, ENT_QUOTES, 'UTF-8') . '" aria-label="Next">&gt;</a></li>';
+        foreach ($pagination->buildItems() as $item) {
+            $html .= $item->render($buildUrl);
         }
 
         $html .= '</ul>';


### PR DESCRIPTION
## Summary
- extract a dedicated PaginationItem value object to encapsulate the rendering of individual pagination entries
- introduce a Pagination coordinator that builds the ordered list of links and ellipses for a given page/total
- simplify PaginationRenderer so it delegates to the new objects for URL generation and markup creation

## Testing
- php -l wwwroot/classes/PaginationItem.php
- php -l wwwroot/classes/Pagination.php
- php -l wwwroot/classes/PaginationRenderer.php

------
https://chatgpt.com/codex/tasks/task_e_68ec17605988832fae454c3734ab5ab2