### PR TITLE
Require init script within cron bootstrap scope

### DIFF
--- a/wwwroot/classes/Cron/CronJobBootstrapper.php
+++ b/wwwroot/classes/Cron/CronJobBootstrapper.php
@@ -31,7 +31,8 @@ final class CronJobBootstrapper
             $this->requireProjectFile('vendor/autoload.php');
         }
 
-        $this->requireProjectFile('init.php', false);
+        $initScript = $this->getProjectFilePath('init.php');
+        require $initScript;
 
         if (!isset($database)) {
             throw new \RuntimeException('The init script did not define a $database variable.');
@@ -67,12 +68,17 @@ final class CronJobBootstrapper
 
     private function requireProjectFile(string $relativePath, bool $requireOnce = true): void
     {
-        $fullPath = $this->projectRoot . '/' . ltrim($relativePath, '/\\');
+        $fullPath = $this->getProjectFilePath($relativePath);
         if ($requireOnce) {
             require_once $fullPath;
             return;
         }
 
         require $fullPath;
+    }
+
+    private function getProjectFilePath(string $relativePath): string
+    {
+        return $this->projectRoot . '/' . ltrim($relativePath, '/\\');
     }
 }


### PR DESCRIPTION
## Summary
- update the cron bootstrapper to re-require init.php each run so the database handle is defined
- allow choosing between require and require_once when loading project files

## Testing
- php -l wwwroot/classes/Cron/CronJobBootstrapper.php

------
https://chatgpt.com/codex/tasks/task_e_68f3f38a2500832f8a9525ad3e4837a4