### PR TITLE
Refactor test runner entry point into command

### DIFF
--- a/tests/TestRunnerCommand.php
+++ b/tests/TestRunnerCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestRunner.php';
+
+final class TestRunnerCommand
+{
+    private TestRunner $runner;
+
+    public function __construct(TestRunner $runner)
+    {
+        $this->runner = $runner;
+    }
+
+    /**
+     * @param callable(string): void|null $outputWriter
+     */
+    public static function fromDirectory(string $directory, ?callable $outputWriter = null): self
+    {
+        $runner = TestRunner::fromDirectory($directory, $outputWriter);
+
+        return new self($runner);
+    }
+
+    public function execute(): int
+    {
+        return $this->runner->run();
+    }
+}

--- a/tests/TestRunnerCommandTest.php
+++ b/tests/TestRunnerCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestRunnerCommand.php';
+require_once __DIR__ . '/TestSuiteInterface.php';
+require_once __DIR__ . '/TestSuiteResult.php';
+require_once __DIR__ . '/TestResult.php';
+
+final class TestRunnerCommandSuiteStub implements TestSuiteInterface
+{
+    private TestSuiteResult $result;
+
+    public function __construct(TestSuiteResult $result)
+    {
+        $this->result = $result;
+    }
+
+    public function run(): TestSuiteResult
+    {
+        return $this->result;
+    }
+}
+
+final class TestRunnerCommandTest extends TestCase
+{
+    public function testExecuteDelegatesToRunner(): void
+    {
+        $suite = new TestRunnerCommandSuiteStub(new TestSuiteResult([]));
+        $runner = new TestRunner($suite, static function (string $line): void {
+            // Intentionally left blank for testing purposes.
+        });
+
+        $command = new TestRunnerCommand($runner);
+
+        $this->assertSame(1, $command->execute());
+    }
+
+    public function testFromDirectoryCreatesCommandUsingTestRunner(): void
+    {
+        $command = TestRunnerCommand::fromDirectory(__DIR__, static function (string $line): void {
+            // Suppress output during tests.
+        });
+
+        $runnerProperty = new ReflectionProperty(TestRunnerCommand::class, 'runner');
+        $runnerProperty->setAccessible(true);
+
+        $runner = $runnerProperty->getValue($command);
+
+        $this->assertTrue($runner instanceof TestRunner);
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/TestRunner.php';
+require __DIR__ . '/TestRunnerCommand.php';
 
-$runner = TestRunner::fromDirectory(__DIR__);
+$command = TestRunnerCommand::fromDirectory(__DIR__);
 
-exit($runner->run());
+exit($command->execute());


### PR DESCRIPTION
## Summary
- introduce a `TestRunnerCommand` class that wraps `TestRunner` execution for the CLI entry point
- update the `tests/run.php` script to create and execute the new command
- cover the command with unit tests to verify delegation and factory behavior

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68ff3f82e910832f8f3e42b17c5e3ad8