### PR TITLE
Prevent duplicate trophies during game copy

### DIFF
--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -170,6 +170,17 @@ class GameCopyService
                     existing.np_communication_id = :parent_np_communication_id
                     AND existing.order_id = t.order_id
             )
+            AND NOT EXISTS (
+                SELECT
+                    1
+                FROM
+                    trophy_merge tm
+                WHERE
+                    tm.child_np_communication_id = :child_np_communication_id
+                    AND tm.child_group_id = t.group_id
+                    AND tm.child_order_id = t.order_id
+                    AND tm.parent_np_communication_id = :parent_np_communication_id
+            )
         SQL;
 
     private PDO $database;


### PR DESCRIPTION
## Summary
- prevent the game copy routine from inserting duplicate trophies that already map to the parent list

## Testing
- php -l wwwroot/classes/Admin/GameCopyService.php

------
https://chatgpt.com/codex/tasks/task_e_68f95d8327cc832fa663ec479eb2dcc1