### PR TITLE
Introduce RouteResultResponder for application responses

### DIFF
--- a/wwwroot/classes/Application.php
+++ b/wwwroot/classes/Application.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Router.php';
-require_once __DIR__ . '/RouteResult.php';
 require_once __DIR__ . '/HttpRequest.php';
 require_once __DIR__ . '/TemplateRenderer.php';
+require_once __DIR__ . '/RouteResultResponder.php';
 
 class Application
 {
@@ -13,21 +13,21 @@ class Application
 
     private HttpRequest $request;
 
-    private TemplateRenderer $templateRenderer;
-
-    private string $notFoundTemplate;
+    private RouteResultResponder $routeResultResponder;
 
     public function __construct(
         Router $router,
         HttpRequest $request,
         TemplateRenderer $templateRenderer,
-        string $notFoundTemplate = '404.php'
-    )
-    {
+        string $notFoundTemplate = '404.php',
+        ?RouteResultResponder $routeResultResponder = null
+    ) {
         $this->router = $router;
         $this->request = $request;
-        $this->templateRenderer = $templateRenderer;
-        $this->notFoundTemplate = $notFoundTemplate;
+        $this->routeResultResponder = $routeResultResponder ?? new RouteResultResponder(
+            $templateRenderer,
+            $notFoundTemplate
+        );
     }
 
     public function run(): void
@@ -35,31 +35,6 @@ class Application
         $requestUri = $this->request->getResolvedUri();
         $routeResult = $this->router->dispatch($requestUri);
 
-        $this->handleRouteResult($routeResult);
-    }
-
-    private function handleRouteResult(RouteResult $routeResult): void
-    {
-        if ($routeResult->shouldRedirect()) {
-            $location = $routeResult->getRedirect() ?? '/';
-            $statusCode = $routeResult->getStatusCode() ?? 303;
-
-            header('Location: ' . $location, true, $statusCode);
-            exit();
-        }
-
-        if ($routeResult->isNotFound()) {
-            $statusCode = $routeResult->getStatusCode() ?? 404;
-            http_response_code($statusCode);
-            $this->templateRenderer->render($this->notFoundTemplate);
-            exit();
-        }
-
-        if ($routeResult->shouldInclude()) {
-            $include = $routeResult->getInclude();
-            if ($include !== null) {
-                $this->templateRenderer->render($include, $routeResult->getVariables());
-            }
-        }
+        $this->routeResultResponder->respond($routeResult);
     }
 }

--- a/wwwroot/classes/RouteResultResponder.php
+++ b/wwwroot/classes/RouteResultResponder.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/RouteResult.php';
+require_once __DIR__ . '/TemplateRenderer.php';
+
+/**
+ * Handles emitting HTTP responses for a given {@see RouteResult}.
+ *
+ * By encapsulating the behaviour in a dedicated class we make it easier to
+ * unit test and reuse response emitting logic while keeping the
+ * {@see Application} class focused on routing concerns.
+ */
+final class RouteResultResponder
+{
+    private TemplateRenderer $templateRenderer;
+
+    private string $notFoundTemplate;
+
+    public function __construct(TemplateRenderer $templateRenderer, string $notFoundTemplate = '404.php')
+    {
+        $this->templateRenderer = $templateRenderer;
+        $this->notFoundTemplate = $notFoundTemplate;
+    }
+
+    public function respond(RouteResult $routeResult): void
+    {
+        if ($routeResult->shouldRedirect()) {
+            $this->emitRedirect(
+                $routeResult->getRedirect() ?? '/',
+                $routeResult->getStatusCode() ?? 303
+            );
+
+            return;
+        }
+
+        if ($routeResult->isNotFound()) {
+            $this->emitNotFound($routeResult->getStatusCode() ?? 404);
+
+            return;
+        }
+
+        if ($routeResult->shouldInclude()) {
+            $include = $routeResult->getInclude();
+            if ($include !== null) {
+                $this->emitTemplate($include, $routeResult->getVariables());
+            }
+        }
+    }
+
+    private function emitRedirect(string $location, int $statusCode): void
+    {
+        header('Location: ' . $location, true, $statusCode);
+        exit();
+    }
+
+    private function emitNotFound(int $statusCode): void
+    {
+        http_response_code($statusCode);
+        $this->templateRenderer->render($this->notFoundTemplate);
+        exit();
+    }
+
+    /**
+     * @param array<string, mixed> $variables
+     */
+    private function emitTemplate(string $template, array $variables): void
+    {
+        $this->templateRenderer->render($template, $variables);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a RouteResultResponder that encapsulates emitting responses for RouteResult instances
- update Application to delegate route handling to the responder and allow optional injection

## Testing
- php -l wwwroot/classes/RouteResultResponder.php
- php -l wwwroot/classes/Application.php

------
https://chatgpt.com/codex/tasks/task_e_68fa911d6644832f9d3e3f66e4e6a524