### PR TITLE
Remove trailing hyphen suffix from sanitized trophy titles

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1215,6 +1215,10 @@ class ThirtyMinuteCronJob implements CronJobInterface
             }
         }
 
+        if (substr($name, -2) === ' -') {
+            $name = rtrim(substr($name, 0, -2));
+        }
+
         $separatorPosition = strpos($name, ' - ');
 
         if ($separatorPosition !== false) {


### PR DESCRIPTION
## Summary
- strip a trailing `" -"` suffix when sanitizing trophy title names before inserts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3ce0bc460832f9adc58b60571039a