### PR TITLE
Add unit tests for pagination components

### DIFF
--- a/tests/PaginationItemTest.php
+++ b/tests/PaginationItemTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PaginationItem.php';
+
+final class PaginationItemTest extends TestCase
+{
+    public function testRenderIncludesAriaAttributesWhenActive(): void
+    {
+        $item = PaginationItem::forPage(2, 'Page 2')
+            ->markAsActive()
+            ->setAriaLabel('Current Page');
+
+        $html = $item->render(static fn (int $page): string => '/page/' . $page);
+
+        $this->assertStringContainsString('class="page-item active"', $html);
+        $this->assertStringContainsString('aria-current="page"', $html);
+        $this->assertStringContainsString('aria-label="Current Page"', $html);
+        $this->assertStringContainsString('href="/page/2"', $html);
+    }
+
+    public function testRenderEscapesLabelAndUrl(): void
+    {
+        $item = PaginationItem::forPage(5, '<Next>')
+            ->setAriaLabel('Go to >');
+
+        $html = $item->render(static fn (int $page): string => '/page/' . $page . '?q=<script>');
+
+        $this->assertStringContainsString('&lt;Next&gt;', $html);
+        $this->assertStringContainsString('href="/page/5?q=&lt;script&gt;"', $html);
+        $this->assertStringContainsString('aria-label="Go to &gt;"', $html);
+    }
+
+    public function testEllipsisIsDisabledAndDoesNotGenerateUrl(): void
+    {
+        $item = PaginationItem::ellipsis();
+
+        $html = $item->render(static fn (int $page): string => '/page/' . $page);
+
+        $this->assertStringContainsString('class="page-item disabled"', $html);
+        $this->assertStringContainsString('href="#"', $html);
+        $this->assertStringContainsString('tabindex="-1"', $html);
+        $this->assertStringContainsString('aria-disabled="true"', $html);
+    }
+}

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/Pagination.php';
+require_once __DIR__ . '/../wwwroot/classes/PaginationItem.php';
+
+final class PaginationTest extends TestCase
+{
+    public function testBuildItemsForMiddlePage(): void
+    {
+        $pagination = Pagination::create(3, 5);
+        $items = $pagination->buildItems();
+
+        $this->assertCount(7, $items);
+
+        $renderedItems = array_map(
+            static fn (PaginationItem $item): string => $item->render(
+                static fn (int $page): string => '/page/' . $page
+            ),
+            $items
+        );
+
+        $this->assertSame(
+            [
+                '<li class="page-item"><a class="page-link" href="/page/2" aria-label="Previous">&lt;</a></li>',
+                '<li class="page-item"><a class="page-link" href="/page/1">1</a></li>',
+                '<li class="page-item"><a class="page-link" href="/page/2">2</a></li>',
+                '<li class="page-item active"><a class="page-link" href="/page/3" aria-current="page">3</a></li>',
+                '<li class="page-item"><a class="page-link" href="/page/4">4</a></li>',
+                '<li class="page-item"><a class="page-link" href="/page/5">5</a></li>',
+                '<li class="page-item"><a class="page-link" href="/page/4" aria-label="Next">&gt;</a></li>',
+            ],
+            $renderedItems
+        );
+    }
+
+    public function testBuildItemsAddsEllipsisWhenSkippingRanges(): void
+    {
+        $pagination = Pagination::create(8, 10);
+        $items = $pagination->buildItems();
+
+        $this->assertCount(9, $items);
+
+        $renderedItems = array_map(
+            static fn (PaginationItem $item): string => $item->render(
+                static fn (int $page): string => '/page/' . $page
+            ),
+            $items
+        );
+
+        $this->assertSame(
+            [
+                '<li class="page-item"><a class="page-link" href="/page/7" aria-label="Previous">&lt;</a></li>',
+                '<li class="page-item"><a class="page-link" href="/page/1">1</a></li>',
+                '<li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">...</a></li>',
+                '<li class="page-item"><a class="page-link" href="/page/6">6</a></li>',
+                '<li class="page-item"><a class="page-link" href="/page/7">7</a></li>',
+                '<li class="page-item active"><a class="page-link" href="/page/8" aria-current="page">8</a></li>',
+                '<li class="page-item"><a class="page-link" href="/page/9">9</a></li>',
+                '<li class="page-item"><a class="page-link" href="/page/10">10</a></li>',
+                '<li class="page-item"><a class="page-link" href="/page/9" aria-label="Next">&gt;</a></li>',
+            ],
+            $renderedItems
+        );
+    }
+
+    public function testCreateNormalizesCurrentPageAndTotalPages(): void
+    {
+        $pagination = Pagination::create(-5, 0);
+        $items = $pagination->buildItems();
+
+        $this->assertCount(1, $items);
+
+        $item = $items[0];
+        $html = $item->render(static fn (int $page): string => '/page/' . $page);
+
+        $this->assertStringContainsString('aria-current="page"', $html);
+        $this->assertStringContainsString('>1<', $html);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+abstract class TestCase
+{
+    /**
+     * @return list<array{method:string,status:string,message?:string}>
+     */
+    public final function runTests(): array
+    {
+        $results = [];
+
+        foreach ($this->getTestMethods() as $method) {
+            $this->setUp();
+
+            try {
+                $this->$method();
+                $results[] = ['method' => $method, 'status' => 'passed'];
+            } catch (AssertionError $assertionError) {
+                $results[] = [
+                    'method' => $method,
+                    'status' => 'failed',
+                    'message' => $assertionError->getMessage(),
+                ];
+            } catch (Throwable $throwable) {
+                $results[] = [
+                    'method' => $method,
+                    'status' => 'error',
+                    'message' => $throwable->getMessage(),
+                ];
+            } finally {
+                $this->tearDown();
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getTestMethods(): array
+    {
+        $methods = get_class_methods($this);
+
+        return array_values(array_filter(
+            $methods,
+            static fn (string $method): bool => str_starts_with($method, 'test')
+        ));
+    }
+
+    protected function setUp(): void
+    {
+        // Intended to be overridden by extending classes when needed.
+    }
+
+    protected function tearDown(): void
+    {
+        // Intended to be overridden by extending classes when needed.
+    }
+
+    protected function assertSame(mixed $expected, mixed $actual, string $message = ''): void
+    {
+        if ($expected !== $actual) {
+            $this->fail(
+                $message !== ''
+                    ? $message
+                    : sprintf('Failed asserting that %s matches expected %s.', var_export($actual, true), var_export($expected, true))
+            );
+        }
+    }
+
+    protected function assertTrue(bool $condition, string $message = ''): void
+    {
+        if ($condition !== true) {
+            $this->fail($message !== '' ? $message : 'Failed asserting that condition is true.');
+        }
+    }
+
+    protected function assertFalse(bool $condition, string $message = ''): void
+    {
+        if ($condition !== false) {
+            $this->fail($message !== '' ? $message : 'Failed asserting that condition is false.');
+        }
+    }
+
+    protected function assertCount(int $expectedCount, Countable|array $value, string $message = ''): void
+    {
+        if (count($value) !== $expectedCount) {
+            $this->fail(
+                $message !== ''
+                    ? $message
+                    : sprintf('Failed asserting that actual count %d matches expected count %d.', count($value), $expectedCount)
+            );
+        }
+    }
+
+    protected function assertStringContainsString(string $needle, string $haystack, string $message = ''): void
+    {
+        if (!str_contains($haystack, $needle)) {
+            $this->fail(
+                $message !== ''
+                    ? $message
+                    : sprintf('Failed asserting that "%s" contains "%s".', $haystack, $needle)
+            );
+        }
+    }
+
+    protected function fail(string $message): never
+    {
+        throw new AssertionError($message);
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/TestCase.php';
+
+foreach (glob(__DIR__ . '/*Test.php') as $testFile) {
+    require $testFile;
+}
+
+$testClasses = array_values(array_filter(
+    get_declared_classes(),
+    static fn (string $className): bool => is_subclass_of($className, TestCase::class)
+));
+
+$total = 0;
+$failures = 0;
+$errors = 0;
+
+foreach ($testClasses as $testClass) {
+    $testCase = new $testClass();
+    $results = $testCase->runTests();
+
+    foreach ($results as $result) {
+        $total++;
+        $status = $result['status'];
+        $method = $result['method'];
+
+        if ($status === 'passed') {
+            echo sprintf("[PASS] %s::%s\n", $testClass, $method);
+            continue;
+        }
+
+        $message = $result['message'] ?? '';
+
+        if ($status === 'failed') {
+            $failures++;
+            echo sprintf("[FAIL] %s::%s - %s\n", $testClass, $method, $message);
+            continue;
+        }
+
+        $errors++;
+        echo sprintf("[ERROR] %s::%s - %s\n", $testClass, $method, $message);
+    }
+}
+
+if ($total === 0) {
+    echo "No tests were executed.\n";
+    exit(1);
+}
+
+if ($failures === 0 && $errors === 0) {
+    echo sprintf("\nAll %d tests passed.\n", $total);
+    exit(0);
+}
+
+echo sprintf("\nTest run completed with %d failure(s) and %d error(s) out of %d tests.\n", $failures, $errors, $total);
+exit(1);


### PR DESCRIPTION
## Summary
- add a lightweight PHP test harness to run repository unit tests
- cover pagination rendering for middle pages, ellipsis handling, and normalization edge cases
- verify PaginationItem rendering escapes labels and includes accessibility attributes

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe061272e0832f8057460140a2daef