### PR TITLE
Refactor test runner to object oriented design

### DIFF
--- a/tests/TestResult.php
+++ b/tests/TestResult.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+final class TestResult
+{
+    private string $className;
+
+    private string $methodName;
+
+    private string $status;
+
+    private ?string $message;
+
+    public function __construct(string $className, string $methodName, string $status, ?string $message = null)
+    {
+        $this->className = $className;
+        $this->methodName = $methodName;
+        $this->status = $status;
+        $this->message = $message;
+    }
+
+    public function getClassName(): string
+    {
+        return $this->className;
+    }
+
+    public function getMethodName(): string
+    {
+        return $this->methodName;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function isPassed(): bool
+    {
+        return $this->status === 'passed';
+    }
+
+    public function isFailed(): bool
+    {
+        return $this->status === 'failed';
+    }
+
+    public function isError(): bool
+    {
+        return $this->status === 'error';
+    }
+}

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/TestResult.php';
+require_once __DIR__ . '/TestSuiteResult.php';
+
+final class TestSuite
+{
+    private string $directory;
+
+    /**
+     * @var list<class-string<TestCase>>
+     */
+    private array $testClasses;
+
+    /**
+     * @param list<class-string<TestCase>> $testClasses
+     */
+    private function __construct(string $directory, array $testClasses)
+    {
+        $this->directory = $directory;
+        $this->testClasses = $testClasses;
+    }
+
+    public static function fromDirectory(string $directory): self
+    {
+        $normalizedDirectory = rtrim($directory, DIRECTORY_SEPARATOR);
+        if ($normalizedDirectory === '') {
+            $normalizedDirectory = '.';
+        }
+
+        $resolvedDirectory = realpath($normalizedDirectory);
+
+        if ($resolvedDirectory === false || !is_dir($resolvedDirectory)) {
+            throw new InvalidArgumentException(sprintf('The directory "%s" does not exist.', $directory));
+        }
+
+        $testFiles = glob($resolvedDirectory . '/*Test.php');
+
+        if ($testFiles === false) {
+            $testFiles = [];
+        }
+
+        $beforeClasses = get_declared_classes();
+
+        foreach ($testFiles as $testFile) {
+            require_once $testFile;
+        }
+
+        $afterClasses = get_declared_classes();
+        $newClasses = array_diff($afterClasses, $beforeClasses);
+
+        $testClasses = array_values(array_filter(
+            $newClasses,
+            static fn (string $className): bool => is_subclass_of($className, TestCase::class)
+        ));
+
+        sort($testClasses);
+
+        return new self($resolvedDirectory, $testClasses);
+    }
+
+    public function run(): TestSuiteResult
+    {
+        $results = [];
+
+        foreach ($this->testClasses as $testClass) {
+            $testCase = new $testClass();
+
+            foreach ($testCase->runTests() as $result) {
+                $results[] = new TestResult(
+                    $testClass,
+                    $result['method'],
+                    $result['status'],
+                    $result['message'] ?? null
+                );
+            }
+        }
+
+        return new TestSuiteResult($results);
+    }
+
+    /**
+     * @return list<class-string<TestCase>>
+     */
+    public function getTestClasses(): array
+    {
+        return $this->testClasses;
+    }
+
+    public function getDirectory(): string
+    {
+        return $this->directory;
+    }
+}

--- a/tests/TestSuiteResult.php
+++ b/tests/TestSuiteResult.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestResult.php';
+
+final class TestSuiteResult
+{
+    /**
+     * @var list<TestResult>
+     */
+    private array $results;
+
+    /**
+     * @param list<TestResult> $results
+     */
+    public function __construct(array $results)
+    {
+        $this->results = array_values($results);
+    }
+
+    /**
+     * @return list<TestResult>
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    public function getTotalTests(): int
+    {
+        return count($this->results);
+    }
+
+    public function getFailureCount(): int
+    {
+        return $this->countByStatus('failed');
+    }
+
+    public function getErrorCount(): int
+    {
+        return $this->countByStatus('error');
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this->getFailureCount() === 0 && $this->getErrorCount() === 0;
+    }
+
+    private function countByStatus(string $status): int
+    {
+        $count = 0;
+
+        foreach ($this->results as $result) {
+            if ($result->getStatus() === $status) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -2,57 +2,45 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/TestCase.php';
+require __DIR__ . '/TestSuite.php';
 
-foreach (glob(__DIR__ . '/*Test.php') as $testFile) {
-    require $testFile;
-}
+$suite = TestSuite::fromDirectory(__DIR__);
+$result = $suite->run();
+$statusMap = [
+    'passed' => 'PASS',
+    'failed' => 'FAIL',
+    'error' => 'ERROR',
+];
 
-$testClasses = array_values(array_filter(
-    get_declared_classes(),
-    static fn (string $className): bool => is_subclass_of($className, TestCase::class)
-));
+foreach ($result->getResults() as $testResult) {
+    $status = $statusMap[$testResult->getStatus()] ?? strtoupper($testResult->getStatus());
+    $className = $testResult->getClassName();
+    $methodName = $testResult->getMethodName();
+    $message = $testResult->getMessage();
 
-$total = 0;
-$failures = 0;
-$errors = 0;
-
-foreach ($testClasses as $testClass) {
-    $testCase = new $testClass();
-    $results = $testCase->runTests();
-
-    foreach ($results as $result) {
-        $total++;
-        $status = $result['status'];
-        $method = $result['method'];
-
-        if ($status === 'passed') {
-            echo sprintf("[PASS] %s::%s\n", $testClass, $method);
-            continue;
-        }
-
-        $message = $result['message'] ?? '';
-
-        if ($status === 'failed') {
-            $failures++;
-            echo sprintf("[FAIL] %s::%s - %s\n", $testClass, $method, $message);
-            continue;
-        }
-
-        $errors++;
-        echo sprintf("[ERROR] %s::%s - %s\n", $testClass, $method, $message);
+    if ($testResult->isPassed()) {
+        echo sprintf('[%s] %s::%s', $status, $className, $methodName) . "\n";
+        continue;
     }
+
+    echo sprintf('[%s] %s::%s - %s', $status, $className, $methodName, $message ?? '') . "\n";
 }
 
-if ($total === 0) {
+if ($result->getTotalTests() === 0) {
     echo "No tests were executed.\n";
     exit(1);
 }
 
-if ($failures === 0 && $errors === 0) {
-    echo sprintf("\nAll %d tests passed.\n", $total);
+if ($result->isSuccessful()) {
+    echo sprintf("\nAll %d tests passed.\n", $result->getTotalTests());
     exit(0);
 }
 
-echo sprintf("\nTest run completed with %d failure(s) and %d error(s) out of %d tests.\n", $failures, $errors, $total);
+echo sprintf(
+    "\nTest run completed with %d failure(s) and %d error(s) out of %d tests.\n",
+    $result->getFailureCount(),
+    $result->getErrorCount(),
+    $result->getTotalTests()
+);
+
 exit(1);


### PR DESCRIPTION
## Summary
- add TestSuite, TestSuiteResult, and TestResult classes to encapsulate loading and running tests
- update tests/run.php to use the new object-oriented test runner flow and maintain existing CLI output

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe7ad52150832f95de8d8b331f48c4