### PR TITLE
Restore scan log entry animation

### DIFF
--- a/wwwroot/about.php
+++ b/wwwroot/about.php
@@ -396,8 +396,21 @@ require_once("header.php");
                                 return levelCell;
                             };
 
+                            const applyRowEntryAnimation = (row) => {
+                                row.classList.add('scan-log-row--enter');
+                                row.addEventListener(
+                                    'animationend',
+                                    () => {
+                                        row.classList.remove('scan-log-row--enter');
+                                    },
+                                    { once: true }
+                                );
+                            };
+
                             const buildRow = (player) => {
                                 const row = document.createElement('tr');
+                                applyRowEntryAnimation(row);
+
                                 row.append(
                                     createRankCell(player),
                                     createUpdatedCell(player),


### PR DESCRIPTION
## Summary
- reintroduce the scan log row entry animation by applying the animation class when building rows
- remove the animation class after the animation finishes so future updates can animate again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69009cf19030832f871fa5a432479f8c