### PR TITLE
Refactor footer rendering into OOP component

### DIFF
--- a/wwwroot/classes/FooterRenderer.php
+++ b/wwwroot/classes/FooterRenderer.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/FooterViewModel.php';
+
+final class FooterRenderer
+{
+    public function render(FooterViewModel $viewModel): string
+    {
+        $yearRangeLabel = htmlspecialchars($viewModel->getYearRangeLabel(), ENT_QUOTES, 'UTF-8');
+        $releaseUrl = htmlspecialchars($viewModel->getReleaseUrl(), ENT_QUOTES, 'UTF-8');
+        $versionLabel = htmlspecialchars($viewModel->getVersionLabel(), ENT_QUOTES, 'UTF-8');
+        $changelogUrl = htmlspecialchars($viewModel->getChangelogUrl(), ENT_QUOTES, 'UTF-8');
+        $issuesUrl = htmlspecialchars($viewModel->getIssuesUrl(), ENT_QUOTES, 'UTF-8');
+        $creatorProfileUrl = htmlspecialchars($viewModel->getCreatorProfileUrl(), ENT_QUOTES, 'UTF-8');
+        $creatorName = htmlspecialchars($viewModel->getCreatorName(), ENT_QUOTES, 'UTF-8');
+        $contributorsUrl = htmlspecialchars($viewModel->getContributorsUrl(), ENT_QUOTES, 'UTF-8');
+
+        return <<<HTML
+        <footer class="container">
+            <hr>
+            <div class="row">
+                <div class="col-3">
+                    &copy; {$yearRangeLabel}<br>
+                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="{$releaseUrl}">{$versionLabel}</a> -
+                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="{$changelogUrl}">Changelog</a>
+                </div>
+                <div class="col-6 text-center">
+                    PSN100 is not affiliated with Sony or PlayStation in any way.<br>
+                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="{$issuesUrl}">Issues</a>
+                </div>
+                <div class="col-3 text-end">
+                    Created and maintained by <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="{$creatorProfileUrl}">{$creatorName}</a>.<br>
+                    Development by
+                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="{$contributorsUrl}">PSN100 Contributors</a>.
+                </div>
+            </div>
+        </footer>
+        HTML;
+    }
+}

--- a/wwwroot/footer.php
+++ b/wwwroot/footer.php
@@ -1,28 +1,13 @@
-        <?php
-        require_once __DIR__ . '/classes/FooterViewModel.php';
+<?php
+require_once __DIR__ . '/classes/FooterViewModel.php';
+require_once __DIR__ . '/classes/FooterRenderer.php';
 
-        $footerViewModel = FooterViewModel::createDefault();
-        ?>
-        <footer class="container">
-            <hr>
-            <div class="row">
-                <div class="col-3">
-                    &copy; <?= htmlspecialchars($footerViewModel->getYearRangeLabel(), ENT_QUOTES, 'UTF-8'); ?><br>
-                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($footerViewModel->getReleaseUrl(), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($footerViewModel->getVersionLabel(), ENT_QUOTES, 'UTF-8'); ?></a> -
-                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($footerViewModel->getChangelogUrl(), ENT_QUOTES, 'UTF-8'); ?>">Changelog</a>
-                </div>
-                <div class="col-6 text-center">
-                    PSN100 is not affiliated with Sony or PlayStation in any way.<br>
-                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($footerViewModel->getIssuesUrl(), ENT_QUOTES, 'UTF-8'); ?>">Issues</a>
-                </div>
-                <div class="col-3 text-end">
-                    Created and maintained by <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($footerViewModel->getCreatorProfileUrl(), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($footerViewModel->getCreatorName(), ENT_QUOTES, 'UTF-8'); ?></a>.<br>
-                    Development by
-                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($footerViewModel->getContributorsUrl(), ENT_QUOTES, 'UTF-8'); ?>">PSN100 Contributors</a>.
-                </div>
-            </div>
-        </footer>
+$footerViewModel = FooterViewModel::createDefault();
+$footerRenderer = new FooterRenderer();
 
+echo $footerRenderer->render($footerViewModel);
+?>
+        
         <!-- jQuery first, then Popper.js, then Bootstrap JS -->
         <script src="https://code.jquery.com/jquery-3.7.1.slim.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- add a `FooterRenderer` class to encapsulate footer markup generation
- update the footer partial to render through the new object-oriented renderer

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68ff08205e4c832f8add50b59319bb3a