### PR TITLE
Fix group ID parsing in GameCopyService

### DIFF
--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -1042,7 +1042,9 @@ class GameCopyService
     {
         $maxBlock = -1;
 
-        foreach (array_keys($existingGroupIds) as $groupId) {
+        foreach ($existingGroupIds as $groupId => $_) {
+            $groupId = (string) $groupId;
+
             $numericGroupId = $this->parseNumericGroupId($groupId);
 
             if ($numericGroupId === null) {


### PR DESCRIPTION
## Summary
- ensure determineGroupOffset casts array keys to strings before parsing numeric group IDs
- prevent fatal type errors when existing trophy group IDs are retrieved as integers

## Testing
- php -l wwwroot/classes/Admin/GameCopyService.php

------
https://chatgpt.com/codex/tasks/task_e_68f96b1f357c832fa7b119c9b36b8514