### PR TITLE
Remove redundant PDO import in cron job application

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
@@ -7,8 +7,6 @@ require_once __DIR__ . '/CronJobCliArguments.php';
 require_once __DIR__ . '/../TrophyCalculator.php';
 require_once __DIR__ . '/ThirtyMinuteCronJob.php';
 
-use PDO;
-
 final class ThirtyMinuteCronJobApplication
 {
     private CronJobEntryPoint $entryPoint;


### PR DESCRIPTION
## Summary
- remove the unnecessary `use PDO;` statement from the thirty minute cron job application to silence runtime warnings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902a136965c832f945caaf267fd251d