### PR TITLE
Remove registered and copyright symbols from trophy title inserts

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1279,7 +1279,7 @@ class ThirtyMinuteCronJob implements CronJobInterface
             return $name;
         }
 
-        $name = str_replace('™', '', $name);
+        $name = str_replace(['™', '®', '©'], '', $name);
 
         if ($name === '') {
             return $name;


### PR DESCRIPTION
## Summary
- remove registered and copyright symbols when sanitizing trophy title names before insertion

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f7e937c5cc832f8c94abb811c98221