### PR TITLE
Normalize player ID handling in player route

### DIFF
--- a/wwwroot/classes/Routing/PlayerRouteHandler.php
+++ b/wwwroot/classes/Routing/PlayerRouteHandler.php
@@ -23,7 +23,9 @@ class PlayerRouteHandler implements RouteHandlerInterface
             return RouteResult::redirect('/leaderboard/trophy');
         }
 
-        $onlineId = array_shift($segments) ?? '';
+        $onlineIdSegment = array_shift($segments) ?? '';
+        $onlineId = rawurldecode($onlineIdSegment);
+
         $accountId = $this->playerRepository->findAccountIdByOnlineId($onlineId);
 
         if ($accountId === null) {
@@ -56,7 +58,7 @@ class PlayerRouteHandler implements RouteHandlerInterface
             case 'report':
                 return RouteResult::include('player_report.php', $variables);
             default:
-                return RouteResult::redirect('/player/' . $onlineId);
+                return RouteResult::redirect('/player/' . rawurlencode($onlineId));
         }
     }
 }


### PR DESCRIPTION
## Summary
- decode the player route segment before looking up the account
- url-encode player identifiers when redirecting to their profile to avoid malformed headers

## Testing
- php -l classes/Routing/PlayerRouteHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68fa9164d5ac832f89a376b5c154aa41