### PR TITLE
Add tests for PaginationRenderer output and error handling

### DIFF
--- a/tests/PaginationRendererTest.php
+++ b/tests/PaginationRendererTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PaginationRenderer.php';
+require_once __DIR__ . '/../wwwroot/classes/Pagination.php';
+require_once __DIR__ . '/../wwwroot/classes/PaginationItem.php';
+
+final class PaginationRendererTest extends TestCase
+{
+    public function testRenderGeneratesBootstrapPaginationHtml(): void
+    {
+        $renderer = new PaginationRenderer();
+
+        $html = $renderer->render(
+            2,
+            4,
+            static fn (int $page): array => [
+                'page' => $page,
+                'sort' => 'name',
+            ],
+            'Player navigation'
+        );
+
+        $this->assertStringContainsString('<nav aria-label="Player navigation">', $html);
+        $this->assertStringContainsString('<ul class="pagination justify-content-center">', $html);
+        $this->assertStringContainsString('href="?page=1&amp;sort=name"', $html);
+        $this->assertStringContainsString('href="?page=2&amp;sort=name"', $html);
+        $this->assertStringContainsString('href="?page=3&amp;sort=name"', $html);
+        $this->assertStringContainsString('href="?page=4&amp;sort=name"', $html);
+    }
+
+    public function testRenderEscapesAriaLabelAndQueryParameters(): void
+    {
+        $renderer = new PaginationRenderer();
+
+        $html = $renderer->render(
+            1,
+            1,
+            static fn (int $page): array => [
+                'page' => $page,
+                'filter' => '<active>',
+            ],
+            'Browse > players'
+        );
+
+        $this->assertStringContainsString('aria-label="Browse &gt; players"', $html);
+        $this->assertStringContainsString('href="?page=1&amp;filter=%3Cactive%3E"', $html);
+    }
+
+    public function testRenderThrowsWhenQueryParametersFactoryReturnsNonArray(): void
+    {
+        $renderer = new PaginationRenderer();
+
+        try {
+            $renderer->render(
+                1,
+                1,
+                static fn (int $page): string => 'page=' . $page,
+                null
+            );
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('must return an array', $exception->getMessage());
+
+            return;
+        }
+
+        $this->fail('Expected InvalidArgumentException to be thrown when the query parameter factory returns a non-array.');
+    }
+}


### PR DESCRIPTION
## Summary
- add tests that ensure PaginationRenderer builds Bootstrap pagination markup with expected links
- verify the renderer escapes aria labels and query parameters when generating URLs
- cover the invalid return type path when the query parameter factory does not return an array

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe097c3ef0832fb63e7f6390c7e4bd