### PR TITLE
Refactor test runner to use TestResult objects

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,33 +2,38 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/TestResult.php';
+
 abstract class TestCase
 {
     /**
-     * @return list<array{method:string,status:string,message?:string}>
+     * @return list<TestResult>
      */
     public final function runTests(): array
     {
         $results = [];
+        $className = get_class($this);
 
         foreach ($this->getTestMethods() as $method) {
             $this->setUp();
 
             try {
                 $this->$method();
-                $results[] = ['method' => $method, 'status' => 'passed'];
+                $results[] = new TestResult($className, $method, 'passed');
             } catch (AssertionError $assertionError) {
-                $results[] = [
-                    'method' => $method,
-                    'status' => 'failed',
-                    'message' => $assertionError->getMessage(),
-                ];
+                $results[] = new TestResult(
+                    $className,
+                    $method,
+                    'failed',
+                    $assertionError->getMessage()
+                );
             } catch (Throwable $throwable) {
-                $results[] = [
-                    'method' => $method,
-                    'status' => 'error',
-                    'message' => $throwable->getMessage(),
-                ];
+                $results[] = new TestResult(
+                    $className,
+                    $method,
+                    'error',
+                    $throwable->getMessage()
+                );
             } finally {
                 $this->tearDown();
             }

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -71,12 +71,11 @@ final class TestSuite implements TestSuiteInterface
             $testCase = new $testClass();
 
             foreach ($testCase->runTests() as $result) {
-                $results[] = new TestResult(
-                    $testClass,
-                    $result['method'],
-                    $result['status'],
-                    $result['message'] ?? null
-                );
+                if (!$result instanceof TestResult) {
+                    throw new UnexpectedValueException('Test cases must return TestResult instances.');
+                }
+
+                $results[] = $result;
             }
         }
 


### PR DESCRIPTION
## Summary
- update TestCase::runTests to construct TestResult value objects for each executed test method
- adjust TestSuite to consume TestResult instances from test cases and validate the result type

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68ff3f82e910832f8f3e42b17c5e3ad8