### PR TITLE
Add tests for GameStatusBadge

### DIFF
--- a/tests/GameStatusBadgeTest.php
+++ b/tests/GameStatusBadgeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/GameStatusBadge.php';
+
+final class GameStatusBadgeTest extends TestCase
+{
+    public function testConstructorAssignsLabelTooltipAndDefaultCssClass(): void
+    {
+        $badge = new GameStatusBadge('Delisted', 'The game is no longer available');
+
+        $this->assertSame('Delisted', $badge->getLabel());
+        $this->assertSame('The game is no longer available', $badge->getTooltip());
+        $this->assertSame('badge rounded-pill text-bg-warning', $badge->getCssClass());
+    }
+
+    public function testConstructorAllowsOverridingCssClass(): void
+    {
+        $badge = new GameStatusBadge('Soon', 'The game releases soon', 'badge text-bg-info');
+
+        $this->assertSame('badge text-bg-info', $badge->getCssClass());
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for GameStatusBadge accessors and default CSS class handling
- verify the constructor respects the default and overridden CSS class values

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe5d8361e4832fb2e876a13b0366cf