### PR TITLE
Refine GameStatusPage rendering

### DIFF
--- a/wwwroot/admin/status.php
+++ b/wwwroot/admin/status.php
@@ -3,50 +3,14 @@ declare(strict_types=1);
 
 require_once '../init.php';
 require_once '../classes/Admin/GameStatusRequestHandler.php';
+require_once '../classes/Admin/GameStatusPage.php';
 
 $gameStatusService = new GameStatusService($database);
 $requestHandler = new GameStatusRequestHandler($gameStatusService);
 
 $request = AdminRequest::fromGlobals($_SERVER ?? [], $_POST ?? []);
 $result = $requestHandler->handleRequest($request);
-$success = $result->getSuccessMessage();
-$error = $result->getErrorMessage();
 
-?>
-<!doctype html>
-<html lang="en" data-bs-theme="dark">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <title>Admin ~ Game Status</title>
-    </head>
-    <body>
-        <div class="p-4">
-            <a href="/admin/">Back</a><br><br>
-            <form method="post" autocomplete="off">
-                Game ID:<br>
-                <input type="number" name="game"><br>
-                Status:<br>
-                <select name="status">
-                    <option value="0">Normal</option>
-                    <option value="1">Delisted</option>
-                    <option value="3">Obsolete</option>
-                    <option value="4">Delisted &amp; Obsolete</option>
-                </select><br><br>
-                <input type="submit" value="Submit">
-            </form>
+$page = GameStatusPage::fromResult($result);
 
-            <?php
-            if ($error !== null) {
-                echo $error;
-            }
-
-            if ($success !== null) {
-                echo $success;
-            }
-            ?>
-        </div>
-    </body>
-</html>
+echo $page->render();

--- a/wwwroot/classes/Admin/GameStatusPage.php
+++ b/wwwroot/classes/Admin/GameStatusPage.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/GameStatusRequestResult.php';
+
+final class GameStatusPage
+{
+    private const STATUS_OPTIONS = [
+        0 => 'Normal',
+        1 => 'Delisted',
+        3 => 'Obsolete',
+        4 => 'Delisted & Obsolete',
+    ];
+
+    private GameStatusRequestResult $result;
+
+    private function __construct(GameStatusRequestResult $result)
+    {
+        $this->result = $result;
+    }
+
+    public static function fromResult(GameStatusRequestResult $result): self
+    {
+        return new self($result);
+    }
+
+    public function render(): string
+    {
+        $optionsHtml = $this->renderStatusOptions();
+        $messagesHtml = $this->renderMessages();
+
+        return <<<HTML
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+    <head>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+        <title>Admin ~ Game Status</title>
+    </head>
+    <body>
+        <div class="p-4">
+            <a href="/admin/">Back</a><br><br>
+            <form method="post" autocomplete="off">
+                Game ID:<br>
+                <input type="number" name="game"><br>
+                Status:<br>
+                <select name="status">
+                    {$optionsHtml}
+                </select><br><br>
+                <input type="submit" value="Submit">
+            </form>
+            {$messagesHtml}
+        </div>
+    </body>
+</html>
+HTML;
+    }
+
+    private function renderStatusOptions(): string
+    {
+        $options = [];
+
+        foreach (self::STATUS_OPTIONS as $value => $label) {
+            $escapedValue = htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
+            $escapedLabel = htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
+            $options[] = sprintf('<option value="%s">%s</option>', $escapedValue, $escapedLabel);
+        }
+
+        return implode('', $options);
+    }
+
+    private function renderMessages(): string
+    {
+        $messages = [];
+
+        $error = $this->result->getErrorMessage();
+        if ($error !== null) {
+            $messages[] = sprintf('<div class="text-danger">%s</div>', htmlspecialchars($error, ENT_QUOTES, 'UTF-8'));
+        }
+
+        $success = $this->result->getSuccessMessage();
+        if ($success !== null) {
+            $messages[] = sprintf('<div class="text-success">%s</div>', htmlspecialchars($success, ENT_QUOTES, 'UTF-8'));
+        }
+
+        if ($messages === []) {
+            return '';
+        }
+
+        return '<div class="mt-3">' . implode('', $messages) . '</div>';
+    }
+}


### PR DESCRIPTION
## Summary
- remove custom newline separators when rendering select options
- wrap admin game status feedback in semantic divs without manual spacing

## Testing
- php -l wwwroot/classes/Admin/GameStatusPage.php
- php -l wwwroot/admin/status.php

------
https://chatgpt.com/codex/tasks/task_e_68fe061fb2a8832f847624d310cefc51