### PR TITLE
Refactor test runner reporting into dedicated reporter

### DIFF
--- a/tests/TestRunReporter.php
+++ b/tests/TestRunReporter.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestSuiteResult.php';
+
+final class TestRunReporter
+{
+    /**
+     * @var callable(string): void
+     */
+    private $outputWriter;
+
+    /**
+     * @param callable(string): void|null $outputWriter
+     */
+    public function __construct(?callable $outputWriter = null)
+    {
+        $this->outputWriter = $outputWriter ?? static function (string $line): void {
+            echo $line . PHP_EOL;
+        };
+    }
+
+    public function report(TestSuiteResult $result): int
+    {
+        $statusMap = [
+            'passed' => 'PASS',
+            'failed' => 'FAIL',
+            'error' => 'ERROR',
+        ];
+
+        foreach ($result->getResults() as $testResult) {
+            $status = $statusMap[$testResult->getStatus()] ?? strtoupper($testResult->getStatus());
+            $className = $testResult->getClassName();
+            $methodName = $testResult->getMethodName();
+            $message = $testResult->getMessage() ?? '';
+
+            if ($testResult->isPassed()) {
+                $this->write(sprintf('[%s] %s::%s', $status, $className, $methodName));
+
+                continue;
+            }
+
+            $this->write(sprintf('[%s] %s::%s - %s', $status, $className, $methodName, $message));
+        }
+
+        if ($result->getTotalTests() === 0) {
+            $this->write('No tests were executed.');
+
+            return 1;
+        }
+
+        $this->write('');
+
+        if ($result->isSuccessful()) {
+            $this->write(sprintf('All %d tests passed.', $result->getTotalTests()));
+
+            return 0;
+        }
+
+        $this->write(sprintf(
+            'Test run completed with %d failure(s) and %d error(s) out of %d tests.',
+            $result->getFailureCount(),
+            $result->getErrorCount(),
+            $result->getTotalTests()
+        ));
+
+        return 1;
+    }
+
+    private function write(string $line): void
+    {
+        ($this->outputWriter)($line);
+    }
+}

--- a/tests/TestRunReporterTest.php
+++ b/tests/TestRunReporterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/TestRunReporter.php';
+require_once __DIR__ . '/TestSuiteResult.php';
+require_once __DIR__ . '/TestResult.php';
+
+final class TestRunReporterTest extends TestCase
+{
+    public function testReportOutputsSummaryForSuccessfulRun(): void
+    {
+        $output = [];
+        $reporter = new TestRunReporter(static function (string $line) use (&$output): void {
+            $output[] = $line;
+        });
+
+        $result = new TestSuiteResult([
+            new TestResult('ExampleTest', 'testExample', 'passed'),
+        ]);
+
+        $exitCode = $reporter->report($result);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame([
+            '[PASS] ExampleTest::testExample',
+            '',
+            'All 1 tests passed.',
+        ], $output);
+    }
+
+    public function testReportOutputsSummaryForFailedRun(): void
+    {
+        $output = [];
+        $reporter = new TestRunReporter(static function (string $line) use (&$output): void {
+            $output[] = $line;
+        });
+
+        $result = new TestSuiteResult([
+            new TestResult('ExampleTest', 'testSuccess', 'passed'),
+            new TestResult('ExampleTest', 'testFailure', 'failed', 'Something went wrong'),
+        ]);
+
+        $exitCode = $reporter->report($result);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame([
+            '[PASS] ExampleTest::testSuccess',
+            '[FAIL] ExampleTest::testFailure - Something went wrong',
+            '',
+            'Test run completed with 1 failure(s) and 0 error(s) out of 2 tests.',
+        ], $output);
+    }
+
+    public function testReportReturnsErrorCodeWhenNoTestsExecuted(): void
+    {
+        $output = [];
+        $reporter = new TestRunReporter(static function (string $line) use (&$output): void {
+            $output[] = $line;
+        });
+
+        $result = new TestSuiteResult([]);
+
+        $exitCode = $reporter->report($result);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(['No tests were executed.'], $output);
+    }
+}

--- a/tests/TestRunner.php
+++ b/tests/TestRunner.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/TestSuiteInterface.php';
 require_once __DIR__ . '/TestSuite.php';
+require_once __DIR__ . '/TestRunReporter.php';
 
 final class TestRunner
 {
     private TestSuiteInterface $suite;
 
-    /**
-     * @var callable(string): void
-     */
-    private $outputWriter;
+    private TestRunReporter $reporter;
 
     /**
      * @param callable(string): void|null $outputWriter
@@ -20,9 +18,7 @@ final class TestRunner
     public function __construct(TestSuiteInterface $suite, ?callable $outputWriter = null)
     {
         $this->suite = $suite;
-        $this->outputWriter = $outputWriter ?? static function (string $line): void {
-            echo $line . PHP_EOL;
-        };
+        $this->reporter = new TestRunReporter($outputWriter);
     }
 
     /**
@@ -38,53 +34,7 @@ final class TestRunner
     public function run(): int
     {
         $result = $this->suite->run();
-        $statusMap = [
-            'passed' => 'PASS',
-            'failed' => 'FAIL',
-            'error' => 'ERROR',
-        ];
 
-        foreach ($result->getResults() as $testResult) {
-            $status = $statusMap[$testResult->getStatus()] ?? strtoupper($testResult->getStatus());
-            $className = $testResult->getClassName();
-            $methodName = $testResult->getMethodName();
-            $message = $testResult->getMessage() ?? '';
-
-            if ($testResult->isPassed()) {
-                $this->write(sprintf('[%s] %s::%s', $status, $className, $methodName));
-
-                continue;
-            }
-
-            $this->write(sprintf('[%s] %s::%s - %s', $status, $className, $methodName, $message));
-        }
-
-        if ($result->getTotalTests() === 0) {
-            $this->write('No tests were executed.');
-
-            return 1;
-        }
-
-        $this->write('');
-
-        if ($result->isSuccessful()) {
-            $this->write(sprintf('All %d tests passed.', $result->getTotalTests()));
-
-            return 0;
-        }
-
-        $this->write(sprintf(
-            'Test run completed with %d failure(s) and %d error(s) out of %d tests.',
-            $result->getFailureCount(),
-            $result->getErrorCount(),
-            $result->getTotalTests()
-        ));
-
-        return 1;
-    }
-
-    private function write(string $line): void
-    {
-        ($this->outputWriter)($line);
+        return $this->reporter->report($result);
     }
 }


### PR DESCRIPTION
## Summary
- extract a dedicated `TestRunReporter` to encapsulate formatting test run results
- update `TestRunner` to delegate reporting responsibilities to the new class
- add unit tests covering `TestRunReporter` behaviors

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68ff08205e4c832f8add50b59319bb3a