### PR TITLE
Refactor game rescan progress handling

### DIFF
--- a/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
+++ b/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/GameRescanProgressListener.php';
+
+final class CallableGameRescanProgressListener implements GameRescanProgressListener
+{
+    /**
+     * @var callable(int, string):void
+     */
+    private $callback;
+
+    /**
+     * @param callable(int, string):void $callback
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    public function onProgress(int $percent, string $message): void
+    {
+        ($this->callback)($percent, $message);
+    }
+}

--- a/wwwroot/classes/Admin/GameRescanProgressListener.php
+++ b/wwwroot/classes/Admin/GameRescanProgressListener.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+interface GameRescanProgressListener
+{
+    public function onProgress(int $percent, string $message): void;
+}

--- a/wwwroot/classes/Admin/GameRescanRequestHandler.php
+++ b/wwwroot/classes/Admin/GameRescanRequestHandler.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../ExecutionEnvironmentConfigurator.php';
+require_once __DIR__ . '/GameRescanProgressListener.php';
+require_once __DIR__ . '/CallableGameRescanProgressListener.php';
 
 class GameRescanRequestHandler
 {
@@ -49,13 +51,15 @@ class GameRescanRequestHandler
         ]);
 
         try {
-            $message = $this->gameRescanService->rescan($gameId, function (int $percent, string $message): void {
+            $progressListener = new CallableGameRescanProgressListener(function (int $percent, string $message): void {
                 $this->sendEvent([
                     'type' => 'progress',
                     'progress' => $percent,
                     'message' => $message,
                 ]);
             });
+
+            $message = $this->gameRescanService->rescan($gameId, $progressListener);
 
             $this->sendEvent([
                 'type' => 'complete',


### PR DESCRIPTION
## Summary
- add a dedicated `GameRescanProgressListener` interface plus a callable-backed implementation for emitting progress updates
- refactor `GameRescanService` to depend on the listener abstraction while preserving sequential progress reporting
- update the admin rescan request handler to leverage the new listener object when streaming NDJSON progress responses

## Testing
- php -l wwwroot/classes/Admin/GameRescanProgressListener.php
- php -l wwwroot/classes/Admin/CallableGameRescanProgressListener.php
- php -l wwwroot/classes/Admin/GameRescanService.php
- php -l wwwroot/classes/Admin/GameRescanRequestHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68f0091b364c832fa0f4f2edb01d343c