### PR TITLE
Introduce guard for player pages requiring an account

### DIFF
--- a/wwwroot/classes/PlayerPageAccessGuard.php
+++ b/wwwroot/classes/PlayerPageAccessGuard.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+final class PlayerPageAccessGuard
+{
+    private const DEFAULT_REDIRECT_URL = '/player/';
+    private const REDIRECT_STATUS_CODE = 303;
+
+    private ?int $accountId;
+
+    private string $redirectUrl;
+
+    private function __construct(?int $accountId, string $redirectUrl)
+    {
+        $this->accountId = $accountId;
+        $this->redirectUrl = $redirectUrl;
+    }
+
+    /**
+     * @param int|string|null $accountId
+     */
+    public static function fromAccountId($accountId, string $redirectUrl = self::DEFAULT_REDIRECT_URL): self
+    {
+        if ($accountId === null) {
+            return new self(null, $redirectUrl);
+        }
+
+        return new self((int) $accountId, $redirectUrl);
+    }
+
+    public function requireAccountId(): int
+    {
+        if ($this->accountId === null) {
+            $this->redirect();
+        }
+
+        return $this->accountId;
+    }
+
+    private function redirect(): void
+    {
+        header('Location: ' . $this->redirectUrl, true, self::REDIRECT_STATUS_CODE);
+        exit();
+    }
+}

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -1,12 +1,11 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerGamesPageContext.php';
 
-if (!isset($accountId)) {
-    header("Location: /player/", true, 303);
-    die();
-}
+$playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
+$accountId = $playerPageAccessGuard->requireAccountId();
 
 $pageContext = PlayerGamesPageContext::fromGlobals(
     $database,

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerAdvisorFilter.php';
 require_once __DIR__ . '/classes/PlayerAdvisorService.php';
 require_once __DIR__ . '/classes/PlayerAdvisorPage.php';
@@ -8,10 +9,8 @@ require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
 require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
 
-if (!isset($accountId)) {
-    header("Location: /player/", true, 303);
-    die();
-}
+$playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
+$accountId = $playerPageAccessGuard->requireAccountId();
 
 $playerAdvisorFilter = PlayerAdvisorFilter::fromArray($_GET ?? []);
 $playerAdvisorService = new PlayerAdvisorService($database, $utility);

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerLogFilter.php';
 require_once __DIR__ . '/classes/PlayerLogService.php';
 require_once __DIR__ . '/classes/PlayerLogPage.php';
@@ -8,10 +9,8 @@ require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
 require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
 
-if (!isset($accountId)) {
-    header("Location: /player/", true, 303);
-    die();
-}
+$playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
+$accountId = $playerPageAccessGuard->requireAccountId();
 
 $playerLogFilter = PlayerLogFilter::fromArray($_GET ?? []);
 $playerLogService = new PlayerLogService($database);

--- a/wwwroot/player_random.php
+++ b/wwwroot/player_random.php
@@ -1,15 +1,16 @@
 <?php
-if (!isset($accountId)) {
-    header("Location: /player/", true, 303);
-    die();
-}
+declare(strict_types=1);
 
+require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerRandomGame.php';
 require_once __DIR__ . '/classes/PlayerRandomGamesFilter.php';
 require_once __DIR__ . '/classes/PlayerRandomGamesService.php';
 require_once __DIR__ . '/classes/PlayerRandomGamesPage.php';
 require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
+
+$playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
+$accountId = $playerPageAccessGuard->requireAccountId();
 
 $playerRandomGamesFilter = PlayerRandomGamesFilter::fromArray($_GET ?? []);
 $playerRandomGamesService = new PlayerRandomGamesService($database, $utility);

--- a/wwwroot/player_report.php
+++ b/wwwroot/player_report.php
@@ -1,14 +1,15 @@
 <?php
-if (!isset($accountId)) {
-    header("Location: /player/", true, 303);
-    die();
-}
+declare(strict_types=1);
 
+require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerReportHandler.php';
 require_once __DIR__ . '/classes/PlayerReportPage.php';
 require_once __DIR__ . '/classes/PlayerReportService.php';
 require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
+
+$playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
+$accountId = $playerPageAccessGuard->requireAccountId();
 
 $playerReportService = new PlayerReportService($database);
 $playerReportHandler = new PlayerReportHandler($playerReportService);


### PR DESCRIPTION
## Summary
- add a PlayerPageAccessGuard utility that centralizes the redirect logic when a player account id is missing
- update all player-related entrypoints to rely on the new guard and enable strict types where it was missing

## Testing
- php -l wwwroot/classes/PlayerPageAccessGuard.php
- php -l wwwroot/player.php
- php -l wwwroot/player_advisor.php
- php -l wwwroot/player_log.php
- php -l wwwroot/player_random.php
- php -l wwwroot/player_report.php

------
https://chatgpt.com/codex/tasks/task_e_68eea58c97c8832faf090feb3342309e