### PR TITLE
Fix null handling in player status data

### DIFF
--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -167,8 +167,12 @@ class PlayerQueueService
         }
 
         return [
-            'account_id' => array_key_exists('account_id', $result) ? (string) $result['account_id'] : null,
-            'status' => array_key_exists('status', $result) ? (int) $result['status'] : null,
+            'account_id' => array_key_exists('account_id', $result) && $result['account_id'] !== null
+                ? (string) $result['account_id']
+                : null,
+            'status' => array_key_exists('status', $result) && $result['status'] !== null
+                ? (int) $result['status']
+                : null,
         ];
     }
 


### PR DESCRIPTION
## Summary
- prevent database NULL values from being converted into empty strings or zero in player status data

## Testing
- php -l wwwroot/classes/PlayerQueueService.php

------
https://chatgpt.com/codex/tasks/task_e_68fe0647edd0832f87aabe2f0ea4e982