### PR TITLE
Ensure trophy titles capitalize words after sentence punctuation

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1439,7 +1439,7 @@ class ThirtyMinuteCronJob implements CronJobInterface
 
             if ($coreWord === '') {
                 $convertedWords[] = $word;
-                $capitalizeNext = str_contains($word, ':');
+                $capitalizeNext = $this->shouldCapitalizeAfterPunctuation($word);
                 continue;
             }
 
@@ -1451,7 +1451,7 @@ class ThirtyMinuteCronJob implements CronJobInterface
 
             $convertedWords[] = $leadingPunctuation . $processedCore . $trailingPunctuation;
 
-            $capitalizeNext = str_contains($trailingPunctuation, ':');
+            $capitalizeNext = $this->shouldCapitalizeAfterPunctuation($trailingPunctuation);
         }
 
         return implode(' ', $convertedWords);
@@ -1523,5 +1523,22 @@ class ThirtyMinuteCronJob implements CronJobInterface
     private function uppercaseFirstCharacter(string $word): string
     {
         return mb_convert_case($word, MB_CASE_TITLE, 'UTF-8');
+    }
+
+    private function shouldCapitalizeAfterPunctuation(string $punctuation): bool
+    {
+        if ($punctuation === '') {
+            return false;
+        }
+
+        $triggerCharacters = [':', '!', '?', '.'];
+
+        foreach ($triggerCharacters as $character) {
+            if (str_contains($punctuation, $character)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- ensure the APA-style title casing logic capitalizes words that follow punctuation-only tokens
- treat trailing punctuation such as colons, exclamation points, question marks, and periods as triggers to capitalize the next word

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa813cf424832faf8461e1ec703269