### PR TITLE
Add tests for GameHeaderService

### DIFF
--- a/tests/GameHeaderServiceTest.php
+++ b/tests/GameHeaderServiceTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/GameHeaderService.php';
+require_once __DIR__ . '/../wwwroot/classes/Game/GameDetails.php';
+
+final class GameHeaderServiceTest extends TestCase
+{
+    private PDO $database;
+
+    private GameHeaderService $service;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->database->exec(
+            'CREATE TABLE trophy_title (' .
+            'id INTEGER PRIMARY KEY, ' .
+            'np_communication_id TEXT NOT NULL, ' .
+            'parent_np_communication_id TEXT NULL, ' .
+            '`name` TEXT NOT NULL, ' .
+            'platform TEXT NOT NULL, ' .
+            'region TEXT NULL)'
+        );
+
+        $this->database->exec(
+            'CREATE TABLE trophy (' .
+            'id INTEGER PRIMARY KEY AUTOINCREMENT, ' .
+            '`status` INTEGER NOT NULL, ' .
+            'np_communication_id TEXT NOT NULL)'
+        );
+
+        $this->service = new GameHeaderService($this->database);
+    }
+
+    public function testBuildHeaderDataIncludesParentStacksAndUnobtainableCount(): void
+    {
+        $this->insertTrophyTitle([
+            'id' => 100,
+            'np_communication_id' => 'PARENT-GAME',
+            'parent_np_communication_id' => null,
+            'name' => 'Parent Game',
+            'platform' => 'PS4',
+            'region' => 'US',
+        ]);
+
+        $this->insertTrophyTitle([
+            'id' => 101,
+            'np_communication_id' => 'STACK-1',
+            'parent_np_communication_id' => 'MERGE-123',
+            'name' => 'Stack Alpha',
+            'platform' => 'PS5',
+            'region' => 'NA',
+        ]);
+
+        $this->insertTrophyTitle([
+            'id' => 102,
+            'np_communication_id' => 'STACK-2',
+            'parent_np_communication_id' => 'MERGE-123',
+            'name' => 'Stack Beta',
+            'platform' => 'PS4',
+            'region' => '',
+        ]);
+
+        $this->insertTrophy([
+            'status' => 1,
+            'np_communication_id' => 'MERGE-123',
+        ]);
+
+        $this->insertTrophy([
+            'status' => 1,
+            'np_communication_id' => 'MERGE-123',
+        ]);
+
+        $this->insertTrophy([
+            'status' => 0,
+            'np_communication_id' => 'MERGE-123',
+        ]);
+
+        $game = $this->createGameDetails([
+            'status' => 2,
+            'np_communication_id' => 'MERGE-123',
+            'parent_np_communication_id' => 'PARENT-GAME',
+        ]);
+
+        $headerData = $this->service->buildHeaderData($game);
+
+        $this->assertTrue($headerData->hasMergedParent());
+        $this->assertSame(100, $headerData->getParentGame()?->getId());
+        $this->assertSame('Parent Game', $headerData->getParentGame()?->getName());
+
+        $this->assertTrue($headerData->hasStacks());
+        $this->assertCount(2, $headerData->getStacks());
+        $this->assertSame('Stack Alpha', $headerData->getStacks()[0]->getName());
+        $this->assertSame('PS5', $headerData->getStacks()[0]->getPlatform());
+        $this->assertSame('NA', $headerData->getStacks()[0]->getRegion());
+        $this->assertSame('Stack Beta', $headerData->getStacks()[1]->getName());
+        $this->assertSame('PS4', $headerData->getStacks()[1]->getPlatform());
+        $this->assertSame(null, $headerData->getStacks()[1]->getRegion());
+
+        $this->assertSame(2, $headerData->getUnobtainableTrophyCount());
+        $this->assertTrue($headerData->hasUnobtainableTrophies());
+    }
+
+    public function testBuildHeaderDataOmitsOptionalDataWhenNotAvailable(): void
+    {
+        $game = $this->createGameDetails([
+            'status' => 1,
+            'np_communication_id' => 'NPWR-1',
+            'parent_np_communication_id' => 'PARENT-GAME',
+        ]);
+
+        $headerData = $this->service->buildHeaderData($game);
+
+        $this->assertFalse($headerData->hasMergedParent());
+        $this->assertSame(null, $headerData->getParentGame());
+        $this->assertFalse($headerData->hasStacks());
+        $this->assertSame([], $headerData->getStacks());
+        $this->assertSame(0, $headerData->getUnobtainableTrophyCount());
+        $this->assertFalse($headerData->hasUnobtainableTrophies());
+    }
+
+    /**
+     * @param array{status:int,np_communication_id:string} $trophy
+     */
+    private function insertTrophy(array $trophy): void
+    {
+        $statement = $this->database->prepare(
+            'INSERT INTO trophy (`status`, np_communication_id) VALUES (:status, :np_communication_id)'
+        );
+        $statement->bindValue(':status', $trophy['status'], PDO::PARAM_INT);
+        $statement->bindValue(':np_communication_id', $trophy['np_communication_id'], PDO::PARAM_STR);
+        $statement->execute();
+    }
+
+    /**
+     * @param array{id:int,np_communication_id:string,parent_np_communication_id:?string,name:string,platform:string,region:?string} $row
+     */
+    private function insertTrophyTitle(array $row): void
+    {
+        $statement = $this->database->prepare(
+            'INSERT INTO trophy_title (id, np_communication_id, parent_np_communication_id, `name`, platform, region)
+            VALUES (:id, :np_communication_id, :parent_np_communication_id, :name, :platform, :region)'
+        );
+        $statement->bindValue(':id', $row['id'], PDO::PARAM_INT);
+        $statement->bindValue(':np_communication_id', $row['np_communication_id'], PDO::PARAM_STR);
+        if ($row['parent_np_communication_id'] === null) {
+            $statement->bindValue(':parent_np_communication_id', null, PDO::PARAM_NULL);
+        } else {
+            $statement->bindValue(':parent_np_communication_id', $row['parent_np_communication_id'], PDO::PARAM_STR);
+        }
+        $statement->bindValue(':name', $row['name'], PDO::PARAM_STR);
+        $statement->bindValue(':platform', $row['platform'], PDO::PARAM_STR);
+        if ($row['region'] === null || $row['region'] === '') {
+            $statement->bindValue(':region', null, PDO::PARAM_NULL);
+        } else {
+            $statement->bindValue(':region', $row['region'], PDO::PARAM_STR);
+        }
+        $statement->execute();
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function createGameDetails(array $overrides): GameDetails
+    {
+        $defaults = [
+            'id' => 1,
+            'name' => 'Example Game',
+            'np_communication_id' => 'NPWR-DEFAULT',
+            'parent_np_communication_id' => null,
+            'platform' => 'PS4',
+            'icon_url' => 'icon.png',
+            'set_version' => '01.00',
+            'region' => 'US',
+            'message' => null,
+            'platinum' => 0,
+            'gold' => 0,
+            'silver' => 0,
+            'bronze' => 0,
+            'owners_completed' => 0,
+            'owners' => 0,
+            'difficulty' => 'Normal',
+            'status' => 0,
+            'rarity_points' => 0,
+        ];
+
+        return GameDetails::fromArray(array_merge($defaults, $overrides));
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for GameHeaderService retrieving parent game, stacks, and unobtainable count
- verify header data omits optional sections when the game does not require them

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6901f4ceeab4832f80b89b6afde75149