### PR TITLE
Optimize MySQL trophy queries

### DIFF
--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -38,14 +38,12 @@ class PlayerAdvisorService
             JOIN trophy_title_player ttp ON
                 t.np_communication_id = ttp.np_communication_id
                 AND ttp.account_id = :account_id
-            WHERE NOT EXISTS (
-                SELECT 1
-                FROM trophy_earned te
-                WHERE te.np_communication_id = t.np_communication_id
-                    AND te.order_id = t.order_id
-                    AND te.account_id = :account_id
-                    AND te.earned = 1
-            )
+            LEFT JOIN trophy_earned te_completed ON
+                te_completed.np_communication_id = t.np_communication_id
+                AND te_completed.order_id = t.order_id
+                AND te_completed.account_id = :account_id
+                AND te_completed.earned = 1
+            WHERE te_completed.account_id IS NULL
                 AND tt.status = 0
                 AND t.status = 0
         SQL;
@@ -79,25 +77,23 @@ class PlayerAdvisorService
                 tt.name AS game_name,
                 tt.icon_url AS game_icon,
                 tt.platform,
-                te.progress
+                te_progress.progress
             FROM trophy t
             JOIN trophy_title tt USING (np_communication_id)
-            LEFT JOIN trophy_earned te ON
-                t.np_communication_id = te.np_communication_id
-                AND t.order_id = te.order_id
-                AND te.account_id = :account_id
-                AND (te.earned = 0 OR te.earned IS NULL)
+            LEFT JOIN trophy_earned te_progress ON
+                t.np_communication_id = te_progress.np_communication_id
+                AND t.order_id = te_progress.order_id
+                AND te_progress.account_id = :account_id
+                AND te_progress.earned = 0
             JOIN trophy_title_player ttp ON
                 t.np_communication_id = ttp.np_communication_id
                 AND ttp.account_id = :account_id
-            WHERE NOT EXISTS (
-                    SELECT 1
-                    FROM trophy_earned te_earned
-                    WHERE te_earned.np_communication_id = t.np_communication_id
-                        AND te_earned.order_id = t.order_id
-                        AND te_earned.account_id = :account_id
-                        AND te_earned.earned = 1
-                )
+            LEFT JOIN trophy_earned te_completed ON
+                te_completed.np_communication_id = t.np_communication_id
+                AND te_completed.order_id = t.order_id
+                AND te_completed.account_id = :account_id
+                AND te_completed.earned = 1
+            WHERE te_completed.account_id IS NULL
                 AND tt.status = 0
                 AND t.status = 0
         SQL;

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -133,7 +133,7 @@ class PlayerGamesService
         }
 
         if ($filter->isUncompletedSelected()) {
-            $conditions[] = 'ttp.progress != 100';
+            $conditions[] = 'ttp.progress < 100';
         }
 
         if ($filter->isBaseSelected()) {

--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -52,7 +52,7 @@ class PlayerRandomGamesService
         $sql = "SELECT tt.id, tt.np_communication_id, tt.name, tt.icon_url, tt.platform, tt.owners, tt.difficulty, tt.platinum, tt.gold, tt.silver, tt.bronze, tt.rarity_points, ttp.progress" .
             " FROM trophy_title tt" .
             " LEFT JOIN trophy_title_player ttp ON ttp.np_communication_id = tt.np_communication_id AND ttp.account_id = :account_id" .
-            " WHERE tt.status = 0 AND (ttp.progress != 100 OR ttp.progress IS NULL)";
+            " WHERE tt.status = 0 AND (ttp.progress IS NULL OR ttp.progress < 100)";
 
         $sql .= $this->buildPlatformFilter($filter);
 


### PR DESCRIPTION
## Summary
- replace correlated trophy_earned subqueries with indexed joins in the player advisor service for faster MySQL lookups
- tighten progress filters to use range comparisons so MySQL can leverage existing indexes when filtering player games and random selections

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_69021d5f9924832fb4a6c6354e6f4400