### PR TITLE
Improve admin game status feedback alerts

### DIFF
--- a/wwwroot/classes/Admin/GameStatusPage.php
+++ b/wwwroot/classes/Admin/GameStatusPage.php
@@ -78,12 +78,12 @@ HTML;
 
         $error = $this->result->getErrorMessage();
         if ($error !== null) {
-            $messages[] = sprintf('<div class="text-danger">%s</div>', htmlspecialchars($error, ENT_QUOTES, 'UTF-8'));
+            $messages[] = $this->renderAlert('danger', $error);
         }
 
         $success = $this->result->getSuccessMessage();
         if ($success !== null) {
-            $messages[] = sprintf('<div class="text-success">%s</div>', htmlspecialchars($success, ENT_QUOTES, 'UTF-8'));
+            $messages[] = $this->renderAlert('success', $success);
         }
 
         if ($messages === []) {
@@ -91,5 +91,12 @@ HTML;
         }
 
         return '<div class="mt-3">' . implode('', $messages) . '</div>';
+    }
+
+    private function renderAlert(string $type, string $message): string
+    {
+        $escapedMessage = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+
+        return sprintf('<div class="alert alert-%s" role="alert">%s</div>', $type, $escapedMessage);
     }
 }

--- a/wwwroot/classes/Admin/GameStatusRequestHandler.php
+++ b/wwwroot/classes/Admin/GameStatusRequestHandler.php
@@ -23,12 +23,12 @@ class GameStatusRequestHandler
 
         $gameId = $request->getPostNonNegativeInt('game');
         if ($gameId === null) {
-            return GameStatusRequestResult::error('<p>Invalid game ID provided.</p>');
+            return GameStatusRequestResult::error('Invalid game ID provided.');
         }
 
         $status = $request->getPostInt('status');
         if ($status === null) {
-            return GameStatusRequestResult::error('<p>Invalid status provided.</p>');
+            return GameStatusRequestResult::error('Invalid status provided.');
         }
 
         try {
@@ -37,28 +37,18 @@ class GameStatusRequestHandler
 
             return GameStatusRequestResult::success($message);
         } catch (InvalidArgumentException $exception) {
-            $message = $this->escapeMessage($exception->getMessage());
-
-            return GameStatusRequestResult::error('<p>' . $message . '</p>');
+            return GameStatusRequestResult::error($exception->getMessage());
         } catch (Throwable $exception) {
-            return GameStatusRequestResult::error('<p>Failed to update game status. Please try again.</p>');
+            return GameStatusRequestResult::error('Failed to update game status. Please try again.');
         }
     }
 
     private function formatSuccessMessage(int $gameId, string $statusText): string
     {
-        $gameIdText = $this->escapeMessage((string) $gameId);
-        $statusTextEscaped = $this->escapeMessage($statusText);
-
         return sprintf(
-            '<p>Game %s is now set as %s. All affected players will be updated soon, and ranks updated the next whole hour.</p>',
-            $gameIdText,
-            $statusTextEscaped
+            'Game %d is now set as %s. All affected players will be updated soon, and ranks updated the next whole hour.',
+            $gameId,
+            $statusText
         );
-    }
-
-    private function escapeMessage(string $message): string
-    {
-        return htmlentities($message, ENT_QUOTES, 'UTF-8');
     }
 }


### PR DESCRIPTION
## Summary
- replace inline status strings with Bootstrap alerts on the admin game status page
- ensure request handler returns plain text messages so alerts render without escaped HTML

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff086fbf6c832f8911df0e988bcb42