### PR TITLE
Encode player IDs when generating game links

### DIFF
--- a/wwwroot/classes/PlayerAdvisableTrophy.php
+++ b/wwwroot/classes/PlayerAdvisableTrophy.php
@@ -186,12 +186,24 @@ class PlayerAdvisableTrophy
 
     public function getGameLink(string $playerOnlineId): string
     {
-        return $this->gameId . '-' . $this->utility->slugify($this->gameName) . '/' . $playerOnlineId;
+        $slug = $this->gameId . '-' . $this->utility->slugify($this->gameName);
+
+        if ($playerOnlineId === '') {
+            return $slug;
+        }
+
+        return $slug . '/' . rawurlencode($playerOnlineId);
     }
 
     public function getTrophyLink(string $playerOnlineId): string
     {
-        return $this->trophyId . '-' . $this->utility->slugify($this->trophyName) . '/' . $playerOnlineId;
+        $slug = $this->trophyId . '-' . $this->utility->slugify($this->trophyName);
+
+        if ($playerOnlineId === '') {
+            return $slug;
+        }
+
+        return $slug . '/' . rawurlencode($playerOnlineId);
     }
 
     /**

--- a/wwwroot/classes/PlayerRandomGame.php
+++ b/wwwroot/classes/PlayerRandomGame.php
@@ -130,6 +130,12 @@ class PlayerRandomGame
 
     public function getGameLink(string $playerOnlineId): string
     {
-        return $this->id . '-' . $this->utility->slugify($this->name) . '/' . $playerOnlineId;
+        $slug = $this->id . '-' . $this->utility->slugify($this->name);
+
+        if ($playerOnlineId === '') {
+            return $slug;
+        }
+
+        return $slug . '/' . rawurlencode($playerOnlineId);
     }
 }

--- a/wwwroot/player_random.php
+++ b/wwwroot/player_random.php
@@ -107,7 +107,7 @@ require_once("header.php");
                             <div>
                                 <div class="card">
                                     <div class="d-flex justify-content-center align-items-center" style="min-height: 11.5rem;">
-                                        <a href="/game/<?= $gameLink; ?>">
+                                        <a href="/game/<?= htmlspecialchars($gameLink, ENT_QUOTES, 'UTF-8'); ?>">
                                             <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= $game->getIconUrl(); ?>" alt="<?= htmlentities($game->getName()); ?>">
                                             <div class="card-img-overlay d-flex align-items-end p-2">
                                                 <?php
@@ -128,7 +128,7 @@ require_once("header.php");
 
                             <!-- name -->
                             <div class="text-center">
-                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= $gameLink; ?>">
+                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= htmlspecialchars($gameLink, ENT_QUOTES, 'UTF-8'); ?>">
                                     <?= htmlentities($game->getName()); ?>
                                 </a>
                             </div>


### PR DESCRIPTION
## Summary
- encode player online IDs when generating random game and trophy advisor URLs so special characters do not break navigation
- escape the random games template output when inserting generated URLs

## Testing
- php -l wwwroot/classes/PlayerRandomGame.php
- php -l wwwroot/classes/PlayerAdvisableTrophy.php
- php -l wwwroot/player_random.php

------
https://chatgpt.com/codex/tasks/task_e_68fa9164d5ac832f89a376b5c154aa41