### PR TITLE
Add tests for footer rendering components

### DIFF
--- a/tests/FooterRendererTest.php
+++ b/tests/FooterRendererTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/FooterRenderer.php';
+require_once __DIR__ . '/../wwwroot/classes/FooterViewModel.php';
+
+final class FooterRendererTest extends TestCase
+{
+    public function testRenderOutputsFooterHtmlWithEscapedValues(): void
+    {
+        $viewModel = new FooterViewModel(
+            2020,
+            2023,
+            'v1.0 "alpha"',
+            'https://example.com/releases?tag="latest"',
+            '"/changelog"',
+            'https://example.com/issues?issue=<1>',
+            'Rago & Co',
+            '"/player/<Rago>"',
+            "https://example.com/contributors?name='Rago'"
+        );
+
+        $renderer = new FooterRenderer();
+
+        $html = $renderer->render($viewModel);
+
+        $this->assertStringContainsString('<footer class="container">', $html);
+        $this->assertStringContainsString('&copy; 2020-2023', $html);
+        $this->assertStringContainsString('href="https://example.com/releases?tag=&quot;latest&quot;"', $html);
+        $this->assertStringContainsString('>v1.0 &quot;alpha&quot;</a>', $html);
+        $this->assertStringContainsString('href="&quot;/changelog&quot;"', $html);
+        $this->assertStringContainsString('href="https://example.com/issues?issue=&lt;1&gt;"', $html);
+        $this->assertStringContainsString('>Rago &amp; Co</a>', $html);
+        $this->assertStringContainsString('href="&quot;/player/&lt;Rago&gt;&quot;"', $html);
+        $this->assertStringContainsString('href="https://example.com/contributors?name=&#039;Rago&#039;"', $html);
+        $this->assertStringContainsString('PSN100 is not affiliated with Sony or PlayStation in any way.', $html);
+    }
+}

--- a/tests/FooterViewModelTest.php
+++ b/tests/FooterViewModelTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/FooterViewModel.php';
+
+final class FooterViewModelTest extends TestCase
+{
+    public function testGettersReturnConfiguredValues(): void
+    {
+        $viewModel = new FooterViewModel(
+            2019,
+            2024,
+            'v1.2.3',
+            'https://example.com/releases',
+            '/changelog',
+            'https://example.com/issues',
+            'Ragowit',
+            '/player/Ragowit',
+            'https://example.com/contributors'
+        );
+
+        $this->assertSame('2019-2024', $viewModel->getYearRangeLabel());
+        $this->assertSame('v1.2.3', $viewModel->getVersionLabel());
+        $this->assertSame('https://example.com/releases', $viewModel->getReleaseUrl());
+        $this->assertSame('/changelog', $viewModel->getChangelogUrl());
+        $this->assertSame('https://example.com/issues', $viewModel->getIssuesUrl());
+        $this->assertSame('Ragowit', $viewModel->getCreatorName());
+        $this->assertSame('/player/Ragowit', $viewModel->getCreatorProfileUrl());
+        $this->assertSame('https://example.com/contributors', $viewModel->getContributorsUrl());
+    }
+
+    public function testGetYearRangeLabelReturnsSingleYearWhenStartYearAtOrAboveCurrent(): void
+    {
+        $viewModel = new FooterViewModel(
+            2025,
+            2024,
+            'v1',
+            'release-url',
+            'changelog-url',
+            'issues-url',
+            'creator',
+            'profile-url',
+            'contributors-url'
+        );
+
+        $this->assertSame('2025', $viewModel->getYearRangeLabel());
+    }
+
+    public function testCreateDefaultConfiguresKnownValues(): void
+    {
+        $viewModel = FooterViewModel::createDefault();
+        $currentYear = (int) date('Y');
+        $expectedYearRangeLabel = $currentYear <= 2019 ? '2019' : '2019-' . $currentYear;
+
+        $this->assertSame($expectedYearRangeLabel, $viewModel->getYearRangeLabel());
+        $this->assertSame('v7.40', $viewModel->getVersionLabel());
+        $this->assertSame('https://github.com/Ragowit/psn100/releases', $viewModel->getReleaseUrl());
+        $this->assertSame('/changelog', $viewModel->getChangelogUrl());
+        $this->assertSame('https://github.com/Ragowit/psn100/issues', $viewModel->getIssuesUrl());
+        $this->assertSame('Ragowit', $viewModel->getCreatorName());
+        $this->assertSame('/player/Ragowit', $viewModel->getCreatorProfileUrl());
+        $this->assertSame('https://github.com/ragowit/psn100/graphs/contributors', $viewModel->getContributorsUrl());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for FooterViewModel getters and default configuration
- cover FooterRenderer output to ensure escaping and footer structure

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6901e0d1b690832fb82a37df02641253