### PR TITLE
Refactor cron scripts to use reusable entry point

### DIFF
--- a/wwwroot/classes/Cron/CronJobEntryPoint.php
+++ b/wwwroot/classes/Cron/CronJobEntryPoint.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/CronJobBootstrapper.php';
+require_once __DIR__ . '/CronJobInterface.php';
+
+/**
+ * Small helper that encapsulates the procedural bootstrapping performed by
+ * each cron entry script.  By funnelling the duplicated logic through this
+ * class the entry scripts themselves can stay focused on describing which
+ * job should run while this class takes care of configuring the environment
+ * and validating the job factory.
+ */
+final class CronJobEntryPoint
+{
+    private CronJobBootstrapper $bootstrapper;
+
+    private function __construct(CronJobBootstrapper $bootstrapper)
+    {
+        $this->bootstrapper = $bootstrapper;
+    }
+
+    public static function create(string $projectRoot, ?CronJobBootstrapper $bootstrapper = null): self
+    {
+        return new self($bootstrapper ?? CronJobBootstrapper::create($projectRoot));
+    }
+
+    /**
+     * Convenience wrapper for cron jobs whose constructor only requires the
+     * PDO connection provided by the bootstrapper.
+     *
+     * @param class-string<CronJobInterface> $cronJobClass
+     */
+    public function runJob(string $cronJobClass, bool $loadComposerAutoload = false): void
+    {
+        if (!is_subclass_of($cronJobClass, CronJobInterface::class)) {
+            throw new InvalidArgumentException(sprintf(
+                'Cron job class "%s" must implement %s.',
+                $cronJobClass,
+                CronJobInterface::class
+            ));
+        }
+
+        $this->runWithFactory(
+            static fn(\PDO $database): CronJobInterface => new $cronJobClass($database),
+            $loadComposerAutoload
+        );
+    }
+
+    /**
+     * @param callable(\PDO):CronJobInterface $factory
+     */
+    public function runWithFactory(callable $factory, bool $loadComposerAutoload = false): void
+    {
+        $this->bootstrapper->bootstrap($loadComposerAutoload);
+
+        $this->bootstrapper->run(static function (\PDO $database) use ($factory): CronJobInterface {
+            $job = $factory($database);
+
+            if (!$job instanceof CronJobInterface) {
+                throw new InvalidArgumentException('Cron job factory must return a CronJobInterface instance.');
+            }
+
+            return $job;
+        });
+    }
+}

--- a/wwwroot/cron/30th_minute.php
+++ b/wwwroot/cron/30th_minute.php
@@ -2,20 +2,19 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/classes/Cron/CronJobBootstrapper.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobEntryPoint.php';
 require_once dirname(__DIR__) . '/classes/Cron/CronJobCliArguments.php';
 require_once dirname(__DIR__) . '/classes/TrophyCalculator.php';
 require_once dirname(__DIR__) . '/classes/Cron/ThirtyMinuteCronJob.php';
 
-$bootstrapper = CronJobBootstrapper::create(dirname(__DIR__));
-$bootstrapper->bootstrap(true);
+$entryPoint = CronJobEntryPoint::create(dirname(__DIR__));
 
 $cliArguments = CronJobCliArguments::fromArgv($_SERVER['argv'] ?? []);
 $workerId = $cliArguments->getWorkerId();
 
-$bootstrapper->run(static function (\PDO $database) use ($workerId): CronJobInterface {
+$entryPoint->runWithFactory(static function (\PDO $database) use ($workerId): CronJobInterface {
     $trophyCalculator = new TrophyCalculator($database);
     $logger = new Psn100Logger($database);
 
     return new ThirtyMinuteCronJob($database, $trophyCalculator, $logger, $workerId);
-});
+}, true);

--- a/wwwroot/cron/5th_minute.php
+++ b/wwwroot/cron/5th_minute.php
@@ -2,13 +2,11 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/classes/Cron/CronJobBootstrapper.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobEntryPoint.php';
 require_once dirname(__DIR__) . '/classes/Cron/PlayerRankingCronJob.php';
 
-$bootstrapper = CronJobBootstrapper::create(dirname(__DIR__));
-$bootstrapper->bootstrap();
-
-$bootstrapper->run(static function (\PDO $database): CronJobInterface {
+$entryPoint = CronJobEntryPoint::create(dirname(__DIR__));
+$entryPoint->runWithFactory(static function (\PDO $database): CronJobInterface {
     $playerRankingUpdater = new PlayerRankingUpdater($database);
 
     return new PlayerRankingCronJob($playerRankingUpdater);

--- a/wwwroot/cron/daily.php
+++ b/wwwroot/cron/daily.php
@@ -2,10 +2,8 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/classes/Cron/CronJobBootstrapper.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobEntryPoint.php';
 require_once dirname(__DIR__) . '/classes/Cron/DailyCronJob.php';
 
-$bootstrapper = CronJobBootstrapper::create(dirname(__DIR__));
-$bootstrapper->bootstrap();
-
-$bootstrapper->run(static fn (\PDO $database): CronJobInterface => new DailyCronJob($database));
+$entryPoint = CronJobEntryPoint::create(dirname(__DIR__));
+$entryPoint->runJob(DailyCronJob::class);

--- a/wwwroot/cron/hourly.php
+++ b/wwwroot/cron/hourly.php
@@ -2,10 +2,8 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/classes/Cron/CronJobBootstrapper.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobEntryPoint.php';
 require_once dirname(__DIR__) . '/classes/Cron/HourlyCronJob.php';
 
-$bootstrapper = CronJobBootstrapper::create(dirname(__DIR__));
-$bootstrapper->bootstrap();
-
-$bootstrapper->run(static fn (\PDO $database): CronJobInterface => new HourlyCronJob($database));
+$entryPoint = CronJobEntryPoint::create(dirname(__DIR__));
+$entryPoint->runJob(HourlyCronJob::class);

--- a/wwwroot/cron/weekly.php
+++ b/wwwroot/cron/weekly.php
@@ -2,10 +2,8 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/classes/Cron/CronJobBootstrapper.php';
+require_once dirname(__DIR__) . '/classes/Cron/CronJobEntryPoint.php';
 require_once dirname(__DIR__) . '/classes/Cron/WeeklyCronJob.php';
 
-$bootstrapper = CronJobBootstrapper::create(dirname(__DIR__));
-$bootstrapper->bootstrap();
-
-$bootstrapper->run(static fn (\PDO $database): CronJobInterface => new WeeklyCronJob($database));
+$entryPoint = CronJobEntryPoint::create(dirname(__DIR__));
+$entryPoint->runJob(WeeklyCronJob::class);


### PR DESCRIPTION
## Summary
- add a CronJobEntryPoint helper to encapsulate shared cron bootstrap logic
- update all cron entry scripts to invoke the new helper instead of duplicating setup

## Testing
- php -l wwwroot/classes/Cron/CronJobEntryPoint.php
- php -l wwwroot/cron/daily.php
- php -l wwwroot/cron/30th_minute.php

------
https://chatgpt.com/codex/tasks/task_e_68f4ea1dff2c832fa0af947388126a9b