### PR TITLE
Preserve HD acronym in title formatting

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1457,6 +1457,7 @@ class ThirtyMinuteCronJob implements CronJobInterface
 
         $acronyms = [
             'VR',
+            'HD',
         ];
 
         if (in_array($word, $acronyms, true)) {


### PR DESCRIPTION
## Summary
- keep the HD acronym in the title formatter's preservation list so it stays uppercase

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6902704d13c8832f9248e6eedc955f06