### PR TITLE
Optimize leaderboard queries for MySQL indexes

### DIFF
--- a/wwwroot/classes/PlayerLeaderboardService.php
+++ b/wwwroot/classes/PlayerLeaderboardService.php
@@ -21,7 +21,8 @@ class PlayerLeaderboardService implements PlayerLeaderboardDataProvider
             SELECT
                 COUNT(*)
             FROM
-                player p
+                player_ranking r
+            JOIN player p ON p.account_id = r.account_id
             WHERE
                 p.status = 0
         SQL;
@@ -46,8 +47,8 @@ class PlayerLeaderboardService implements PlayerLeaderboardDataProvider
                 r.ranking,
                 r.ranking_country
             FROM
-                player p
-            JOIN player_ranking r ON p.account_id = r.account_id
+                player_ranking r
+            JOIN player p ON p.account_id = r.account_id
             WHERE
                 p.status = 0
         SQL;

--- a/wwwroot/classes/PlayerRarityLeaderboardService.php
+++ b/wwwroot/classes/PlayerRarityLeaderboardService.php
@@ -21,7 +21,8 @@ class PlayerRarityLeaderboardService implements PlayerLeaderboardDataProvider
             SELECT
                 COUNT(*)
             FROM
-                player p
+                player_ranking r
+            JOIN player p ON p.account_id = r.account_id
             WHERE
                 p.status = 0
         SQL;
@@ -46,8 +47,8 @@ class PlayerRarityLeaderboardService implements PlayerLeaderboardDataProvider
                 r.rarity_ranking AS ranking,
                 r.rarity_ranking_country AS ranking_country
             FROM
-                player p
-            JOIN player_ranking r ON p.account_id = r.account_id
+                player_ranking r
+            JOIN player p ON p.account_id = r.account_id
             WHERE
                 p.status = 0
         SQL;


### PR DESCRIPTION
## Summary
- start leaderboard queries from `player_ranking` so MySQL can satisfy the ORDER BY with an index scan before joining player metadata
- update the rarity leaderboard to use the same optimized join order as the standard leaderboard service
- adjust the about-page test double to return aggregated counts from the optimized scan summary query

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_69028dca983c832f9c98475008c72d64