### PR TITLE
Add PlayerQueueResponse unit tests

### DIFF
--- a/tests/PlayerQueueResponseTest.php
+++ b/tests/PlayerQueueResponseTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponse.php';
+
+final class PlayerQueueResponseTest extends TestCase
+{
+    public function testQueuedResponseIncludesShouldPollTrue(): void
+    {
+        $response = PlayerQueueResponse::queued('Queued for processing');
+
+        $this->assertSame('queued', $response->getStatus());
+        $this->assertSame('Queued for processing', $response->getMessage());
+        $this->assertTrue($response->shouldPoll());
+        $this->assertSame(
+            [
+                'status' => 'queued',
+                'message' => 'Queued for processing',
+                'shouldPoll' => true,
+            ],
+            $response->toArray()
+        );
+        $this->assertSame($response->toArray(), $response->jsonSerialize());
+    }
+
+    public function testCompleteResponseIncludesShouldPollFalse(): void
+    {
+        $response = PlayerQueueResponse::complete('Processing complete');
+
+        $this->assertSame('complete', $response->getStatus());
+        $this->assertSame('Processing complete', $response->getMessage());
+        $this->assertFalse($response->shouldPoll());
+        $this->assertSame(
+            [
+                'status' => 'complete',
+                'message' => 'Processing complete',
+                'shouldPoll' => false,
+            ],
+            $response->toArray()
+        );
+        $this->assertSame($response->toArray(), $response->jsonSerialize());
+    }
+
+    public function testErrorResponseIncludesShouldPollFalse(): void
+    {
+        $response = PlayerQueueResponse::error('An error occurred');
+
+        $this->assertSame('error', $response->getStatus());
+        $this->assertSame('An error occurred', $response->getMessage());
+        $this->assertFalse($response->shouldPoll());
+        $this->assertSame(
+            [
+                'status' => 'error',
+                'message' => 'An error occurred',
+                'shouldPoll' => false,
+            ],
+            $response->toArray()
+        );
+        $this->assertSame($response->toArray(), $response->jsonSerialize());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering the PlayerQueueResponse factory helpers
- verify the response serialization and polling flag for each status

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe4eff84e0832fb88b561d4a281854