### PR TITLE
Refactor 404 page to use object oriented view model

### DIFF
--- a/wwwroot/404.php
+++ b/wwwroot/404.php
@@ -1,20 +1,27 @@
 <?php
-$title = "404 ~ PSN 100%";
-require_once("header.php");
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/classes/NotFoundPage.php';
+
+$notFoundPage = NotFoundPage::createDefault();
+
+$title = $notFoundPage->getTitle();
+require_once __DIR__ . '/header.php';
 ?>
 
 <main class="container">
     <div class="row">
         <div class="col-12">
-            <h1>404</h1>
+            <h1><?= htmlspecialchars($notFoundPage->getHeading(), ENT_QUOTES, 'UTF-8'); ?></h1>
         </div>
 
         <div class="col-12">
-            <p>There are no trophies here.</p>
+            <p><?= htmlspecialchars($notFoundPage->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
         </div>
     </div>
 </main>
 
 <?php
-require_once("footer.php");
+require_once __DIR__ . '/footer.php';
 ?>

--- a/wwwroot/classes/NotFoundPage.php
+++ b/wwwroot/classes/NotFoundPage.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+final class NotFoundPage
+{
+    private string $title;
+
+    private string $heading;
+
+    private string $message;
+
+    private function __construct(string $title, string $heading, string $message)
+    {
+        $this->title = $title;
+        $this->heading = $heading;
+        $this->message = $message;
+    }
+
+    public static function createDefault(): self
+    {
+        return new self(
+            '404 ~ PSN 100%',
+            '404',
+            'There are no trophies here.'
+        );
+    }
+
+    public function withHeading(string $heading): self
+    {
+        $clone = clone $this;
+        $clone->heading = $heading;
+
+        return $clone;
+    }
+
+    public function withMessage(string $message): self
+    {
+        $clone = clone $this;
+        $clone->message = $message;
+
+        return $clone;
+    }
+
+    public function withTitle(string $title): self
+    {
+        $clone = clone $this;
+        $clone->title = $title;
+
+        return $clone;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getHeading(): string
+    {
+        return $this->heading;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a NotFoundPage view model that encapsulates the 404 page title, heading, and message
- update the 404 template to leverage the new view model and escape rendered content

## Testing
- php -l wwwroot/classes/NotFoundPage.php
- php -l wwwroot/404.php

------
https://chatgpt.com/codex/tasks/task_e_68eea58c97c8832faf090feb3342309e