### PR TITLE
Refactor scan log poll endpoint into controller

### DIFF
--- a/tests/AboutPageScanLogControllerTest.php
+++ b/tests/AboutPageScanLogControllerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/AboutPageScanLogController.php';
+require_once __DIR__ . '/../wwwroot/classes/AboutPageService.php';
+require_once __DIR__ . '/../wwwroot/classes/AboutPageScanSummary.php';
+require_once __DIR__ . '/../wwwroot/classes/AboutPagePlayer.php';
+require_once __DIR__ . '/../wwwroot/classes/AboutPagePlayerArraySerializer.php';
+require_once __DIR__ . '/../wwwroot/classes/Utility.php';
+require_once __DIR__ . '/../wwwroot/classes/JsonResponseEmitter.php';
+
+final class FakeAboutPageService extends AboutPageService
+{
+    private AboutPageScanSummary $summary;
+
+    /**
+     * @var array<int, AboutPagePlayer>
+     */
+    private array $players;
+
+    private ?int $capturedLimit = null;
+
+    /**
+     * @param array<int, AboutPagePlayer> $players
+     */
+    public function __construct(AboutPageScanSummary $summary, array $players)
+    {
+        $this->summary = $summary;
+        $this->players = $players;
+    }
+
+    public function getScanSummary(): AboutPageScanSummary
+    {
+        return $this->summary;
+    }
+
+    /**
+     * @return array<int, AboutPagePlayer>
+     */
+    public function getScanLogPlayers(int $limit = 10): array
+    {
+        $this->capturedLimit = $limit;
+
+        return array_slice($this->players, 0, $limit);
+    }
+
+    public function getCapturedLimit(): ?int
+    {
+        return $this->capturedLimit;
+    }
+}
+
+final class FailingAboutPageService extends AboutPageService
+{
+    public function __construct()
+    {
+    }
+
+    public function getScanSummary(): AboutPageScanSummary
+    {
+        throw new \RuntimeException('Failed to load summary');
+    }
+}
+
+final class AboutPageScanLogControllerTest extends TestCase
+{
+    public function testHandleRespondsWithSerializedPlayersAndSummary(): void
+    {
+        $utility = new Utility();
+
+        $players = [
+            new AboutPagePlayer($utility, 'Ragowit', 'se', 'avatar1.png', '2024-01-01 00:00:00', 999, '50', 0, 0, 10, 10, 1),
+            new AboutPagePlayer($utility, 'Hunter', 'us', 'avatar2.png', '2024-01-02 12:00:00', 123, '25', 1, 0, 5, 10, 2),
+        ];
+        $summary = new AboutPageScanSummary(25, 7);
+        $service = new FakeAboutPageService($summary, $players);
+        $controller = AboutPageScanLogController::create($service, new JsonResponseEmitter());
+
+        header_remove();
+        ob_start();
+
+        $controller->handle();
+
+        $output = ob_get_clean();
+
+        $this->assertSame(30, $service->getCapturedLimit());
+        $this->assertSame(200, http_response_code());
+
+        $decodedOutput = json_decode((string) $output, true);
+        $this->assertTrue(is_array($decodedOutput));
+        $this->assertSame('ok', $decodedOutput['status'] ?? null);
+        $this->assertSame([
+            'scannedPlayers' => 25,
+            'newPlayers' => 7,
+        ], $decodedOutput['summary'] ?? null);
+        $this->assertSame(
+            AboutPagePlayerArraySerializer::serializeCollection($players),
+            $decodedOutput['players'] ?? null
+        );
+    }
+
+    public function testHandleRespectsLimitQueryParameter(): void
+    {
+        $utility = new Utility();
+        $players = [
+            new AboutPagePlayer($utility, 'SoloPlayer', 'gb', 'avatar3.png', '2024-01-03 08:30:00', 75, '90', 0, 0, 1, 1, 5),
+        ];
+        $summary = new AboutPageScanSummary(3, 1);
+        $service = new FakeAboutPageService($summary, $players);
+        $controller = new AboutPageScanLogController($service, new JsonResponseEmitter());
+
+        header_remove();
+        ob_start();
+
+        $controller->handle(['limit' => '5']);
+
+        ob_end_clean();
+
+        $this->assertSame(5, $service->getCapturedLimit());
+    }
+
+    public function testHandleRespondsWithErrorWhenExceptionThrown(): void
+    {
+        $controller = AboutPageScanLogController::create(new FailingAboutPageService(), new JsonResponseEmitter());
+
+        header_remove();
+        ob_start();
+
+        $controller->handle();
+
+        $output = ob_get_clean();
+
+        $this->assertSame(500, http_response_code());
+
+        $decodedOutput = json_decode((string) $output, true);
+        $this->assertTrue(is_array($decodedOutput));
+        $this->assertSame('error', $decodedOutput['status'] ?? null);
+        $this->assertSame('Unable to load scan log data at this time.', $decodedOutput['message'] ?? null);
+    }
+}

--- a/wwwroot/classes/AboutPageScanLogController.php
+++ b/wwwroot/classes/AboutPageScanLogController.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/AboutPageService.php';
+require_once __DIR__ . '/AboutPageScanSummary.php';
+require_once __DIR__ . '/AboutPagePlayerArraySerializer.php';
+require_once __DIR__ . '/JsonResponseEmitter.php';
+
+final class AboutPageScanLogController
+{
+    private const DEFAULT_LIMIT = 30;
+    private const MIN_LIMIT = 1;
+    private const MAX_LIMIT = 100;
+
+    private AboutPageService $aboutPageService;
+    private JsonResponseEmitter $jsonResponder;
+    private int $defaultLimit;
+    private int $minLimit;
+    private int $maxLimit;
+
+    public function __construct(
+        AboutPageService $aboutPageService,
+        JsonResponseEmitter $jsonResponder,
+        int $defaultLimit = self::DEFAULT_LIMIT,
+        int $minLimit = self::MIN_LIMIT,
+        int $maxLimit = self::MAX_LIMIT
+    ) {
+        $this->aboutPageService = $aboutPageService;
+        $this->jsonResponder = $jsonResponder;
+        $this->defaultLimit = $defaultLimit;
+        $this->minLimit = $minLimit;
+        $this->maxLimit = $maxLimit;
+    }
+
+    public static function create(AboutPageService $aboutPageService, JsonResponseEmitter $jsonResponder): self
+    {
+        return new self($aboutPageService, $jsonResponder);
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public function handle(array $queryParameters = []): void
+    {
+        $limit = $this->resolveLimit($queryParameters['limit'] ?? null);
+
+        try {
+            $scanSummary = $this->aboutPageService->getScanSummary();
+            $scanLogPlayers = $this->aboutPageService->getScanLogPlayers($limit);
+
+            $this->jsonResponder->respond([
+                'status' => 'ok',
+                'summary' => [
+                    'scannedPlayers' => $scanSummary->getScannedPlayers(),
+                    'newPlayers' => $scanSummary->getNewPlayers(),
+                ],
+                'players' => AboutPagePlayerArraySerializer::serializeCollection($scanLogPlayers),
+            ]);
+        } catch (\Throwable) {
+            $this->jsonResponder->respond([
+                'status' => 'error',
+                'message' => 'Unable to load scan log data at this time.',
+            ], 500);
+        }
+    }
+
+    private function resolveLimit(mixed $limit): int
+    {
+        if ($limit instanceof \Stringable) {
+            $limit = (string) $limit;
+        }
+
+        if (!is_scalar($limit)) {
+            return $this->defaultLimit;
+        }
+
+        $validatedLimit = filter_var(
+            $limit,
+            FILTER_VALIDATE_INT,
+            [
+                'options' => [
+                    'default' => $this->defaultLimit,
+                    'min_range' => $this->minLimit,
+                    'max_range' => $this->maxLimit,
+                ],
+            ]
+        );
+
+        if ($validatedLimit === false) {
+            return $this->defaultLimit;
+        }
+
+        return (int) $validatedLimit;
+    }
+}

--- a/wwwroot/scan_log_poll.php
+++ b/wwwroot/scan_log_poll.php
@@ -4,42 +4,11 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/init.php';
 require_once __DIR__ . '/classes/AboutPageService.php';
-require_once __DIR__ . '/classes/AboutPagePlayerArraySerializer.php';
 require_once __DIR__ . '/classes/JsonResponseEmitter.php';
+require_once __DIR__ . '/classes/AboutPageScanLogController.php';
 
-$jsonResponder = new JsonResponseEmitter();
 $aboutPageService = new AboutPageService($database, $utility);
+$jsonResponder = new JsonResponseEmitter();
+$controller = AboutPageScanLogController::create($aboutPageService, $jsonResponder);
 
-$limit = 30;
-if (isset($_GET['limit'])) {
-    $requestedLimit = filter_var($_GET['limit'], FILTER_VALIDATE_INT, [
-        'options' => [
-            'default' => $limit,
-            'min_range' => 1,
-            'max_range' => 100,
-        ],
-    ]);
-
-    if ($requestedLimit !== false) {
-        $limit = $requestedLimit;
-    }
-}
-
-try {
-    $scanSummary = $aboutPageService->getScanSummary();
-    $scanLogPlayers = $aboutPageService->getScanLogPlayers($limit);
-
-    $jsonResponder->respond([
-        'status' => 'ok',
-        'summary' => [
-            'scannedPlayers' => $scanSummary->getScannedPlayers(),
-            'newPlayers' => $scanSummary->getNewPlayers(),
-        ],
-        'players' => AboutPagePlayerArraySerializer::serializeCollection($scanLogPlayers),
-    ]);
-} catch (Throwable $exception) {
-    $jsonResponder->respond([
-        'status' => 'error',
-        'message' => 'Unable to load scan log data at this time.',
-    ], 500);
-}
+$controller->handle($_GET ?? []);


### PR DESCRIPTION
## Summary
- introduce an AboutPageScanLogController that encapsulates scan log polling logic
- update the scan_log_poll entry script to delegate to the controller
- add tests covering success, limit handling, and error responses for the new controller

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6901e31f4444832fae9d74b87c8e9263