### PR TITLE
Handle non-string queue parameters safely

### DIFF
--- a/wwwroot/classes/PlayerQueueRequest.php
+++ b/wwwroot/classes/PlayerQueueRequest.php
@@ -37,8 +37,24 @@ class PlayerQueueRequest
         return $this->playerName === '';
     }
 
-    private static function sanitizeValue(?string $value): string
+    private static function sanitizeValue(mixed $value): string
     {
+        if (is_array($value)) {
+            $value = reset($value);
+        }
+
+        if (is_object($value)) {
+            if (method_exists($value, '__toString')) {
+                $value = (string) $value;
+            } else {
+                return '';
+            }
+        }
+
+        if (!is_scalar($value) && $value !== null) {
+            return '';
+        }
+
         return trim((string) ($value ?? ''));
     }
 }


### PR DESCRIPTION
## Summary
- update PlayerQueueRequest input sanitization to accept array and object values without throwing
- normalize non-string values into safe strings before trimming

## Testing
- php -l wwwroot/classes/PlayerQueueRequest.php
- php -r "require 'wwwroot/classes/PlayerQueueRequest.php'; var_dump(PlayerQueueRequest::fromArrays(['q'=>['abc']], []));"

------
https://chatgpt.com/codex/tasks/task_e_68fa91345820832f942a59dd5c4472cc