### PR TITLE
Fix htmlentities error in psnp-plus.php

### DIFF
--- a/wwwroot/admin/psnp-plus.php
+++ b/wwwroot/admin/psnp-plus.php
@@ -39,7 +39,7 @@ try {
                     <div class="mb-3">
                         <?php foreach ($psnpPlusReport->getMissingGames() as $missingGame) { ?>
                             <p>
-                                PSNProfiles ID <a href="<?= $missingGame->getPsnprofilesUrl(); ?>" target="_blank" rel="noopener"><?= htmlentities($missingGame->getPsnprofilesId(), ENT_QUOTES, 'UTF-8'); ?></a> not in our database.
+                                PSNProfiles ID <a href="<?= htmlentities($missingGame->getPsnprofilesUrl(), ENT_QUOTES, 'UTF-8'); ?>" target="_blank" rel="noopener"><?= htmlentities((string) $missingGame->getPsnprofilesId(), ENT_QUOTES, 'UTF-8'); ?></a> not in our database.
                             </p>
                         <?php } ?>
                     </div>


### PR DESCRIPTION
## Summary
- HTML-escape the PSNProfiles URL for missing games so the page renders plain text instead of executing injected markup
- Cast the PSNProfiles ID to a string before escaping so strict types do not cause rendering errors

## Testing
- php -l wwwroot/admin/psnp-plus.php

------
https://chatgpt.com/codex/tasks/task_e_68fc8a2c23c0832fa0698b886a06b265