### PR TITLE
Add polling for about page scan log

### DIFF
--- a/wwwroot/classes/AboutPagePlayerArraySerializer.php
+++ b/wwwroot/classes/AboutPagePlayerArraySerializer.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/AboutPagePlayer.php';
+
+final class AboutPagePlayerArraySerializer
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function serialize(AboutPagePlayer $player): array
+    {
+        return [
+            'onlineId' => $player->getOnlineId(),
+            'countryCode' => $player->getCountryCode(),
+            'countryName' => $player->getCountryName(),
+            'avatarUrl' => $player->getAvatarUrl(),
+            'lastUpdatedDate' => $player->getLastUpdatedDate(),
+            'isRanked' => $player->isRanked(),
+            'ranking' => $player->getRanking(),
+            'hasHiddenTrophies' => $player->hasHiddenTrophies(),
+            'statusLabel' => $player->getStatusLabel(),
+            'isNew' => $player->isNew(),
+            'rankDeltaLabel' => $player->getRankDeltaLabel(),
+            'rankDeltaColor' => $player->getRankDeltaColor(),
+            'progress' => $player->getProgress(),
+            'level' => $player->getLevel(),
+            'status' => $player->getStatus(),
+        ];
+    }
+
+    /**
+     * @param array<int, AboutPagePlayer> $players
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function serializeCollection(array $players): array
+    {
+        $serializedPlayers = [];
+
+        foreach ($players as $player) {
+            if (!$player instanceof AboutPagePlayer) {
+                continue;
+            }
+
+            $serializedPlayers[] = self::serialize($player);
+        }
+
+        return $serializedPlayers;
+    }
+}

--- a/wwwroot/scan_log_poll.php
+++ b/wwwroot/scan_log_poll.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/init.php';
+require_once __DIR__ . '/classes/AboutPageService.php';
+require_once __DIR__ . '/classes/AboutPagePlayerArraySerializer.php';
+require_once __DIR__ . '/classes/JsonResponseEmitter.php';
+
+$jsonResponder = new JsonResponseEmitter();
+$aboutPageService = new AboutPageService($database, $utility);
+
+$limit = 30;
+if (isset($_GET['limit'])) {
+    $requestedLimit = filter_var($_GET['limit'], FILTER_VALIDATE_INT, [
+        'options' => [
+            'default' => $limit,
+            'min_range' => 1,
+            'max_range' => 100,
+        ],
+    ]);
+
+    if ($requestedLimit !== false) {
+        $limit = $requestedLimit;
+    }
+}
+
+try {
+    $scanSummary = $aboutPageService->getScanSummary();
+    $scanLogPlayers = $aboutPageService->getScanLogPlayers($limit);
+
+    $jsonResponder->respond([
+        'status' => 'ok',
+        'summary' => [
+            'scannedPlayers' => $scanSummary->getScannedPlayers(),
+            'newPlayers' => $scanSummary->getNewPlayers(),
+        ],
+        'players' => AboutPagePlayerArraySerializer::serializeCollection($scanLogPlayers),
+    ]);
+} catch (Throwable $exception) {
+    $jsonResponder->respond([
+        'status' => 'error',
+        'message' => 'Unable to load scan log data at this time.',
+    ], 500);
+}


### PR DESCRIPTION
## Summary
- add a reusable serializer for scan log player data
- expose a scan_log_poll endpoint that returns the latest scan summary and entries
- enhance the About page scan log script to poll for updates, refresh the table, and animate new rows

## Testing
- php -l wwwroot/classes/AboutPagePlayerArraySerializer.php
- php -l wwwroot/scan_log_poll.php
- php -l wwwroot/about.php

------
https://chatgpt.com/codex/tasks/task_e_69009ee6a160832fbb1436854fc1303b