### PR TITLE
Refactor leaderboard contexts into shared base

### DIFF
--- a/wwwroot/classes/Leaderboard/AbstractLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/AbstractLeaderboardPageContext.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../PlayerLeaderboardFilter.php';
+require_once __DIR__ . '/../PlayerLeaderboardPage.php';
+require_once __DIR__ . '/../PlayerLeaderboardDataProvider.php';
+require_once __DIR__ . '/../Utility.php';
+require_once __DIR__ . '/AbstractLeaderboardRow.php';
+
+abstract class AbstractLeaderboardPageContext
+{
+    private PlayerLeaderboardPage $leaderboardPage;
+
+    private PlayerLeaderboardFilter $filter;
+
+    private Utility $utility;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $filterParameters;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $currentPageParameters;
+
+    private ?string $highlightedPlayerId;
+
+    /**
+     * @var AbstractLeaderboardRow[]
+     */
+    private array $rows;
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    protected function __construct(
+        PlayerLeaderboardPage $leaderboardPage,
+        PlayerLeaderboardFilter $filter,
+        Utility $utility,
+        array $queryParameters
+    ) {
+        $this->leaderboardPage = $leaderboardPage;
+        $this->filter = $filter;
+        $this->utility = $utility;
+        $this->filterParameters = $leaderboardPage->getFilterParameters();
+        $this->currentPageParameters = $leaderboardPage->getPageQueryParameters($leaderboardPage->getCurrentPage());
+        $this->highlightedPlayerId = $this->resolveHighlightedPlayerId($queryParameters);
+        $this->rows = $this->buildRows();
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    final public static function fromGlobals(PDO $database, Utility $utility, array $queryParameters): static
+    {
+        $dataProvider = static::createDataProvider($database);
+        $playerLeaderboardFilter = PlayerLeaderboardFilter::fromArray($queryParameters);
+        $playerLeaderboardPage = new PlayerLeaderboardPage($dataProvider, $playerLeaderboardFilter);
+
+        return new static($playerLeaderboardPage, $playerLeaderboardFilter, $utility, $queryParameters);
+    }
+
+    abstract public function getTitle(): string;
+
+    /**
+     * @return AbstractLeaderboardRow[]
+     */
+    final public function getRows(): array
+    {
+        return $this->rows;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    final public function getFilterQueryParameters(): array
+    {
+        return $this->filterParameters;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    final public function getCurrentPageQueryParameters(): array
+    {
+        return $this->currentPageParameters;
+    }
+
+    final public function shouldShowCountryRank(): bool
+    {
+        return $this->filter->hasCountry();
+    }
+
+    final public function getLeaderboardPage(): PlayerLeaderboardPage
+    {
+        return $this->leaderboardPage;
+    }
+
+    abstract protected static function createDataProvider(PDO $database): PlayerLeaderboardDataProvider;
+
+    /**
+     * @param array<string, mixed> $player
+     */
+    abstract protected function createRow(
+        array $player,
+        PlayerLeaderboardFilter $filter,
+        Utility $utility,
+        ?string $highlightedPlayerId,
+        array $filterParameters
+    ): AbstractLeaderboardRow;
+
+    /**
+     * @return AbstractLeaderboardRow[]
+     */
+    private function buildRows(): array
+    {
+        $players = $this->leaderboardPage->getPlayers();
+
+        return array_map(
+            fn (array $player): AbstractLeaderboardRow => $this->createRow(
+                $player,
+                $this->filter,
+                $this->utility,
+                $this->highlightedPlayerId,
+                $this->filterParameters
+            ),
+            $players
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    private function resolveHighlightedPlayerId(array $queryParameters): ?string
+    {
+        $highlightedPlayer = $queryParameters['player'] ?? null;
+
+        if ($highlightedPlayer === null) {
+            return null;
+        }
+
+        $highlightedPlayer = trim((string) $highlightedPlayer);
+
+        return $highlightedPlayer !== '' ? $highlightedPlayer : null;
+    }
+}
+

--- a/wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
@@ -2,140 +2,40 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../PlayerLeaderboardFilter.php';
+require_once __DIR__ . '/AbstractLeaderboardPageContext.php';
 require_once __DIR__ . '/../PlayerRarityLeaderboardService.php';
-require_once __DIR__ . '/../PlayerLeaderboardPage.php';
-require_once __DIR__ . '/../Utility.php';
 require_once __DIR__ . '/RarityLeaderboardRow.php';
 
-class RarityLeaderboardPageContext
+class RarityLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
     private const TITLE = 'PSN Rarity Leaderboard ~ PSN 100%';
-
-    private PlayerLeaderboardPage $leaderboardPage;
-
-    private PlayerLeaderboardFilter $filter;
-
-    private Utility $utility;
-
-    /**
-     * @var array<string, string>
-     */
-    private array $filterParameters;
-
-    /**
-     * @var array<string, string>
-     */
-    private array $currentPageParameters;
-
-    private ?string $highlightedPlayerId;
-
-    /**
-     * @var RarityLeaderboardRow[]
-     */
-    private array $rows;
-
-    /**
-     * @param array<string, mixed> $queryParameters
-     */
-    private function __construct(
-        PlayerLeaderboardPage $leaderboardPage,
-        PlayerLeaderboardFilter $filter,
-        Utility $utility,
-        array $queryParameters
-    ) {
-        $this->leaderboardPage = $leaderboardPage;
-        $this->filter = $filter;
-        $this->utility = $utility;
-        $this->filterParameters = $leaderboardPage->getFilterParameters();
-        $this->currentPageParameters = $leaderboardPage->getPageQueryParameters($leaderboardPage->getCurrentPage());
-        $this->highlightedPlayerId = $this->resolveHighlightedPlayerId($queryParameters);
-        $this->rows = $this->buildRows();
-    }
-
-    /**
-     * @param array<string, mixed> $queryParameters
-     */
-    public static function fromGlobals(PDO $database, Utility $utility, array $queryParameters): self
-    {
-        $playerLeaderboardService = new PlayerRarityLeaderboardService($database);
-        $playerLeaderboardFilter = PlayerLeaderboardFilter::fromArray($queryParameters);
-        $playerLeaderboardPage = new PlayerLeaderboardPage($playerLeaderboardService, $playerLeaderboardFilter);
-
-        return new self($playerLeaderboardPage, $playerLeaderboardFilter, $utility, $queryParameters);
-    }
-
-    /**
-     * @param array<string, mixed> $queryParameters
-     */
-    private function resolveHighlightedPlayerId(array $queryParameters): ?string
-    {
-        $highlightedPlayer = $queryParameters['player'] ?? null;
-
-        if ($highlightedPlayer === null) {
-            return null;
-        }
-
-        $highlightedPlayer = trim((string) $highlightedPlayer);
-
-        return $highlightedPlayer !== '' ? $highlightedPlayer : null;
-    }
-
-    /**
-     * @return RarityLeaderboardRow[]
-     */
-    private function buildRows(): array
-    {
-        $players = $this->leaderboardPage->getPlayers();
-
-        return array_map(
-            fn(array $player): RarityLeaderboardRow => new RarityLeaderboardRow(
-                $player,
-                $this->filter,
-                $this->utility,
-                $this->highlightedPlayerId,
-                $this->filterParameters
-            ),
-            $players
-        );
-    }
 
     public function getTitle(): string
     {
         return self::TITLE;
     }
 
-    /**
-     * @return RarityLeaderboardRow[]
-     */
-    public function getRows(): array
+    protected static function createDataProvider(PDO $database): PlayerLeaderboardDataProvider
     {
-        return $this->rows;
+        return new PlayerRarityLeaderboardService($database);
     }
 
     /**
-     * @return array<string, string>
+     * @param array<string, mixed> $player
      */
-    public function getFilterQueryParameters(): array
-    {
-        return $this->filterParameters;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    public function getCurrentPageQueryParameters(): array
-    {
-        return $this->currentPageParameters;
-    }
-
-    public function shouldShowCountryRank(): bool
-    {
-        return $this->filter->hasCountry();
-    }
-
-    public function getLeaderboardPage(): PlayerLeaderboardPage
-    {
-        return $this->leaderboardPage;
+    protected function createRow(
+        array $player,
+        PlayerLeaderboardFilter $filter,
+        Utility $utility,
+        ?string $highlightedPlayerId,
+        array $filterParameters
+    ): AbstractLeaderboardRow {
+        return new RarityLeaderboardRow(
+            $player,
+            $filter,
+            $utility,
+            $highlightedPlayerId,
+            $filterParameters
+        );
     }
 }

--- a/wwwroot/classes/Leaderboard/TrophyLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/TrophyLeaderboardPageContext.php
@@ -2,140 +2,40 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../PlayerLeaderboardFilter.php';
+require_once __DIR__ . '/AbstractLeaderboardPageContext.php';
 require_once __DIR__ . '/../PlayerLeaderboardService.php';
-require_once __DIR__ . '/../PlayerLeaderboardPage.php';
-require_once __DIR__ . '/../Utility.php';
 require_once __DIR__ . '/TrophyLeaderboardRow.php';
 
-class TrophyLeaderboardPageContext
+class TrophyLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
     private const TITLE = 'PSN Trophy Leaderboard ~ PSN 100%';
-
-    private PlayerLeaderboardPage $leaderboardPage;
-
-    private PlayerLeaderboardFilter $filter;
-
-    private Utility $utility;
-
-    /**
-     * @var array<string, string>
-     */
-    private array $filterParameters;
-
-    /**
-     * @var array<string, string>
-     */
-    private array $currentPageParameters;
-
-    private ?string $highlightedPlayerId;
-
-    /**
-     * @var TrophyLeaderboardRow[]
-     */
-    private array $rows;
-
-    /**
-     * @param array<string, mixed> $queryParameters
-     */
-    private function __construct(
-        PlayerLeaderboardPage $leaderboardPage,
-        PlayerLeaderboardFilter $filter,
-        Utility $utility,
-        array $queryParameters
-    ) {
-        $this->leaderboardPage = $leaderboardPage;
-        $this->filter = $filter;
-        $this->utility = $utility;
-        $this->filterParameters = $leaderboardPage->getFilterParameters();
-        $this->currentPageParameters = $leaderboardPage->getPageQueryParameters($leaderboardPage->getCurrentPage());
-        $this->highlightedPlayerId = $this->resolveHighlightedPlayerId($queryParameters);
-        $this->rows = $this->buildRows();
-    }
-
-    /**
-     * @param array<string, mixed> $queryParameters
-     */
-    public static function fromGlobals(PDO $database, Utility $utility, array $queryParameters): self
-    {
-        $playerLeaderboardService = new PlayerLeaderboardService($database);
-        $playerLeaderboardFilter = PlayerLeaderboardFilter::fromArray($queryParameters);
-        $playerLeaderboardPage = new PlayerLeaderboardPage($playerLeaderboardService, $playerLeaderboardFilter);
-
-        return new self($playerLeaderboardPage, $playerLeaderboardFilter, $utility, $queryParameters);
-    }
-
-    /**
-     * @param array<string, mixed> $queryParameters
-     */
-    private function resolveHighlightedPlayerId(array $queryParameters): ?string
-    {
-        $highlightedPlayer = $queryParameters['player'] ?? null;
-
-        if ($highlightedPlayer === null) {
-            return null;
-        }
-
-        $highlightedPlayer = trim((string) $highlightedPlayer);
-
-        return $highlightedPlayer !== '' ? $highlightedPlayer : null;
-    }
-
-    /**
-     * @return TrophyLeaderboardRow[]
-     */
-    private function buildRows(): array
-    {
-        $players = $this->leaderboardPage->getPlayers();
-
-        return array_map(
-            fn(array $player): TrophyLeaderboardRow => new TrophyLeaderboardRow(
-                $player,
-                $this->filter,
-                $this->utility,
-                $this->highlightedPlayerId,
-                $this->filterParameters
-            ),
-            $players
-        );
-    }
 
     public function getTitle(): string
     {
         return self::TITLE;
     }
 
-    /**
-     * @return TrophyLeaderboardRow[]
-     */
-    public function getRows(): array
+    protected static function createDataProvider(PDO $database): PlayerLeaderboardDataProvider
     {
-        return $this->rows;
+        return new PlayerLeaderboardService($database);
     }
 
     /**
-     * @return array<string, string>
+     * @param array<string, mixed> $player
      */
-    public function getFilterQueryParameters(): array
-    {
-        return $this->filterParameters;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    public function getCurrentPageQueryParameters(): array
-    {
-        return $this->currentPageParameters;
-    }
-
-    public function shouldShowCountryRank(): bool
-    {
-        return $this->filter->hasCountry();
-    }
-
-    public function getLeaderboardPage(): PlayerLeaderboardPage
-    {
-        return $this->leaderboardPage;
+    protected function createRow(
+        array $player,
+        PlayerLeaderboardFilter $filter,
+        Utility $utility,
+        ?string $highlightedPlayerId,
+        array $filterParameters
+    ): AbstractLeaderboardRow {
+        return new TrophyLeaderboardRow(
+            $player,
+            $filter,
+            $utility,
+            $highlightedPlayerId,
+            $filterParameters
+        );
     }
 }


### PR DESCRIPTION
## Summary
- extract a shared `AbstractLeaderboardPageContext` to encapsulate common leaderboard filtering and row-building logic
- update the trophy and rarity leaderboard contexts to extend the shared base and focus on their specific data providers and rows

## Testing
- php -l wwwroot/classes/Leaderboard/AbstractLeaderboardPageContext.php
- php -l wwwroot/classes/Leaderboard/TrophyLeaderboardPageContext.php
- php -l wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php

------
https://chatgpt.com/codex/tasks/task_e_68fa911d6644832f9d3e3f66e4e6a524