### PR TITLE
Add unit tests for PlayerAdvisorFilter

### DIFF
--- a/tests/PlayerAdvisorFilterTest.php
+++ b/tests/PlayerAdvisorFilterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerAdvisorFilter.php';
+require_once __DIR__ . '/TestCase.php';
+
+final class PlayerAdvisorFilterTest extends TestCase
+{
+    public function testFromArrayUsesDefaultValuesWhenParametersMissing(): void
+    {
+        $filter = PlayerAdvisorFilter::fromArray([]);
+
+        $this->assertSame(1, $filter->getPage());
+        $this->assertSame(PlayerAdvisorFilter::SORT_RARITY, $filter->getSort());
+        $this->assertFalse($filter->hasPlatformFilters());
+        $this->assertSame([], $filter->getPlatforms());
+    }
+
+    public function testFromArrayParsesPageAndSupportedPlatforms(): void
+    {
+        $filter = PlayerAdvisorFilter::fromArray([
+            'page' => '3',
+            'ps3' => '1',
+            'ps4' => '',
+            'ps5' => 'true',
+            'pc' => 'yes',
+            'unknown' => 'true',
+        ]);
+
+        $this->assertSame(3, $filter->getPage());
+        $this->assertTrue($filter->hasPlatformFilters());
+        $this->assertSame(['pc', 'ps3', 'ps5'], $filter->getPlatforms());
+        $this->assertTrue($filter->isPlatformSelected('pc'));
+        $this->assertTrue($filter->isPlatformSelected('ps3'));
+        $this->assertTrue($filter->isPlatformSelected('ps5'));
+        $this->assertFalse($filter->isPlatformSelected('ps4'));
+        $this->assertFalse($filter->isPlatformSelected('unknown'));
+    }
+
+    public function testPageIsNeverBelowOne(): void
+    {
+        $filter = PlayerAdvisorFilter::fromArray(['page' => '0']);
+
+        $this->assertSame(1, $filter->getPage());
+    }
+
+    public function testGetOffsetCalculatesOffsetFromPage(): void
+    {
+        $filter = PlayerAdvisorFilter::fromArray(['page' => 4]);
+
+        $this->assertSame(60, $filter->getOffset(20));
+    }
+
+    public function testGetFilterParametersIncludesSortAndPlatforms(): void
+    {
+        $filter = PlayerAdvisorFilter::fromArray([
+            'psvr' => '1',
+            'psvita' => 'yes',
+        ]);
+
+        $this->assertSame([
+            'psvita' => 'true',
+            'psvr' => 'true',
+            'sort' => PlayerAdvisorFilter::SORT_RARITY,
+        ], $filter->getFilterParameters());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering PlayerAdvisorFilter defaults, platform selection, and pagination helpers

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe616ed4b8832f9455e49d0f6b962f