### PR TITLE
Refactor admin pages to share OOP layout

### DIFF
--- a/wwwroot/admin/cheater.php
+++ b/wwwroot/admin/cheater.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once '../init.php';
 require_once '../classes/Admin/CheaterRequestHandler.php';
+require_once '../classes/Admin/AdminLayoutRenderer.php';
 
 $cheaterService = new CheaterService($database);
 $requestHandler = new CheaterRequestHandler($cheaterService);
@@ -13,34 +14,24 @@ $result = $requestHandler->handle($request);
 $successMessage = $result->getSuccessMessage();
 $errorMessage = $result->getErrorMessage();
 
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin ~ Cheater</title>
-    </head>
-    <body>
-        <div class="p-4">
-            <a href="/admin/">Back</a><br><br>
-            <form method="post" autocomplete="off">
-                Player:<br>
-                <input type="text" name="player"><br><br>
-                <input type="submit" value="Submit">
-            </form>
+$layoutRenderer = new AdminLayoutRenderer();
 
-            <?php
-            if ($successMessage !== null) {
-                echo $successMessage;
-            }
+echo $layoutRenderer->render('Admin ~ Cheater', static function () use ($successMessage, $errorMessage): void {
+    ?>
+    <form method="post" autocomplete="off">
+        Player:<br>
+        <input type="text" name="player"><br><br>
+        <input type="submit" value="Submit">
+    </form>
 
-            if ($errorMessage !== null) {
-                echo $errorMessage;
-            }
-            ?>
-        </div>
-    </body>
-</html>
+    <?php
+    if ($successMessage !== null) {
+        echo $successMessage;
+    }
+
+    if ($errorMessage !== null) {
+        echo $errorMessage;
+    }
+    ?>
+    <?php
+});

--- a/wwwroot/admin/copy.php
+++ b/wwwroot/admin/copy.php
@@ -5,33 +5,25 @@ declare(strict_types=1);
 require_once '../init.php';
 require_once '../classes/Admin/GameCopyService.php';
 require_once '../classes/Admin/GameCopyHandler.php';
+require_once '../classes/Admin/AdminLayoutRenderer.php';
 
 $gameCopyService = new GameCopyService($database);
 $gameCopyHandler = new GameCopyHandler($gameCopyService);
 $message = $gameCopyHandler->handle($_POST);
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin ~ Copy</title>
-    </head>
-    <body>
-        <div class="p-4">
-            <a href="/admin/">Back</a><br><br>
-            <form method="post" autocomplete="off">
-                Game Child ID:<br>
-                <input type="number" name="child"><br>
-                Game Parent ID:<br>
-                <input type="number" name="parent"><br>
-                <br>
-                <input type="submit" value="Submit">
-            </form>
 
-            <?= $message; ?>
-        </div>
-    </body>
-</html>
+$layoutRenderer = new AdminLayoutRenderer();
+
+echo $layoutRenderer->render('Admin ~ Copy', static function () use ($message): void {
+    ?>
+    <form method="post" autocomplete="off">
+        Game Child ID:<br>
+        <input type="number" name="child"><br>
+        Game Parent ID:<br>
+        <input type="number" name="parent"><br>
+        <br>
+        <input type="submit" value="Submit">
+    </form>
+
+    <?= $message; ?>
+    <?php
+});

--- a/wwwroot/admin/detail.php
+++ b/wwwroot/admin/detail.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 require_once '../init.php';
@@ -6,6 +7,7 @@ require_once '../classes/Admin/GameDetail.php';
 require_once '../classes/Admin/GameDetailService.php';
 require_once '../classes/Admin/GameDetailPage.php';
 require_once '../classes/Admin/GameDetailPageResult.php';
+require_once '../classes/Admin/AdminLayoutRenderer.php';
 
 $gameDetailService = new GameDetailService($database);
 $gameDetailPage = new GameDetailPage($gameDetailService);
@@ -15,63 +17,53 @@ $gameDetail = $pageResult->getGameDetail();
 $success = $pageResult->getSuccessMessage();
 $error = $pageResult->getErrorMessage();
 
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin ~ Game Details</title>
-    </head>
-    <body>
-        <div class="p-4">
-            <a href="/admin/">Back</a><br><br>
-            <form method="get" autocomplete="off">
-                Game ID:<br>
-                <input type="number" name="game"><br>
-                <input type="submit" value="Fetch">
-            </form>
+$layoutRenderer = new AdminLayoutRenderer();
 
-            <?php if ($gameDetail !== null) { ?>
-                <form method="post" autocomplete="off">
-                    <input type="hidden" name="game" value="<?= $gameDetail->getId(); ?>"><br>
-                    Name:<br>
-                    <input type="text" name="name" style="width: 859px;" value="<?= htmlentities($gameDetail->getName(), ENT_QUOTES, 'UTF-8'); ?>"><br>
-                    Icon URL:<br>
-                    <input type="text" name="icon_url" style="width: 859px;" value="<?= htmlentities($gameDetail->getIconUrl(), ENT_QUOTES, 'UTF-8'); ?>"><br>
-                    Platform:<br>
-                    <input type="text" name="platform" style="width: 859px;" value="<?= htmlentities($gameDetail->getPlatform(), ENT_QUOTES, 'UTF-8'); ?>"><br>
-                    Set Version:<br>
-                    <input type="text" name="set_version" style="width: 859px;" value="<?= htmlentities($gameDetail->getSetVersion(), ENT_QUOTES, 'UTF-8'); ?>"><br>
-                    Region:<br>
-                    <input type="text" name="region" style="width: 859px;" value="<?= htmlentities((string) ($gameDetail->getRegion() ?? ''), ENT_QUOTES, 'UTF-8'); ?>"><br>
-                    NP Communication ID:<br>
-                    <input type="text" name="np_communication_id" style="width: 859px;" value="<?= htmlentities((string) ($gameDetail->getNpCommunicationId() ?? ''), ENT_QUOTES, 'UTF-8'); ?>" readonly><br>
-                    PSNProfiles ID:<br>
-                    <input type="text" name="psnprofiles_id" style="width: 859px;" value="<?= htmlentities((string) ($gameDetail->getPsnprofilesId() ?? ''), ENT_QUOTES, 'UTF-8'); ?>"><br>
-                    Message:<br>
-                    <textarea name="message" rows="6" cols="120"><?= $gameDetail->getMessage(); ?></textarea><br><br>
-                    <input type="submit" value="Submit">
-                </form>
+echo $layoutRenderer->render('Admin ~ Game Details', static function () use ($gameDetail, $success, $error): void {
+    ?>
+    <form method="get" autocomplete="off">
+        Game ID:<br>
+        <input type="number" name="game"><br>
+        <input type="submit" value="Fetch">
+    </form>
 
-                <p>
-                    Standard messages:<br>
-                    <?= htmlentities("This game is delisted (<a href=\"https://github.com/Ragowit/psn100/issues/\">source</a>). No trophies will be accounted for on any leaderboard."); ?><br>
-                    <?= htmlentities("This game is obsolete, no trophies will be accounted for on any leaderboard. Please play <a href=\"/game/\"></a> instead."); ?><br>
-                </p>
-            <?php } ?>
+    <?php if ($gameDetail !== null) { ?>
+        <form method="post" autocomplete="off">
+            <input type="hidden" name="game" value="<?= $gameDetail->getId(); ?>"><br>
+            Name:<br>
+            <input type="text" name="name" style="width: 859px;" value="<?= htmlentities($gameDetail->getName(), ENT_QUOTES, 'UTF-8'); ?>"><br>
+            Icon URL:<br>
+            <input type="text" name="icon_url" style="width: 859px;" value="<?= htmlentities($gameDetail->getIconUrl(), ENT_QUOTES, 'UTF-8'); ?>"><br>
+            Platform:<br>
+            <input type="text" name="platform" style="width: 859px;" value="<?= htmlentities($gameDetail->getPlatform(), ENT_QUOTES, 'UTF-8'); ?>"><br>
+            Set Version:<br>
+            <input type="text" name="set_version" style="width: 859px;" value="<?= htmlentities($gameDetail->getSetVersion(), ENT_QUOTES, 'UTF-8'); ?>"><br>
+            Region:<br>
+            <input type="text" name="region" style="width: 859px;" value="<?= htmlentities((string) ($gameDetail->getRegion() ?? ''), ENT_QUOTES, 'UTF-8'); ?>"><br>
+            NP Communication ID:<br>
+            <input type="text" name="np_communication_id" style="width: 859px;" value="<?= htmlentities((string) ($gameDetail->getNpCommunicationId() ?? ''), ENT_QUOTES, 'UTF-8'); ?>" readonly><br>
+            PSNProfiles ID:<br>
+            <input type="text" name="psnprofiles_id" style="width: 859px;" value="<?= htmlentities((string) ($gameDetail->getPsnprofilesId() ?? ''), ENT_QUOTES, 'UTF-8'); ?>"><br>
+            Message:<br>
+            <textarea name="message" rows="6" cols="120"><?= $gameDetail->getMessage(); ?></textarea><br><br>
+            <input type="submit" value="Submit">
+        </form>
 
-            <?php
-            if ($error !== null) {
-                echo $error;
-            }
+        <p>
+            Standard messages:<br>
+            <?= htmlentities("This game is delisted (<a href=\"https://github.com/Ragowit/psn100/issues/\">source</a>).No trophies will be accounted for on any leaderboard."); ?><br>
+            <?= htmlentities("This game is obsolete, no trophies will be accounted for on any leaderboard. Please play <a href=\"/game/\"></a> instead."); ?><br>
+        </p>
+    <?php } ?>
 
-            if ($success !== null) {
-                echo $success;
-            }
-            ?>
-        </div>
-    </body>
-</html>
+    <?php
+    if ($error !== null) {
+        echo $error;
+    }
+
+    if ($success !== null) {
+        echo $success;
+    }
+    ?>
+    <?php
+});

--- a/wwwroot/admin/index.php
+++ b/wwwroot/admin/index.php
@@ -3,30 +3,24 @@
 declare(strict_types=1);
 
 require_once '../classes/Admin/AdminNavigation.php';
+require_once '../classes/Admin/AdminLayoutRenderer.php';
 
 $navigation = new AdminNavigation();
 $navigationItems = $navigation->getItems();
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin</title>
-    </head>
-    <body>
-        <div class="p-4">
-            <ul>
-                <?php foreach ($navigationItems as $item) { ?>
-                    <li>
-                        <a href="<?= htmlspecialchars($item->getHref(), ENT_QUOTES, 'UTF-8'); ?>">
-                            <?= htmlspecialchars($item->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
-                        </a>
-                    </li>
-                <?php } ?>
-            </ul>
-        </div>
-    </body>
-</html>
+
+$layoutRenderer = new AdminLayoutRenderer();
+$options = AdminLayoutOptions::create()->withBackLink(false);
+
+echo $layoutRenderer->render('Admin', static function () use ($navigationItems): void {
+    ?>
+    <ul>
+        <?php foreach ($navigationItems as $item) { ?>
+            <li>
+                <a href="<?= htmlspecialchars($item->getHref(), ENT_QUOTES, 'UTF-8'); ?>">
+                    <?= htmlspecialchars($item->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
+                </a>
+            </li>
+        <?php } ?>
+    </ul>
+    <?php
+}, $options);

--- a/wwwroot/admin/merge.php
+++ b/wwwroot/admin/merge.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 require_once __DIR__ . '/../classes/ExecutionEnvironmentConfigurator.php';
@@ -10,45 +11,37 @@ ExecutionEnvironmentConfigurator::create()
     ->enableUnlimitedExecution()
     ->configure();
 
-require_once("../init.php");
-require_once("../classes/TrophyMergeService.php");
-require_once("../classes/Admin/TrophyMergeRequestHandler.php");
+require_once '../init.php';
+require_once '../classes/TrophyMergeService.php';
+require_once '../classes/Admin/TrophyMergeRequestHandler.php';
+require_once '../classes/Admin/AdminLayoutRenderer.php';
 
 $mergeService = new TrophyMergeService($database);
 $requestHandler = new TrophyMergeRequestHandler($mergeService);
 $message = $requestHandler->handle($_POST ?? []);
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin ~ Merge Games</title>
-    </head>
-    <body>
-        <div class="p-4">
-            <a href="/admin/">Back</a><br><br>
-            <form method="post" autocomplete="off">
-                Game Child ID:<br>
-                <input type="number" name="child"><br>
-                Game Parent ID:<br>
-                <input type="number" name="parent"><br>
-                Method:<br>
-                <select name="method">
-                    <option value="order">Order</option>
-                    <option value="name">Name</option>
-                    <option value="icon">Icon</option>
-                </select><br><br>
-                Trophy Child ID:<br>
-                <input type="text" name="trophychild"><br>
-                Trophy Parent ID:<br>
-                <input type="number" name="trophyparent"><br><br>
-                <input type="submit" value="Submit">
-            </form>
 
-            <?= $message; ?>
-        </div>
-    </body>
-</html>
+$layoutRenderer = new AdminLayoutRenderer();
+
+echo $layoutRenderer->render('Admin ~ Merge Games', static function () use ($message): void {
+    ?>
+    <form method="post" autocomplete="off">
+        Game Child ID:<br>
+        <input type="number" name="child"><br>
+        Game Parent ID:<br>
+        <input type="number" name="parent"><br>
+        Method:<br>
+        <select name="method">
+            <option value="order">Order</option>
+            <option value="name">Name</option>
+            <option value="icon">Icon</option>
+        </select><br><br>
+        Trophy Child ID:<br>
+        <input type="text" name="trophychild"><br>
+        Trophy Parent ID:<br>
+        <input type="number" name="trophyparent"><br><br>
+        <input type="submit" value="Submit">
+    </form>
+
+    <?= $message; ?>
+    <?php
+});

--- a/wwwroot/admin/possible.php
+++ b/wwwroot/admin/possible.php
@@ -4,38 +4,30 @@ declare(strict_types=1);
 require_once '../init.php';
 require_once '../classes/Admin/PossibleCheaterPage.php';
 require_once '../classes/Admin/PossibleCheaterService.php';
+require_once '../classes/Admin/AdminLayoutRenderer.php';
 
 $possibleCheaterService = new PossibleCheaterService($database);
 $possibleCheaterPage = new PossibleCheaterPage($possibleCheaterService);
 $possibleCheaterReport = $possibleCheaterPage->getReport();
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin ~ Possible Cheaters</title>
-    </head>
-    <body>
-        <div class="p-4">
-            <a href="/admin/">Back</a><br><br>
-            <?php foreach ($possibleCheaterReport->getGeneralCheaters() as $possibleCheater): ?>
-                <a href="<?= htmlspecialchars($possibleCheater->getProfileUrl($utility), ENT_QUOTES, 'UTF-8'); ?>">
-                    <?= htmlspecialchars($possibleCheater->getPlayerName(), ENT_QUOTES, 'UTF-8'); ?> (<?= $possibleCheater->getAccountId(); ?>)
-                </a><br>
-            <?php endforeach; ?>
 
-            <?php foreach ($possibleCheaterReport->getSections() as $section): ?>
-                <br>
-                <?= htmlspecialchars($section->getTitle(), ENT_QUOTES, 'UTF-8'); ?><br>
-                <?php foreach ($section->getEntries() as $entry): ?>
-                    <a href="<?= htmlspecialchars($entry->getUrl(), ENT_QUOTES, 'UTF-8'); ?>">
-                        <?= htmlspecialchars($entry->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?> (<?= $entry->getAccountId(); ?>)
-                    </a><br>
-                <?php endforeach; ?>
-            <?php endforeach; ?>
-        </div>
-    </body>
-</html>
+$layoutRenderer = new AdminLayoutRenderer();
+
+echo $layoutRenderer->render('Admin ~ Possible Cheaters', static function () use ($possibleCheaterReport, $utility): void {
+    ?>
+    <?php foreach ($possibleCheaterReport->getGeneralCheaters() as $possibleCheater): ?>
+        <a href="<?= htmlspecialchars($possibleCheater->getProfileUrl($utility), ENT_QUOTES, 'UTF-8'); ?>">
+            <?= htmlspecialchars($possibleCheater->getPlayerName(), ENT_QUOTES, 'UTF-8'); ?> (<?= $possibleCheater->getAccountId(); ?>)
+        </a><br>
+    <?php endforeach; ?>
+
+    <?php foreach ($possibleCheaterReport->getSections() as $section): ?>
+        <br>
+        <?= htmlspecialchars($section->getTitle(), ENT_QUOTES, 'UTF-8'); ?><br>
+        <?php foreach ($section->getEntries() as $entry): ?>
+            <a href="<?= htmlspecialchars($entry->getUrl(), ENT_QUOTES, 'UTF-8'); ?>">
+                <?= htmlspecialchars($entry->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?> (<?= $entry->getAccountId(); ?>)
+            </a><br>
+        <?php endforeach; ?>
+    <?php endforeach; ?>
+    <?php
+});

--- a/wwwroot/admin/psnp-plus.php
+++ b/wwwroot/admin/psnp-plus.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../init.php';
 require_once __DIR__ . '/../classes/Admin/PsnpPlusService.php';
+require_once __DIR__ . '/../classes/Admin/AdminLayoutRenderer.php';
 
 $psnpPlusService = new PsnpPlusService($database);
 $psnpPlusReport = null;
@@ -14,77 +15,67 @@ try {
 } catch (RuntimeException $exception) {
     $errorMessage = $exception->getMessage();
 }
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin ~ PSNP+</title>
-    </head>
-    <body>
-        <div class="p-4">
-            <a href="/admin/">Back</a><br><br>
 
-            <h1>PSNP+ changes</h1>
+$layoutRenderer = new AdminLayoutRenderer();
 
-            <?php if ($errorMessage !== null) { ?>
-                <div class="alert alert-danger" role="alert">
-                    <?= htmlentities($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
-                </div>
-            <?php } elseif ($psnpPlusReport !== null) { ?>
-                <?php if ($psnpPlusReport->hasMissingGames()) { ?>
-                    <div class="mb-3">
-                        <?php foreach ($psnpPlusReport->getMissingGames() as $missingGame) { ?>
-                            <p>
-                                PSNProfiles ID <a href="<?= $missingGame->getPsnprofilesUrl(); ?>" target="_blank" rel="noopener"><?= htmlentities($missingGame->getPsnprofilesId(), ENT_QUOTES, 'UTF-8'); ?></a> not in our database.
-                            </p>
-                        <?php } ?>
-                    </div>
-                <?php } ?>
+echo $layoutRenderer->render('Admin ~ PSNP+', static function () use ($psnpPlusReport, $errorMessage): void {
+    ?>
+    <h1>PSNP+ changes</h1>
 
-                <?php foreach ($psnpPlusReport->getGameDifferences() as $difference) { ?>
-                    <div class="mb-3">
-                        <strong>
-                            <a href="../game/<?= $difference->getGameId(); ?>" target="_blank" rel="noopener">
-                                <?= htmlentities($difference->getGameName(), ENT_QUOTES, 'UTF-8'); ?>
-                            </a>
-                        </strong><br>
-
-                        <?php if ($difference->hasUnobtainable()) { ?>
-                            <a href="unobtainable.php?status=1&amp;trophy=<?= $difference->getUnobtainableTrophyIdQuery(); ?>">
-                                Unobtainable
-                            </a>: <?= htmlentities($difference->getUnobtainableOrderList(), ENT_QUOTES, 'UTF-8'); ?><br>
-                        <?php } ?>
-
-                        <?php if ($difference->hasObtainable()) { ?>
-                            <a href="unobtainable.php?status=0&amp;trophy=<?= $difference->getObtainableTrophyIdQuery(); ?>">
-                                Obtainable
-                            </a>: <?= htmlentities($difference->getObtainableOrderList(), ENT_QUOTES, 'UTF-8'); ?><br>
-                        <?php } ?>
-                    </div>
-                <?php } ?>
-
-                <h1>No longer in PSNP+ (all trophies fixed!)</h1>
-
-                <?php foreach ($psnpPlusReport->getFixedGames() as $fixedGame) { ?>
-                    <div class="mb-3">
-                        <strong>
-                            <a href="../game/<?= $fixedGame->getGameId(); ?>" target="_blank" rel="noopener">
-                                <?= htmlentities($fixedGame->getGameName(), ENT_QUOTES, 'UTF-8'); ?>
-                            </a>
-                        </strong><br>
-
-                        <?php if ($fixedGame->hasTrophies()) { ?>
-                            <a href="unobtainable.php?status=0&amp;trophy=<?= $fixedGame->getTrophyIdQuery(); ?>">
-                                Obtainable
-                            </a>: <?= htmlentities($fixedGame->getTrophyIdList(), ENT_QUOTES, 'UTF-8'); ?><br>
-                        <?php } ?>
-                    </div>
-                <?php } ?>
-            <?php } ?>
+    <?php if ($errorMessage !== null) { ?>
+        <div class="alert alert-danger" role="alert">
+            <?= htmlentities($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
         </div>
-    </body>
-</html>
+    <?php } elseif ($psnpPlusReport !== null) { ?>
+        <?php if ($psnpPlusReport->hasMissingGames()) { ?>
+            <div class="mb-3">
+                <?php foreach ($psnpPlusReport->getMissingGames() as $missingGame) { ?>
+                    <p>
+                        PSNProfiles ID <a href="<?= $missingGame->getPsnprofilesUrl(); ?>" target="_blank" rel="noopener"><?= htmlentities($missingGame->getPsnprofilesId(), ENT_QUOTES, 'UTF-8'); ?></a> not in our database.
+                    </p>
+                <?php } ?>
+            </div>
+        <?php } ?>
+
+        <?php foreach ($psnpPlusReport->getGameDifferences() as $difference) { ?>
+            <div class="mb-3">
+                <strong>
+                    <a href="../game/<?= $difference->getGameId(); ?>" target="_blank" rel="noopener">
+                        <?= htmlentities($difference->getGameName(), ENT_QUOTES, 'UTF-8'); ?>
+                    </a>
+                </strong><br>
+
+                <?php if ($difference->hasUnobtainable()) { ?>
+                    <a href="unobtainable.php?status=1&amp;trophy=<?= $difference->getUnobtainableTrophyIdQuery(); ?>">
+                        Unobtainable
+                    </a>: <?= htmlentities($difference->getUnobtainableOrderList(), ENT_QUOTES, 'UTF-8'); ?><br>
+                <?php } ?>
+
+                <?php if ($difference->hasObtainable()) { ?>
+                    <a href="unobtainable.php?status=0&amp;trophy=<?= $difference->getObtainableTrophyIdQuery(); ?>">
+                        Obtainable
+                    </a>: <?= htmlentities($difference->getObtainableOrderList(), ENT_QUOTES, 'UTF-8'); ?><br>
+                <?php } ?>
+            </div>
+        <?php } ?>
+
+        <h1>No longer in PSNP+ (all trophies fixed!)</h1>
+
+        <?php foreach ($psnpPlusReport->getFixedGames() as $fixedGame) { ?>
+            <div class="mb-3">
+                <strong>
+                    <a href="../game/<?= $fixedGame->getGameId(); ?>" target="_blank" rel="noopener">
+                        <?= htmlentities($fixedGame->getGameName(), ENT_QUOTES, 'UTF-8'); ?>
+                    </a>
+                </strong><br>
+
+                <?php if ($fixedGame->hasTrophies()) { ?>
+                    <a href="unobtainable.php?status=0&amp;trophy=<?= $fixedGame->getTrophyIdQuery(); ?>">
+                        Obtainable
+                    </a>: <?= htmlentities($fixedGame->getTrophyIdList(), ENT_QUOTES, 'UTF-8'); ?><br>
+                <?php } ?>
+            </div>
+        <?php } ?>
+    <?php } ?>
+    <?php
+});

--- a/wwwroot/admin/report.php
+++ b/wwwroot/admin/report.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require_once '../init.php';
 require_once '../classes/Admin/PlayerReportAdminService.php';
 require_once '../classes/Admin/PlayerReportAdminPage.php';
+require_once '../classes/Admin/AdminLayoutRenderer.php';
 
 $playerReportAdminService = new PlayerReportAdminService($database);
 $playerReportAdminPage = new PlayerReportAdminPage($playerReportAdminService);
@@ -12,43 +13,34 @@ $pageResult = $playerReportAdminPage->handle($_GET ?? []);
 $reportedPlayers = $pageResult->getReportedPlayers();
 $successMessage = $pageResult->getSuccessMessage();
 $errorMessage = $pageResult->getErrorMessage();
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin ~ Reported Players</title>
-    </head>
-    <body>
-        <div class="p-4">
-            <a href="/admin/">Back</a><br><br>
-            <?php if ($successMessage !== null) { ?>
-                <div class="alert alert-success" role="alert">
-                    <?= htmlentities($successMessage, ENT_QUOTES, 'UTF-8'); ?>
-                </div>
-            <?php } ?>
-            <?php if ($errorMessage !== null) { ?>
-                <div class="alert alert-warning" role="alert">
-                    <?= htmlentities($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
-                </div>
-            <?php } ?>
-            <?php foreach ($reportedPlayers as $reportedPlayer) { ?>
-                <div class="mb-3">
-                    <a href="/player/<?= htmlentities($reportedPlayer->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>">
-                        <?= htmlentities($reportedPlayer->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>
-                    </a>
-                    <div class="mt-2">
-                        <?= nl2br(htmlentities($reportedPlayer->getExplanation(), ENT_QUOTES, 'UTF-8')); ?>
-                    </div>
-                    <div class="mt-2">
-                        <a href="?delete=<?= $reportedPlayer->getReportId(); ?>">Delete</a>
-                    </div>
-                </div>
-                <hr>
-            <?php } ?>
+
+$layoutRenderer = new AdminLayoutRenderer();
+
+echo $layoutRenderer->render('Admin ~ Reported Players', static function () use ($reportedPlayers, $successMessage, $errorMessage): void {
+    ?>
+    <?php if ($successMessage !== null) { ?>
+        <div class="alert alert-success" role="alert">
+            <?= htmlentities($successMessage, ENT_QUOTES, 'UTF-8'); ?>
         </div>
-    </body>
-</html>
+    <?php } ?>
+    <?php if ($errorMessage !== null) { ?>
+        <div class="alert alert-warning" role="alert">
+            <?= htmlentities($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
+        </div>
+    <?php } ?>
+    <?php foreach ($reportedPlayers as $reportedPlayer) { ?>
+        <div class="mb-3">
+            <a href="/player/<?= htmlentities($reportedPlayer->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>">
+                <?= htmlentities($reportedPlayer->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>
+            </a>
+            <div class="mt-2">
+                <?= nl2br(htmlentities($reportedPlayer->getExplanation(), ENT_QUOTES, 'UTF-8')); ?>
+            </div>
+            <div class="mt-2">
+                <a href="?delete=<?= $reportedPlayer->getReportId(); ?>">Delete</a>
+            </div>
+        </div>
+        <hr>
+    <?php } ?>
+    <?php
+});

--- a/wwwroot/admin/rescan.php
+++ b/wwwroot/admin/rescan.php
@@ -1,249 +1,222 @@
 <?php
-require_once("../vendor/autoload.php");
-require_once("../init.php");
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin ~ Rescan Game</title>
-    </head>
-    <body>
-        <div class="container py-4">
-            <a href="/admin/">Back</a>
-            <h1 class="h3 mt-3">Rescan Game</h1>
-            <p class="text-body-secondary">Enter the numeric game identifier to trigger a rescan.</p>
+require_once '../vendor/autoload.php';
+require_once '../init.php';
+require_once '../classes/Admin/AdminLayoutRenderer.php';
 
-            <form id="rescan-form" class="row row-cols-lg-auto g-3 align-items-center" autocomplete="off">
-                <div class="col-12">
-                    <label class="form-label" for="game">Game ID</label>
-                    <input type="text" class="form-control" id="game" name="game" inputmode="numeric" pattern="[0-9]*" required>
-                </div>
-                <div class="col-12 align-self-end">
-                    <button type="submit" class="btn btn-primary" id="rescan-submit">Rescan</button>
-                </div>
-            </form>
+$layoutRenderer = new AdminLayoutRenderer();
+$options = AdminLayoutOptions::create()->withContainerClass('container py-4');
 
-            <div id="progress-wrapper" class="mt-4 d-none">
-                <div class="progress">
-                    <div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%;" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">0%</div>
-                </div>
-                <p id="progress-message" class="text-body-secondary small mt-2">Preparing rescan…</p>
-            </div>
+echo $layoutRenderer->render('Admin ~ Rescan Game', static function (): void {
+    ?>
+    <h1 class="h3 mt-3">Rescan Game</h1>
+    <p class="text-body-secondary">Enter the numeric game identifier to trigger a rescan.</p>
 
-            <div id="result" class="mt-3"></div>
+    <form id="rescan-form" class="row row-cols-lg-auto g-3 align-items-center" autocomplete="off">
+        <div class="col-12">
+            <label class="form-label" for="game">Game ID</label>
+            <input type="text" class="form-control" id="game" name="game" inputmode="numeric" pattern="[0-9]*" required>
         </div>
+        <div class="col-12 align-self-end">
+            <button type="submit" class="btn btn-primary" id="rescan-submit">Rescan</button>
+        </div>
+    </form>
 
-        <script>
-            class RescanFormController {
-                constructor({
-                    formId,
-                    gameInputId,
-                    submitButtonId,
-                    progressWrapperId,
-                    progressBarId,
-                    progressMessageId,
-                    resultId,
-                }) {
-                    this.form = document.getElementById(formId);
-                    this.gameInput = document.getElementById(gameInputId);
-                    this.submitButton = document.getElementById(submitButtonId);
-                    this.progressWrapper = document.getElementById(progressWrapperId);
-                    this.progressBar = document.getElementById(progressBarId);
-                    this.progressMessage = document.getElementById(progressMessageId);
-                    this.result = document.getElementById(resultId);
+    <div id="progress-wrapper" class="mt-4 d-none">
+        <div class="progress">
+            <div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%;" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">0%</div>
+        </div>
+        <p id="progress-message" class="text-body-secondary small mt-2">Preparing rescan…</p>
+    </div>
+
+    <div id="result" class="mt-3"></div>
+
+    <script>
+        class RescanFormController {
+            constructor({
+                formId,
+                gameInputId,
+                submitButtonId,
+                progressWrapperId,
+                progressBarId,
+                progressMessageId,
+                resultId,
+            }) {
+                this.form = document.getElementById(formId);
+                this.gameInput = document.getElementById(gameInputId);
+                this.submitButton = document.getElementById(submitButtonId);
+                this.progressWrapper = document.getElementById(progressWrapperId);
+                this.progressBar = document.getElementById(progressBarId);
+                this.progressMessage = document.getElementById(progressMessageId);
+                this.result = document.getElementById(resultId);
+            }
+
+            initialize() {
+                if (!this.hasRequiredElements()) {
+                    return;
                 }
 
-                initialize() {
-                    if (!this.hasRequiredElements()) {
-                        return;
-                    }
+                this.form.addEventListener('submit', (event) => this.handleSubmit(event));
+            }
 
-                    this.form.addEventListener('submit', (event) => this.handleSubmit(event));
+            hasRequiredElements() {
+                return [
+                    this.form,
+                    this.gameInput,
+                    this.submitButton,
+                    this.progressWrapper,
+                    this.progressBar,
+                    this.progressMessage,
+                    this.result,
+                ].every((element) => element instanceof HTMLElement);
+            }
+
+            handleSubmit(event) {
+                event.preventDefault();
+                this.clearResult();
+
+                const trimmedValue = (this.gameInput.value || '').trim();
+                if (!/^\d+$/.test(trimmedValue)) {
+                    this.showAlert('danger', 'Please provide a valid game id.');
+                    return;
                 }
 
-                hasRequiredElements() {
-                    return [
-                        this.form,
-                        this.gameInput,
-                        this.submitButton,
-                        this.progressWrapper,
-                        this.progressBar,
-                        this.progressMessage,
-                        this.result,
-                    ].every((element) => element instanceof HTMLElement);
-                }
+                this.resetProgress();
+                this.showProgress();
+                this.setFormDisabled(true);
 
-                handleSubmit(event) {
-                    event.preventDefault();
-                    this.clearResult();
+                this.processRescan(trimmedValue)
+                    .catch(() => {
+                        // Errors are handled in processRescan; this catch prevents
+                        // unhandled promise rejections in older browsers.
+                    })
+                    .finally(() => {
+                        this.setFormDisabled(false);
+                    });
+            }
 
-                    const trimmedValue = (this.gameInput.value || '').trim();
-                    if (!/^\d+$/.test(trimmedValue)) {
-                        this.showAlert('danger', 'Please provide a valid game id.');
-                        return;
-                    }
+            async processRescan(gameId) {
+                try {
+                    const response = await fetch('rescan_process.php', {
+                        method: 'POST',
+                        headers: {
+                            'Accept': 'application/x-ndjson, application/json',
+                            'Content-Type': 'application/x-www-form-urlencoded',
+                        },
+                        body: new URLSearchParams({ game: gameId }),
+                    });
 
-                    this.resetProgress();
-                    this.showProgress();
-                    this.setFormDisabled(true);
-
-                    this.processRescan(trimmedValue)
-                        .catch(() => {
-                            // Errors are handled in processRescan; this catch prevents
-                            // unhandled promise rejections in older browsers.
-                        })
-                        .finally(() => {
-                            this.setFormDisabled(false);
-                        });
-                }
-
-                async processRescan(gameId) {
-                    try {
-                        const response = await fetch('rescan_process.php', {
-                            method: 'POST',
-                            headers: {
-                                'Accept': 'application/x-ndjson, application/json',
-                                'Content-Type': 'application/x-www-form-urlencoded',
-                            },
-                            body: new URLSearchParams({ game: gameId }),
-                        });
-
-                        const contentType = response.headers.get('Content-Type') ?? '';
-                        let finalPayload = null;
-
-                        if (contentType.includes('application/x-ndjson')) {
-                            finalPayload = await this.consumeProgressStream(response);
-                        } else {
-                            let data = null;
-
-                            try {
-                                data = await response.json();
-                            } catch (error) {
-                                data = null;
-                            }
-
-                            if (!response.ok || !data || !data.success) {
-                                const errorMessage = data && (data.error || data.message)
-                                    ? (data.error || data.message)
-                                    : 'Unable to rescan the specified game.';
-
-                                this.markProgressAsError('Rescan failed.');
-                                this.showAlert('danger', errorMessage);
-
-                                return;
-                            }
-
-                            finalPayload = {
-                                type: 'complete',
-                                success: true,
-                                progress: 100,
-                                message: data.message ?? 'Rescan completed successfully.',
-                            };
-
-                            this.updateProgress(100, finalPayload.message);
-                        }
-
-                        this.setProgressAnimated(false);
-
-                        if (finalPayload && finalPayload.success) {
-                            const successMessage = finalPayload.message ?? 'Rescan completed successfully.';
-                            this.markProgressAsSuccess(successMessage);
-                            this.showAlert('success', successMessage);
-
-                            return;
-                        }
-
-                        const errorMessage = (finalPayload && (finalPayload.error || finalPayload.message))
-                            ? (finalPayload.error || finalPayload.message)
-                            : 'Unable to rescan the specified game.';
-
-                        this.markProgressAsError(finalPayload?.message ?? finalPayload?.error ?? 'Rescan failed.');
-                        this.showAlert('danger', errorMessage);
-                    } catch (error) {
-                        this.markProgressAsError('Rescan failed.');
-                        this.showAlert('danger', 'An unexpected error occurred while processing the rescan request.');
-                    }
-                }
-
-                async consumeProgressStream(response) {
-                    const reader = response.body?.getReader();
-
-                    if (!reader) {
-                        throw new Error('Streaming reader unavailable.');
-                    }
-
-                    const decoder = new TextDecoder();
-                    let buffer = '';
+                    const contentType = response.headers.get('Content-Type') ?? '';
                     let finalPayload = null;
 
-                    const processPayload = (payload) => {
-                        if (!payload || typeof payload !== 'object') {
+                    if (contentType.includes('application/x-ndjson')) {
+                        finalPayload = await this.consumeProgressStream(response);
+                    } else {
+                        let data = null;
+
+                        try {
+                            data = await response.json();
+                        } catch (error) {
+                            data = null;
+                        }
+
+                        if (!response.ok || !data || !data.success) {
+                            const errorMessage = data && (data.error || data.message)
+                                ? (data.error || data.message)
+                                : 'Unable to rescan the specified game.';
+
+                            this.markProgressAsError('Rescan failed.');
+                            this.showAlert('danger', errorMessage);
+
                             return;
                         }
 
-                        if (payload.type === 'progress') {
-                            let progressValue = 0;
+                        finalPayload = {
+                            type: 'complete',
+                            success: true,
+                            progress: 100,
+                            message: data.message ?? 'Rescan completed successfully.',
+                        };
 
-                            if (typeof payload.progress === 'number' && Number.isFinite(payload.progress)) {
-                                progressValue = payload.progress;
-                            } else if (typeof payload.progress === 'string') {
-                                const parsedProgress = Number(payload.progress.trim());
-
-                                if (Number.isFinite(parsedProgress)) {
-                                    progressValue = parsedProgress;
-                                }
-                            }
-
-                            this.updateProgress(progressValue, payload.message ?? null);
-
-                            return;
-                        }
-
-                        if (payload.type === 'complete' || payload.type === 'error') {
-                            finalPayload = payload;
-                            if (typeof payload.progress === 'number') {
-                                const finalMessage = payload.message ?? payload.error ?? null;
-                                this.updateProgress(payload.progress, finalMessage);
-                            }
-                        }
-                    };
-
-                    while (true) {
-                        const { done, value } = await reader.read();
-
-                        if (done) {
-                            break;
-                        }
-
-                        buffer += decoder.decode(value, { stream: true });
-                        const lines = buffer.split('\n');
-                        buffer = lines.pop() ?? '';
-
-                        for (const line of lines) {
-                            const trimmed = line.trim();
-
-                            if (trimmed === '') {
-                                continue;
-                            }
-
-                            try {
-                                const payload = JSON.parse(trimmed);
-                                processPayload(payload);
-                            } catch (error) {
-                                // Ignore malformed payloads.
-                            }
-                        }
+                        this.updateProgress(100, finalPayload.message);
                     }
 
-                    buffer += decoder.decode();
-                    const finalLines = buffer.split('\n');
-                    buffer = finalLines.pop() ?? '';
+                    this.setProgressAnimated(false);
 
-                    for (const line of finalLines) {
+                    if (finalPayload && finalPayload.success) {
+                        const successMessage = finalPayload.message ?? 'Rescan completed successfully.';
+                        this.markProgressAsSuccess(successMessage);
+                        this.showAlert('success', successMessage);
+
+                        return;
+                    }
+
+                    const errorMessage = (finalPayload && (finalPayload.error || finalPayload.message))
+                        ? (finalPayload.error || finalPayload.message)
+                        : 'Unable to rescan the specified game.';
+
+                    this.markProgressAsError(finalPayload?.message ?? finalPayload?.error ?? 'Rescan failed.');
+                    this.showAlert('danger', errorMessage);
+                } catch (error) {
+                    this.markProgressAsError('Rescan failed.');
+                    this.showAlert('danger', 'An unexpected error occurred while processing the rescan request.');
+                }
+            }
+
+            async consumeProgressStream(response) {
+                const reader = response.body?.getReader();
+
+                if (!reader) {
+                    throw new Error('Streaming reader unavailable.');
+                }
+
+                const decoder = new TextDecoder();
+                let buffer = '';
+                let finalPayload = null;
+
+                const processPayload = (payload) => {
+                    if (!payload || typeof payload !== 'object') {
+                        return;
+                    }
+
+                    if (payload.type === 'progress') {
+                        let progressValue = 0;
+
+                        if (typeof payload.progress === 'number' && Number.isFinite(payload.progress)) {
+                            progressValue = payload.progress;
+                        } else if (typeof payload.progress === 'string') {
+                            const parsedProgress = Number(payload.progress.trim());
+
+                            if (Number.isFinite(parsedProgress)) {
+                                progressValue = parsedProgress;
+                            }
+                        }
+
+                        this.updateProgress(progressValue, payload.message ?? null);
+
+                        return;
+                    }
+
+                    if (payload.type === 'complete' || payload.type === 'error') {
+                        finalPayload = payload;
+                        if (typeof payload.progress === 'number') {
+                            const finalMessage = payload.message ?? payload.error ?? null;
+                            this.updateProgress(payload.progress, finalMessage);
+                        }
+                    }
+                };
+
+                while (true) {
+                    const { done, value } = await reader.read();
+
+                    if (done) {
+                        break;
+                    }
+
+                    buffer += decoder.decode(value, { stream: true });
+                    const lines = buffer.split('\n');
+                    buffer = lines.pop() ?? '';
+
+                    for (const line of lines) {
                         const trimmed = line.trim();
 
                         if (trimmed === '') {
@@ -257,142 +230,162 @@ require_once("../init.php");
                             // Ignore malformed payloads.
                         }
                     }
-
-                    const remaining = buffer.trim();
-
-                    if (remaining !== '') {
-                        try {
-                            const payload = JSON.parse(remaining);
-                            processPayload(payload);
-                        } catch (error) {
-                            // Ignore malformed payloads.
-                        }
-                    }
-
-                    if (finalPayload === null) {
-                        throw new Error('Missing final status from rescan process.');
-                    }
-
-                    return finalPayload;
                 }
 
-                resetProgress() {
-                    if (!this.progressBar || !this.progressMessage) {
-                        return;
+                buffer += decoder.decode();
+                const finalLines = buffer.split('\n');
+                buffer = finalLines.pop() ?? '';
+
+                for (const line of finalLines) {
+                    const trimmed = line.trim();
+
+                    if (trimmed === '') {
+                        continue;
                     }
 
-                    this.progressBar.style.width = '0%';
-                    this.progressBar.setAttribute('aria-valuenow', '0');
-                    this.progressBar.textContent = '0%';
-                    this.clearProgressStatus();
-                    this.setProgressAnimated(true);
-                    this.progressMessage.textContent = 'Preparing rescan…';
-                }
-
-                updateProgress(value, message = null) {
-                    if (!this.progressBar) {
-                        return;
-                    }
-
-                    const numericValue = Number.isFinite(value) ? value : Number(value);
-                    const clampedValue = Math.min(100, Math.max(0, typeof numericValue === 'number' && Number.isFinite(numericValue) ? numericValue : 0));
-                    const displayValue = Math.round(clampedValue);
-
-                    this.progressBar.style.width = `${clampedValue}%`;
-                    this.progressBar.setAttribute('aria-valuenow', String(displayValue));
-                    this.progressBar.textContent = `${displayValue}%`;
-
-                    if (message !== null && this.progressMessage) {
-                        this.progressMessage.textContent = message;
+                    try {
+                        const payload = JSON.parse(trimmed);
+                        processPayload(payload);
+                    } catch (error) {
+                        // Ignore malformed payloads.
                     }
                 }
 
-                setFormDisabled(disabled) {
-                    if (this.submitButton) {
-                        this.submitButton.disabled = disabled;
-                    }
+                const remaining = buffer.trim();
 
-                    if (this.gameInput) {
-                        this.gameInput.disabled = disabled;
-                    }
-                }
-
-                showAlert(type, message) {
-                    if (!this.result) {
-                        return;
-                    }
-
-                    const alert = document.createElement('div');
-                    alert.className = `alert alert-${type}`;
-                    alert.setAttribute('role', 'alert');
-                    alert.textContent = message;
-
-                    this.result.replaceChildren(alert);
-                }
-
-                clearResult() {
-                    if (this.result) {
-                        this.result.replaceChildren();
+                if (remaining !== '') {
+                    try {
+                        const payload = JSON.parse(remaining);
+                        processPayload(payload);
+                    } catch (error) {
+                        // Ignore malformed payloads.
                     }
                 }
 
-                showProgress() {
-                    if (this.progressWrapper) {
-                        this.progressWrapper.classList.remove('d-none');
-                    }
+                if (finalPayload === null) {
+                    throw new Error('Missing final status from rescan process.');
                 }
 
-                clearProgressStatus() {
-                    if (this.progressBar) {
-                        this.progressBar.classList.remove('bg-success', 'bg-danger');
-                    }
+                return finalPayload;
+            }
+
+            resetProgress() {
+                if (!this.progressBar || !this.progressMessage) {
+                    return;
                 }
 
-                setProgressAnimated(animated) {
-                    if (!this.progressBar) {
-                        return;
-                    }
+                this.progressBar.style.width = '0%';
+                this.progressBar.setAttribute('aria-valuenow', '0');
+                this.progressBar.textContent = '0%';
+                this.clearProgressStatus();
+                this.setProgressAnimated(true);
+                this.progressMessage.textContent = 'Preparing rescan…';
+            }
 
-                    if (animated) {
-                        this.progressBar.classList.add('progress-bar-animated');
-                    } else {
-                        this.progressBar.classList.remove('progress-bar-animated');
-                    }
+            updateProgress(value, message = null) {
+                if (!this.progressBar) {
+                    return;
                 }
 
-                markProgressAsSuccess(message) {
-                    this.setProgressAnimated(false);
-                    this.clearProgressStatus();
-                    if (this.progressBar) {
-                        this.progressBar.classList.add('bg-success');
-                    }
-                    this.updateProgress(100, message);
-                }
+                const numericValue = Number.isFinite(value) ? value : Number(value);
+                const clampedValue = Math.min(100, Math.max(0, typeof numericValue === 'number' && Number.isFinite(numericValue) ? numericValue : 0));
+                const displayValue = Math.round(clampedValue);
 
-                markProgressAsError(message) {
-                    this.setProgressAnimated(false);
-                    this.clearProgressStatus();
-                    if (this.progressBar) {
-                        this.progressBar.classList.add('bg-danger');
-                    }
-                    this.updateProgress(100, message);
+                this.progressBar.style.width = `${clampedValue}%`;
+                this.progressBar.setAttribute('aria-valuenow', String(displayValue));
+                this.progressBar.textContent = `${displayValue}%`;
+
+                if (message !== null && this.progressMessage) {
+                    this.progressMessage.textContent = message;
                 }
             }
 
-            document.addEventListener('DOMContentLoaded', () => {
-                const controller = new RescanFormController({
-                    formId: 'rescan-form',
-                    gameInputId: 'game',
-                    submitButtonId: 'rescan-submit',
-                    progressWrapperId: 'progress-wrapper',
-                    progressBarId: 'progress-bar',
-                    progressMessageId: 'progress-message',
-                    resultId: 'result',
-                });
+            setFormDisabled(disabled) {
+                if (this.submitButton) {
+                    this.submitButton.disabled = disabled;
+                }
 
-                controller.initialize();
-                window.rescanFormController = controller;
+                if (this.gameInput) {
+                    this.gameInput.disabled = disabled;
+                }
+            }
+
+            showAlert(type, message) {
+                if (!this.result) {
+                    return;
+                }
+
+                const alert = document.createElement('div');
+                alert.className = `alert alert-${type}`;
+                alert.setAttribute('role', 'alert');
+                alert.textContent = message;
+
+                this.result.replaceChildren(alert);
+            }
+
+            clearResult() {
+                if (this.result) {
+                    this.result.replaceChildren();
+                }
+            }
+
+            showProgress() {
+                if (this.progressWrapper) {
+                    this.progressWrapper.classList.remove('d-none');
+                }
+            }
+
+            clearProgressStatus() {
+                if (this.progressBar) {
+                    this.progressBar.classList.remove('bg-success', 'bg-danger');
+                }
+            }
+
+            setProgressAnimated(animated) {
+                if (!this.progressBar) {
+                    return;
+                }
+
+                if (animated) {
+                    this.progressBar.classList.add('progress-bar-animated');
+                } else {
+                    this.progressBar.classList.remove('progress-bar-animated');
+                }
+            }
+
+            markProgressAsSuccess(message) {
+                this.setProgressAnimated(false);
+                this.clearProgressStatus();
+                if (this.progressBar) {
+                    this.progressBar.classList.add('bg-success');
+                }
+                this.updateProgress(100, message);
+            }
+
+            markProgressAsError(message) {
+                this.setProgressAnimated(false);
+                this.clearProgressStatus();
+                if (this.progressBar) {
+                    this.progressBar.classList.add('bg-danger');
+                }
+                this.updateProgress(100, message);
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const controller = new RescanFormController({
+                formId: 'rescan-form',
+                gameInputId: 'game',
+                submitButtonId: 'rescan-submit',
+                progressWrapperId: 'progress-wrapper',
+                progressBarId: 'progress-bar',
+                progressMessageId: 'progress-message',
+                resultId: 'result',
             });
-        </script>
-    </body>
-</html>
+
+            controller.initialize();
+            window.rescanFormController = controller;
+        });
+    </script>
+    <?php
+}, $options);

--- a/wwwroot/admin/reset.php
+++ b/wwwroot/admin/reset.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once '../init.php';
 require_once '../classes/GameResetService.php';
 require_once '../classes/Admin/GameResetRequestHandler.php';
+require_once '../classes/Admin/AdminLayoutRenderer.php';
 
 $gameResetService = new GameResetService($database);
 $requestHandler = new GameResetRequestHandler($gameResetService);
@@ -14,39 +15,29 @@ $result = $requestHandler->handleRequest($request);
 $success = $result->getSuccessMessage();
 $error = $result->getErrorMessage();
 
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin ~ Reset / Delete</title>
-    </head>
-    <body>
-        <div class="p-4">
-            <a href="/admin/">Back</a><br><br>
-            <form method="post" autocomplete="off">
-                Game ID:<br>
-                <input type="number" name="game"><br>
-                Reset or Delete:<br>
-                <select name="status">
-                    <option value="0">Reset</option>
-                    <option value="1">Delete</option>
-                </select><br><br>
-                <input type="submit" value="Submit">
-            </form>
+$layoutRenderer = new AdminLayoutRenderer();
 
-            <?php
-            if ($error !== null) {
-                echo $error;
-            }
+echo $layoutRenderer->render('Admin ~ Reset / Delete', static function () use ($success, $error): void {
+    ?>
+    <form method="post" autocomplete="off">
+        Game ID:<br>
+        <input type="number" name="game"><br>
+        Reset or Delete:<br>
+        <select name="status">
+            <option value="0">Reset</option>
+            <option value="1">Delete</option>
+        </select><br><br>
+        <input type="submit" value="Submit">
+    </form>
 
-            if ($success !== null) {
-                echo $success;
-            }
-            ?>
-        </div>
-    </body>
-</html>
+    <?php
+    if ($error !== null) {
+        echo $error;
+    }
+
+    if ($success !== null) {
+        echo $success;
+    }
+    ?>
+    <?php
+});

--- a/wwwroot/admin/status.php
+++ b/wwwroot/admin/status.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require_once '../init.php';
 require_once '../classes/Admin/GameStatusRequestHandler.php';
+require_once '../classes/Admin/AdminLayoutRenderer.php';
 
 $gameStatusService = new GameStatusService($database);
 $requestHandler = new GameStatusRequestHandler($gameStatusService);
@@ -12,41 +13,31 @@ $result = $requestHandler->handleRequest($request);
 $success = $result->getSuccessMessage();
 $error = $result->getErrorMessage();
 
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin ~ Game Status</title>
-    </head>
-    <body>
-        <div class="p-4">
-            <a href="/admin/">Back</a><br><br>
-            <form method="post" autocomplete="off">
-                Game ID:<br>
-                <input type="number" name="game"><br>
-                Status:<br>
-                <select name="status">
-                    <option value="0">Normal</option>
-                    <option value="1">Delisted</option>
-                    <option value="3">Obsolete</option>
-                    <option value="4">Delisted &amp; Obsolete</option>
-                </select><br><br>
-                <input type="submit" value="Submit">
-            </form>
+$layoutRenderer = new AdminLayoutRenderer();
 
-            <?php
-            if ($error !== null) {
-                echo $error;
-            }
+echo $layoutRenderer->render('Admin ~ Game Status', static function () use ($success, $error): void {
+    ?>
+    <form method="post" autocomplete="off">
+        Game ID:<br>
+        <input type="number" name="game"><br>
+        Status:<br>
+        <select name="status">
+            <option value="0">Normal</option>
+            <option value="1">Delisted</option>
+            <option value="3">Obsolete</option>
+            <option value="4">Delisted &amp; Obsolete</option>
+        </select><br><br>
+        <input type="submit" value="Submit">
+    </form>
 
-            if ($success !== null) {
-                echo $success;
-            }
-            ?>
-        </div>
-    </body>
-</html>
+    <?php
+    if ($error !== null) {
+        echo $error;
+    }
+
+    if ($success !== null) {
+        echo $success;
+    }
+    ?>
+    <?php
+});

--- a/wwwroot/admin/unobtainable.php
+++ b/wwwroot/admin/unobtainable.php
@@ -10,9 +10,10 @@ ExecutionEnvironmentConfigurator::create()
     ->enableUnlimitedExecution()
     ->configure();
 
-require_once("../init.php");
-require_once("../classes/Admin/TrophyStatusService.php");
-require_once("../classes/Admin/TrophyStatusPage.php");
+require_once '../init.php';
+require_once '../classes/Admin/TrophyStatusService.php';
+require_once '../classes/Admin/TrophyStatusPage.php';
+require_once '../classes/Admin/AdminLayoutRenderer.php';
 
 $trophyStatusService = new TrophyStatusService($database);
 $trophyStatusPage = new TrophyStatusPage($trophyStatusService);
@@ -25,38 +26,28 @@ $pageResult = $trophyStatusPage->handleRequest($requestMethod, $postData, $query
 $trophyInput = $pageResult->getTrophyInput();
 $statusInput = $pageResult->getStatusInput();
 
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin ~ Unobtainable Trophy</title>
-    </head>
-    <body>
-        <div class="p-4">
-            <a href="/admin/">Back</a><br><br>
-            <form method="post" autocomplete="off">
-                Game ID:<br>
-                <input type="text" name="game" /><br>
-                Trophy ID:<br>
-                <textarea name="trophy" rows="10" cols="30"><?= htmlspecialchars(str_replace(",", PHP_EOL, $trophyInput), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></textarea>
-                <br>
-                Status:<br>
-                <select name="status">
-                    <option value="1" <?= ($statusInput == "1" ? "selected" : ""); ?>>Unobtainable</option>
-                    <option value="0" <?= ($statusInput == "0" ? "selected" : ""); ?>>Obtainable</option>
-                </select><br><br>
-                <input type="submit" value="Submit">
-            </form>
+$layoutRenderer = new AdminLayoutRenderer();
 
-            <?php
-            if ($pageResult->hasMessage()) {
-                echo $pageResult->getMessage();
-            }
-            ?>
-        </div>
-    </body>
-</html>
+echo $layoutRenderer->render('Admin ~ Unobtainable Trophy', static function () use ($pageResult, $trophyInput, $statusInput): void {
+    ?>
+    <form method="post" autocomplete="off">
+        Game ID:<br>
+        <input type="text" name="game" /><br>
+        Trophy ID:<br>
+        <textarea name="trophy" rows="10" cols="30"><?= htmlspecialchars(str_replace(',', PHP_EOL, $trophyInput), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></textarea>
+        <br>
+        Status:<br>
+        <select name="status">
+            <option value="1" <?= ($statusInput == "1" ? "selected" : ""); ?>>Unobtainable</option>
+            <option value="0" <?= ($statusInput == "0" ? "selected" : ""); ?>>Obtainable</option>
+        </select><br><br>
+        <input type="submit" value="Submit">
+    </form>
+
+    <?php
+    if ($pageResult->hasMessage()) {
+        echo $pageResult->getMessage();
+    }
+    ?>
+    <?php
+});

--- a/wwwroot/classes/Admin/AdminLayoutOptions.php
+++ b/wwwroot/classes/Admin/AdminLayoutOptions.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+final class AdminLayoutOptions
+{
+    private bool $showBackLink;
+
+    private string $containerClass;
+
+    public function __construct(bool $showBackLink = true, string $containerClass = 'p-4')
+    {
+        $this->showBackLink = $showBackLink;
+        $this->containerClass = $this->normaliseContainerClass($containerClass);
+    }
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function withBackLink(bool $showBackLink): self
+    {
+        $clone = clone $this;
+        $clone->showBackLink = $showBackLink;
+
+        return $clone;
+    }
+
+    public function withContainerClass(string $containerClass): self
+    {
+        $clone = clone $this;
+        $clone->containerClass = $this->normaliseContainerClass($containerClass);
+
+        return $clone;
+    }
+
+    public function shouldShowBackLink(): bool
+    {
+        return $this->showBackLink;
+    }
+
+    public function getContainerClass(): string
+    {
+        return $this->containerClass;
+    }
+
+    private function normaliseContainerClass(string $containerClass): string
+    {
+        $trimmed = trim($containerClass);
+
+        return $trimmed === '' ? 'p-4' : $trimmed;
+    }
+}

--- a/wwwroot/classes/Admin/AdminLayoutRenderer.php
+++ b/wwwroot/classes/Admin/AdminLayoutRenderer.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/AdminLayoutOptions.php';
+
+final class AdminLayoutRenderer
+{
+    private const BOOTSTRAP_STYLESHEET = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css';
+
+    private const BOOTSTRAP_INTEGRITY = 'sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH';
+
+    /**
+     * @param callable():void $bodyRenderer
+     */
+    public function render(
+        string $title,
+        callable $bodyRenderer,
+        ?AdminLayoutOptions $options = null
+    ): string {
+        $options ??= AdminLayoutOptions::create();
+
+        ob_start();
+        ?>
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+    <head>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <link href="<?= htmlspecialchars(self::BOOTSTRAP_STYLESHEET, ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet" integrity="<?= htmlspecialchars(self::BOOTSTRAP_INTEGRITY, ENT_QUOTES, 'UTF-8'); ?>" crossorigin="anonymous">
+        <title><?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?></title>
+    </head>
+    <body>
+        <div class="<?= htmlspecialchars($options->getContainerClass(), ENT_QUOTES, 'UTF-8'); ?>">
+            <?php if ($options->shouldShowBackLink()) { ?>
+                <a href="/admin/">Back</a><br><br>
+            <?php } ?>
+            <?php $bodyRenderer(); ?>
+        </div>
+    </body>
+</html>
+<?php
+        $output = ob_get_clean();
+
+        return $output === false ? '' : $output;
+    }
+}


### PR DESCRIPTION
## Summary
- add an AdminLayoutRenderer and options class to encapsulate common admin page chrome
- update the admin dashboard and tools to render through the shared layout renderer while preserving existing content

## Testing
- `for file in   wwwroot/classes/Admin/AdminLayoutOptions.php   wwwroot/classes/Admin/AdminLayoutRenderer.php   wwwroot/admin/index.php   wwwroot/admin/cheater.php   wwwroot/admin/copy.php   wwwroot/admin/detail.php   wwwroot/admin/merge.php   wwwroot/admin/possible.php   wwwroot/admin/psnp-plus.php   wwwroot/admin/report.php   wwwroot/admin/rescan.php   wwwroot/admin/reset.php   wwwroot/admin/status.php   wwwroot/admin/unobtainable.php; do   php -l "$file" || exit 1 done`

------
https://chatgpt.com/codex/tasks/task_e_68f3ed403414832f8e1e7960b9a2a22f