### PR TITLE
Optimize player leaderboard filters for MySQL

### DIFF
--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -348,11 +348,10 @@ ALTER TABLE `player`
   ADD KEY `idx_last_updated_date` (`last_updated_date`),
   ADD KEY `player_idx_online_id_account_id` (`online_id`,`account_id`),
   ADD KEY `player_idx_status_last_date_online_id` (`status`,`last_updated_date`,`online_id`),
-  ADD KEY `player_idx_status_online_last_da_account` (`status`,`online_id`,`last_updated_date`,`account_id`),
-  ADD KEY `player_idx_status_account_avatar_online` (`status`,`account_id`,`avatar_url`,`online_id`) USING BTREE,
+  ADD KEY `idx_player_status_avatar_account` (`status`,`avatar_url`,`account_id`),
+  ADD KEY `idx_player_status_country_account` (`status`,`country`,`account_id`),
   ADD KEY `idx_trophy_count_npwr` (`trophy_count_npwr`),
   ADD KEY `idx_player_ranking` (`status`,`points` DESC,`platinum` DESC,`gold` DESC,`silver` DESC),
-  ADD KEY `player_idx_status_country` (`status`,`country`),
   ADD KEY `player_idx_status_rank_last_week` (`status`,`rank_last_week`);
 
 --


### PR DESCRIPTION
## Summary
- replace redundant player status indexes with ones that cover status + avatar or country + account joins
- ensure filters used by leaderboard queries map to covering indexes in MySQL 8.4.7

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69027d978f7c832f83ba75540877ce38