### PR TITLE
Remove trademark symbols from new trophy titles

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1187,6 +1187,12 @@ class ThirtyMinuteCronJob implements CronJobInterface
             return $name;
         }
 
+        $name = str_replace('™', '', $name);
+
+        if ($name === '') {
+            return $name;
+        }
+
         $prefixPatterns = [
             '/^Trophy Set\b[:\s-]*/i',
         ];


### PR DESCRIPTION
## Summary
- strip the trademark symbol from trophy title names before formatting them during inserts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3ca93ea60832fb0f5f80b244c53b2