### PR TITLE
Normalize en dash when sanitizing trophy titles

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1281,6 +1281,9 @@ class ThirtyMinuteCronJob implements CronJobInterface
 
         $name = str_replace(['™', '®', '©'], '', $name);
 
+        // Normalize en dash to hyphen-minus to keep downstream handling consistent.
+        $name = str_replace('–', '-', $name);
+
         if ($name === '') {
             return $name;
         }


### PR DESCRIPTION
## Summary
- normalize en dash characters to a standard hyphen when sanitizing new trophy titles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa6fb76e58832faa688465df4f7614