### PR TITLE
Remove Trophy Set prefix from trophy titles

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1187,6 +1187,14 @@ class ThirtyMinuteCronJob implements CronJobInterface
             return $name;
         }
 
+        $prefixPatterns = [
+            '/^Trophy Set\b[:\s-]*/i',
+        ];
+
+        foreach ($prefixPatterns as $pattern) {
+            $name = preg_replace($pattern, '', $name, 1);
+        }
+
         $suffixPatterns = [
             '/\s*Trophy Set\.$/i',
             '/\s*Trophy Set$/i',


### PR DESCRIPTION
## Summary
- strip the "Trophy Set" prefix when sanitizing trophy title names before insertion

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0f4245ebc832f8185bb29139ec4aa