### PR TITLE
Refactor player navigation include to use renderer

### DIFF
--- a/tests/PlayerNavigationRendererTest.php
+++ b/tests/PlayerNavigationRendererTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerNavigationRenderer.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerNavigation.php';
+
+final class PlayerNavigationRendererTest extends TestCase
+{
+    public function testRenderOutputsAllNavigationLinks(): void
+    {
+        $navigation = PlayerNavigation::forSection('Example User', PlayerNavigation::SECTION_LOG);
+        $renderer = new PlayerNavigationRenderer();
+
+        $html = $renderer->render($navigation);
+        $trimmedHtml = trim($html);
+
+        $this->assertTrue(str_starts_with($trimmedHtml, '<div class="btn-group">'));
+        $this->assertSame(5, substr_count($html, '<a class="'));
+        $this->assertStringContainsString('href="/player/Example%20User/log"', $html);
+        $this->assertStringContainsString('class="btn btn-primary active"', $html);
+        $this->assertStringContainsString('aria-current="page"', $html);
+    }
+
+    public function testRenderEscapesAttributes(): void
+    {
+        $navigation = PlayerNavigation::forSection('user & user', PlayerNavigation::SECTION_RANDOM);
+        $renderer = new PlayerNavigationRenderer();
+
+        $html = $renderer->render($navigation);
+
+        $this->assertStringContainsString('href="/player/user%20%26%20user/random"', $html);
+        $this->assertStringContainsString('user%20%26%20user', $html);
+        $this->assertStringContainsString('Random Games', $html);
+    }
+}

--- a/wwwroot/classes/PlayerNavigationRenderer.php
+++ b/wwwroot/classes/PlayerNavigationRenderer.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerNavigation.php';
+
+final class PlayerNavigationRenderer
+{
+    public function render(PlayerNavigation $navigation): string
+    {
+        $links = array_map(
+            fn (PlayerNavigationLink $link): string => $this->renderLink($link),
+            $navigation->getLinks()
+        );
+
+        $linksHtml = implode(PHP_EOL, $links);
+
+        return <<<HTML
+<div class="btn-group">
+{$linksHtml}
+</div>
+HTML;
+    }
+
+    private function renderLink(PlayerNavigationLink $link): string
+    {
+        $cssClass = htmlspecialchars($link->getButtonCssClass(), ENT_QUOTES, 'UTF-8');
+        $url = htmlspecialchars($link->getUrl(), ENT_QUOTES, 'UTF-8');
+        $label = htmlspecialchars($link->getLabel(), ENT_QUOTES, 'UTF-8');
+        $ariaAttribute = $this->renderAriaAttribute($link->getAriaCurrent());
+
+        return sprintf(
+            '    <a class="%s" href="%s"%s>%s</a>',
+            $cssClass,
+            $url,
+            $ariaAttribute,
+            $label
+        );
+    }
+
+    private function renderAriaAttribute(?string $ariaCurrent): string
+    {
+        if ($ariaCurrent === null) {
+            return '';
+        }
+
+        $value = htmlspecialchars($ariaCurrent, ENT_QUOTES, 'UTF-8');
+
+        return ' aria-current="' . $value . '"';
+    }
+}

--- a/wwwroot/player_navigation.php
+++ b/wwwroot/player_navigation.php
@@ -2,21 +2,12 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/PlayerNavigationRenderer.php';
+
 if (!isset($playerNavigation) || !$playerNavigation instanceof PlayerNavigation) {
     throw new RuntimeException('Player navigation data is missing.');
 }
 
-$links = $playerNavigation->getLinks();
-?>
-<div class="btn-group">
-    <?php foreach ($links as $link) { ?>
-        <?php $ariaCurrent = $link->getAriaCurrent(); ?>
-        <a
-            class="<?= htmlspecialchars($link->getButtonCssClass(), ENT_QUOTES, 'UTF-8'); ?>"
-            href="<?= htmlspecialchars($link->getUrl(), ENT_QUOTES, 'UTF-8'); ?>"
-            <?php if ($ariaCurrent !== null) { ?>aria-current="<?= htmlspecialchars($ariaCurrent, ENT_QUOTES, 'UTF-8'); ?>"<?php } ?>
-        >
-            <?= htmlspecialchars($link->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
-        </a>
-    <?php } ?>
-</div>
+$renderer = new PlayerNavigationRenderer();
+
+echo $renderer->render($playerNavigation);


### PR DESCRIPTION
## Summary
- introduce a PlayerNavigationRenderer class to encapsulate navigation link markup generation
- update the player navigation include to delegate rendering to the new class
- cover the renderer with unit tests to ensure correct markup and escaping

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68fe7ad52150832f95de8d8b331f48c4