### PR TITLE
Add unit tests for trophy rarity logic

### DIFF
--- a/tests/TrophyRarityFormatterTest.php
+++ b/tests/TrophyRarityFormatterTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/TrophyRarityFormatter.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyRarity.php';
+
+final class TrophyRarityFormatterTest extends TestCase
+{
+    public function testFormatReturnsUnobtainableWhenStatusIsOne(): void
+    {
+        $formatter = new TrophyRarityFormatter();
+
+        $rarity = $formatter->format(42, 1);
+
+        $this->assertSame('42', $rarity->getPercentage());
+        $this->assertSame('Unobtainable', $rarity->getLabel());
+        $this->assertSame(null, $rarity->getCssClass());
+        $this->assertTrue($rarity->isUnobtainable());
+    }
+
+    public function testFormatClassifiesLegendaryAndTrimsString(): void
+    {
+        $formatter = new TrophyRarityFormatter();
+
+        $rarity = $formatter->format(' 0.015 ');
+
+        $this->assertSame('0.015', $rarity->getPercentage());
+        $this->assertSame('Legendary', $rarity->getLabel());
+        $this->assertSame('trophy-legendary', $rarity->getCssClass());
+        $this->assertFalse($rarity->isUnobtainable());
+    }
+
+    public function testFormatClassifiesRareThreshold(): void
+    {
+        $formatter = new TrophyRarityFormatter();
+
+        $rarity = $formatter->format(0.5);
+
+        $this->assertSame('0.5', $rarity->getPercentage());
+        $this->assertSame('Rare', $rarity->getLabel());
+        $this->assertSame('trophy-rare', $rarity->getCssClass());
+        $this->assertFalse($rarity->isUnobtainable());
+    }
+
+    public function testFormatDefaultsToCommonWhenValueIsNotNumeric(): void
+    {
+        $formatter = new TrophyRarityFormatter();
+
+        $rarity = $formatter->format('N/A');
+
+        $this->assertSame('N/A', $rarity->getPercentage());
+        $this->assertSame('Common', $rarity->getLabel());
+        $this->assertSame('trophy-common', $rarity->getCssClass());
+        $this->assertFalse($rarity->isUnobtainable());
+    }
+}

--- a/tests/TrophyRarityTest.php
+++ b/tests/TrophyRarityTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/TrophyRarity.php';
+
+final class TrophyRarityTest extends TestCase
+{
+    public function testRenderSpanIncludesPercentageAndCssClass(): void
+    {
+        $rarity = new TrophyRarity('12.5', 'Common', 'trophy-common', false);
+
+        $html = $rarity->renderSpan();
+
+        $this->assertSame('<span class="trophy-common">12.5%<br>Common</span>', $html);
+    }
+
+    public function testRenderSpanSkipsPercentageWhenUnobtainable(): void
+    {
+        $rarity = new TrophyRarity('0.1', 'Unobtainable', null, true);
+
+        $html = $rarity->renderSpan();
+
+        $this->assertSame('<span>Unobtainable</span>', $html);
+    }
+
+    public function testRenderSpanIncludesPercentageWhenRequestedForUnobtainable(): void
+    {
+        $rarity = new TrophyRarity('0.1', 'Unobtainable', 'trophy-unobtainable', true);
+
+        $html = $rarity->renderSpan(' / ', true);
+
+        $this->assertSame('<span class="trophy-unobtainable">0.1% / Unobtainable</span>', $html);
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for TrophyRarityFormatter to verify formatting and classification rules
- add TrophyRarity rendering tests to ensure span output handles unobtainable cases

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe097c3ef0832fb63e7f6390c7e4bd