### PR TITLE
Refactor admin rescan handler into OOP processor

### DIFF
--- a/wwwroot/admin/rescan_process.php
+++ b/wwwroot/admin/rescan_process.php
@@ -4,12 +4,7 @@ declare(strict_types=1);
 
 require_once '../vendor/autoload.php';
 require_once '../init.php';
-require_once '../classes/TrophyCalculator.php';
-require_once '../classes/Admin/GameRescanService.php';
-require_once '../classes/Admin/GameRescanRequestHandler.php';
+require_once '../classes/Admin/GameRescanProcessor.php';
 
-$trophyCalculator = new TrophyCalculator($database);
-$gameRescanService = new GameRescanService($database, $trophyCalculator);
-$requestHandler = new GameRescanRequestHandler($gameRescanService);
-
-$requestHandler->handleRequest($_POST ?? [], $_SERVER ?? []);
+$processor = GameRescanProcessor::fromDatabase($database);
+$processor->processRequest($_POST ?? [], $_SERVER ?? []);

--- a/wwwroot/classes/Admin/GameRescanProcessor.php
+++ b/wwwroot/classes/Admin/GameRescanProcessor.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TrophyCalculator.php';
+require_once __DIR__ . '/GameRescanService.php';
+require_once __DIR__ . '/GameRescanRequestHandler.php';
+
+final class GameRescanProcessor
+{
+    private GameRescanRequestHandler $requestHandler;
+
+    public function __construct(GameRescanRequestHandler $requestHandler)
+    {
+        $this->requestHandler = $requestHandler;
+    }
+
+    public static function fromDatabase(PDO $database): self
+    {
+        $trophyCalculator = new TrophyCalculator($database);
+        $gameRescanService = new GameRescanService($database, $trophyCalculator);
+        $requestHandler = new GameRescanRequestHandler($gameRescanService);
+
+        return new self($requestHandler);
+    }
+
+    /**
+     * @param array<string, mixed> $postData
+     * @param array<string, mixed> $serverData
+     */
+    public function processRequest(array $postData, array $serverData): void
+    {
+        $this->requestHandler->handleRequest($postData, $serverData);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a `GameRescanProcessor` class that wires together the rescan dependencies
- update the admin rescan endpoint to delegate to the new processor

## Testing
- php -l wwwroot/classes/Admin/GameRescanProcessor.php
- php -l wwwroot/admin/rescan_process.php

------
https://chatgpt.com/codex/tasks/task_e_68f15b4806c8832fbff0e3e2bac08dd6