### PR TITLE
Refactor maintenance page into OOP components

### DIFF
--- a/wwwroot/classes/MaintenancePage.php
+++ b/wwwroot/classes/MaintenancePage.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/MaintenancePageStylesheet.php';
+
+final class MaintenancePage
+{
+    private string $title;
+
+    private string $heading;
+
+    private string $description;
+
+    private string $author;
+
+    private string $message;
+
+    /**
+     * @var MaintenancePageStylesheet[]
+     */
+    private array $stylesheets;
+
+    /**
+     * @param MaintenancePageStylesheet[] $stylesheets
+     */
+    private function __construct(
+        string $title,
+        string $heading,
+        string $description,
+        string $author,
+        string $message,
+        array $stylesheets
+    ) {
+        $this->title = $title;
+        $this->heading = $heading;
+        $this->description = $description;
+        $this->author = $author;
+        $this->message = $message;
+        $this->stylesheets = $stylesheets;
+    }
+
+    public static function createDefault(): self
+    {
+        return new self(
+            'Maintenance ~ PSN 100%',
+            'Maintenance',
+            'Check your leaderboard position against other PlayStation trophy hunters!',
+            "Markus 'Ragowit' Persson, and other contributors via GitHub project",
+            'The site is undergoing some maintenance. Should be back soon!',
+            [MaintenancePageStylesheet::bootstrapCdn()]
+        );
+    }
+
+    public function withMessage(string $message): self
+    {
+        $clone = clone $this;
+        $clone->message = $message;
+
+        return $clone;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getHeading(): string
+    {
+        return $this->heading;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getAuthor(): string
+    {
+        return $this->author;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return MaintenancePageStylesheet[]
+     */
+    public function getStylesheets(): array
+    {
+        return $this->stylesheets;
+    }
+}

--- a/wwwroot/classes/MaintenancePageRenderer.php
+++ b/wwwroot/classes/MaintenancePageRenderer.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/MaintenancePage.php';
+
+final class MaintenancePageRenderer
+{
+    public function render(MaintenancePage $page): string
+    {
+        $title = $this->escape($page->getTitle());
+        $heading = $this->escape($page->getHeading());
+        $description = $this->escape($page->getDescription());
+        $author = $this->escape($page->getAuthor());
+        $message = nl2br($this->escape($page->getMessage()));
+        $stylesheets = $this->renderStylesheets($page->getStylesheets());
+
+        return <<<HTML
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+    <head>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="description" content="{$description}">
+        <meta name="author" content="{$author}">
+{$stylesheets}
+        <title>{$title}</title>
+    </head>
+    <body>
+        <div class="container py-5">
+            <div class="row justify-content-center">
+                <div class="col-lg-6 text-center">
+                    <h1 class="display-5 mb-3">{$heading}</h1>
+                    <p class="lead mb-0">{$message}</p>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>
+HTML
+        . "\n";
+    }
+
+    /**
+     * @param MaintenancePageStylesheet[] $stylesheets
+     */
+    private function renderStylesheets(array $stylesheets): string
+    {
+        if ($stylesheets === []) {
+            return '';
+        }
+
+        $links = array_map(
+            function (MaintenancePageStylesheet $stylesheet): string {
+                $attributes = [
+                    sprintf('rel="%s"', $this->escape($stylesheet->getRel())),
+                    sprintf('href="%s"', $this->escape($stylesheet->getHref())),
+                ];
+
+                $integrity = $stylesheet->getIntegrity();
+                if ($integrity !== null && $integrity !== '') {
+                    $attributes[] = sprintf('integrity="%s"', $this->escape($integrity));
+                }
+
+                $crossorigin = $stylesheet->getCrossorigin();
+                if ($crossorigin !== null && $crossorigin !== '') {
+                    $attributes[] = sprintf('crossorigin="%s"', $this->escape($crossorigin));
+                }
+
+                return '        <link ' . implode(' ', $attributes) . '>';
+            },
+            $stylesheets
+        );
+
+        return implode("\n", $links);
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/wwwroot/classes/MaintenancePageStylesheet.php
+++ b/wwwroot/classes/MaintenancePageStylesheet.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+final class MaintenancePageStylesheet
+{
+    private string $href;
+
+    private string $rel;
+
+    private ?string $integrity;
+
+    private ?string $crossorigin;
+
+    private function __construct(string $href, string $rel = 'stylesheet', ?string $integrity = null, ?string $crossorigin = null)
+    {
+        $this->href = $href;
+        $this->rel = $rel;
+        $this->integrity = $integrity;
+        $this->crossorigin = $crossorigin;
+    }
+
+    public static function create(string $href, string $rel = 'stylesheet', ?string $integrity = null, ?string $crossorigin = null): self
+    {
+        return new self($href, $rel, $integrity, $crossorigin);
+    }
+
+    public static function bootstrapCdn(string $version = '5.3.8'): self
+    {
+        $href = sprintf('https://cdn.jsdelivr.net/npm/bootstrap@%s/dist/css/bootstrap.min.css', $version);
+        $integrity = 'sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB';
+        $crossorigin = 'anonymous';
+
+        return new self($href, 'stylesheet', $integrity, $crossorigin);
+    }
+
+    public function getHref(): string
+    {
+        return $this->href;
+    }
+
+    public function getRel(): string
+    {
+        return $this->rel;
+    }
+
+    public function getIntegrity(): ?string
+    {
+        return $this->integrity;
+    }
+
+    public function getCrossorigin(): ?string
+    {
+        return $this->crossorigin;
+    }
+}

--- a/wwwroot/maintenance.php
+++ b/wwwroot/maintenance.php
@@ -1,19 +1,10 @@
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+<?php
 
-        <meta name="description" content="Check your leaderboard position against other PlayStation trophy hunters!">
-        <meta name="author" content="Markus 'Ragowit' Persson, and other contributors via GitHub project">
+declare(strict_types=1);
 
-        <!-- Bootstrap CSS -->
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+require_once __DIR__ . '/classes/MaintenancePageRenderer.php';
 
-        <title>Maintenance ~ PSN 100%</title>
-    </head>
-    <body>
-        The site is undergoing some maintenance. Should be back soon!
-    </body>
-</html>
+$page = MaintenancePage::createDefault();
+$renderer = new MaintenancePageRenderer();
+
+echo $renderer->render($page);


### PR DESCRIPTION
## Summary
- replace the static maintenance template with dedicated MaintenancePage and renderer classes
- add a stylesheet value object and default configuration for the maintenance view
- update the maintenance entry point to render the page via the new OOP components

## Testing
- php -l wwwroot/maintenance.php
- php -l wwwroot/classes/MaintenancePage.php
- php -l wwwroot/classes/MaintenancePageRenderer.php
- php -l wwwroot/classes/MaintenancePageStylesheet.php

------
https://chatgpt.com/codex/tasks/task_e_68fa911d6644832f9d3e3f66e4e6a524