### PR TITLE
Handle Trophyset prefix when sanitizing trophy titles

### DIFF
--- a/tests/TrophyTitleNamingTest.php
+++ b/tests/TrophyTitleNamingTest.php
@@ -42,6 +42,13 @@ final class TrophyTitleNamingTest extends TestCase
         $this->assertSame('Ratchet & Clank', $formatted);
     }
 
+    public function testSanitizeRemovesTrophysetPrefix(): void
+    {
+        $formatted = $this->formatTitle('Trophyset: Horizon Forbidden West');
+
+        $this->assertSame('Horizon Forbidden West', $formatted);
+    }
+
     public function testHyphenSeparatorsAreConvertedToColons(): void
     {
         $formatted = $this->formatTitle("Marvel's Spider-Man - Miles Morales");

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1290,6 +1290,7 @@ class ThirtyMinuteCronJob implements CronJobInterface
 
         $prefixPatterns = [
             '/^Trophy Set\b[:\s-]*/i',
+            '/^Trophyset\b[:\s-]*/i',
         ];
 
         foreach ($prefixPatterns as $pattern) {


### PR DESCRIPTION
## Summary
- strip the "Trophyset" prefix when normalizing trophy title names during cron imports
- cover the new normalization rule with a dedicated unit test

## Testing
- php tests/run.php *(fails: PlayerQueueResponseFactoryTest expectations differ from current HTML output)*

------
https://chatgpt.com/codex/tasks/task_e_68fe3abf320c832f88e51fa75624b1f6