### PR TITLE
Add admin toggles for copying icon URL and set version

### DIFF
--- a/wwwroot/admin/copy.php
+++ b/wwwroot/admin/copy.php
@@ -27,6 +27,20 @@ $message = $gameCopyHandler->handle($_POST);
                 <input type="number" name="child"><br>
                 Game Parent ID:<br>
                 <input type="number" name="parent"><br>
+                <div class="form-check mt-3">
+                    <input type="hidden" name="copy_icon_url" value="0">
+                    <input class="form-check-input" type="checkbox" name="copy_icon_url" id="copy-icon-url" value="1" checked>
+                    <label class="form-check-label" for="copy-icon-url">
+                        Copy icon URL
+                    </label>
+                </div>
+                <div class="form-check mt-2">
+                    <input type="hidden" name="copy_set_version" value="0">
+                    <input class="form-check-input" type="checkbox" name="copy_set_version" id="copy-set-version" value="1" checked>
+                    <label class="form-check-label" for="copy-set-version">
+                        Copy set version
+                    </label>
+                </div>
                 <br>
                 <input type="submit" value="Submit">
             </form>

--- a/wwwroot/classes/Admin/GameCopyHandler.php
+++ b/wwwroot/classes/Admin/GameCopyHandler.php
@@ -24,8 +24,16 @@ class GameCopyHandler
             return 'Child and parent must be numeric IDs.';
         }
 
+        $copyIconUrl = $this->shouldCopySetting($postData, 'copy_icon_url');
+        $copySetVersion = $this->shouldCopySetting($postData, 'copy_set_version');
+
         try {
-            $this->gameCopyService->copyChildToParent($childId, $parentId);
+            $this->gameCopyService->copyChildToParent(
+                $childId,
+                $parentId,
+                $copyIconUrl,
+                $copySetVersion
+            );
         } catch (RuntimeException $exception) {
             return $exception->getMessage();
         }
@@ -49,5 +57,22 @@ class GameCopyHandler
         }
 
         return (int) $value;
+    }
+
+    private function shouldCopySetting(array $postData, string $key): bool
+    {
+        if (!array_key_exists($key, $postData)) {
+            return true;
+        }
+
+        $value = $postData[$key];
+
+        if (is_array($value)) {
+            $value = end($value);
+        }
+
+        $value = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+
+        return $value ?? true;
     }
 }


### PR DESCRIPTION
## Summary
- add checkbox controls on the admin copy form to decide whether icon URLs and set versions are copied
- teach the game copy handler to read the new settings and forward them to the service with sensible defaults
- update the game copy service to honour the new flags when updating the parent trophy title

## Testing
- php -l wwwroot/admin/copy.php
- php -l wwwroot/classes/Admin/GameCopyHandler.php
- php -l wwwroot/classes/Admin/GameCopyService.php

------
https://chatgpt.com/codex/tasks/task_e_68f96fc7afc8832faa069c43f5fc2ff4