### PR TITLE
Refactor search helper into injectable service

### DIFF
--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -11,9 +11,12 @@ class GameListService
 
     private PDO $database;
 
-    public function __construct(PDO $database)
+    private SearchQueryHelper $searchQueryHelper;
+
+    public function __construct(PDO $database, SearchQueryHelper $searchQueryHelper)
     {
         $this->database = $database;
+        $this->searchQueryHelper = $searchQueryHelper;
     }
 
     public function resolvePlayer(?string $onlineId): ?string
@@ -105,7 +108,7 @@ class GameListService
         $statement->bindValue(':online_id', $player, PDO::PARAM_STR);
 
         if ($filter->shouldApplySearch()) {
-            SearchQueryHelper::bindSearchParameters(
+            $this->searchQueryHelper->bindSearchParameters(
                 $statement,
                 $filter->getSearch(),
                 $bindPrefix
@@ -160,7 +163,7 @@ class GameListService
             'ttp.progress',
         ];
 
-        $columns = SearchQueryHelper::addFulltextSelectColumns(
+        $columns = $this->searchQueryHelper->addFulltextSelectColumns(
             $columns,
             'tt.name',
             $filter->shouldApplySearch(),
@@ -215,7 +218,7 @@ class GameListService
                 break;
         }
 
-        $conditions = SearchQueryHelper::appendFulltextCondition(
+        $conditions = $this->searchQueryHelper->appendFulltextCondition(
             $conditions,
             $filter->shouldApplySearch(),
             'tt.name',

--- a/wwwroot/classes/PlayerGamesPageContext.php
+++ b/wwwroot/classes/PlayerGamesPageContext.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/PageMetaData.php';
 require_once __DIR__ . '/PlayerGamesFilter.php';
 require_once __DIR__ . '/PlayerGamesPage.php';
 require_once __DIR__ . '/PlayerGamesService.php';
+require_once __DIR__ . '/SearchQueryHelper.php';
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/PlayerSummaryService.php';
 
@@ -57,7 +58,8 @@ final class PlayerGamesPageContext
         $playerSummary = $playerSummaryService->getSummary($accountId);
 
         $filter = PlayerGamesFilter::fromArray($queryParameters);
-        $playerGamesService = new PlayerGamesService($database);
+        $searchQueryHelper = new SearchQueryHelper();
+        $playerGamesService = new PlayerGamesService($database, $searchQueryHelper);
         $playerGamesPage = new PlayerGamesPage(
             $playerGamesService,
             $filter,

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -20,9 +20,12 @@ class PlayerGamesService
 
     private PDO $database;
 
-    public function __construct(PDO $database)
+    private SearchQueryHelper $searchQueryHelper;
+
+    public function __construct(PDO $database, SearchQueryHelper $searchQueryHelper)
     {
         $this->database = $database;
+        $this->searchQueryHelper = $searchQueryHelper;
     }
 
     public function countPlayerGames(int $accountId, PlayerGamesFilter $filter): int
@@ -67,7 +70,7 @@ class PlayerGamesService
             'ttp.rarity_points',
         ];
 
-        $columns = SearchQueryHelper::addFulltextSelectColumns(
+        $columns = $this->searchQueryHelper->addFulltextSelectColumns(
             $columns,
             'tt.name',
             $filter->shouldIncludeScoreColumn(),
@@ -118,7 +121,7 @@ class PlayerGamesService
             "tgp.group_id = 'default'",
         ];
 
-        $conditions = SearchQueryHelper::appendFulltextCondition(
+        $conditions = $this->searchQueryHelper->appendFulltextCondition(
             $conditions,
             $filter->shouldApplyFulltextCondition(),
             'tt.name',
@@ -175,7 +178,7 @@ class PlayerGamesService
         $statement->bindValue(':account_id', $accountId, PDO::PARAM_INT);
 
         if ($filter->shouldApplyFulltextCondition()) {
-            SearchQueryHelper::bindSearchParameters(
+            $this->searchQueryHelper->bindSearchParameters(
                 $statement,
                 $filter->getSearch(),
                 $bindPrefix

--- a/wwwroot/games.php
+++ b/wwwroot/games.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 require_once __DIR__ . '/classes/GameListFilter.php';
 require_once __DIR__ . '/classes/GameListService.php';
 require_once __DIR__ . '/classes/GameListPage.php';
+require_once __DIR__ . '/classes/SearchQueryHelper.php';
 
 $title = "Games ~ PSN 100%";
 
 $filter = GameListFilter::fromArray($_GET ?? []);
-$gameListService = new GameListService($database);
+$searchQueryHelper = new SearchQueryHelper();
+$gameListService = new GameListService($database, $searchQueryHelper);
 $gameListPage = new GameListPage($gameListService, $filter);
 
 $filter = $gameListPage->getFilter();


### PR DESCRIPTION
## Summary
- convert `SearchQueryHelper` from static helpers to an instance-based class
- inject the helper into `PlayerGamesService` and `GameListService`, adjusting the player page context to build it
- instantiate and share the helper when assembling the games list page

## Testing
- php -l wwwroot/classes/SearchQueryHelper.php
- php -l wwwroot/classes/PlayerGamesService.php
- php -l wwwroot/classes/GameListService.php
- php -l wwwroot/classes/PlayerGamesPageContext.php
- php -l wwwroot/games.php

------
https://chatgpt.com/codex/tasks/task_e_68f3ed403414832f8e1e7960b9a2a22f