### PR TITLE
Fix spacing around PSNP+ status labels

### DIFF
--- a/wwwroot/admin/psnp-plus.php
+++ b/wwwroot/admin/psnp-plus.php
@@ -54,15 +54,11 @@ try {
                         </strong><br>
 
                         <?php if ($difference->hasUnobtainable()) { ?>
-                            <a href="unobtainable.php?status=1&amp;trophy=<?= $difference->getUnobtainableTrophyIdQuery(); ?>">
-                                Unobtainable
-                            </a>: <?= htmlentities($difference->getUnobtainableOrderList(), ENT_QUOTES, 'UTF-8'); ?><br>
+                            <a href="unobtainable.php?status=1&amp;trophy=<?= $difference->getUnobtainableTrophyIdQuery(); ?>">Unobtainable</a>: <?= htmlentities($difference->getUnobtainableOrderList(), ENT_QUOTES, 'UTF-8'); ?><br>
                         <?php } ?>
 
                         <?php if ($difference->hasObtainable()) { ?>
-                            <a href="unobtainable.php?status=0&amp;trophy=<?= $difference->getObtainableTrophyIdQuery(); ?>">
-                                Obtainable
-                            </a>: <?= htmlentities($difference->getObtainableOrderList(), ENT_QUOTES, 'UTF-8'); ?><br>
+                            <a href="unobtainable.php?status=0&amp;trophy=<?= $difference->getObtainableTrophyIdQuery(); ?>">Obtainable</a>: <?= htmlentities($difference->getObtainableOrderList(), ENT_QUOTES, 'UTF-8'); ?><br>
                         <?php } ?>
                     </div>
                 <?php } ?>
@@ -78,9 +74,7 @@ try {
                         </strong><br>
 
                         <?php if ($fixedGame->hasTrophies()) { ?>
-                            <a href="unobtainable.php?status=0&amp;trophy=<?= $fixedGame->getTrophyIdQuery(); ?>">
-                                Obtainable
-                            </a>: <?= htmlentities($fixedGame->getTrophyIdList(), ENT_QUOTES, 'UTF-8'); ?><br>
+                            <a href="unobtainable.php?status=0&amp;trophy=<?= $fixedGame->getTrophyIdQuery(); ?>">Obtainable</a>: <?= htmlentities($fixedGame->getTrophyIdList(), ENT_QUOTES, 'UTF-8'); ?><br>
                         <?php } ?>
                     </div>
                 <?php } ?>


### PR DESCRIPTION
## Summary
- eliminate extra whitespace before the unobtainable/obtainable colons in the PSNP+ admin report
- keep the colon out of the anchor so the link text is just the status label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc951131ac832f98b9d74f3660949a