### PR TITLE
Refactor test runner to object oriented design

### DIFF
--- a/tests/TestRunner.php
+++ b/tests/TestRunner.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestSuiteInterface.php';
+require_once __DIR__ . '/TestSuite.php';
+
+final class TestRunner
+{
+    private TestSuiteInterface $suite;
+
+    /**
+     * @var callable(string): void
+     */
+    private $outputWriter;
+
+    /**
+     * @param callable(string): void|null $outputWriter
+     */
+    public function __construct(TestSuiteInterface $suite, ?callable $outputWriter = null)
+    {
+        $this->suite = $suite;
+        $this->outputWriter = $outputWriter ?? static function (string $line): void {
+            echo $line . PHP_EOL;
+        };
+    }
+
+    /**
+     * @param callable(string): void|null $outputWriter
+     */
+    public static function fromDirectory(string $directory, ?callable $outputWriter = null): self
+    {
+        $suite = TestSuite::fromDirectory($directory);
+
+        return new self($suite, $outputWriter);
+    }
+
+    public function run(): int
+    {
+        $result = $this->suite->run();
+        $statusMap = [
+            'passed' => 'PASS',
+            'failed' => 'FAIL',
+            'error' => 'ERROR',
+        ];
+
+        foreach ($result->getResults() as $testResult) {
+            $status = $statusMap[$testResult->getStatus()] ?? strtoupper($testResult->getStatus());
+            $className = $testResult->getClassName();
+            $methodName = $testResult->getMethodName();
+            $message = $testResult->getMessage() ?? '';
+
+            if ($testResult->isPassed()) {
+                $this->write(sprintf('[%s] %s::%s', $status, $className, $methodName));
+
+                continue;
+            }
+
+            $this->write(sprintf('[%s] %s::%s - %s', $status, $className, $methodName, $message));
+        }
+
+        if ($result->getTotalTests() === 0) {
+            $this->write('No tests were executed.');
+
+            return 1;
+        }
+
+        $this->write('');
+
+        if ($result->isSuccessful()) {
+            $this->write(sprintf('All %d tests passed.', $result->getTotalTests()));
+
+            return 0;
+        }
+
+        $this->write(sprintf(
+            'Test run completed with %d failure(s) and %d error(s) out of %d tests.',
+            $result->getFailureCount(),
+            $result->getErrorCount(),
+            $result->getTotalTests()
+        ));
+
+        return 1;
+    }
+
+    private function write(string $line): void
+    {
+        ($this->outputWriter)($line);
+    }
+}

--- a/tests/TestRunnerTest.php
+++ b/tests/TestRunnerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestRunner.php';
+require_once __DIR__ . '/TestSuiteResult.php';
+require_once __DIR__ . '/TestResult.php';
+
+final class TestSuiteStub implements TestSuiteInterface
+{
+    private TestSuiteResult $result;
+
+    public function __construct(TestSuiteResult $result)
+    {
+        $this->result = $result;
+    }
+
+    public function run(): TestSuiteResult
+    {
+        return $this->result;
+    }
+}
+
+final class TestRunnerTest extends TestCase
+{
+    public function testRunOutputsSummaryForSuccessfulRun(): void
+    {
+        $suite = new TestSuiteStub(new TestSuiteResult([
+            new TestResult('ExampleTest', 'testExample', 'passed'),
+        ]));
+
+        $output = [];
+        $runner = new TestRunner($suite, static function (string $line) use (&$output): void {
+            $output[] = $line;
+        });
+
+        $exitCode = $runner->run();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame([
+            '[PASS] ExampleTest::testExample',
+            '',
+            'All 1 tests passed.',
+        ], $output);
+    }
+
+    public function testRunOutputsSummaryForFailedRun(): void
+    {
+        $suite = new TestSuiteStub(new TestSuiteResult([
+            new TestResult('ExampleTest', 'testSuccess', 'passed'),
+            new TestResult('ExampleTest', 'testFailure', 'failed', 'Something went wrong'),
+        ]));
+
+        $output = [];
+        $runner = new TestRunner($suite, static function (string $line) use (&$output): void {
+            $output[] = $line;
+        });
+
+        $exitCode = $runner->run();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame([
+            '[PASS] ExampleTest::testSuccess',
+            '[FAIL] ExampleTest::testFailure - Something went wrong',
+            '',
+            'Test run completed with 1 failure(s) and 0 error(s) out of 2 tests.',
+        ], $output);
+    }
+
+    public function testRunReturnsErrorCodeWhenNoTestsExecuted(): void
+    {
+        $suite = new TestSuiteStub(new TestSuiteResult([]));
+
+        $output = [];
+        $runner = new TestRunner($suite, static function (string $line) use (&$output): void {
+            $output[] = $line;
+        });
+
+        $exitCode = $runner->run();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(['No tests were executed.'], $output);
+    }
+}

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/TestResult.php';
 require_once __DIR__ . '/TestSuiteResult.php';
+require_once __DIR__ . '/TestSuiteInterface.php';
 
-final class TestSuite
+final class TestSuite implements TestSuiteInterface
 {
     private string $directory;
 

--- a/tests/TestSuiteInterface.php
+++ b/tests/TestSuiteInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestSuiteResult.php';
+
+interface TestSuiteInterface
+{
+    public function run(): TestSuiteResult;
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -2,45 +2,8 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/TestSuite.php';
+require __DIR__ . '/TestRunner.php';
 
-$suite = TestSuite::fromDirectory(__DIR__);
-$result = $suite->run();
-$statusMap = [
-    'passed' => 'PASS',
-    'failed' => 'FAIL',
-    'error' => 'ERROR',
-];
+$runner = TestRunner::fromDirectory(__DIR__);
 
-foreach ($result->getResults() as $testResult) {
-    $status = $statusMap[$testResult->getStatus()] ?? strtoupper($testResult->getStatus());
-    $className = $testResult->getClassName();
-    $methodName = $testResult->getMethodName();
-    $message = $testResult->getMessage();
-
-    if ($testResult->isPassed()) {
-        echo sprintf('[%s] %s::%s', $status, $className, $methodName) . "\n";
-        continue;
-    }
-
-    echo sprintf('[%s] %s::%s - %s', $status, $className, $methodName, $message ?? '') . "\n";
-}
-
-if ($result->getTotalTests() === 0) {
-    echo "No tests were executed.\n";
-    exit(1);
-}
-
-if ($result->isSuccessful()) {
-    echo sprintf("\nAll %d tests passed.\n", $result->getTotalTests());
-    exit(0);
-}
-
-echo sprintf(
-    "\nTest run completed with %d failure(s) and %d error(s) out of %d tests.\n",
-    $result->getFailureCount(),
-    $result->getErrorCount(),
-    $result->getTotalTests()
-);
-
-exit(1);
+exit($runner->run());


### PR DESCRIPTION
## Summary
- introduce a TestSuiteInterface and TestRunner class so the test harness follows an object-oriented structure
- update the CLI entry point to delegate to the TestRunner and add tests that verify the runner output and exit codes

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68feff7e03c4832fa587be6e641dad2b