### PR TITLE
Align PSVR filters across player services

### DIFF
--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -15,7 +15,7 @@ class PlayerAdvisorService
         'ps4' => "tt.platform LIKE '%PS4%'",
         'ps5' => "tt.platform LIKE '%PS5%'",
         'psvita' => "tt.platform LIKE '%PSVITA%'",
-        'psvr' => "(tt.platform LIKE '%PSVR' OR tt.platform LIKE '%PSVR,%')",
+        'psvr' => "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'",
         'psvr2' => "tt.platform LIKE '%PSVR2%'",
     ];
 

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -14,7 +14,7 @@ class PlayerGamesService
         PlayerGamesFilter::PLATFORM_PS4 => "tt.platform LIKE '%PS4%'",
         PlayerGamesFilter::PLATFORM_PS5 => "tt.platform LIKE '%PS5%'",
         PlayerGamesFilter::PLATFORM_PSVITA => "tt.platform LIKE '%PSVITA%'",
-        PlayerGamesFilter::PLATFORM_PSVR => "(tt.platform LIKE '%PSVR' OR tt.platform LIKE '%PSVR,%')",
+        PlayerGamesFilter::PLATFORM_PSVR => "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'",
         PlayerGamesFilter::PLATFORM_PSVR2 => "tt.platform LIKE '%PSVR2%'",
     ];
 

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -14,7 +14,7 @@ class PlayerLogService
         'ps4' => "tt.platform LIKE '%PS4%'",
         'ps5' => "tt.platform LIKE '%PS5%'",
         'psvita' => "tt.platform LIKE '%PSVITA%'",
-        'psvr' => "tt.platform LIKE '%PSVR' OR tt.platform LIKE '%PSVR,%'",
+        'psvr' => "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'",
         'psvr2' => "tt.platform LIKE '%PSVR2%'",
     ];
 

--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -10,7 +10,7 @@ class PlayerRandomGamesService
         'ps4' => "tt.platform LIKE '%PS4%'",
         'ps5' => "tt.platform LIKE '%PS5%'",
         'psvita' => "tt.platform LIKE '%PSVITA%'",
-        'psvr' => "tt.platform LIKE '%PSVR' OR tt.platform LIKE '%PSVR,%'",
+        'psvr' => "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'",
         'psvr2' => "tt.platform LIKE '%PSVR2%'",
     ];
 


### PR DESCRIPTION
## Summary
- update the PlayerLogService PSVR platform clause to use the comma-delimited LIKE matcher
- apply the same PSVR filter adjustment to PlayerGamesService and PlayerAdvisorService for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa91345820832f942a59dd5c4472cc