### PR TITLE
Add unit tests for player queue request and responses

### DIFF
--- a/tests/PlayerQueueRequestTest.php
+++ b/tests/PlayerQueueRequestTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerQueueRequest.php';
+
+final class PlayerQueueRequestTest extends TestCase
+{
+    public function testFromArraysTrimsAndNormalizesValues(): void
+    {
+        $request = PlayerQueueRequest::fromArrays(
+            ['q' => '  ExamplePlayer  '],
+            ['REMOTE_ADDR' => '  127.0.0.1  ']
+        );
+
+        $this->assertSame('ExamplePlayer', $request->getPlayerName());
+        $this->assertSame('127.0.0.1', $request->getIpAddress());
+        $this->assertFalse($request->isPlayerNameEmpty());
+    }
+
+    public function testFromArraysUsesFirstArrayValueAndTrims(): void
+    {
+        $request = PlayerQueueRequest::fromArrays(
+            ['q' => [' first ', ' second ']],
+            ['REMOTE_ADDR' => [' 8.8.8.8 ', ' 9.9.9.9 ']]
+        );
+
+        $this->assertSame('first', $request->getPlayerName());
+        $this->assertSame('8.8.8.8', $request->getIpAddress());
+    }
+
+    public function testFromArraysHandlesNonScalarAndStringableValues(): void
+    {
+        $stringable = new class {
+            public function __toString(): string
+            {
+                return 'Player <name>';
+            }
+        };
+
+        $resource = fopen('php://temp', 'r');
+
+        $request = PlayerQueueRequest::fromArrays(
+            ['q' => $stringable],
+            ['REMOTE_ADDR' => $resource]
+        );
+
+        if (is_resource($resource)) {
+            fclose($resource);
+        }
+
+        $this->assertSame('Player <name>', $request->getPlayerName());
+        $this->assertSame('', $request->getIpAddress());
+        $this->assertFalse($request->isPlayerNameEmpty());
+
+        $emptyRequest = PlayerQueueRequest::fromArrays(
+            ['q' => new stdClass()],
+            ['REMOTE_ADDR' => null]
+        );
+
+        $this->assertSame('', $emptyRequest->getPlayerName());
+        $this->assertSame('', $emptyRequest->getIpAddress());
+        $this->assertTrue($emptyRequest->isPlayerNameEmpty());
+    }
+}

--- a/tests/PlayerQueueResponseFactoryTest.php
+++ b/tests/PlayerQueueResponseFactoryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponseFactory.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponse.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerQueueService.php';
+
+/**
+ * @extends PlayerQueueService
+ */
+final class RecordingPlayerQueueServiceStub extends PlayerQueueService
+{
+    /** @var list<string> */
+    private array $escapedValues = [];
+
+    public function __construct()
+    {
+        // Parent constructor requires a PDO instance which is not needed for tests.
+    }
+
+    public function escapeHtml(string $value): string
+    {
+        $this->escapedValues[] = $value;
+
+        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getEscapedValues(): array
+    {
+        return $this->escapedValues;
+    }
+}
+
+final class PlayerQueueResponseFactoryTest extends TestCase
+{
+    public function testCreateCheaterResponseEscapesValuesAndIncludesDisputeLink(): void
+    {
+        $service = new RecordingPlayerQueueServiceStub();
+        $factory = new PlayerQueueResponseFactory($service);
+
+        $response = $factory->createCheaterResponse('Bad User', 'Account/123');
+
+        $this->assertSame('error', $response->getStatus());
+
+        $message = $response->getMessage();
+        $this->assertStringContainsString("Player '<a class=\"link-underline link-underline-opacity-0 link-underline-opacity-100-hover\" href=\"/player/Bad User\">Bad User</a>' is tagged as a cheater and won't be scanned.", $message);
+        $this->assertStringContainsString('Dispute</a>?', $message);
+        $this->assertStringContainsString('https://github.com/Ragowit/psn100/issues?q=label%3Acheater+Bad%20User+OR+Account%2F123', $message);
+
+        $this->assertSame(
+            [
+                'Bad User',
+                'https://github.com/Ragowit/psn100/issues?q=label%3Acheater+Bad%20User+OR+Account%2F123',
+            ],
+            $service->getEscapedValues()
+        );
+    }
+
+    public function testCreateQueuePositionResponseMarksQueuedAndEscapesValues(): void
+    {
+        $service = new RecordingPlayerQueueServiceStub();
+        $factory = new PlayerQueueResponseFactory($service);
+
+        $response = $factory->createQueuePositionResponse('Queue <User>', '<script>');
+
+        $this->assertSame('queued', $response->getStatus());
+        $this->assertTrue($response->shouldPoll());
+
+        $message = $response->getMessage();
+        $this->assertStringContainsString('href="/player/Queue &lt;User&gt;"', $message);
+        $this->assertStringContainsString('">Queue &lt;User&gt;</a> is in the update queue, currently in position &lt;script&gt;.', $message);
+        $this->assertStringContainsString('<div class="spinner-border" role="status">', $message);
+
+        $this->assertSame(
+            ['<script>', 'Queue <User>'],
+            $service->getEscapedValues()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for PlayerQueueRequest to ensure request data is normalized and sanitized
- verify PlayerQueueResponseFactory builds escaped response messages via a stubbed service

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe097c3ef0832fb63e7f6390c7e4bd