### PR TITLE
Strip Trophyset suffix when storing trophy titles

### DIFF
--- a/tests/TrophyTitleNamingTest.php
+++ b/tests/TrophyTitleNamingTest.php
@@ -56,6 +56,13 @@ final class TrophyTitleNamingTest extends TestCase
         $this->assertSame('Fortnite', $formatted);
     }
 
+    public function testSanitizeRemovesTrophysetSuffix(): void
+    {
+        $formatted = $this->formatTitle('Fortnite Trophyset');
+
+        $this->assertSame('Fortnite', $formatted);
+    }
+
     public function testHyphenSeparatorsAreConvertedToColons(): void
     {
         $formatted = $this->formatTitle("Marvel's Spider-Man - Miles Morales");

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1301,6 +1301,8 @@ class ThirtyMinuteCronJob implements CronJobInterface
         $suffixPatterns = [
             '/\s*Trophy Set\.$/i',
             '/\s*Trophy Set$/i',
+            '/\s*Trophyset\.$/i',
+            '/\s*Trophyset$/i',
             '/\s*Trophies$/i',
             '/\s*Trophy$/i',
         ];


### PR DESCRIPTION
## Summary
- remove trailing "Trophyset" suffix when sanitizing trophy title names before inserting
- add coverage for the new suffix handling in the trophy title naming tests

## Testing
- php tests/run.php tests/TrophyTitleNamingTest.php

------
https://chatgpt.com/codex/tasks/task_e_6901de249c74832fb81e20066bb767d8