### PR TITLE
Simplify player join in game list queries

### DIFF
--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -126,14 +126,7 @@ class GameListService
                 COUNT(*)
             FROM
                 trophy_title tt
-            LEFT JOIN (
-                SELECT
-                    account_id
-                FROM
-                    player
-                WHERE
-                    online_id = :online_id
-            ) p ON TRUE
+            LEFT JOIN player p ON p.online_id = :online_id
             LEFT JOIN trophy_title_player ttp ON
                 ttp.np_communication_id = tt.np_communication_id
                 AND ttp.progress = 100
@@ -180,14 +173,7 @@ class GameListService
                 %s
             FROM
                 trophy_title tt
-            LEFT JOIN (
-                SELECT
-                    account_id
-                FROM
-                    player
-                WHERE
-                    online_id = :online_id
-            ) p ON TRUE
+            LEFT JOIN player p ON p.online_id = :online_id
             LEFT JOIN trophy_title_player ttp ON
                 ttp.np_communication_id = tt.np_communication_id
                 AND ttp.progress = 100


### PR DESCRIPTION
## Summary
- replace the derived player subquery in the game list queries with a direct LEFT JOIN so MySQL can leverage indexes

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_69021d5f9924832fb4a6c6354e6f4400