### PR TITLE
Fix trophy_title to follow APA naming standard

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1466,14 +1466,14 @@ class ThirtyMinuteCronJob implements CronJobInterface
             return implode('-', $segments);
         }
 
-        if ($this->shouldPreserveTitleWord($word)) {
-            return $word;
-        }
-
         $wordLower = mb_strtolower($word, 'UTF-8');
 
         if (!$forceCapitalize && in_array($wordLower, $lowercaseWords, true)) {
             return $wordLower;
+        }
+
+        if ($this->shouldPreserveTitleWord($word)) {
+            return $word;
         }
 
         return $this->uppercaseFirstCharacter($wordLower);


### PR DESCRIPTION
## Summary
- updated the APA title case conversion so that lowercase words are being treated correctly, ensuring trophy titles follow the intended casing.

## Testing
- php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php

------
https://chatgpt.com/codex/tasks/task_e_68f9c3fd5174832fabc79a23f08c036d