### PR TITLE
Strip "Trophy Set For" prefix when importing trophy titles

### DIFF
--- a/tests/TrophyTitleNamingTest.php
+++ b/tests/TrophyTitleNamingTest.php
@@ -49,6 +49,13 @@ final class TrophyTitleNamingTest extends TestCase
         $this->assertSame('Horizon Forbidden West', $formatted);
     }
 
+    public function testSanitizeRemovesTrophySetForPrefix(): void
+    {
+        $formatted = $this->formatTitle('TROPHY SET FOR FORTNITE');
+
+        $this->assertSame('Fortnite', $formatted);
+    }
+
     public function testHyphenSeparatorsAreConvertedToColons(): void
     {
         $formatted = $this->formatTitle("Marvel's Spider-Man - Miles Morales");

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1289,6 +1289,7 @@ class ThirtyMinuteCronJob implements CronJobInterface
         }
 
         $prefixPatterns = [
+            '/^Trophy Set For\b[:\s-]*/i',
             '/^Trophy Set\b[:\s-]*/i',
             '/^Trophyset\b[:\s-]*/i',
         ];


### PR DESCRIPTION
## Summary
- expand trophy title sanitization to drop the "Trophy Set For" prefix used by new titles
- add a regression test to ensure the prefix is removed before applying title case

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68ff3e087c60832f9e6dbb462d213110