### PR TITLE
Fix queue response player links

### DIFF
--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -84,9 +84,11 @@ final class PlayerQueueResponseFactory
     private function createPlayerLink(string $playerName): string
     {
         $escapedPlayerName = $this->service->escapeHtml($playerName);
+        $playerUrl = '/player/' . rawurlencode($playerName);
+        $escapedPlayerUrl = $this->service->escapeHtml($playerUrl);
 
-        return '<a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/player/'
-            . $escapedPlayerName . '">' . $escapedPlayerName . '</a>';
+        return '<a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="'
+            . $escapedPlayerUrl . '">' . $escapedPlayerName . '</a>';
     }
 
     private function createSpinnerMessage(string $message): string


### PR DESCRIPTION
## Summary
- ensure queue player links encode player names in URLs so special characters don't break navigation

## Testing
- php -l wwwroot/classes/PlayerQueueResponseFactory.php

------
https://chatgpt.com/codex/tasks/task_e_68fe063253f4832fb91b4a536db20a51