### PR TITLE
Refactor admin request handling to use reusable request object

### DIFF
--- a/wwwroot/admin/cheater.php
+++ b/wwwroot/admin/cheater.php
@@ -8,10 +8,8 @@ require_once '../classes/Admin/CheaterRequestHandler.php';
 $cheaterService = new CheaterService($database);
 $requestHandler = new CheaterRequestHandler($cheaterService);
 
-$requestMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';
-$postData = $_POST ?? [];
-
-$result = $requestHandler->handle($requestMethod, $postData);
+$request = AdminRequest::fromGlobals($_SERVER ?? [], $_POST ?? []);
+$result = $requestHandler->handle($request);
 $successMessage = $result->getSuccessMessage();
 $errorMessage = $result->getErrorMessage();
 

--- a/wwwroot/admin/reset.php
+++ b/wwwroot/admin/reset.php
@@ -9,10 +9,8 @@ require_once '../classes/Admin/GameResetRequestHandler.php';
 $gameResetService = new GameResetService($database);
 $requestHandler = new GameResetRequestHandler($gameResetService);
 
-$requestMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';
-$postData = $_POST ?? [];
-
-$result = $requestHandler->handleRequest($requestMethod, $postData);
+$request = AdminRequest::fromGlobals($_SERVER ?? [], $_POST ?? []);
+$result = $requestHandler->handleRequest($request);
 $success = $result->getSuccessMessage();
 $error = $result->getErrorMessage();
 

--- a/wwwroot/admin/status.php
+++ b/wwwroot/admin/status.php
@@ -7,10 +7,8 @@ require_once '../classes/Admin/GameStatusRequestHandler.php';
 $gameStatusService = new GameStatusService($database);
 $requestHandler = new GameStatusRequestHandler($gameStatusService);
 
-$requestMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';
-$postData = $_POST ?? [];
-
-$result = $requestHandler->handleRequest($requestMethod, $postData);
+$request = AdminRequest::fromGlobals($_SERVER ?? [], $_POST ?? []);
+$result = $requestHandler->handleRequest($request);
 $success = $result->getSuccessMessage();
 $error = $result->getErrorMessage();
 

--- a/wwwroot/classes/Admin/AdminRequest.php
+++ b/wwwroot/classes/Admin/AdminRequest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+final class AdminRequest
+{
+    private string $method;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $postData;
+
+    /**
+     * @param array<string, mixed> $postData
+     */
+    public function __construct(string $method, array $postData)
+    {
+        $normalizedMethod = strtoupper(trim($method));
+        $this->method = $normalizedMethod === '' ? 'GET' : $normalizedMethod;
+        $this->postData = $postData;
+    }
+
+    /**
+     * @param array<string, mixed> $serverData
+     * @param array<string, mixed> $postData
+     */
+    public static function fromGlobals(array $serverData, array $postData): self
+    {
+        $method = $serverData['REQUEST_METHOD'] ?? 'GET';
+
+        if (!is_string($method)) {
+            $method = 'GET';
+        }
+
+        return new self($method, $postData);
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function isPost(): bool
+    {
+        return $this->method === 'POST';
+    }
+
+    public function getPostValue(string $key): mixed
+    {
+        return $this->postData[$key] ?? null;
+    }
+
+    public function getPostString(string $key): string
+    {
+        $value = $this->getPostValue($key);
+
+        if (!is_scalar($value)) {
+            return '';
+        }
+
+        return trim((string) $value);
+    }
+
+    public function getPostInt(string $key): ?int
+    {
+        $value = $this->getPostValue($key);
+
+        if (!is_scalar($value)) {
+            return null;
+        }
+
+        $filtered = filter_var($value, FILTER_VALIDATE_INT);
+
+        return $filtered === false ? null : (int) $filtered;
+    }
+
+    public function getPostNonNegativeInt(string $key): ?int
+    {
+        $number = $this->getPostInt($key);
+
+        if ($number === null || $number < 0) {
+            return null;
+        }
+
+        return $number;
+    }
+
+    public function getPostPositiveInt(string $key): ?int
+    {
+        $number = $this->getPostInt($key);
+
+        if ($number === null || $number <= 0) {
+            return null;
+        }
+
+        return $number;
+    }
+
+    /**
+     * @param array<int, int> $allowedValues
+     */
+    public function getPostIntInSet(string $key, array $allowedValues): ?int
+    {
+        $number = $this->getPostInt($key);
+
+        if ($number === null) {
+            return null;
+        }
+
+        return in_array($number, $allowedValues, true) ? $number : null;
+    }
+}

--- a/wwwroot/classes/Admin/CheaterRequestHandler.php
+++ b/wwwroot/classes/Admin/CheaterRequestHandler.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/AdminRequest.php';
 require_once __DIR__ . '/CheaterRequestResult.php';
 require_once __DIR__ . '/CheaterService.php';
 
@@ -14,16 +15,13 @@ class CheaterRequestHandler
         $this->cheaterService = $cheaterService;
     }
 
-    /**
-     * @param array<string, mixed> $postData
-     */
-    public function handle(string $requestMethod, array $postData): CheaterRequestResult
+    public function handle(AdminRequest $request): CheaterRequestResult
     {
-        if (strtoupper($requestMethod) !== 'POST') {
+        if (!$request->isPost()) {
             return CheaterRequestResult::empty();
         }
 
-        $onlineId = $this->sanitizeOnlineId($postData['player'] ?? null);
+        $onlineId = $request->getPostString('player');
 
         if ($onlineId === '') {
             return CheaterRequestResult::error('<p class="text-danger">Online ID cannot be empty.</p>');
@@ -43,11 +41,6 @@ class CheaterRequestHandler
         $message = sprintf('<p>Player %s is now tagged as a cheater.</p>', $player);
 
         return CheaterRequestResult::success($message);
-    }
-
-    private function sanitizeOnlineId(mixed $onlineId): string
-    {
-        return trim((string) ($onlineId ?? ''));
     }
 
     private function escapeHtml(string $value): string


### PR DESCRIPTION
## Summary
- add an `AdminRequest` value object that encapsulates HTTP method and form data parsing for admin flows
- refactor the cheater, game status, and game reset handlers to consume the new object and drop inline request parsing logic
- update the related admin entrypoints to construct the reusable request object before dispatching to their handlers

## Testing
- for file in wwwroot/classes/Admin/AdminRequest.php wwwroot/classes/Admin/CheaterRequestHandler.php wwwroot/classes/Admin/GameStatusRequestHandler.php wwwroot/classes/Admin/GameResetRequestHandler.php wwwroot/admin/cheater.php wwwroot/admin/status.php wwwroot/admin/reset.php; do php -l $file; done

------
https://chatgpt.com/codex/tasks/task_e_68f0091b364c832fa0f4f2edb01d343c