### PR TITLE
Handle regex failures in slugify

### DIFF
--- a/wwwroot/classes/Utility.php
+++ b/wwwroot/classes/Utility.php
@@ -8,7 +8,11 @@ class Utility
     {
         $text = $text ?? '';
 
-        $text = trim(preg_replace('/\s+/', ' ', $text));
+        $normalizedWhitespace = preg_replace('/\s+/', ' ', $text);
+        if (!is_string($normalizedWhitespace)) {
+            $normalizedWhitespace = $text;
+        }
+        $text = trim($normalizedWhitespace);
         $text = str_replace('&', 'and', $text);
         $text = str_replace('%', 'percent', $text);
         $text = str_replace(' - ', ' ', $text);
@@ -33,8 +37,12 @@ class Utility
         }
 
         $text = strtolower($text);
-        $text = preg_replace('/[^a-z0-9]+/', '-', $text);
-        return trim($text, '-');
+        $slug = preg_replace('/[^a-z0-9]+/', '-', $text);
+        if (!is_string($slug)) {
+            $slug = $text;
+        }
+
+        return trim($slug, '-');
     }
 
     public function getCountryName(?string $countryCode): string


### PR DESCRIPTION
## Summary
- ensure Utility::slugify falls back to original text when preg_replace fails
- avoid TypeErrors by trimming only validated regex results

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe0647edd0832f87aabe2f0ea4e982