### PR TITLE
Fix PSNP+ missing game link spacing

### DIFF
--- a/wwwroot/admin/psnp-plus.php
+++ b/wwwroot/admin/psnp-plus.php
@@ -39,11 +39,7 @@ try {
                     <div class="mb-3">
                         <?php foreach ($psnpPlusReport->getMissingGames() as $missingGame) { ?>
                             <p>
-                                PSNProfiles ID
-                                <a href="<?= $missingGame->getPsnprofilesUrl(); ?>" target="_blank" rel="noopener">
-                                    <?= $missingGame->getPsnprofilesId(); ?>
-                                </a>
-                                not in our database.
+                                PSNProfiles ID <a href="<?= $missingGame->getPsnprofilesUrl(); ?>" target="_blank" rel="noopener"><?= htmlentities($missingGame->getPsnprofilesId(), ENT_QUOTES, 'UTF-8'); ?></a> not in our database.
                             </p>
                         <?php } ?>
                     </div>


### PR DESCRIPTION
## Summary
- keep PSNP+ missing game links from including extra trailing whitespace by placing the ID inline and escaping it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f2a768b570832fa9829b943cb97037