### PR TITLE
Refactor player report handling to use request object

### DIFF
--- a/tests/PlayerReportRequestTest.php
+++ b/tests/PlayerReportRequestTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerReportRequest.php';
+
+final class PlayerReportRequestTest extends TestCase
+{
+    public function testFromArraysTrimsExplanationAndCapturesIpAddress(): void
+    {
+        $queryParameters = ['explanation' => '  Needs review  '];
+        $serverParameters = ['REMOTE_ADDR' => '198.51.100.24'];
+
+        $request = PlayerReportRequest::fromArrays($queryParameters, $serverParameters);
+
+        $this->assertSame('Needs review', $request->getExplanation());
+        $this->assertTrue($request->wasExplanationSubmitted());
+        $this->assertSame('198.51.100.24', $request->getIpAddress());
+    }
+
+    public function testFromArraysHandlesMissingExplanationAndInvalidIp(): void
+    {
+        $request = PlayerReportRequest::fromArrays([], ['REMOTE_ADDR' => 'invalid']);
+
+        $this->assertSame('', $request->getExplanation());
+        $this->assertFalse($request->wasExplanationSubmitted());
+        $this->assertSame('', $request->getIpAddress());
+    }
+
+    public function testFromArraysSanitizesNonScalarExplanationValues(): void
+    {
+        $queryParameters = ['explanation' => ['value', 'other']];
+        $serverParameters = ['REMOTE_ADDR' => new class {
+            public function __toString(): string
+            {
+                return '203.0.113.12';
+            }
+        }];
+
+        $request = PlayerReportRequest::fromArrays($queryParameters, $serverParameters);
+
+        $this->assertSame('', $request->getExplanation());
+        $this->assertTrue($request->wasExplanationSubmitted());
+        $this->assertSame('203.0.113.12', $request->getIpAddress());
+    }
+}

--- a/wwwroot/classes/PlayerReportHandler.php
+++ b/wwwroot/classes/PlayerReportHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerReportService.php';
 require_once __DIR__ . '/PlayerReportResult.php';
+require_once __DIR__ . '/PlayerReportRequest.php';
 
 class PlayerReportHandler
 {
@@ -14,61 +15,23 @@ class PlayerReportHandler
         $this->playerReportService = $playerReportService;
     }
 
-    /**
-     * @param array<string, mixed> $queryParameters
-     */
-    public function getExplanation(array $queryParameters): string
-    {
-        return $this->sanitizeExplanation($queryParameters['explanation'] ?? null);
-    }
-
-    /**
-     * @param int $accountId
-     * @param string $explanation
-     * @param bool $explanationSubmitted
-     * @param array<string, mixed> $serverParameters
-     */
     public function handleReportRequest(
         int $accountId,
-        string $explanation,
-        bool $explanationSubmitted,
-        array $serverParameters
-    ): PlayerReportResult
-    {
-        if (!$explanationSubmitted) {
+        PlayerReportRequest $request
+    ): PlayerReportResult {
+        if (!$request->wasExplanationSubmitted()) {
             return PlayerReportResult::empty();
         }
 
+        $explanation = $request->getExplanation();
         if ($explanation === '') {
             return PlayerReportResult::error('Please provide an explanation for your report.');
         }
 
-        $ipAddress = $this->resolveIpAddress($serverParameters);
-
-        return $this->playerReportService->submitReport($accountId, $ipAddress, $explanation);
-    }
-
-    private function sanitizeExplanation(mixed $explanation): string
-    {
-        if (!is_scalar($explanation)) {
-            return '';
-        }
-
-        return trim((string) $explanation);
-    }
-
-    /**
-     * @param array<string, mixed> $serverParameters
-     */
-    private function resolveIpAddress(array $serverParameters): string
-    {
-        $ipAddress = (string) ($serverParameters['REMOTE_ADDR'] ?? '');
-        if ($ipAddress === '') {
-            return '';
-        }
-
-        $validatedAddress = filter_var($ipAddress, FILTER_VALIDATE_IP);
-
-        return is_string($validatedAddress) ? $validatedAddress : '';
+        return $this->playerReportService->submitReport(
+            $accountId,
+            $request->getIpAddress(),
+            $explanation
+        );
     }
 }

--- a/wwwroot/classes/PlayerReportPage.php
+++ b/wwwroot/classes/PlayerReportPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerReportHandler.php';
 require_once __DIR__ . '/PlayerReportResult.php';
+require_once __DIR__ . '/PlayerReportRequest.php';
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/PlayerSummaryService.php';
 
@@ -56,13 +57,12 @@ class PlayerReportPage
     private function initialize(): void
     {
         $this->playerSummary = $this->playerSummaryService->getSummary($this->accountId);
-        $this->explanation = $this->playerReportHandler->getExplanation($this->queryParameters);
-        $this->explanationSubmitted = array_key_exists('explanation', $this->queryParameters);
+        $request = PlayerReportRequest::fromArrays($this->queryParameters, $this->serverParameters);
+        $this->explanation = $request->getExplanation();
+        $this->explanationSubmitted = $request->wasExplanationSubmitted();
         $this->reportResult = $this->playerReportHandler->handleReportRequest(
             $this->accountId,
-            $this->explanation,
-            $this->explanationSubmitted,
-            $this->serverParameters
+            $request
         );
     }
 

--- a/wwwroot/classes/PlayerReportRequest.php
+++ b/wwwroot/classes/PlayerReportRequest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+final class PlayerReportRequest
+{
+    private string $explanation;
+
+    private bool $explanationSubmitted;
+
+    private string $ipAddress;
+
+    private function __construct(string $explanation, bool $explanationSubmitted, string $ipAddress)
+    {
+        $this->explanation = $explanation;
+        $this->explanationSubmitted = $explanationSubmitted;
+        $this->ipAddress = $ipAddress;
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     * @param array<string, mixed> $serverParameters
+     */
+    public static function fromArrays(array $queryParameters, array $serverParameters): self
+    {
+        $explanationSubmitted = array_key_exists('explanation', $queryParameters);
+        $explanation = self::sanitizeExplanation($queryParameters['explanation'] ?? null);
+        $ipAddress = self::resolveIpAddress($serverParameters);
+
+        return new self($explanation, $explanationSubmitted, $ipAddress);
+    }
+
+    public function getExplanation(): string
+    {
+        return $this->explanation;
+    }
+
+    public function wasExplanationSubmitted(): bool
+    {
+        return $this->explanationSubmitted;
+    }
+
+    public function getIpAddress(): string
+    {
+        return $this->ipAddress;
+    }
+
+    private static function sanitizeExplanation(mixed $explanation): string
+    {
+        if (!is_scalar($explanation)) {
+            return '';
+        }
+
+        return trim((string) $explanation);
+    }
+
+    /**
+     * @param array<string, mixed> $serverParameters
+     */
+    private static function resolveIpAddress(array $serverParameters): string
+    {
+        $ipAddress = (string) ($serverParameters['REMOTE_ADDR'] ?? '');
+        if ($ipAddress === '') {
+            return '';
+        }
+
+        $validatedAddress = filter_var($ipAddress, FILTER_VALIDATE_IP);
+
+        return is_string($validatedAddress) ? $validatedAddress : '';
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a PlayerReportRequest value object to encapsulate request sanitization
- update the report handler and page to consume the new request object instead of raw arrays
- add unit tests covering the new request behaviour

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68ff08205e4c832f8add50b59319bb3a