### PR TITLE
Normalize PSPC platform label on trophy title insert

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -557,7 +557,12 @@ class ThirtyMinuteCronJob implements CronJobInterface
                             $query->bindValue(":icon_url", $trophyTitleIconFilename, PDO::PARAM_STR);
                             $platforms = "";
                             foreach ($trophyTitle->platform() as $platform) {
-                                $platforms .= $platform->value .",";
+                                $platformValue = $platform->value;
+                                if ($platformValue === 'PSPC') {
+                                    $platformValue = 'PC';
+                                }
+
+                                $platforms .= $platformValue .",";
                             }
                             $platforms = rtrim($platforms, ",");
                             $query->bindValue(":platform", $platforms, PDO::PARAM_STR);


### PR DESCRIPTION
## Summary
- map the PSPC platform identifier to PC when inserting trophy title records so the stored platform list matches expectations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4db30efa0832f899e322ac7ea6733