### PR TITLE
Add PlayerLogPageContext to streamline player log setup

### DIFF
--- a/tests/PlayerLogPageContextTest.php
+++ b/tests/PlayerLogPageContextTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerLogPageContext.php';
+
+final class PlayerLogPageContextTest extends TestCase
+{
+    public function testContextAggregatesDependencies(): void
+    {
+        $filter = PlayerLogFilter::fromArray(['ps5' => 'true', 'sort' => 'rarity']);
+        $entries = [
+            PlayerLogEntry::fromArray([
+                'trophy_id' => 123,
+                'trophy_type' => 'gold',
+                'trophy_name' => 'Gold Trophy',
+                'trophy_detail' => 'Do something impressive',
+                'trophy_icon' => 'gold.png',
+                'rarity_percent' => '1.5',
+                'trophy_status' => 0,
+                'game_id' => 456,
+                'game_name' => 'Example Game',
+                'game_status' => 0,
+                'game_icon' => 'example.png',
+                'platform' => 'PS5',
+                'earned_date' => '2024-01-01 00:00:00',
+            ]),
+        ];
+
+        $playerLogPage = $this->createPlayerLogPage($filter, $entries, 0, 99);
+        $playerSummary = new PlayerSummary(10, 4, 75.0, 12);
+
+        $context = PlayerLogPageContext::fromComponents(
+            $playerLogPage,
+            $playerSummary,
+            $filter,
+            'ExampleUser',
+            99,
+            0
+        );
+
+        $this->assertSame($playerLogPage, $context->getPlayerLogPage());
+        $this->assertSame($playerSummary, $context->getPlayerSummary());
+        $this->assertSame("ExampleUser's Trophy Log ~ PSN 100%", $context->getTitle());
+        $this->assertSame('ExampleUser', $context->getPlayerOnlineId());
+        $this->assertSame(99, $context->getPlayerAccountId());
+        $this->assertTrue($context->shouldDisplayLog());
+        $this->assertFalse($context->isPlayerFlagged());
+        $this->assertFalse($context->isPlayerPrivate());
+        $this->assertCount(1, $context->getTrophies());
+
+        $navigation = $context->getPlayerNavigation();
+        $links = $navigation->getLinks();
+        $this->assertSame('/player/ExampleUser/log', $links[1]->getUrl());
+        $this->assertTrue($links[1]->isActive());
+
+        $platformOptions = $context->getPlatformFilterOptions()->getOptions();
+        $ps5Option = null;
+        foreach ($platformOptions as $option) {
+            if ($option->getInputName() === 'ps5') {
+                $ps5Option = $option;
+                break;
+            }
+        }
+
+        $this->assertTrue($ps5Option instanceof PlayerPlatformFilterOption);
+        $this->assertTrue($ps5Option->isSelected());
+        $this->assertTrue($context->getTrophyRarityFormatter() instanceof TrophyRarityFormatter);
+    }
+
+    public function testContextReflectsPlayerStatuses(): void
+    {
+        $filter = PlayerLogFilter::fromArray([]);
+        $playerSummary = new PlayerSummary(0, 0, null, 0);
+
+        $flaggedPage = $this->createPlayerLogPage($filter, [], 1, 50);
+        $flaggedContext = PlayerLogPageContext::fromComponents(
+            $flaggedPage,
+            $playerSummary,
+            $filter,
+            'FlaggedUser',
+            50,
+            1
+        );
+
+        $this->assertTrue($flaggedContext->isPlayerFlagged());
+        $this->assertFalse($flaggedContext->shouldDisplayLog());
+
+        $privatePage = $this->createPlayerLogPage($filter, [], 3, 75);
+        $privateContext = PlayerLogPageContext::fromComponents(
+            $privatePage,
+            $playerSummary,
+            $filter,
+            'PrivateUser',
+            75,
+            3
+        );
+
+        $this->assertTrue($privateContext->isPlayerPrivate());
+        $this->assertFalse($privateContext->shouldDisplayLog());
+    }
+
+    /**
+     * @param PlayerLogEntry[] $entries
+     */
+    private function createPlayerLogPage(
+        PlayerLogFilter $filter,
+        array $entries,
+        int $playerStatus,
+        int $accountId
+    ): PlayerLogPage {
+        $service = new class($entries) extends PlayerLogService {
+            /** @var PlayerLogEntry[] */
+            private array $entries;
+
+            public function __construct(array $entries)
+            {
+                $this->entries = $entries;
+            }
+
+            public function countTrophies(int $accountId, PlayerLogFilter $filter): int
+            {
+                return count($this->entries);
+            }
+
+            public function getTrophies(
+                int $accountId,
+                PlayerLogFilter $filter,
+                int $offset,
+                int $limit = self::PAGE_SIZE
+            ): array {
+                return $this->entries;
+            }
+        };
+
+        return new PlayerLogPage($service, $filter, $accountId, $playerStatus);
+    }
+}

--- a/wwwroot/classes/PlayerLogPageContext.php
+++ b/wwwroot/classes/PlayerLogPageContext.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerLogFilter.php';
+require_once __DIR__ . '/PlayerLogPage.php';
+require_once __DIR__ . '/PlayerLogService.php';
+require_once __DIR__ . '/PlayerNavigation.php';
+require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
+require_once __DIR__ . '/PlayerSummary.php';
+require_once __DIR__ . '/PlayerSummaryService.php';
+require_once __DIR__ . '/TrophyRarityFormatter.php';
+
+final class PlayerLogPageContext
+{
+    private const STATUS_FLAGGED = 1;
+    private const STATUS_PRIVATE = 3;
+
+    private PlayerLogPage $playerLogPage;
+
+    private PlayerSummary $playerSummary;
+
+    private PlayerLogFilter $filter;
+
+    private PlayerNavigation $playerNavigation;
+
+    private PlayerPlatformFilterOptions $platformFilterOptions;
+
+    private TrophyRarityFormatter $trophyRarityFormatter;
+
+    private string $title;
+
+    private string $playerOnlineId;
+
+    private int $playerAccountId;
+
+    private int $playerStatus;
+
+    /**
+     * @param array<string, mixed> $playerData
+     * @param array<string, mixed> $queryParameters
+     */
+    public static function fromGlobals(
+        PDO $database,
+        array $playerData,
+        int $accountId,
+        array $queryParameters
+    ): self {
+        $filter = PlayerLogFilter::fromArray($queryParameters);
+        $playerLogService = new PlayerLogService($database);
+        $playerLogPage = new PlayerLogPage(
+            $playerLogService,
+            $filter,
+            self::extractPlayerAccountId($playerData),
+            self::extractPlayerStatus($playerData)
+        );
+
+        $playerSummaryService = new PlayerSummaryService($database);
+        $playerSummary = $playerSummaryService->getSummary($accountId);
+
+        return new self(
+            $playerLogPage,
+            $playerSummary,
+            $filter,
+            self::extractOnlineId($playerData),
+            self::extractPlayerAccountId($playerData),
+            self::extractPlayerStatus($playerData)
+        );
+    }
+
+    public static function fromComponents(
+        PlayerLogPage $playerLogPage,
+        PlayerSummary $playerSummary,
+        PlayerLogFilter $filter,
+        string $playerOnlineId,
+        int $playerAccountId,
+        int $playerStatus
+    ): self {
+        return new self(
+            $playerLogPage,
+            $playerSummary,
+            $filter,
+            $playerOnlineId,
+            $playerAccountId,
+            $playerStatus
+        );
+    }
+
+    private function __construct(
+        PlayerLogPage $playerLogPage,
+        PlayerSummary $playerSummary,
+        PlayerLogFilter $filter,
+        string $playerOnlineId,
+        int $playerAccountId,
+        int $playerStatus
+    ) {
+        $this->playerLogPage = $playerLogPage;
+        $this->playerSummary = $playerSummary;
+        $this->filter = $filter;
+        $this->playerOnlineId = $playerOnlineId;
+        $this->playerAccountId = $playerAccountId;
+        $this->playerStatus = $playerStatus;
+        $this->playerNavigation = PlayerNavigation::forSection($playerOnlineId, PlayerNavigation::SECTION_LOG);
+        $this->platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
+            fn (string $platform): bool => $this->filter->isPlatformSelected($platform)
+        );
+        $this->trophyRarityFormatter = new TrophyRarityFormatter();
+        $this->title = sprintf("%s's Trophy Log ~ PSN 100%%", $playerOnlineId);
+    }
+
+    public function getPlayerLogPage(): PlayerLogPage
+    {
+        return $this->playerLogPage;
+    }
+
+    public function getPlayerSummary(): PlayerSummary
+    {
+        return $this->playerSummary;
+    }
+
+    public function getFilter(): PlayerLogFilter
+    {
+        return $this->filter;
+    }
+
+    public function getPlayerNavigation(): PlayerNavigation
+    {
+        return $this->playerNavigation;
+    }
+
+    public function getPlatformFilterOptions(): PlayerPlatformFilterOptions
+    {
+        return $this->platformFilterOptions;
+    }
+
+    public function getTrophyRarityFormatter(): TrophyRarityFormatter
+    {
+        return $this->trophyRarityFormatter;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getPlayerOnlineId(): string
+    {
+        return $this->playerOnlineId;
+    }
+
+    public function getPlayerAccountId(): int
+    {
+        return $this->playerAccountId;
+    }
+
+    public function isPlayerFlagged(): bool
+    {
+        return $this->playerStatus === self::STATUS_FLAGGED;
+    }
+
+    public function isPlayerPrivate(): bool
+    {
+        return $this->playerStatus === self::STATUS_PRIVATE;
+    }
+
+    public function shouldDisplayLog(): bool
+    {
+        return !$this->isPlayerFlagged() && !$this->isPlayerPrivate();
+    }
+
+    /**
+     * @return PlayerLogEntry[]
+     */
+    public function getTrophies(): array
+    {
+        return $this->playerLogPage->getTrophies();
+    }
+
+    private static function extractOnlineId(array $playerData): string
+    {
+        return (string) ($playerData['online_id'] ?? '');
+    }
+
+    private static function extractPlayerAccountId(array $playerData): int
+    {
+        return (int) ($playerData['account_id'] ?? 0);
+    }
+
+    private static function extractPlayerStatus(array $playerData): int
+    {
+        return (int) ($playerData['status'] ?? 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add a PlayerLogPageContext class to encapsulate player log data, navigation, and helper state
- refactor player_log.php to build its view model from the new context object
- add coverage for the context to ensure platform filters, navigation, and status flags behave as expected

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68ff08205e4c832f8add50b59319bb3a