### PR TITLE
Optimize recent player query for MySQL

### DIFF
--- a/wwwroot/classes/GameRecentPlayersQueryBuilder.php
+++ b/wwwroot/classes/GameRecentPlayersQueryBuilder.php
@@ -22,11 +22,17 @@ final class GameRecentPlayersQueryBuilder
             ttp.last_updated_date AS last_known_date
         FROM
             trophy_title_player ttp
-        JOIN player p ON ttp.account_id = p.account_id
-        JOIN player_ranking r ON p.account_id = r.account_id
+        JOIN player p ON p.account_id = ttp.account_id
+        JOIN (
+            SELECT
+                account_id
+            FROM
+                player_ranking
+            WHERE
+                ranking <= 10000
+        ) r ON r.account_id = ttp.account_id
         WHERE
             p.status = 0
-            AND r.ranking <= 10000
             AND ttp.np_communication_id = :np_communication_id
     SQL;
 


### PR DESCRIPTION
## Summary
- limit the GameRecentPlayers query to ranked players via a derived table so MySQL can leverage the ranking index

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690278391044832fbbaafd65568d0532