### PR TITLE
Allow admin detail lookup by NP communication ID

### DIFF
--- a/wwwroot/admin/detail.php
+++ b/wwwroot/admin/detail.php
@@ -15,6 +15,9 @@ $gameDetail = $pageResult->getGameDetail();
 $success = $pageResult->getSuccessMessage();
 $error = $pageResult->getErrorMessage();
 
+$requestedGameId = isset($_GET['game']) ? (string) $_GET['game'] : '';
+$requestedNpCommunicationId = isset($_GET['np_communication_id']) ? (string) $_GET['np_communication_id'] : '';
+
 ?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">
@@ -30,7 +33,10 @@ $error = $pageResult->getErrorMessage();
             <a href="/admin/">Back</a><br><br>
             <form method="get" autocomplete="off">
                 Game ID:<br>
-                <input type="number" name="game"><br>
+                <input type="number" name="game" value="<?= htmlentities($requestedGameId, ENT_QUOTES, 'UTF-8'); ?>"><br>
+                NP Communication ID:<br>
+                <input type="text" name="np_communication_id" style="width: 300px;" value="<?= htmlentities($requestedNpCommunicationId, ENT_QUOTES, 'UTF-8'); ?>"><br>
+                <small>Examples: NPWR10853_00, MERGE_048500</small><br>
                 <input type="submit" value="Fetch">
             </form>
 

--- a/wwwroot/classes/Admin/GameDetailPage.php
+++ b/wwwroot/classes/Admin/GameDetailPage.php
@@ -40,14 +40,21 @@ class GameDetailPage
                     $success = sprintf('<p>Game ID %d is updated.</p>', $gameDetail->getId());
                 }
             } elseif ($method === 'GET') {
+                $npCommunicationId = null;
                 $gameId = $this->parseGameId($queryParameters['game'] ?? null);
 
                 if ($gameId !== null) {
                     $gameDetail = $this->gameDetailService->getGameDetail($gameId);
+                } else {
+                    $npCommunicationId = $this->parseNpCommunicationId($queryParameters['np_communication_id'] ?? null);
 
-                    if ($gameDetail === null) {
-                        $error = '<p>Unable to find the requested game.</p>';
+                    if ($npCommunicationId !== null) {
+                        $gameDetail = $this->gameDetailService->getGameDetailByNpCommunicationId($npCommunicationId);
                     }
+                }
+
+                if (($gameId !== null || isset($npCommunicationId)) && $gameDetail === null) {
+                    $error = '<p>Unable to find the requested game.</p>';
                 }
             }
         } catch (Throwable $exception) {
@@ -55,6 +62,17 @@ class GameDetailPage
         }
 
         return new GameDetailPageResult($gameDetail, $success, $error);
+    }
+
+    private function parseNpCommunicationId(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
     }
 
     private function parseGameId(mixed $value): ?int

--- a/wwwroot/classes/Admin/GameDetailService.php
+++ b/wwwroot/classes/Admin/GameDetailService.php
@@ -39,6 +39,37 @@ class GameDetailService
         return GameDetail::fromArray($gameId, $row);
     }
 
+    public function getGameDetailByNpCommunicationId(string $npCommunicationId): ?GameDetail
+    {
+        $query = $this->database->prepare(
+            'SELECT
+                id,
+                np_communication_id,
+                name,
+                icon_url,
+                platform,
+                message,
+                set_version,
+                region,
+                psnprofiles_id
+            FROM
+                trophy_title
+            WHERE
+                np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        $row = $query->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+
+        $gameId = (int) ($row['id'] ?? 0);
+
+        return GameDetail::fromArray($gameId, $row);
+    }
+
     public function updateGameDetail(GameDetail $gameDetail): GameDetail
     {
         $this->database->beginTransaction();


### PR DESCRIPTION
## Summary
- allow the admin detail page to request a game by numeric id or NP communication id
- add a service helper that loads game details by NP communication id
- keep the requested identifiers in the fetch form when re-rendered

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6901583d266c832fa676321c2d2facef