### PR TITLE
Add unit tests for PlayerReportResult

### DIFF
--- a/tests/PlayerReportResultTest.php
+++ b/tests/PlayerReportResultTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerReportResult.php';
+
+final class PlayerReportResultTest extends TestCase
+{
+    public function testSuccessResultContainsMessageAndIsSuccessful(): void
+    {
+        $result = PlayerReportResult::success('All good');
+
+        $this->assertTrue($result->hasMessage());
+        $this->assertTrue($result->isSuccess());
+        $this->assertSame('All good', $result->getMessage());
+    }
+
+    public function testErrorResultContainsMessageAndIsNotSuccessful(): void
+    {
+        $result = PlayerReportResult::error('Something went wrong');
+
+        $this->assertTrue($result->hasMessage());
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame('Something went wrong', $result->getMessage());
+    }
+
+    public function testEmptyResultDoesNotHaveMessageAndIsNotSuccessful(): void
+    {
+        $result = PlayerReportResult::empty();
+
+        $this->assertFalse($result->hasMessage());
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame('', $result->getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering the success, error, and empty factory helpers in `PlayerReportResult`

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe661e9268832fb95d96c2b251aaf3