### PR TITLE
Refactor player random games bootstrap

### DIFF
--- a/tests/PlayerRandomGamesPageContextTest.php
+++ b/tests/PlayerRandomGamesPageContextTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerRandomGamesPageContext.php';
+
+final class PlayerRandomGamesPageContextTest extends TestCase
+{
+    public function testContextAggregatesDependencies(): void
+    {
+        $filter = PlayerRandomGamesFilter::fromArray(['ps5' => 'true']);
+        $utility = new Utility();
+        $randomGame = new PlayerRandomGame(
+            [
+                'id' => 123,
+                'np_communication_id' => 'NPWR12345_00',
+                'name' => 'Random Game',
+                'icon_url' => 'random.png',
+                'platform' => 'PS5',
+                'owners' => 1000,
+                'difficulty' => '12.5',
+                'platinum' => 1,
+                'gold' => 2,
+                'silver' => 3,
+                'bronze' => 4,
+                'rarity_points' => 500,
+                'progress' => '50',
+            ],
+            $utility
+        );
+        $randomGames = [$randomGame];
+
+        $playerSummary = new PlayerSummary(10, 4, 75.0, 12);
+        $page = $this->createPage($filter, $randomGames, $playerSummary, 0, 99);
+
+        $context = PlayerRandomGamesPageContext::fromComponents(
+            $page,
+            $page->getPlayerSummary(),
+            $page->getFilter(),
+            'ExampleUser',
+            99,
+            0
+        );
+
+        $this->assertSame("ExampleUser's Random Games ~ PSN 100%", $context->getTitle());
+        $this->assertSame('ExampleUser', $context->getPlayerOnlineId());
+        $this->assertSame(99, $context->getPlayerAccountId());
+        $this->assertSame($page, $context->getPlayerRandomGamesPage());
+        $this->assertSame($page->getPlayerSummary(), $context->getPlayerSummary());
+        $this->assertSame($page->getFilter(), $context->getFilter());
+        $this->assertSame($randomGames, $context->getRandomGames());
+        $this->assertTrue($context->shouldShowRandomGames());
+        $this->assertFalse($context->shouldShowFlaggedMessage());
+        $this->assertFalse($context->shouldShowPrivateMessage());
+
+        $navigation = $context->getPlayerNavigation();
+        $links = $navigation->getLinks();
+        $this->assertSame('/player/ExampleUser/random', $links[4]->getUrl());
+        $this->assertTrue($links[4]->isActive());
+
+        $platformOptions = $context->getPlatformFilterOptions()->getOptions();
+        $ps5Option = null;
+        foreach ($platformOptions as $option) {
+            if ($option->getInputName() === 'ps5') {
+                $ps5Option = $option;
+                break;
+            }
+        }
+
+        $this->assertTrue($ps5Option instanceof PlayerPlatformFilterOption);
+        $this->assertTrue($ps5Option->isSelected());
+    }
+
+    public function testContextReflectsPlayerStatuses(): void
+    {
+        $filter = PlayerRandomGamesFilter::fromArray([]);
+        $playerSummary = new PlayerSummary(0, 0, null, 0);
+        $randomGames = [];
+
+        $flaggedPage = $this->createPage($filter, $randomGames, $playerSummary, 1, 50);
+        $flaggedContext = PlayerRandomGamesPageContext::fromComponents(
+            $flaggedPage,
+            $flaggedPage->getPlayerSummary(),
+            $flaggedPage->getFilter(),
+            'FlaggedUser',
+            50,
+            1
+        );
+
+        $this->assertTrue($flaggedContext->shouldShowFlaggedMessage());
+        $this->assertFalse($flaggedContext->shouldShowRandomGames());
+
+        $privatePage = $this->createPage($filter, $randomGames, $playerSummary, 3, 75);
+        $privateContext = PlayerRandomGamesPageContext::fromComponents(
+            $privatePage,
+            $privatePage->getPlayerSummary(),
+            $privatePage->getFilter(),
+            'PrivateUser',
+            75,
+            3
+        );
+
+        $this->assertTrue($privateContext->shouldShowPrivateMessage());
+        $this->assertFalse($privateContext->shouldShowRandomGames());
+    }
+
+    /**
+     * @param PlayerRandomGame[] $randomGames
+     */
+    private function createPage(
+        PlayerRandomGamesFilter $filter,
+        array $randomGames,
+        PlayerSummary $playerSummary,
+        int $playerStatus,
+        int $accountId
+    ): PlayerRandomGamesPage {
+        $randomGamesService = new class($randomGames) extends PlayerRandomGamesService {
+            /** @var PlayerRandomGame[] */
+            private array $randomGames;
+
+            public function __construct(array $randomGames)
+            {
+                $this->randomGames = $randomGames;
+            }
+
+            public function getRandomGames(int $accountId, PlayerRandomGamesFilter $filter, int $limit = 8): array
+            {
+                return $this->randomGames;
+            }
+        };
+
+        $summaryService = new class($playerSummary) extends PlayerSummaryService {
+            private PlayerSummary $summary;
+
+            public function __construct(PlayerSummary $summary)
+            {
+                $this->summary = $summary;
+            }
+
+            public function getSummary(int $accountId): PlayerSummary
+            {
+                return $this->summary;
+            }
+        };
+
+        return new PlayerRandomGamesPage(
+            $randomGamesService,
+            $summaryService,
+            $filter,
+            $accountId,
+            $playerStatus
+        );
+    }
+}

--- a/wwwroot/classes/PlayerRandomGamesPageContext.php
+++ b/wwwroot/classes/PlayerRandomGamesPageContext.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerRandomGame.php';
+require_once __DIR__ . '/PlayerRandomGamesFilter.php';
+require_once __DIR__ . '/PlayerRandomGamesPage.php';
+require_once __DIR__ . '/PlayerRandomGamesService.php';
+require_once __DIR__ . '/PlayerSummary.php';
+require_once __DIR__ . '/PlayerSummaryService.php';
+require_once __DIR__ . '/PlayerNavigation.php';
+require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
+require_once __DIR__ . '/Utility.php';
+
+final class PlayerRandomGamesPageContext
+{
+    private const STATUS_FLAGGED = 1;
+    private const STATUS_PRIVATE = 3;
+
+    private PlayerRandomGamesPage $playerRandomGamesPage;
+
+    private PlayerSummary $playerSummary;
+
+    private PlayerRandomGamesFilter $filter;
+
+    private PlayerNavigation $playerNavigation;
+
+    private PlayerPlatformFilterOptions $platformFilterOptions;
+
+    private string $title;
+
+    private string $playerOnlineId;
+
+    private int $playerAccountId;
+
+    private int $playerStatus;
+
+    /**
+     * @param array<string, mixed> $playerData
+     * @param array<string, mixed> $queryParameters
+     */
+    public static function fromGlobals(
+        PDO $database,
+        Utility $utility,
+        array $playerData,
+        int $accountId,
+        array $queryParameters
+    ): self {
+        $filter = PlayerRandomGamesFilter::fromArray($queryParameters);
+        $playerStatus = self::extractPlayerStatus($playerData);
+
+        $randomGamesService = new PlayerRandomGamesService($database, $utility);
+        $summaryService = new PlayerSummaryService($database);
+
+        $playerRandomGamesPage = new PlayerRandomGamesPage(
+            $randomGamesService,
+            $summaryService,
+            $filter,
+            $accountId,
+            $playerStatus
+        );
+
+        return self::fromComponents(
+            $playerRandomGamesPage,
+            $playerRandomGamesPage->getPlayerSummary(),
+            $playerRandomGamesPage->getFilter(),
+            self::extractOnlineId($playerData),
+            $accountId,
+            $playerStatus
+        );
+    }
+
+    public static function fromComponents(
+        PlayerRandomGamesPage $playerRandomGamesPage,
+        PlayerSummary $playerSummary,
+        PlayerRandomGamesFilter $filter,
+        string $playerOnlineId,
+        int $playerAccountId,
+        int $playerStatus
+    ): self {
+        return new self(
+            $playerRandomGamesPage,
+            $playerSummary,
+            $filter,
+            $playerOnlineId,
+            $playerAccountId,
+            $playerStatus
+        );
+    }
+
+    private function __construct(
+        PlayerRandomGamesPage $playerRandomGamesPage,
+        PlayerSummary $playerSummary,
+        PlayerRandomGamesFilter $filter,
+        string $playerOnlineId,
+        int $playerAccountId,
+        int $playerStatus
+    ) {
+        $this->playerRandomGamesPage = $playerRandomGamesPage;
+        $this->playerSummary = $playerSummary;
+        $this->filter = $filter;
+        $this->playerOnlineId = $playerOnlineId;
+        $this->playerAccountId = $playerAccountId;
+        $this->playerStatus = $playerStatus;
+        $this->playerNavigation = PlayerNavigation::forSection($playerOnlineId, PlayerNavigation::SECTION_RANDOM);
+        $this->platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
+            fn (string $platform): bool => $this->filter->isPlatformSelected($platform)
+        );
+        $this->title = sprintf("%s's Random Games ~ PSN 100%%", $playerOnlineId);
+    }
+
+    public function getPlayerRandomGamesPage(): PlayerRandomGamesPage
+    {
+        return $this->playerRandomGamesPage;
+    }
+
+    public function getPlayerSummary(): PlayerSummary
+    {
+        return $this->playerSummary;
+    }
+
+    public function getFilter(): PlayerRandomGamesFilter
+    {
+        return $this->filter;
+    }
+
+    public function getPlayerNavigation(): PlayerNavigation
+    {
+        return $this->playerNavigation;
+    }
+
+    public function getPlatformFilterOptions(): PlayerPlatformFilterOptions
+    {
+        return $this->platformFilterOptions;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getPlayerOnlineId(): string
+    {
+        return $this->playerOnlineId;
+    }
+
+    public function getPlayerAccountId(): int
+    {
+        return $this->playerAccountId;
+    }
+
+    public function isPlayerFlagged(): bool
+    {
+        return $this->playerStatus === self::STATUS_FLAGGED;
+    }
+
+    public function isPlayerPrivate(): bool
+    {
+        return $this->playerStatus === self::STATUS_PRIVATE;
+    }
+
+    public function shouldShowFlaggedMessage(): bool
+    {
+        return $this->playerRandomGamesPage->shouldShowFlaggedMessage();
+    }
+
+    public function shouldShowPrivateMessage(): bool
+    {
+        return $this->playerRandomGamesPage->shouldShowPrivateMessage();
+    }
+
+    public function shouldShowRandomGames(): bool
+    {
+        return $this->playerRandomGamesPage->shouldShowRandomGames();
+    }
+
+    /**
+     * @return PlayerRandomGame[]
+     */
+    public function getRandomGames(): array
+    {
+        return $this->playerRandomGamesPage->getRandomGames();
+    }
+
+    /**
+     * @param array<string, mixed> $playerData
+     */
+    private static function extractOnlineId(array $playerData): string
+    {
+        return (string) ($playerData['online_id'] ?? '');
+    }
+
+    /**
+     * @param array<string, mixed> $playerData
+     */
+    private static function extractPlayerStatus(array $playerData): int
+    {
+        return (int) ($playerData['status'] ?? 0);
+    }
+}


### PR DESCRIPTION
## Summary
- extract player random games bootstrapping into a reusable page context
- update the random games page to consume the new context accessors instead of manual wiring
- add unit tests covering the new page context behaviour and status handling

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68ff3f82e910832f8f3e42b17c5e3ad8