### PR TITLE
Add unit tests for PlayerLeaderboardFilter

### DIFF
--- a/tests/PlayerLeaderboardFilterTest.php
+++ b/tests/PlayerLeaderboardFilterTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerLeaderboardFilter.php';
+
+final class PlayerLeaderboardFilterTest extends TestCase
+{
+    public function testConstructorNormalizesInputs(): void
+    {
+        $filter = new PlayerLeaderboardFilter('  US  ', "  cat-01  ", 0);
+
+        $this->assertSame('US', $filter->getCountry());
+        $this->assertSame('cat-01', $filter->getAvatar());
+        $this->assertSame(1, $filter->getPage());
+        $this->assertTrue($filter->hasCountry());
+        $this->assertTrue($filter->hasAvatar());
+    }
+
+    public function testConstructorTreatsEmptyStringsAsNull(): void
+    {
+        $filter = new PlayerLeaderboardFilter('   ', "", 2);
+
+        $this->assertSame(null, $filter->getCountry());
+        $this->assertSame(null, $filter->getAvatar());
+        $this->assertFalse($filter->hasCountry());
+        $this->assertFalse($filter->hasAvatar());
+    }
+
+    public function testFromArrayCastsValuesAndHandlesInvalidPage(): void
+    {
+        $filter = PlayerLeaderboardFilter::fromArray([
+            'country' => '  CA ',
+            'avatar' => '  fox  ',
+            'page' => '3',
+        ]);
+
+        $this->assertSame('CA', $filter->getCountry());
+        $this->assertSame('fox', $filter->getAvatar());
+        $this->assertSame(3, $filter->getPage());
+
+        $invalidPageFilter = PlayerLeaderboardFilter::fromArray([
+            'country' => 'FR',
+            'page' => 'invalid',
+        ]);
+
+        $this->assertSame(1, $invalidPageFilter->getPage());
+    }
+
+    public function testGetFilterParametersOnlyIncludesDefinedFilters(): void
+    {
+        $filter = new PlayerLeaderboardFilter(null, 'ghost', 4);
+
+        $this->assertSame(['avatar' => 'ghost'], $filter->getFilterParameters());
+    }
+
+    public function testOffsetAndQueryParameterHelpers(): void
+    {
+        $filter = new PlayerLeaderboardFilter('JP', null, 5);
+
+        $this->assertSame(40, $filter->getOffset(10));
+        $this->assertSame(
+            ['country' => 'JP', 'page' => 5],
+            $filter->toQueryParameters()
+        );
+
+        $this->assertSame(
+            ['country' => 'JP', 'page' => 1],
+            $filter->withPage(0)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for PlayerLeaderboardFilter constructor normalization and query helpers
- ensure fromArray handles invalid page values and filter parameter generation

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe3f8930f0832fbafb1f50de7069c8