### PR TITLE
Add targeted indexes for player filters

### DIFF
--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -347,7 +347,9 @@ ALTER TABLE `player`
   ADD KEY `player_idx_online_id_account_id` (`online_id`,`account_id`),
   ADD KEY `player_idx_status_last_date_online_id` (`status`,`last_updated_date`,`online_id`),
   ADD KEY `player_idx_status_online_last_da_account` (`status`,`online_id`,`last_updated_date`,`account_id`),
-  ADD KEY `player_idx_status_account_avatar_online` (`status`,`account_id`,`avatar_url`,`online_id`) USING BTREE;
+  ADD KEY `player_idx_status_account_avatar_online` (`status`,`account_id`,`avatar_url`,`online_id`) USING BTREE,
+  ADD KEY `player_idx_status_country` (`status`,`country`),
+  ADD KEY `player_idx_status_rank_last_week` (`status`,`rank_last_week`);
 
 --
 -- Indexes for table `player_queue`


### PR DESCRIPTION
## Summary
- add composite indexes on the player table to cover status/country and status/rank filters used by the UI
- keep leaderboard and summary queries efficient on MySQL 8.4.7

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_69014843ed68832fbfdee16f44ed7603