### PR TITLE
Normalize trophy title separators before insertion

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1209,6 +1209,16 @@ class ThirtyMinuteCronJob implements CronJobInterface
             }
         }
 
+        $separatorPosition = strpos($name, ' - ');
+
+        if ($separatorPosition !== false) {
+            $prefix = substr($name, 0, $separatorPosition);
+
+            if (strpos($prefix, ':') === false) {
+                $name = substr_replace($name, ': ', $separatorPosition, 3);
+            }
+        }
+
         return trim($name);
     }
 


### PR DESCRIPTION
## Summary
- ensure sanitized trophy titles replace " - " with ": " when no colon exists prior to the dash separator

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f0f71a7cb8832f9d61b2ed2f4917f8