### PR TITLE
Fix TemplateRenderer to include templates on each render

### DIFF
--- a/wwwroot/classes/TemplateRenderer.php
+++ b/wwwroot/classes/TemplateRenderer.php
@@ -34,6 +34,6 @@ class TemplateRenderer
         $utility = $this->utility;
         $paginationRenderer = $this->paginationRenderer;
 
-        require_once $templatePath;
+        require $templatePath;
     }
 }


### PR DESCRIPTION
## Summary
- replace `require_once` with `require` inside the template renderer so templates can be included repeatedly within the same request

## Testing
- php -l wwwroot/classes/TemplateRenderer.php

------
https://chatgpt.com/codex/tasks/task_e_68fe063253f4832fb91b4a536db20a51