### PR TITLE
Capitalize 'Into' when storing trophy titles

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1263,7 +1263,6 @@ class ThirtyMinuteCronJob implements CronJobInterface
             'vs',
             'vs.',
             'from',
-            'into',
             'onto',
             'upon',
             'without',


### PR DESCRIPTION
## Summary
- remove "into" from the lowercase APA title-case word list so it is capitalized when saving trophy titles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3d1e4c0e8832faf46e92654ed08a8