### PR TITLE
Refactor player platform filter UI into reusable classes

### DIFF
--- a/wwwroot/classes/PlayerPlatformFilterOptions.php
+++ b/wwwroot/classes/PlayerPlatformFilterOptions.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+final class PlayerPlatformFilterOption
+{
+    private string $key;
+
+    private string $label;
+
+    private bool $selected;
+
+    public function __construct(string $key, string $label, bool $selected)
+    {
+        $this->key = $key;
+        $this->label = $label;
+        $this->selected = $selected;
+    }
+
+    public function getInputName(): string
+    {
+        return $this->key;
+    }
+
+    public function getInputId(): string
+    {
+        return 'filter' . strtoupper($this->key);
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function isSelected(): bool
+    {
+        return $this->selected;
+    }
+}
+
+final class PlayerPlatformFilterOptions
+{
+    /**
+     * @var array<string, string>
+     */
+    private const PLATFORM_LABELS = [
+        'pc' => 'PC',
+        'ps3' => 'PS3',
+        'ps4' => 'PS4',
+        'ps5' => 'PS5',
+        'psvita' => 'PSVITA',
+        'psvr' => 'PSVR',
+        'psvr2' => 'PSVR2',
+    ];
+
+    /**
+     * @var PlayerPlatformFilterOption[]
+     */
+    private array $options;
+
+    /**
+     * @param PlayerPlatformFilterOption[] $options
+     */
+    private function __construct(array $options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * @param callable(string):bool $selectionCallback
+     */
+    public static function fromSelectionCallback(callable $selectionCallback): self
+    {
+        $options = [];
+
+        foreach (self::PLATFORM_LABELS as $key => $label) {
+            $options[] = new PlayerPlatformFilterOption(
+                $key,
+                $label,
+                (bool) $selectionCallback($key)
+            );
+        }
+
+        return new self($options);
+    }
+
+    /**
+     * @return PlayerPlatformFilterOption[]
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}
+

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerGamesPageContext.php';
 require_once __DIR__ . '/classes/PlayerNavigation.php';
+require_once __DIR__ . '/classes/PlayerPlatformFilterOptions.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -23,6 +24,9 @@ $metaData = $pageContext->getMetaData();
 $playerSearch = $pageContext->getSearch();
 $sort = $pageContext->getSort();
 $playerNavigation = PlayerNavigation::forSection((string) $player['online_id'], PlayerNavigation::SECTION_GAMES);
+$platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
+    static fn (string $platform): bool => $playerGamesFilter->isPlatformSelected($platform)
+);
 $title = $pageContext->getTitle();
 require_once("header.php");
 ?>
@@ -65,62 +69,24 @@ require_once("header.php");
                                     </label>
                                 </div>
                             </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerGamesFilter->isPlatformSelected(PlayerGamesFilter::PLATFORM_PC) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPC" name="pc">
-                                    <label class="form-check-label" for="filterPC">
-                                        PC
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerGamesFilter->isPlatformSelected(PlayerGamesFilter::PLATFORM_PS3) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPS3" name="ps3">
-                                    <label class="form-check-label" for="filterPS3">
-                                        PS3
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerGamesFilter->isPlatformSelected(PlayerGamesFilter::PLATFORM_PS4) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPS4" name="ps4">
-                                    <label class="form-check-label" for="filterPS4">
-                                        PS4
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerGamesFilter->isPlatformSelected(PlayerGamesFilter::PLATFORM_PS5) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPS5" name="ps5">
-                                    <label class="form-check-label" for="filterPS5">
-                                        PS5
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerGamesFilter->isPlatformSelected(PlayerGamesFilter::PLATFORM_PSVITA) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPSVITA" name="psvita">
-                                    <label class="form-check-label" for="filterPSVITA">
-                                        PSVITA
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerGamesFilter->isPlatformSelected(PlayerGamesFilter::PLATFORM_PSVR) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPSVR" name="psvr">
-                                    <label class="form-check-label" for="filterPSVR">
-                                        PSVR
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerGamesFilter->isPlatformSelected(PlayerGamesFilter::PLATFORM_PSVR2) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPSVR2" name="psvr2">
-                                    <label class="form-check-label" for="filterPSVR2">
-                                        PSVR2
-                                    </label>
-                                </div>
-                            </li>
+                            <?php foreach ($platformFilterOptions->getOptions() as $platformOption) { ?>
+                                <li>
+                                    <div class="form-check">
+                                        <?php $inputId = htmlspecialchars($platformOption->getInputId(), ENT_QUOTES, 'UTF-8'); ?>
+                                        <input
+                                            class="form-check-input"
+                                            type="checkbox"<?= $platformOption->isSelected() ? ' checked' : ''; ?>
+                                            value="true"
+                                            onChange="this.form.submit()"
+                                            id="<?= $inputId; ?>"
+                                            name="<?= htmlspecialchars($platformOption->getInputName(), ENT_QUOTES, 'UTF-8'); ?>"
+                                        >
+                                        <label class="form-check-label" for="<?= $inputId; ?>">
+                                            <?= htmlspecialchars($platformOption->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
+                                        </label>
+                                    </div>
+                                </li>
+                            <?php } ?>
                             <li>
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox"<?= ($playerGamesFilter->isUncompletedSelected() ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterUncompletedGames" name="uncompleted">

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
 require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
 require_once __DIR__ . '/classes/PlayerNavigation.php';
+require_once __DIR__ . '/classes/PlayerPlatformFilterOptions.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -35,6 +36,9 @@ $filterParameters = $playerAdvisorPage->getFilterParameters();
 $shouldDisplayAdvisor = $playerAdvisorPage->shouldDisplayAdvisor();
 $trophyRarityFormatter = new TrophyRarityFormatter();
 $playerNavigation = PlayerNavigation::forSection((string) $player['online_id'], PlayerNavigation::SECTION_TROPHY_ADVISOR);
+$platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
+    static fn (string $platform): bool => $playerAdvisorFilter->isPlatformSelected($platform)
+);
 
 $title = $player["online_id"] . "'s Trophy Advisor ~ PSN 100%";
 require_once("header.php");
@@ -60,62 +64,24 @@ require_once("header.php");
                     <div class="input-group d-flex justify-content-end">
                         <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Filter</button>
                         <ul class="dropdown-menu p-2">
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerAdvisorFilter->isPlatformSelected('pc') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPC" name="pc">
-                                    <label class="form-check-label" for="filterPC">
-                                        PC
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerAdvisorFilter->isPlatformSelected('ps3') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPS3" name="ps3">
-                                    <label class="form-check-label" for="filterPS3">
-                                        PS3
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerAdvisorFilter->isPlatformSelected('ps4') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPS4" name="ps4">
-                                    <label class="form-check-label" for="filterPS4">
-                                        PS4
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerAdvisorFilter->isPlatformSelected('ps5') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPS5" name="ps5">
-                                    <label class="form-check-label" for="filterPS5">
-                                        PS5
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerAdvisorFilter->isPlatformSelected('psvita') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPSVITA" name="psvita">
-                                    <label class="form-check-label" for="filterPSVITA">
-                                        PSVITA
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerAdvisorFilter->isPlatformSelected('psvr') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPSVR" name="psvr">
-                                    <label class="form-check-label" for="filterPSVR">
-                                        PSVR
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerAdvisorFilter->isPlatformSelected('psvr2') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPSVR2" name="psvr2">
-                                    <label class="form-check-label" for="filterPSVR2">
-                                        PSVR2
-                                    </label>
-                                </div>
-                            </li>
+                            <?php foreach ($platformFilterOptions->getOptions() as $platformOption) { ?>
+                                <li>
+                                    <div class="form-check">
+                                        <?php $inputId = htmlspecialchars($platformOption->getInputId(), ENT_QUOTES, 'UTF-8'); ?>
+                                        <input
+                                            class="form-check-input"
+                                            type="checkbox"<?= $platformOption->isSelected() ? ' checked' : ''; ?>
+                                            value="true"
+                                            onChange="this.form.submit()"
+                                            id="<?= $inputId; ?>"
+                                            name="<?= htmlspecialchars($platformOption->getInputName(), ENT_QUOTES, 'UTF-8'); ?>"
+                                        >
+                                        <label class="form-check-label" for="<?= $inputId; ?>">
+                                            <?= htmlspecialchars($platformOption->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
+                                        </label>
+                                    </div>
+                                </li>
+                            <?php } ?>
                         </ul>
                     </div>
                 </form>

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
 require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
 require_once __DIR__ . '/classes/PlayerNavigation.php';
+require_once __DIR__ . '/classes/PlayerPlatformFilterOptions.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -26,6 +27,9 @@ $playerLogPage = new PlayerLogPage(
 $trophiesLog = $playerLogPage->getTrophies();
 $trophyRarityFormatter = new TrophyRarityFormatter();
 $playerNavigation = PlayerNavigation::forSection((string) $player['online_id'], PlayerNavigation::SECTION_LOG);
+$platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
+    static fn (string $platform): bool => $playerLogFilter->isPlatformSelected($platform)
+);
 
 $title = $player["online_id"] . "'s Trophy Log ~ PSN 100%";
 require_once("header.php");
@@ -51,62 +55,24 @@ require_once("header.php");
                     <div class="input-group d-flex justify-content-end">
                         <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Filter</button>
                         <ul class="dropdown-menu p-2">
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerLogFilter->isPlatformSelected('pc') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPC" name="pc">
-                                    <label class="form-check-label" for="filterPC">
-                                        PC
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerLogFilter->isPlatformSelected('ps3') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPS3" name="ps3">
-                                    <label class="form-check-label" for="filterPS3">
-                                        PS3
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerLogFilter->isPlatformSelected('ps4') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPS4" name="ps4">
-                                    <label class="form-check-label" for="filterPS4">
-                                        PS4
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerLogFilter->isPlatformSelected('ps5') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPS5" name="ps5">
-                                    <label class="form-check-label" for="filterPS5">
-                                        PS5
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerLogFilter->isPlatformSelected('psvita') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPSVITA" name="psvita">
-                                    <label class="form-check-label" for="filterPSVITA">
-                                        PSVITA
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerLogFilter->isPlatformSelected('psvr') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPSVR" name="psvr">
-                                    <label class="form-check-label" for="filterPSVR">
-                                        PSVR
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= $playerLogFilter->isPlatformSelected('psvr2') ? ' checked' : ''; ?> value="true" onChange="this.form.submit()" id="filterPSVR2" name="psvr2">
-                                    <label class="form-check-label" for="filterPSVR2">
-                                        PSVR2
-                                    </label>
-                                </div>
-                            </li>
+                            <?php foreach ($platformFilterOptions->getOptions() as $platformOption) { ?>
+                                <li>
+                                    <div class="form-check">
+                                        <?php $inputId = htmlspecialchars($platformOption->getInputId(), ENT_QUOTES, 'UTF-8'); ?>
+                                        <input
+                                            class="form-check-input"
+                                            type="checkbox"<?= $platformOption->isSelected() ? ' checked' : ''; ?>
+                                            value="true"
+                                            onChange="this.form.submit()"
+                                            id="<?= $inputId; ?>"
+                                            name="<?= htmlspecialchars($platformOption->getInputName(), ENT_QUOTES, 'UTF-8'); ?>"
+                                        >
+                                        <label class="form-check-label" for="<?= $inputId; ?>">
+                                            <?= htmlspecialchars($platformOption->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
+                                        </label>
+                                    </div>
+                                </li>
+                            <?php } ?>
                         </ul>
 
                         <select class="form-select" name="sort" onChange="this.form.submit()">

--- a/wwwroot/player_random.php
+++ b/wwwroot/player_random.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/classes/PlayerRandomGamesPage.php';
 require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
 require_once __DIR__ . '/classes/PlayerNavigation.php';
+require_once __DIR__ . '/classes/PlayerPlatformFilterOptions.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -28,6 +29,9 @@ $playerRandomGamesFilter = $playerRandomGamesPage->getFilter();
 $playerSummary = $playerRandomGamesPage->getPlayerSummary();
 $randomGames = $playerRandomGamesPage->getRandomGames();
 $playerNavigation = PlayerNavigation::forSection((string) $player['online_id'], PlayerNavigation::SECTION_RANDOM);
+$platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
+    static fn (string $platform): bool => $playerRandomGamesFilter->isPlatformSelected($platform)
+);
 
 $title = $player["online_id"] . "'s Random Games ~ PSN 100%";
 require_once("header.php");
@@ -53,62 +57,24 @@ require_once("header.php");
                     <div class="input-group d-flex justify-content-end">
                         <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Filter</button>
                         <ul class="dropdown-menu p-2">
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerRandomGamesFilter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PC) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPC" name="pc">
-                                    <label class="form-check-label" for="filterPC">
-                                        PC
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerRandomGamesFilter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS3) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPS3" name="ps3">
-                                    <label class="form-check-label" for="filterPS3">
-                                        PS3
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerRandomGamesFilter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS4) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPS4" name="ps4">
-                                    <label class="form-check-label" for="filterPS4">
-                                        PS4
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerRandomGamesFilter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS5) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPS5" name="ps5">
-                                    <label class="form-check-label" for="filterPS5">
-                                        PS5
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerRandomGamesFilter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVITA) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPSVITA" name="psvita">
-                                    <label class="form-check-label" for="filterPSVITA">
-                                        PSVITA
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerRandomGamesFilter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVR) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPSVR" name="psvr">
-                                    <label class="form-check-label" for="filterPSVR">
-                                        PSVR
-                                    </label>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox"<?= ($playerRandomGamesFilter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVR2) ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterPSVR2" name="psvr2">
-                                    <label class="form-check-label" for="filterPSVR2">
-                                        PSVR2
-                                    </label>
-                                </div>
-                            </li>
+                            <?php foreach ($platformFilterOptions->getOptions() as $platformOption) { ?>
+                                <li>
+                                    <div class="form-check">
+                                        <?php $inputId = htmlspecialchars($platformOption->getInputId(), ENT_QUOTES, 'UTF-8'); ?>
+                                        <input
+                                            class="form-check-input"
+                                            type="checkbox"<?= $platformOption->isSelected() ? ' checked' : ''; ?>
+                                            value="true"
+                                            onChange="this.form.submit()"
+                                            id="<?= $inputId; ?>"
+                                            name="<?= htmlspecialchars($platformOption->getInputName(), ENT_QUOTES, 'UTF-8'); ?>"
+                                        >
+                                        <label class="form-check-label" for="<?= $inputId; ?>">
+                                            <?= htmlspecialchars($platformOption->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
+                                        </label>
+                                    </div>
+                                </li>
+                            <?php } ?>
                         </ul>
                     </div>
                 </form>


### PR DESCRIPTION
## Summary
- add PlayerPlatformFilterOptions value objects to encapsulate common platform checkbox data
- update player-related pages to build filter options via the new class instead of duplicated inline logic

## Testing
- php -l wwwroot/classes/PlayerPlatformFilterOptions.php
- php -l wwwroot/player.php
- php -l wwwroot/player_advisor.php
- php -l wwwroot/player_log.php
- php -l wwwroot/player_random.php

------
https://chatgpt.com/codex/tasks/task_e_68f545e78400832fb6e7d02fea2aa931