### PR TITLE
Optimize queue and random game queries for MySQL 8.4.7

### DIFF
--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 class PlayerRandomGamesService
 {
+    private const MIN_POOL_SIZE = 32;
+
     private const PLATFORM_FILTERS = [
         'pc' => "tt.platform LIKE '%PC%'",
         'ps3' => "tt.platform LIKE '%PS3%'",
@@ -29,35 +31,95 @@ class PlayerRandomGamesService
      */
     public function getRandomGames(int $accountId, PlayerRandomGamesFilter $filter, int $limit = 8): array
     {
-        $sql = $this->buildSqlQuery($filter, $limit);
+        $limit = max(1, $limit);
+        $totalEligible = $this->countEligibleGames($accountId, $filter);
+
+        if ($totalEligible === 0) {
+            return [];
+        }
+
+        $poolSize = (int) min($totalEligible, max($limit * 4, self::MIN_POOL_SIZE));
+        $offset = $totalEligible > $poolSize ? random_int(0, $totalEligible - $poolSize) : 0;
+
+        $sql = $this->buildSelectableQuery($filter) . ' ORDER BY tt.id LIMIT :offset, :limit';
 
         $statement = $this->database->prepare($sql);
         $statement->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $statement->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $statement->bindValue(':limit', $poolSize, PDO::PARAM_INT);
         $statement->execute();
 
-        $games = [];
-        foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $gameData) {
-            if (!is_array($gameData)) {
-                continue;
-            }
+        $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
 
+        if (!is_array($rows) || $rows === []) {
+            return [];
+        }
+
+        $rows = array_values(array_filter($rows, 'is_array'));
+
+        if ($rows === []) {
+            return [];
+        }
+
+        shuffle($rows);
+        $selectedRows = array_slice($rows, 0, $limit);
+
+        $games = [];
+
+        foreach ($selectedRows as $gameData) {
             $games[] = new PlayerRandomGame($gameData, $this->utility);
         }
 
         return $games;
     }
 
-    private function buildSqlQuery(PlayerRandomGamesFilter $filter, int $limit): string
+    private function buildSelectableQuery(PlayerRandomGamesFilter $filter): string
     {
-        $sql = "SELECT tt.id, tt.np_communication_id, tt.name, tt.icon_url, tt.platform, tt.owners, tt.difficulty, tt.platinum, tt.gold, tt.silver, tt.bronze, tt.rarity_points, ttp.progress" .
-            " FROM trophy_title tt" .
-            " LEFT JOIN trophy_title_player ttp ON ttp.np_communication_id = tt.np_communication_id AND ttp.account_id = :account_id" .
-            " WHERE tt.status = 0 AND (ttp.progress IS NULL OR ttp.progress < 100)";
+        return <<<'SQL'
+            SELECT
+                tt.id,
+                tt.np_communication_id,
+                tt.name,
+                tt.icon_url,
+                tt.platform,
+                tt.owners,
+                tt.difficulty,
+                tt.platinum,
+                tt.gold,
+                tt.silver,
+                tt.bronze,
+                tt.rarity_points,
+                ttp.progress
+            SQL
+            . $this->buildBaseQuery($filter);
+    }
+
+    private function countEligibleGames(int $accountId, PlayerRandomGamesFilter $filter): int
+    {
+        $sql = 'SELECT COUNT(*)' . $this->buildBaseQuery($filter);
+
+        $statement = $this->database->prepare($sql);
+        $statement->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $statement->execute();
+
+        $count = $statement->fetchColumn();
+
+        return $count === false ? 0 : (int) $count;
+    }
+
+    private function buildBaseQuery(PlayerRandomGamesFilter $filter): string
+    {
+        $sql = <<<'SQL'
+             FROM trophy_title tt
+            LEFT JOIN trophy_title_player ttp ON
+                ttp.np_communication_id = tt.np_communication_id
+                AND ttp.account_id = :account_id
+            WHERE
+                tt.status = 0
+                AND (ttp.progress IS NULL OR ttp.progress < 100)
+        SQL;
 
         $sql .= $this->buildPlatformFilter($filter);
-
-        $limit = max(1, $limit);
-        $sql .= ' ORDER BY RAND() LIMIT ' . $limit;
 
         return $sql;
     }


### PR DESCRIPTION
## Summary
- rewrite the queue position lookup to use indexed comparisons instead of a window function CTE
- replace ORDER BY RAND() when selecting random games with a two-step selection that samples an indexed slice and shuffles it in PHP

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_690278391044832fbbaafd65568d0532