### PR TITLE
Add maintenance page unit tests

### DIFF
--- a/tests/MaintenancePageRendererTest.php
+++ b/tests/MaintenancePageRendererTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/MaintenancePageRenderer.php';
+
+final class MaintenancePageRendererTest extends TestCase
+{
+    public function testRenderEscapesContentAndFormatsMessage(): void
+    {
+        $page = MaintenancePage::createDefault()->withMessage("Hello & welcome!\nLine <two>");
+        $renderer = new MaintenancePageRenderer();
+
+        $html = $renderer->render($page);
+
+        $this->assertStringContainsString('<!doctype html>', $html);
+        $this->assertStringContainsString('<title>Maintenance ~ PSN 100%</title>', $html);
+        $this->assertStringContainsString(
+            '<meta name="description" content="Check your leaderboard position against other PlayStation trophy hunters!">',
+            $html
+        );
+        $this->assertStringContainsString(
+            '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" '
+            . 'integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">',
+            $html
+        );
+        $this->assertStringContainsString('Hello &amp; welcome!<br />
+Line &lt;two&gt;', $html);
+        $this->assertTrue(str_ends_with($html, "\n"), 'Rendered HTML should end with a newline.');
+    }
+}

--- a/tests/MaintenancePageTest.php
+++ b/tests/MaintenancePageTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/MaintenancePage.php';
+
+final class MaintenancePageTest extends TestCase
+{
+    public function testCreateDefaultProvidesExpectedMetadata(): void
+    {
+        $page = MaintenancePage::createDefault();
+
+        $this->assertSame('Maintenance ~ PSN 100%', $page->getTitle());
+        $this->assertSame('Maintenance', $page->getHeading());
+        $this->assertSame(
+            'Check your leaderboard position against other PlayStation trophy hunters!',
+            $page->getDescription()
+        );
+        $this->assertSame(
+            "Markus 'Ragowit' Persson, and other contributors via GitHub project",
+            $page->getAuthor()
+        );
+        $this->assertSame('The site is undergoing some maintenance. Should be back soon!', $page->getMessage());
+
+        $stylesheets = $page->getStylesheets();
+        $this->assertCount(1, $stylesheets);
+
+        $stylesheet = $stylesheets[0];
+        $this->assertSame(
+            'https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css',
+            $stylesheet->getHref()
+        );
+        $this->assertSame('stylesheet', $stylesheet->getRel());
+        $this->assertSame(
+            'sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB',
+            $stylesheet->getIntegrity()
+        );
+        $this->assertSame('anonymous', $stylesheet->getCrossorigin());
+    }
+
+    public function testWithMessageReturnsClonedInstanceWithUpdatedMessage(): void
+    {
+        $page = MaintenancePage::createDefault();
+        $updated = $page->withMessage("Custom\nMessage");
+
+        $this->assertTrue($page !== $updated, 'Expected a cloned instance.');
+        $this->assertSame("Custom\nMessage", $updated->getMessage());
+        $this->assertSame('The site is undergoing some maintenance. Should be back soon!', $page->getMessage());
+        $this->assertSame($page->getTitle(), $updated->getTitle());
+        $this->assertSame($page->getHeading(), $updated->getHeading());
+        $this->assertSame($page->getDescription(), $updated->getDescription());
+        $this->assertSame($page->getAuthor(), $updated->getAuthor());
+        $this->assertSame($page->getStylesheets(), $updated->getStylesheets());
+    }
+
+    public function testStylesheetFactoryCreatesConfiguredInstances(): void
+    {
+        $custom = MaintenancePageStylesheet::create('style.css', 'alternate', 'hash', 'use-credentials');
+
+        $this->assertSame('style.css', $custom->getHref());
+        $this->assertSame('alternate', $custom->getRel());
+        $this->assertSame('hash', $custom->getIntegrity());
+        $this->assertSame('use-credentials', $custom->getCrossorigin());
+
+        $bootstrap = MaintenancePageStylesheet::bootstrapCdn('5.3.0');
+
+        $this->assertSame(
+            'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css',
+            $bootstrap->getHref()
+        );
+        $this->assertSame('stylesheet', $bootstrap->getRel());
+        $this->assertSame(
+            'sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB',
+            $bootstrap->getIntegrity()
+        );
+        $this->assertSame('anonymous', $bootstrap->getCrossorigin());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for MaintenancePage default metadata, cloning, and stylesheet factories
- cover MaintenancePageRenderer output escaping and formatting

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe5d8361e4832fb2e876a13b0366cf