### PR TITLE
Declare strict types in remaining classes

### DIFF
--- a/wwwroot/classes/AboutPagePlayer.php
+++ b/wwwroot/classes/AboutPagePlayer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class AboutPagePlayer
 {
     private const STATUS_LABELS = [

--- a/wwwroot/classes/AboutPageScanSummary.php
+++ b/wwwroot/classes/AboutPageScanSummary.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class AboutPageScanSummary
 {
     private int $scannedPlayers;

--- a/wwwroot/classes/AboutPageService.php
+++ b/wwwroot/classes/AboutPageService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/AboutPagePlayer.php';
 require_once __DIR__ . '/AboutPageScanSummary.php';
 

--- a/wwwroot/classes/Avatar.php
+++ b/wwwroot/classes/Avatar.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Avatar
 {
     private string $url;

--- a/wwwroot/classes/AvatarService.php
+++ b/wwwroot/classes/AvatarService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/Avatar.php';
 
 class AvatarService

--- a/wwwroot/classes/GameResetService.php
+++ b/wwwroot/classes/GameResetService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class GameResetService
 {
     private const ACTION_RESET = 0;

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/Homepage/HomepageItem.php';
 require_once __DIR__ . '/Homepage/HomepageTitle.php';
 require_once __DIR__ . '/Homepage/HomepageNewGame.php';

--- a/wwwroot/classes/PlayerQueueHandler.php
+++ b/wwwroot/classes/PlayerQueueHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/PlayerQueueRequest.php';
 require_once __DIR__ . '/PlayerQueueResponse.php';
 require_once __DIR__ . '/PlayerQueueResponseFactory.php';

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class PlayerQueueService
 {
     public const MAX_QUEUE_SUBMISSIONS_PER_IP = 10;

--- a/wwwroot/classes/RouteResult.php
+++ b/wwwroot/classes/RouteResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class RouteResult
 {
     private ?string $include;

--- a/wwwroot/classes/TrophyCalculator.php
+++ b/wwwroot/classes/TrophyCalculator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class TrophyCalculator
 {
     private PDO $database;

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class TrophyMergeService
 {
     private const PLATFORM_ORDER = ['PS3', 'PSVITA', 'PS4', 'PSVR', 'PS5', 'PSVR2', 'PC'];

--- a/wwwroot/classes/Utility.php
+++ b/wwwroot/classes/Utility.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Utility
 {
     public function slugify(?string $text): string


### PR DESCRIPTION
## Summary
- add strict type declarations to legacy page, avatar, queue, routing, trophy, and utility classes for consistency

## Testing
- for file in wwwroot/classes/AboutPagePlayer.php wwwroot/classes/AboutPageScanSummary.php wwwroot/classes/AboutPageService.php wwwroot/classes/Avatar.php wwwroot/classes/AvatarService.php wwwroot/classes/GameResetService.php wwwroot/classes/HomepageContentService.php wwwroot/classes/PlayerQueueHandler.php wwwroot/classes/PlayerQueueService.php wwwroot/classes/RouteResult.php wwwroot/classes/TrophyCalculator.php wwwroot/classes/TrophyMergeService.php wwwroot/classes/Utility.php; do php -l "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68fa9164d5ac832f89a376b5c154aa41