### PR TITLE
Allow queue position lookups after hitting submission limit

### DIFF
--- a/wwwroot/classes/PlayerQueueHandler.php
+++ b/wwwroot/classes/PlayerQueueHandler.php
@@ -52,11 +52,6 @@ class PlayerQueueHandler
         }
 
         $playerName = $request->getPlayerName();
-        $ipAddress = $request->getIpAddress();
-
-        if ($this->service->hasReachedIpSubmissionLimit($ipAddress)) {
-            return $this->responseFactory->createQueueLimitResponse();
-        }
 
         if (!$this->service->isValidPlayerName($playerName)) {
             return $this->responseFactory->createInvalidNameResponse();


### PR DESCRIPTION
## Summary
- allow queue position requests to bypass the per-IP submission limit guard
- ensure players can still check queue status when they can no longer add new entries

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68fe063253f4832fb91b4a536db20a51