### PR TITLE
Refactor cron entrypoints to use bootstrapper

### DIFF
--- a/wwwroot/classes/Cron/CronJobBootstrapper.php
+++ b/wwwroot/classes/Cron/CronJobBootstrapper.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/CronJobApplication.php';
+
+final class CronJobBootstrapper
+{
+    private CronJobApplication $application;
+
+    private string $projectRoot;
+
+    private ?\PDO $database = null;
+
+    private function __construct(string $projectRoot, CronJobApplication $application)
+    {
+        $this->projectRoot = rtrim($projectRoot, '/\\');
+        $this->application = $application;
+    }
+
+    public static function create(string $projectRoot, ?CronJobApplication $application = null): self
+    {
+        return new self($projectRoot, $application ?? CronJobApplication::create());
+    }
+
+    public function bootstrap(bool $loadComposerAutoload = false): void
+    {
+        $this->application->configureEnvironment();
+
+        if ($loadComposerAutoload) {
+            $this->requireProjectFile('vendor/autoload.php');
+        }
+
+        $this->requireProjectFile('init.php');
+
+        if (!isset($database)) {
+            throw new \RuntimeException('The init script did not define a $database variable.');
+        }
+
+        if (!$database instanceof \PDO) {
+            throw new \RuntimeException('The $database variable defined by the init script must be a PDO instance.');
+        }
+
+        $this->database = $database;
+    }
+
+    /**
+     * @param callable(\PDO): CronJobInterface $jobFactory
+     */
+    public function run(callable $jobFactory): void
+    {
+        $database = $this->getDatabase();
+
+        $this->application->run(static function () use ($jobFactory, $database): CronJobInterface {
+            return $jobFactory($database);
+        });
+    }
+
+    public function getDatabase(): \PDO
+    {
+        if (!$this->database instanceof \PDO) {
+            throw new \RuntimeException('CronJobBootstrapper::bootstrap() must be called before accessing the database.');
+        }
+
+        return $this->database;
+    }
+
+    private function requireProjectFile(string $relativePath): void
+    {
+        $fullPath = $this->projectRoot . '/' . ltrim($relativePath, '/\\');
+        require_once $fullPath;
+    }
+}

--- a/wwwroot/cron/30th_minute.php
+++ b/wwwroot/cron/30th_minute.php
@@ -2,22 +2,18 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
-require_once dirname(__DIR__) . '/classes/Cron/CronJobApplication.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobBootstrapper.php';
 require_once dirname(__DIR__) . '/classes/Cron/CronJobCliArguments.php';
-
-$application = CronJobApplication::create();
-$application->configureEnvironment();
-
-require_once dirname(__DIR__) . '/vendor/autoload.php';
-require_once dirname(__DIR__) . '/init.php';
 require_once dirname(__DIR__) . '/classes/TrophyCalculator.php';
 require_once dirname(__DIR__) . '/classes/Cron/ThirtyMinuteCronJob.php';
 
-$application->run(static function () use ($database): CronJobInterface {
-    $cliArguments = CronJobCliArguments::fromArgv($_SERVER['argv'] ?? []);
-    $workerId = $cliArguments->getWorkerId();
+$bootstrapper = CronJobBootstrapper::create(dirname(__DIR__));
+$bootstrapper->bootstrap(true);
 
+$cliArguments = CronJobCliArguments::fromArgv($_SERVER['argv'] ?? []);
+$workerId = $cliArguments->getWorkerId();
+
+$bootstrapper->run(static function (\PDO $database) use ($workerId): CronJobInterface {
     $trophyCalculator = new TrophyCalculator($database);
     $logger = new Psn100Logger($database);
 

--- a/wwwroot/cron/5th_minute.php
+++ b/wwwroot/cron/5th_minute.php
@@ -2,16 +2,13 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
-require_once dirname(__DIR__) . '/classes/Cron/CronJobApplication.php';
-
-$application = CronJobApplication::create();
-$application->configureEnvironment();
-
-require_once dirname(__DIR__) . '/init.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobBootstrapper.php';
 require_once dirname(__DIR__) . '/classes/Cron/PlayerRankingCronJob.php';
 
-$application->run(static function () use ($database): CronJobInterface {
+$bootstrapper = CronJobBootstrapper::create(dirname(__DIR__));
+$bootstrapper->bootstrap();
+
+$bootstrapper->run(static function (\PDO $database): CronJobInterface {
     $playerRankingUpdater = new PlayerRankingUpdater($database);
 
     return new PlayerRankingCronJob($playerRankingUpdater);

--- a/wwwroot/cron/daily.php
+++ b/wwwroot/cron/daily.php
@@ -2,13 +2,10 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
-require_once dirname(__DIR__) . '/classes/Cron/CronJobApplication.php';
-
-$application = CronJobApplication::create();
-$application->configureEnvironment();
-
-require_once dirname(__DIR__) . '/init.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobBootstrapper.php';
 require_once dirname(__DIR__) . '/classes/Cron/DailyCronJob.php';
 
-$application->run(static fn (): CronJobInterface => new DailyCronJob($database));
+$bootstrapper = CronJobBootstrapper::create(dirname(__DIR__));
+$bootstrapper->bootstrap();
+
+$bootstrapper->run(static fn (\PDO $database): CronJobInterface => new DailyCronJob($database));

--- a/wwwroot/cron/hourly.php
+++ b/wwwroot/cron/hourly.php
@@ -2,13 +2,10 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
-require_once dirname(__DIR__) . '/classes/Cron/CronJobApplication.php';
-
-$application = CronJobApplication::create();
-$application->configureEnvironment();
-
-require_once dirname(__DIR__) . '/init.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobBootstrapper.php';
 require_once dirname(__DIR__) . '/classes/Cron/HourlyCronJob.php';
 
-$application->run(static fn (): CronJobInterface => new HourlyCronJob($database));
+$bootstrapper = CronJobBootstrapper::create(dirname(__DIR__));
+$bootstrapper->bootstrap();
+
+$bootstrapper->run(static fn (\PDO $database): CronJobInterface => new HourlyCronJob($database));

--- a/wwwroot/cron/weekly.php
+++ b/wwwroot/cron/weekly.php
@@ -2,13 +2,10 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/classes/Cron/CronJobRunner.php';
-require_once dirname(__DIR__) . '/classes/Cron/CronJobApplication.php';
-
-$application = CronJobApplication::create();
-$application->configureEnvironment();
-
-require_once dirname(__DIR__) . '/init.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobBootstrapper.php';
 require_once dirname(__DIR__) . '/classes/Cron/WeeklyCronJob.php';
 
-$application->run(static fn (): CronJobInterface => new WeeklyCronJob($database));
+$bootstrapper = CronJobBootstrapper::create(dirname(__DIR__));
+$bootstrapper->bootstrap();
+
+$bootstrapper->run(static fn (\PDO $database): CronJobInterface => new WeeklyCronJob($database));


### PR DESCRIPTION
## Summary
- add a CronJobBootstrapper helper to encapsulate cron environment setup and database bootstrapping
- refactor all cron entrypoints to construct jobs via the bootstrapper for a consistent OOP workflow

## Testing
- php -l wwwroot/classes/Cron/CronJobBootstrapper.php wwwroot/cron/30th_minute.php wwwroot/cron/5th_minute.php wwwroot/cron/daily.php wwwroot/cron/hourly.php wwwroot/cron/weekly.php

------
https://chatgpt.com/codex/tasks/task_e_68f15b4806c8832fbff0e3e2bac08dd6