### PR TITLE
Refactor possible cheater report service to return domain objects

### DIFF
--- a/wwwroot/classes/Admin/PossibleCheaterPage.php
+++ b/wwwroot/classes/Admin/PossibleCheaterPage.php
@@ -11,17 +11,7 @@ class PossibleCheaterPage
 
     public function __construct(PossibleCheaterService $service)
     {
-        $generalCheaters = array_map(
-            static fn(array $cheater): PossibleCheaterReportEntry => PossibleCheaterReportEntry::fromArray($cheater),
-            $service->getGeneralPossibleCheaters()
-        );
-
-        $sections = array_map(
-            static fn(array $section): PossibleCheaterReportSection => PossibleCheaterReportSection::fromArray($section),
-            $service->getSectionResults()
-        );
-
-        $this->report = new PossibleCheaterReport($generalCheaters, $sections);
+        $this->report = $service->createReport();
     }
 
     public function getReport(): PossibleCheaterReport


### PR DESCRIPTION
## Summary
- update the possible cheater service to assemble a `PossibleCheaterReport` made up of domain objects instead of raw arrays
- simplify the admin possible cheater page to rely on the new service method

## Testing
- php -l wwwroot/classes/Admin/PossibleCheaterService.php
- php -l wwwroot/classes/Admin/PossibleCheaterPage.php

------
https://chatgpt.com/codex/tasks/task_e_68f0091b364c832fa0f4f2edb01d343c