### PR TITLE
Send maintenance mode responses with 503 status

### DIFF
--- a/wwwroot/classes/ApplicationRunner.php
+++ b/wwwroot/classes/ApplicationRunner.php
@@ -37,6 +37,12 @@ final class ApplicationRunner
 
     private function renderMaintenancePage(): void
     {
+        http_response_code(503);
+
+        if (!headers_sent()) {
+            header('Retry-After: 300');
+        }
+
         require_once $this->maintenanceMode->getTemplatePath();
         exit();
     }


### PR DESCRIPTION
## Summary
- send maintenance page responses with an HTTP 503 status code instead of 200
- add a Retry-After header to encourage clients and caches to retry later

## Testing
- php -l wwwroot/classes/ApplicationRunner.php

------
https://chatgpt.com/codex/tasks/task_e_68fa9164d5ac832f89a376b5c154aa41