### PR TITLE
Refactor thirty minute cron script into application class

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/CronJobEntryPoint.php';
+require_once __DIR__ . '/CronJobCliArguments.php';
+require_once __DIR__ . '/../TrophyCalculator.php';
+require_once __DIR__ . '/ThirtyMinuteCronJob.php';
+
+use PDO;
+
+final class ThirtyMinuteCronJobApplication
+{
+    private CronJobEntryPoint $entryPoint;
+
+    private CronJobCliArguments $cliArguments;
+
+    private function __construct(CronJobEntryPoint $entryPoint, CronJobCliArguments $cliArguments)
+    {
+        $this->entryPoint = $entryPoint;
+        $this->cliArguments = $cliArguments;
+    }
+
+    /**
+     * @param array<int, string>|string[] $argv
+     */
+    public static function fromGlobals(string $rootDirectory, array $argv = []): self
+    {
+        $entryPoint = CronJobEntryPoint::create($rootDirectory);
+        $cliArguments = CronJobCliArguments::fromArgv($argv);
+
+        return new self($entryPoint, $cliArguments);
+    }
+
+    public function run(): void
+    {
+        $workerId = $this->cliArguments->getWorkerId();
+
+        $this->entryPoint->runWithFactory(function (PDO $database) use ($workerId): \CronJobInterface {
+            $trophyCalculator = new TrophyCalculator($database);
+            $logger = new Psn100Logger($database);
+
+            return new ThirtyMinuteCronJob($database, $trophyCalculator, $logger, $workerId);
+        }, true);
+    }
+}

--- a/wwwroot/cron/30th_minute.php
+++ b/wwwroot/cron/30th_minute.php
@@ -2,19 +2,11 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/classes/Cron/CronJobEntryPoint.php';
-require_once dirname(__DIR__) . '/classes/Cron/CronJobCliArguments.php';
-require_once dirname(__DIR__) . '/classes/TrophyCalculator.php';
-require_once dirname(__DIR__) . '/classes/Cron/ThirtyMinuteCronJob.php';
+require_once dirname(__DIR__) . '/classes/Cron/ThirtyMinuteCronJobApplication.php';
 
-$entryPoint = CronJobEntryPoint::create(dirname(__DIR__));
+$application = ThirtyMinuteCronJobApplication::fromGlobals(
+    dirname(__DIR__),
+    $_SERVER['argv'] ?? []
+);
 
-$cliArguments = CronJobCliArguments::fromArgv($_SERVER['argv'] ?? []);
-$workerId = $cliArguments->getWorkerId();
-
-$entryPoint->runWithFactory(static function (\PDO $database) use ($workerId): CronJobInterface {
-    $trophyCalculator = new TrophyCalculator($database);
-    $logger = new Psn100Logger($database);
-
-    return new ThirtyMinuteCronJob($database, $trophyCalculator, $logger, $workerId);
-}, true);
+$application->run();


### PR DESCRIPTION
## Summary
- add a dedicated `ThirtyMinuteCronJobApplication` to orchestrate worker selection
- update the `30th_minute` cron entrypoint to instantiate and run the new application class

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68ff3f82e910832f8f3e42b17c5e3ad8