### PR TITLE
Refactor player navigation to reusable classes

### DIFF
--- a/wwwroot/classes/PlayerNavigation.php
+++ b/wwwroot/classes/PlayerNavigation.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+final class PlayerNavigation
+{
+    public const SECTION_GAMES = 'games';
+    public const SECTION_LOG = 'log';
+    public const SECTION_TROPHY_ADVISOR = 'trophy-advisor';
+    public const SECTION_GAME_ADVISOR = 'game-advisor';
+    public const SECTION_RANDOM = 'random';
+
+    private string $onlineId;
+
+    private ?string $activeSection;
+
+    private function __construct(string $onlineId, ?string $activeSection)
+    {
+        $this->onlineId = $onlineId;
+        $this->activeSection = $activeSection;
+    }
+
+    public static function forSection(string $onlineId, ?string $activeSection = null): self
+    {
+        return new self($onlineId, $activeSection);
+    }
+
+    /**
+     * @return PlayerNavigationLink[]
+     */
+    public function getLinks(): array
+    {
+        $encodedOnlineId = rawurlencode($this->onlineId);
+
+        return [
+            new PlayerNavigationLink(
+                'Games',
+                '/player/' . $encodedOnlineId,
+                $this->isActive(self::SECTION_GAMES)
+            ),
+            new PlayerNavigationLink(
+                'Log',
+                '/player/' . $encodedOnlineId . '/log',
+                $this->isActive(self::SECTION_LOG)
+            ),
+            new PlayerNavigationLink(
+                'Trophy Advisor',
+                '/player/' . $encodedOnlineId . '/advisor',
+                $this->isActive(self::SECTION_TROPHY_ADVISOR)
+            ),
+            new PlayerNavigationLink(
+                'Game Advisor',
+                '/game?sort=completion&filter=true&player=' . $encodedOnlineId,
+                $this->isActive(self::SECTION_GAME_ADVISOR)
+            ),
+            new PlayerNavigationLink(
+                'Random Games',
+                '/player/' . $encodedOnlineId . '/random',
+                $this->isActive(self::SECTION_RANDOM)
+            ),
+        ];
+    }
+
+    private function isActive(string $section): bool
+    {
+        return $this->activeSection === $section;
+    }
+}
+
+final class PlayerNavigationLink
+{
+    private string $label;
+
+    private string $url;
+
+    private bool $active;
+
+    public function __construct(string $label, string $url, bool $active)
+    {
+        $this->label = $label;
+        $this->url = $url;
+        $this->active = $active;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function getButtonCssClass(): string
+    {
+        return $this->active
+            ? 'btn btn-primary active'
+            : 'btn btn-outline-primary';
+    }
+
+    public function getAriaCurrent(): ?string
+    {
+        return $this->active ? 'page' : null;
+    }
+}

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerGamesPageContext.php';
+require_once __DIR__ . '/classes/PlayerNavigation.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -21,6 +22,7 @@ $playerGames = $pageContext->getGames();
 $metaData = $pageContext->getMetaData();
 $playerSearch = $pageContext->getSearch();
 $sort = $pageContext->getSort();
+$playerNavigation = PlayerNavigation::forSection((string) $player['online_id'], PlayerNavigation::SECTION_GAMES);
 $title = $pageContext->getTitle();
 require_once("header.php");
 ?>
@@ -37,13 +39,7 @@ require_once("header.php");
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">
-                <div class="btn-group">
-                    <a class="btn btn-primary active" href="/player/<?= $player["online_id"]; ?>">Games</a>
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>/log">Log</a>
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>/advisor">Trophy Advisor</a>
-                    <a class="btn btn-outline-primary" href="/game?sort=completion&filter=true&player=<?= $player["online_id"]; ?>">Game Advisor</a>
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>/random">Random Games</a>
-                </div>
+                <?php require __DIR__ . '/player_navigation.php'; ?>
             </div>
 
             <div class="col-12 col-lg-3 mb-3">

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/classes/PlayerAdvisorPage.php';
 require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
 require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
+require_once __DIR__ . '/classes/PlayerNavigation.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -33,6 +34,7 @@ $totalPages = $playerAdvisorPage->getTotalPages();
 $filterParameters = $playerAdvisorPage->getFilterParameters();
 $shouldDisplayAdvisor = $playerAdvisorPage->shouldDisplayAdvisor();
 $trophyRarityFormatter = new TrophyRarityFormatter();
+$playerNavigation = PlayerNavigation::forSection((string) $player['online_id'], PlayerNavigation::SECTION_TROPHY_ADVISOR);
 
 $title = $player["online_id"] . "'s Trophy Advisor ~ PSN 100%";
 require_once("header.php");
@@ -50,13 +52,7 @@ require_once("header.php");
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">
-                <div class="btn-group">
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>">Games</a>
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>/log">Log</a>
-                    <a class="btn btn-primary active" href="/player/<?= $player["online_id"]; ?>/advisor">Trophy Advisor</a>
-                    <a class="btn btn-outline-primary" href="/game?sort=completion&filter=true&player=<?= $player["online_id"]; ?>">Game Advisor</a>
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>/random">Random Games</a>
-                </div>
+                <?php require __DIR__ . '/player_navigation.php'; ?>
             </div>
 
             <div class="col-12 col-lg-3 mb-3">

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/classes/PlayerLogPage.php';
 require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
 require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
+require_once __DIR__ . '/classes/PlayerNavigation.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -24,6 +25,7 @@ $playerLogPage = new PlayerLogPage(
 );
 $trophiesLog = $playerLogPage->getTrophies();
 $trophyRarityFormatter = new TrophyRarityFormatter();
+$playerNavigation = PlayerNavigation::forSection((string) $player['online_id'], PlayerNavigation::SECTION_LOG);
 
 $title = $player["online_id"] . "'s Trophy Log ~ PSN 100%";
 require_once("header.php");
@@ -41,13 +43,7 @@ require_once("header.php");
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">
-                <div class="btn-group">
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>">Games</a>
-                    <a class="btn btn-primary active" href="/player/<?= $player["online_id"]; ?>/log">Log</a>
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>/advisor">Trophy Advisor</a>
-                    <a class="btn btn-outline-primary" href="/game?sort=completion&filter=true&player=<?= $player["online_id"]; ?>">Game Advisor</a>
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>/random">Random Games</a>
-                </div>
+                <?php require __DIR__ . '/player_navigation.php'; ?>
             </div>
 
             <div class="col-12 col-lg-3 mb-3">

--- a/wwwroot/player_navigation.php
+++ b/wwwroot/player_navigation.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+if (!isset($playerNavigation) || !$playerNavigation instanceof PlayerNavigation) {
+    throw new RuntimeException('Player navigation data is missing.');
+}
+
+$links = $playerNavigation->getLinks();
+?>
+<div class="btn-group">
+    <?php foreach ($links as $link) { ?>
+        <?php $ariaCurrent = $link->getAriaCurrent(); ?>
+        <a
+            class="<?= htmlspecialchars($link->getButtonCssClass(), ENT_QUOTES, 'UTF-8'); ?>"
+            href="<?= htmlspecialchars($link->getUrl(), ENT_QUOTES, 'UTF-8'); ?>"
+            <?php if ($ariaCurrent !== null) { ?>aria-current="<?= htmlspecialchars($ariaCurrent, ENT_QUOTES, 'UTF-8'); ?>"<?php } ?>
+        >
+            <?= htmlspecialchars($link->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
+        </a>
+    <?php } ?>
+</div>

--- a/wwwroot/player_random.php
+++ b/wwwroot/player_random.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/classes/PlayerRandomGamesService.php';
 require_once __DIR__ . '/classes/PlayerRandomGamesPage.php';
 require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
+require_once __DIR__ . '/classes/PlayerNavigation.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -26,6 +27,7 @@ $playerRandomGamesPage = new PlayerRandomGamesPage(
 $playerRandomGamesFilter = $playerRandomGamesPage->getFilter();
 $playerSummary = $playerRandomGamesPage->getPlayerSummary();
 $randomGames = $playerRandomGamesPage->getRandomGames();
+$playerNavigation = PlayerNavigation::forSection((string) $player['online_id'], PlayerNavigation::SECTION_RANDOM);
 
 $title = $player["online_id"] . "'s Random Games ~ PSN 100%";
 require_once("header.php");
@@ -43,13 +45,7 @@ require_once("header.php");
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">
-                <div class="btn-group">
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>">Games</a>
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>/log">Log</a>
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>/advisor">Trophy Advisor</a>
-                    <a class="btn btn-outline-primary" href="/game?sort=completion&filter=true&player=<?= $player["online_id"]; ?>">Game Advisor</a>
-                    <a class="btn btn-primary active" href="/player/<?= $player["online_id"]; ?>/random">Random Games</a>
-                </div>
+                <?php require __DIR__ . '/player_navigation.php'; ?>
             </div>
 
             <div class="col-12 col-lg-3 mb-3">

--- a/wwwroot/player_report.php
+++ b/wwwroot/player_report.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/classes/PlayerReportPage.php';
 require_once __DIR__ . '/classes/PlayerReportService.php';
 require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
+require_once __DIR__ . '/classes/PlayerNavigation.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -25,6 +26,7 @@ $playerReportPage = new PlayerReportPage(
 $playerSummary = $playerReportPage->getPlayerSummary();
 $explanation = $playerReportPage->getExplanation();
 $reportResult = $playerReportPage->getReportResult();
+$playerNavigation = PlayerNavigation::forSection((string) $player['online_id']);
 
 $title = $player["online_id"] . "'s Report ~ PSN 100%";
 require_once("header.php");
@@ -42,13 +44,7 @@ require_once("header.php");
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">
-                <div class="btn-group">
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>">Games</a>
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>/log">Log</a>
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>/advisor">Trophy Advisor</a>
-                    <a class="btn btn-outline-primary" href="/game?sort=completion&filter=true&player=<?= $player["online_id"]; ?>">Game Advisor</a>
-                    <a class="btn btn-outline-primary" href="/player/<?= $player["online_id"]; ?>/random">Random Games</a>
-                </div>
+                <?php require __DIR__ . '/player_navigation.php'; ?>
             </div>
 
             <div class="col-12 col-lg-3 mb-3">


### PR DESCRIPTION
## Summary
- create `PlayerNavigation` and `PlayerNavigationLink` classes to build the player navigation structure centrally
- add a reusable `player_navigation.php` partial that renders navigation links with consistent markup and accessibility data
- update player-related pages to consume the new view model instead of duplicating navigation markup

## Testing
- php -l wwwroot/classes/PlayerNavigation.php
- php -l wwwroot/player_navigation.php
- php -l wwwroot/player.php
- php -l wwwroot/player_log.php
- php -l wwwroot/player_advisor.php
- php -l wwwroot/player_random.php
- php -l wwwroot/player_report.php

------
https://chatgpt.com/codex/tasks/task_e_68f4ea1dff2c832fa0af947388126a9b