### PR TITLE
Encapsulate maintenance mode handling in responder

### DIFF
--- a/tests/ApplicationRunnerTest.php
+++ b/tests/ApplicationRunnerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/ApplicationRunner.php';
+require_once __DIR__ . '/../wwwroot/classes/ApplicationContainer.php';
+require_once __DIR__ . '/../wwwroot/classes/Application.php';
+require_once __DIR__ . '/../wwwroot/classes/HttpRequest.php';
+require_once __DIR__ . '/../wwwroot/classes/MaintenanceMode.php';
+require_once __DIR__ . '/../wwwroot/classes/MaintenanceResponder.php';
+
+final class ThrowingApplicationContainerStub extends ApplicationContainer
+{
+    public function __construct()
+    {
+        // Parent constructor intentionally not called; overrides provide behaviour.
+    }
+
+    public function createRequestFromGlobals(): HttpRequest
+    {
+        throw new RuntimeException('createRequestFromGlobals should not be called when in maintenance mode.');
+    }
+
+    public function createApplication(HttpRequest $request): Application
+    {
+        throw new RuntimeException('createApplication should not be called when in maintenance mode.');
+    }
+}
+
+final class ApplicationSpy extends Application
+{
+    public int $runCalls = 0;
+
+    public function __construct()
+    {
+        // Parent constructor intentionally not called; overrides provide behaviour.
+    }
+
+    public function run(): void
+    {
+        $this->runCalls++;
+    }
+}
+
+final class ApplicationContainerSpy extends ApplicationContainer
+{
+    private HttpRequest $request;
+
+    private ApplicationSpy $application;
+
+    public ?HttpRequest $receivedRequest = null;
+
+    public function __construct(HttpRequest $request, ApplicationSpy $application)
+    {
+        $this->request = $request;
+        $this->application = $application;
+    }
+
+    public function createRequestFromGlobals(): HttpRequest
+    {
+        return $this->request;
+    }
+
+    public function createApplication(HttpRequest $request): Application
+    {
+        $this->receivedRequest = $request;
+
+        return $this->application;
+    }
+}
+
+final class ApplicationRunnerTest extends TestCase
+{
+    public function testRunSkipsApplicationWhenMaintenanceModeEnabled(): void
+    {
+        $maintenanceMode = MaintenanceMode::enabled('/maintenance.php');
+        $headers = [];
+        $includedTemplate = null;
+        $terminated = false;
+        $responder = new MaintenanceResponder(
+            static function (): void {
+                // No-op for testing.
+            },
+            static function (string $header) use (&$headers): void {
+                $headers[] = $header;
+            },
+            static function (string $template) use (&$includedTemplate): void {
+                $includedTemplate = $template;
+            },
+            static function () use (&$terminated): void {
+                $terminated = true;
+            },
+            static function (): bool {
+                return false;
+            }
+        );
+        $container = new ThrowingApplicationContainerStub();
+
+        $runner = new ApplicationRunner($container, $maintenanceMode, $responder);
+        $runner->run();
+
+        $this->assertSame(['Retry-After: 300'], $headers);
+        $this->assertSame('/maintenance.php', $includedTemplate);
+        $this->assertTrue($terminated);
+    }
+
+    public function testRunDelegatesToContainerWhenMaintenanceModeDisabled(): void
+    {
+        $maintenanceMode = MaintenanceMode::disabled('/maintenance.php');
+        $request = new HttpRequest(['REQUEST_URI' => '/example']);
+        $application = new ApplicationSpy();
+        $container = new ApplicationContainerSpy($request, $application);
+        $headers = [];
+        $includedTemplate = null;
+        $terminated = false;
+        $responder = new MaintenanceResponder(
+            static function (): void {
+                // No-op for testing.
+            },
+            static function (string $header) use (&$headers): void {
+                $headers[] = $header;
+            },
+            static function (string $template) use (&$includedTemplate): void {
+                $includedTemplate = $template;
+            },
+            static function () use (&$terminated): void {
+                $terminated = true;
+            },
+            static function (): bool {
+                return false;
+            }
+        );
+
+        $runner = new ApplicationRunner($container, $maintenanceMode, $responder);
+        $runner->run();
+
+        $this->assertSame($request, $container->receivedRequest);
+        $this->assertSame(1, $application->runCalls);
+        $this->assertSame([], $headers);
+        $this->assertSame(null, $includedTemplate);
+        $this->assertFalse($terminated);
+    }
+}

--- a/tests/MaintenanceResponderTest.php
+++ b/tests/MaintenanceResponderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/MaintenanceResponder.php';
+require_once __DIR__ . '/../wwwroot/classes/MaintenanceMode.php';
+
+final class MaintenanceResponderTest extends TestCase
+{
+    public function testRespondEmitsStatusHeaderAndTerminates(): void
+    {
+        $status = null;
+        $headers = [];
+        $includedTemplate = null;
+        $terminated = false;
+        $headersSent = false;
+
+        $responder = new MaintenanceResponder(
+            static function (int $code) use (&$status): void {
+                $status = $code;
+            },
+            static function (string $header) use (&$headers): void {
+                $headers[] = $header;
+            },
+            static function (string $template) use (&$includedTemplate): void {
+                $includedTemplate = $template;
+            },
+            static function () use (&$terminated): void {
+                $terminated = true;
+            },
+            static function () use (&$headersSent): bool {
+                return $headersSent;
+            }
+        );
+
+        $mode = MaintenanceMode::enabled('/path/to/maintenance.php');
+        $responder->respond($mode);
+
+        $this->assertSame(503, $status);
+        $this->assertSame(['Retry-After: 300'], $headers);
+        $this->assertSame('/path/to/maintenance.php', $includedTemplate);
+        $this->assertTrue($terminated);
+    }
+
+    public function testRespondSkipsRetryHeaderWhenHeadersAlreadySent(): void
+    {
+        $headers = [];
+        $headersSent = true;
+
+        $responder = new MaintenanceResponder(
+            static function (): void {
+                // No-op for testing.
+            },
+            static function (string $header) use (&$headers): void {
+                $headers[] = $header;
+            },
+            static function (): void {
+                // No-op for testing.
+            },
+            static function (): void {
+                // No-op for testing.
+            },
+            static function () use (&$headersSent): bool {
+                return $headersSent;
+            }
+        );
+
+        $mode = MaintenanceMode::enabled('/template.php');
+        $responder->respond($mode);
+
+        $this->assertSame([], $headers);
+    }
+}

--- a/wwwroot/classes/ApplicationBootstrapper.php
+++ b/wwwroot/classes/ApplicationBootstrapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/ApplicationContainer.php';
 require_once __DIR__ . '/ApplicationRunner.php';
+require_once __DIR__ . '/MaintenanceResponder.php';
 
 final class ApplicationBootstrapper
 {
@@ -41,6 +42,10 @@ final class ApplicationBootstrapper
 
     public function createApplicationRunner(MaintenanceMode $maintenanceMode): ApplicationRunner
     {
-        return ApplicationRunner::create($this->applicationContainer, $maintenanceMode);
+        return ApplicationRunner::create(
+            $this->applicationContainer,
+            $maintenanceMode,
+            new MaintenanceResponder()
+        );
     }
 }

--- a/wwwroot/classes/MaintenanceResponder.php
+++ b/wwwroot/classes/MaintenanceResponder.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/MaintenanceMode.php';
+
+final class MaintenanceResponder
+{
+    /**
+     * @var callable(int): void
+     */
+    private $statusEmitter;
+
+    /**
+     * @var callable(string): void
+     */
+    private $headerEmitter;
+
+    /**
+     * @var callable(string): void
+     */
+    private $templateIncluder;
+
+    /**
+     * @var callable(): void
+     */
+    private $terminator;
+
+    /**
+     * @var callable(): bool
+     */
+    private $headersSentDetector;
+
+    public function __construct(
+        ?callable $statusEmitter = null,
+        ?callable $headerEmitter = null,
+        ?callable $templateIncluder = null,
+        ?callable $terminator = null,
+        ?callable $headersSentDetector = null
+    ) {
+        $this->statusEmitter = $statusEmitter ?? static function (int $status): void {
+            http_response_code($status);
+        };
+        $this->headerEmitter = $headerEmitter ?? static function (string $header): void {
+            header($header);
+        };
+        $this->templateIncluder = $templateIncluder ?? static function (string $template): void {
+            require_once $template;
+        };
+        $this->terminator = $terminator ?? static function (): void {
+            exit();
+        };
+        $this->headersSentDetector = $headersSentDetector ?? static function (): bool {
+            return headers_sent();
+        };
+    }
+
+    public function respond(MaintenanceMode $maintenanceMode): void
+    {
+        ($this->statusEmitter)(503);
+
+        if (!($this->headersSentDetector)()) {
+            ($this->headerEmitter)('Retry-After: 300');
+        }
+
+        ($this->templateIncluder)($maintenanceMode->getTemplatePath());
+
+        ($this->terminator)();
+    }
+}

--- a/wwwroot/index.php
+++ b/wwwroot/index.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/classes/MaintenanceMode.php';
+require_once __DIR__ . '/classes/MaintenanceResponder.php';
 
 $defaultMaintenanceState = false;
 $maintenanceMode = MaintenanceMode::fromEnvironment(
@@ -11,9 +12,8 @@ $maintenanceMode = MaintenanceMode::fromEnvironment(
 );
 
 if ($maintenanceMode->isEnabled()) {
-    require_once $maintenanceMode->getTemplatePath();
-
-    exit();
+    $maintenanceResponder = new MaintenanceResponder();
+    $maintenanceResponder->respond($maintenanceMode);
 }
 
 require_once __DIR__ . '/init.php';


### PR DESCRIPTION
## Summary
- add a dedicated `MaintenanceResponder` to encapsulate maintenance-mode response behaviour and update the runner, bootstrapper, and entry point to use it
- cover the responder and runner flow with focused unit tests to validate header emission and application dispatch

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6901e31f4444832fae9d74b87c8e9263