### PR TITLE
Adjust trophy group copying for merged games

### DIFF
--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -457,11 +457,13 @@ class GameCopyService
                 $candidateOffset = $preferredOffset ?? $groupOffset;
                 $newGroupId = $this->formatGroupId($numericGroupId + $candidateOffset, (string) $group['group_id']);
 
-                if ($preferredOffset === null) {
-                    while (isset($existingGroupIds[$newGroupId])) {
-                        $candidateOffset += 100;
-                        $newGroupId = $this->formatGroupId($numericGroupId + $candidateOffset, (string) $group['group_id']);
+                while (isset($existingGroupIds[$newGroupId])) {
+                    if ($preferredOffset !== null) {
+                        $preferredOffset = null;
                     }
+
+                    $candidateOffset += 100;
+                    $newGroupId = $this->formatGroupId($numericGroupId + $candidateOffset, (string) $group['group_id']);
                 }
 
                 $groupOffset = $candidateOffset;


### PR DESCRIPTION
## Summary
- preserve existing trophy group ids when copying a base list so the merged title is fully overwritten instead of remapped
- reuse a split list's existing numeric block when adding or updating trophy groups and trophies
- add a helper to derive the preferred numeric offset for previously mapped groups

## Testing
- php -l wwwroot/classes/Admin/GameCopyService.php

------
https://chatgpt.com/codex/tasks/task_e_68f9639ec5b8832fb084e1725e111610