### PR TITLE
Limit player queue endpoints to GET parameters

### DIFF
--- a/wwwroot/add_to_queue.php
+++ b/wwwroot/add_to_queue.php
@@ -6,4 +6,4 @@ require_once 'init.php';
 require_once 'classes/PlayerQueueEndpoint.php';
 
 $endpoint = PlayerQueueEndpoint::fromDatabase($database);
-$endpoint->handleAddToQueue($_REQUEST ?? [], $_SERVER ?? []);
+$endpoint->handleAddToQueue($_GET ?? [], $_SERVER ?? []);

--- a/wwwroot/check_queue_position.php
+++ b/wwwroot/check_queue_position.php
@@ -6,4 +6,4 @@ require_once 'init.php';
 require_once 'classes/PlayerQueueEndpoint.php';
 
 $endpoint = PlayerQueueEndpoint::fromDatabase($database);
-$endpoint->handleQueuePosition($_REQUEST ?? [], $_SERVER ?? []);
+$endpoint->handleQueuePosition($_GET ?? [], $_SERVER ?? []);


### PR DESCRIPTION
## Summary
- ensure the add_to_queue endpoint only reads player names from GET input
- restrict the queue position endpoint to GET parameters to avoid cookie injection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe0647edd0832f87aabe2f0ea4e982