### PR TITLE
Remove trailing periods from trophy titles

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1229,6 +1229,12 @@ class ThirtyMinuteCronJob implements CronJobInterface
             }
         }
 
+        $name = rtrim($name);
+
+        if ($name !== '') {
+            $name = rtrim($name, '.');
+        }
+
         return trim($name);
     }
 


### PR DESCRIPTION
## Summary
- trim trailing periods from sanitized trophy title names before inserting them into the database

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3f06a7760832faf2bcd61baab2912