### PR TITLE
Add coverage for Utility and PlayerRandomGamesFilter

### DIFF
--- a/tests/PlayerRandomGamesFilterTest.php
+++ b/tests/PlayerRandomGamesFilterTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerRandomGamesFilter.php';
+
+final class PlayerRandomGamesFilterTest extends TestCase
+{
+    public function testFromArrayNormalizesSelectedPlatforms(): void
+    {
+        $filter = PlayerRandomGamesFilter::fromArray([
+            'pc' => '1',
+            'ps3' => '',
+            'ps4' => '0',
+            'ps5' => 'yes',
+            'psvita' => null,
+            'psvr' => 0,
+            'psvr2' => 'on',
+            'extra' => true,
+        ]);
+
+        $this->assertTrue($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PC));
+        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS3));
+        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS4));
+        $this->assertTrue($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS5));
+        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVITA));
+        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVR));
+        $this->assertTrue($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVR2));
+        $this->assertFalse($filter->isPlatformSelected('extra'));
+    }
+
+    public function testFromArrayDefaultsToFalseForMissingPlatforms(): void
+    {
+        $filter = PlayerRandomGamesFilter::fromArray([]);
+
+        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PC));
+        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS3));
+        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS4));
+        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS5));
+        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVITA));
+        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVR));
+        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVR2));
+    }
+}

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/Utility.php';
+
+final class UtilityTest extends TestCase
+{
+    public function testSlugifyNormalizesTextAndRemovesSpecialCharacters(): void
+    {
+        $utility = new Utility();
+
+        $slug = $utility->slugify('  God of War: Ragnarök & Friends  ');
+
+        $this->assertSame('god-of-war-ragnarok-and-friends', $slug);
+    }
+
+    public function testSlugifyReplacesPercentAndWhitespaceWithHyphens(): void
+    {
+        $utility = new Utility();
+
+        $slug = $utility->slugify('100% Ready for 2024');
+
+        $this->assertSame('100percent-ready-for-2024', $slug);
+    }
+
+    public function testGetCountryNameReturnsLocaleDisplayNameWhenAvailable(): void
+    {
+        $utility = new Utility();
+
+        $this->assertSame('United States', $utility->getCountryName(' us '));
+    }
+
+    public function testGetCountryNameReturnsUnknownWhenInputEmpty(): void
+    {
+        $utility = new Utility();
+
+        $this->assertSame('Unknown', $utility->getCountryName(''));
+    }
+
+    public function testGetCountryNameFallsBackToUppercaseCodeWhenLocaleReturnsEmpty(): void
+    {
+        $utility = new Utility();
+
+        $this->assertSame('ABC', $utility->getCountryName('abc'));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests to confirm PlayerRandomGamesFilter platform normalization
- add Utility tests covering slug generation and country name lookup

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe1ba1fdf0832fa0d21f50ae7d7bea