### PR TITLE
Refactor navigation rendering to object

### DIFF
--- a/wwwroot/classes/NavigationBarRenderer.php
+++ b/wwwroot/classes/NavigationBarRenderer.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/NavigationState.php';
+require_once __DIR__ . '/NavigationMenu.php';
+
+final class NavigationBarRenderer
+{
+    private NavigationState $state;
+
+    private NavigationMenu $menu;
+
+    private function __construct(NavigationState $state, NavigationMenu $menu)
+    {
+        $this->state = $state;
+        $this->menu = $menu;
+    }
+
+    public static function create(NavigationState $state, ?NavigationMenu $menu = null): self
+    {
+        return new self($state, $menu ?? NavigationMenu::createDefault($state));
+    }
+
+    public function render(): string
+    {
+        $sort = $this->state->getSort();
+        $player = $this->state->getPlayer();
+        $filter = $this->state->getFilter();
+        $search = $this->state->getSearch();
+
+        $itemsHtml = $this->renderNavigationItems();
+
+        return <<<HTML
+<nav class="navbar navbar-expand-md navbar-dark bg-dark mb-2">
+    <div class="container">
+        <a class="navbar-brand" href="/">
+            <img src="/img/logo-via-logohub.png" alt="PSN 100%" height="24">
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="navbarCollapse">
+            <form action="/game" class="d-flex" role="search">
+                <input type="hidden" name="sort" value="{$sort}">
+                <input type="hidden" name="player" value="{$player}">
+                <input type="hidden" name="filter" value="{$filter}">
+                <input class="form-control me-2" name="search" type="search" placeholder="Search game..." aria-label="Search" value="{$search}">
+                <button class="btn btn-outline-primary" type="submit">Search</button>
+            </form>
+
+            <ul class="navbar-nav ms-auto mb-2 mb-md-0">
+{$itemsHtml}
+            </ul>
+        </div>
+    </div>
+</nav>
+HTML;
+    }
+
+    private function renderNavigationItems(): string
+    {
+        $items = [];
+
+        foreach ($this->menu->getItems() as $item) {
+            $linkClass = htmlspecialchars($item->getLinkCssClass(), ENT_QUOTES, 'UTF-8');
+            $href = htmlspecialchars($item->getHref(), ENT_QUOTES, 'UTF-8');
+            $label = htmlspecialchars($item->getLabel(), ENT_QUOTES, 'UTF-8');
+            $ariaAttribute = $this->renderAriaAttribute($item->getAriaCurrentValue());
+
+            $items[] = sprintf(
+                '                <li class="nav-item"><a class="%s" href="%s"%s>%s</a></li>',
+                $linkClass,
+                $href,
+                $ariaAttribute,
+                $label
+            );
+        }
+
+        return implode(PHP_EOL, $items);
+    }
+
+    private function renderAriaAttribute(?string $ariaCurrent): string
+    {
+        if ($ariaCurrent === null) {
+            return '';
+        }
+
+        $value = htmlspecialchars($ariaCurrent, ENT_QUOTES, 'UTF-8');
+
+        return ' aria-current="' . $value . '"';
+    }
+}

--- a/wwwroot/nav.php
+++ b/wwwroot/nav.php
@@ -1,46 +1,7 @@
 <?php
-require_once __DIR__ . '/classes/NavigationState.php';
-require_once __DIR__ . '/classes/NavigationMenu.php';
+require_once __DIR__ . '/classes/NavigationBarRenderer.php';
 
-$navigationState = NavigationState::fromGlobals($_SERVER, $_GET);
-$navigationMenu = NavigationMenu::createDefault($navigationState);
-?>
+$navigationState = NavigationState::fromGlobals($_SERVER ?? [], $_GET ?? []);
+$navigationBarRenderer = NavigationBarRenderer::create($navigationState);
 
-<nav class="navbar navbar-expand-md navbar-dark bg-dark mb-2">
-    <div class="container">
-        <a class="navbar-brand" href="/">
-            <img src="/img/logo-via-logohub.png" alt="PSN 100%" height="24">
-        </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div class="collapse navbar-collapse" id="navbarCollapse">
-            <form action="/game" class="d-flex" role="search">
-                <input type="hidden" name="sort" value="<?= $navigationState->getSort(); ?>">
-                <input type="hidden" name="player" value="<?= $navigationState->getPlayer(); ?>">
-                <input type="hidden" name="filter" value="<?= $navigationState->getFilter(); ?>">
-                <input class="form-control me-2" name="search" type="search" placeholder="Search game..." aria-label="Search" value="<?= $navigationState->getSearch(); ?>">
-                <button class="btn btn-outline-primary" type="submit">Search</button>
-            </form>
-
-            <ul class="navbar-nav ms-auto mb-2 mb-md-0">
-                <?php foreach ($navigationMenu->getItems() as $item) { ?>
-                    <?php
-                    $linkClass = htmlspecialchars($item->getLinkCssClass(), ENT_QUOTES, 'UTF-8');
-                    $href = htmlspecialchars($item->getHref(), ENT_QUOTES, 'UTF-8');
-                    $ariaCurrent = $item->getAriaCurrentValue();
-                    $ariaAttribute = $ariaCurrent !== null
-                        ? ' aria-current="' . htmlspecialchars($ariaCurrent, ENT_QUOTES, 'UTF-8') . '"'
-                        : '';
-                    ?>
-                    <li class="nav-item">
-                        <a class="<?= $linkClass; ?>" href="<?= $href; ?>"<?= $ariaAttribute; ?>>
-                            <?= htmlspecialchars($item->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
-                        </a>
-                    </li>
-                <?php } ?>
-            </ul>
-        </div>
-    </div>
-</nav>
+echo $navigationBarRenderer->render();


### PR DESCRIPTION
## Summary
- introduce a NavigationBarRenderer that encapsulates composing the navigation HTML using the existing state and menu objects
- simplify nav.php to delegate rendering to the new renderer for a cleaner, object-oriented entrypoint

## Testing
- php -l wwwroot/classes/NavigationBarRenderer.php
- php -l wwwroot/nav.php

------
https://chatgpt.com/codex/tasks/task_e_68f15b4806c8832fbff0e3e2bac08dd6