### PR TITLE
Adopt trophy_title_meta in services and tests

### DIFF
--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -299,6 +299,146 @@ CREATE TABLE `trophy_title` (
   `rarity_points` int UNSIGNED NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE `trophy_title_meta` (
+  `np_communication_id` varchar(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `owners` int UNSIGNED NOT NULL DEFAULT '0',
+  `difficulty` decimal(5,2) UNSIGNED NOT NULL DEFAULT '0.00',
+  `message` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` tinyint UNSIGNED NOT NULL DEFAULT '0',
+  `recent_players` int UNSIGNED NOT NULL DEFAULT '0',
+  `owners_completed` int UNSIGNED NOT NULL DEFAULT '0',
+  `psnprofiles_id` int UNSIGNED DEFAULT NULL,
+  `parent_np_communication_id` varchar(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `region` varchar(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `rarity_points` int UNSIGNED NOT NULL DEFAULT '0'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+DELIMITER $$
+CREATE TRIGGER `after_insert_trophy_title` AFTER INSERT ON `trophy_title` FOR EACH ROW BEGIN
+    INSERT INTO `trophy_title_meta` (
+        `np_communication_id`,
+        `owners`,
+        `difficulty`,
+        `message`,
+        `status`,
+        `recent_players`,
+        `owners_completed`,
+        `psnprofiles_id`,
+        `parent_np_communication_id`,
+        `region`,
+        `rarity_points`
+    ) VALUES (
+        NEW.`np_communication_id`,
+        NEW.`owners`,
+        NEW.`difficulty`,
+        NEW.`message`,
+        NEW.`status`,
+        NEW.`recent_players`,
+        NEW.`owners_completed`,
+        NEW.`psnprofiles_id`,
+        NEW.`parent_np_communication_id`,
+        NEW.`region`,
+        NEW.`rarity_points`
+    )
+    ON DUPLICATE KEY UPDATE
+        `owners` = VALUES(`owners`),
+        `difficulty` = VALUES(`difficulty`),
+        `message` = VALUES(`message`),
+        `status` = VALUES(`status`),
+        `recent_players` = VALUES(`recent_players`),
+        `owners_completed` = VALUES(`owners_completed`),
+        `psnprofiles_id` = VALUES(`psnprofiles_id`),
+        `parent_np_communication_id` = VALUES(`parent_np_communication_id`),
+        `region` = VALUES(`region`),
+        `rarity_points` = VALUES(`rarity_points`);
+END$$
+
+CREATE TRIGGER `after_update_trophy_title` AFTER UPDATE ON `trophy_title` FOR EACH ROW BEGIN
+    IF NEW.`np_communication_id` <> OLD.`np_communication_id` THEN
+        DELETE FROM `trophy_title_meta` WHERE `np_communication_id` = OLD.`np_communication_id`;
+    END IF;
+
+    INSERT INTO `trophy_title_meta` (
+        `np_communication_id`,
+        `owners`,
+        `difficulty`,
+        `message`,
+        `status`,
+        `recent_players`,
+        `owners_completed`,
+        `psnprofiles_id`,
+        `parent_np_communication_id`,
+        `region`,
+        `rarity_points`
+    ) VALUES (
+        NEW.`np_communication_id`,
+        NEW.`owners`,
+        NEW.`difficulty`,
+        NEW.`message`,
+        NEW.`status`,
+        NEW.`recent_players`,
+        NEW.`owners_completed`,
+        NEW.`psnprofiles_id`,
+        NEW.`parent_np_communication_id`,
+        NEW.`region`,
+        NEW.`rarity_points`
+    )
+    ON DUPLICATE KEY UPDATE
+        `owners` = VALUES(`owners`),
+        `difficulty` = VALUES(`difficulty`),
+        `message` = VALUES(`message`),
+        `status` = VALUES(`status`),
+        `recent_players` = VALUES(`recent_players`),
+        `owners_completed` = VALUES(`owners_completed`),
+        `psnprofiles_id` = VALUES(`psnprofiles_id`),
+        `parent_np_communication_id` = VALUES(`parent_np_communication_id`),
+        `region` = VALUES(`region`),
+        `rarity_points` = VALUES(`rarity_points`);
+END$$
+
+CREATE TRIGGER `after_delete_trophy_title` AFTER DELETE ON `trophy_title` FOR EACH ROW BEGIN
+    DELETE FROM `trophy_title_meta` WHERE `np_communication_id` = OLD.`np_communication_id`;
+END$$
+DELIMITER ;
+
+INSERT INTO `trophy_title_meta` (
+    `np_communication_id`,
+    `owners`,
+    `difficulty`,
+    `message`,
+    `status`,
+    `recent_players`,
+    `owners_completed`,
+    `psnprofiles_id`,
+    `parent_np_communication_id`,
+    `region`,
+    `rarity_points`
+)
+SELECT
+    `np_communication_id`,
+    `owners`,
+    `difficulty`,
+    `message`,
+    `status`,
+    `recent_players`,
+    `owners_completed`,
+    `psnprofiles_id`,
+    `parent_np_communication_id`,
+    `region`,
+    `rarity_points`
+FROM `trophy_title`
+ON DUPLICATE KEY UPDATE
+    `owners` = VALUES(`owners`),
+    `difficulty` = VALUES(`difficulty`),
+    `message` = VALUES(`message`),
+    `status` = VALUES(`status`),
+    `recent_players` = VALUES(`recent_players`),
+    `owners_completed` = VALUES(`owners_completed`),
+    `psnprofiles_id` = VALUES(`psnprofiles_id`),
+    `parent_np_communication_id` = VALUES(`parent_np_communication_id`),
+    `region` = VALUES(`region`),
+    `rarity_points` = VALUES(`rarity_points`);
+
 -- --------------------------------------------------------
 
 --
@@ -454,6 +594,22 @@ ALTER TABLE `trophy_title`
   ADD KEY `idx_psnprofiles_id` (`psnprofiles_id`),
   ADD KEY `trophy_title_idx_np_id_owners` (`np_communication_id`,`owners`);
 ALTER TABLE `trophy_title` ADD FULLTEXT KEY `idx_name` (`name`);
+
+--
+-- Indexes for table `trophy_title_meta`
+--
+ALTER TABLE `trophy_title_meta`
+  ADD PRIMARY KEY (`np_communication_id`),
+  ADD KEY `idx_ttm_status` (`status`),
+  ADD KEY `idx_ttm_parent_np_communication_id` (`parent_np_communication_id`),
+  ADD KEY `idx_ttm_psnprofiles_id` (`psnprofiles_id`),
+  ADD KEY `idx_ttm_np_id_owners` (`np_communication_id`,`owners`);
+
+--
+-- Constraints for table `trophy_title_meta`
+--
+ALTER TABLE `trophy_title_meta`
+  ADD CONSTRAINT `fk_trophy_title_meta_np` FOREIGN KEY (`np_communication_id`) REFERENCES `trophy_title` (`np_communication_id`) ON DELETE CASCADE;
 
 --
 -- Indexes for table `trophy_title_player`

--- a/tests/AboutPageServiceTest.php
+++ b/tests/AboutPageServiceTest.php
@@ -42,48 +42,48 @@ final class AboutPageServicePdoStub extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
-        if (str_contains($query, 'SUM(CASE WHEN last_updated_date >= NOW() - INTERVAL 1 DAY')) {
-            return new class($this->scannedCount, $this->newCount) extends PDOStatement {
+        if (str_contains($query, 'COUNT(*) FROM player WHERE last_updated_date >= NOW() - INTERVAL 1 DAY')) {
+            return new class($this->scannedCount) extends PDOStatement {
                 /** @var string|int */
-                private string|int $scannedCount;
+                private string|int $count;
 
-                /** @var string|int */
-                private string|int $newCount;
-
-                private bool $fetched = false;
-
-                /**
-                 * @param string|int $scannedCount
-                 * @param string|int $newCount
-                 */
-                public function __construct(string|int $scannedCount, string|int $newCount)
+                /** @param string|int $count */
+                public function __construct(string|int $count)
                 {
-                    $this->scannedCount = $scannedCount;
-                    $this->newCount = $newCount;
+                    $this->count = $count;
                 }
 
                 public function execute(?array $params = null): bool
                 {
-                    $this->fetched = false;
-
                     return true;
                 }
 
-                public function fetch(
-                    int $mode = PDO::ATTR_DEFAULT_FETCH_MODE,
-                    int $cursorOrientation = PDO::FETCH_ORI_NEXT,
-                    int $cursorOffset = 0
-                ): mixed {
-                    if ($this->fetched) {
-                        return false;
-                    }
+                public function fetchColumn(int $column = 0): string|int|false
+                {
+                    return $this->count;
+                }
+            };
+        }
 
-                    $this->fetched = true;
+        if (str_contains($query, 'COUNT(*) FROM player WHERE status = 0 AND rank_last_week = 0')) {
+            return new class($this->newCount) extends PDOStatement {
+                /** @var string|int */
+                private string|int $count;
 
-                    return [
-                        'scanned_players' => $this->scannedCount,
-                        'new_players' => $this->newCount,
-                    ];
+                /** @param string|int $count */
+                public function __construct(string|int $count)
+                {
+                    $this->count = $count;
+                }
+
+                public function execute(?array $params = null): bool
+                {
+                    return true;
+                }
+
+                public function fetchColumn(int $column = 0): string|int|false
+                {
+                    return $this->count;
                 }
             };
         }

--- a/tests/GameHeaderServiceTest.php
+++ b/tests/GameHeaderServiceTest.php
@@ -21,9 +21,14 @@ final class GameHeaderServiceTest extends TestCase
             'CREATE TABLE trophy_title (' .
             'id INTEGER PRIMARY KEY, ' .
             'np_communication_id TEXT NOT NULL, ' .
-            'parent_np_communication_id TEXT NULL, ' .
             '`name` TEXT NOT NULL, ' .
-            'platform TEXT NOT NULL, ' .
+            'platform TEXT NOT NULL)'
+        );
+
+        $this->database->exec(
+            'CREATE TABLE trophy_title_meta (' .
+            'np_communication_id TEXT PRIMARY KEY, ' .
+            'parent_np_communication_id TEXT NULL, ' .
             'region TEXT NULL)'
         );
 
@@ -143,24 +148,29 @@ final class GameHeaderServiceTest extends TestCase
     private function insertTrophyTitle(array $row): void
     {
         $statement = $this->database->prepare(
-            'INSERT INTO trophy_title (id, np_communication_id, parent_np_communication_id, `name`, platform, region)
-            VALUES (:id, :np_communication_id, :parent_np_communication_id, :name, :platform, :region)'
+            'INSERT INTO trophy_title (id, np_communication_id, `name`, platform) VALUES (:id, :np, :name, :platform)'
         );
         $statement->bindValue(':id', $row['id'], PDO::PARAM_INT);
-        $statement->bindValue(':np_communication_id', $row['np_communication_id'], PDO::PARAM_STR);
-        if ($row['parent_np_communication_id'] === null) {
-            $statement->bindValue(':parent_np_communication_id', null, PDO::PARAM_NULL);
-        } else {
-            $statement->bindValue(':parent_np_communication_id', $row['parent_np_communication_id'], PDO::PARAM_STR);
-        }
+        $statement->bindValue(':np', $row['np_communication_id'], PDO::PARAM_STR);
         $statement->bindValue(':name', $row['name'], PDO::PARAM_STR);
         $statement->bindValue(':platform', $row['platform'], PDO::PARAM_STR);
-        if ($row['region'] === null || $row['region'] === '') {
-            $statement->bindValue(':region', null, PDO::PARAM_NULL);
-        } else {
-            $statement->bindValue(':region', $row['region'], PDO::PARAM_STR);
-        }
         $statement->execute();
+
+        $meta = $this->database->prepare(
+            'INSERT INTO trophy_title_meta (np_communication_id, parent_np_communication_id, region) VALUES (:np, :parent, :region)'
+        );
+        $meta->bindValue(':np', $row['np_communication_id'], PDO::PARAM_STR);
+        if ($row['parent_np_communication_id'] === null) {
+            $meta->bindValue(':parent', null, PDO::PARAM_NULL);
+        } else {
+            $meta->bindValue(':parent', $row['parent_np_communication_id'], PDO::PARAM_STR);
+        }
+        if ($row['region'] === null || $row['region'] === '') {
+            $meta->bindValue(':region', null, PDO::PARAM_NULL);
+        } else {
+            $meta->bindValue(':region', $row['region'], PDO::PARAM_STR);
+        }
+        $meta->execute();
     }
 
     /**

--- a/tests/GameRecentPlayersServiceTest.php
+++ b/tests/GameRecentPlayersServiceTest.php
@@ -29,6 +29,7 @@ final class GameRecentPlayersServiceTest extends TestCase
         $this->insertTrophyTitle([
             'id' => 1,
             'name' => 'Example Game',
+            'detail' => 'Example detail',
             'np_communication_id' => self::NP_COMMUNICATION_ID,
             'parent_np_communication_id' => null,
             'platform' => 'PS5',
@@ -36,6 +37,7 @@ final class GameRecentPlayersServiceTest extends TestCase
             'set_version' => '01.00',
             'region' => 'US',
             'message' => 'Play responsibly',
+            'recent_players' => 10,
             'platinum' => 1,
             'gold' => 2,
             'silver' => 3,
@@ -44,6 +46,7 @@ final class GameRecentPlayersServiceTest extends TestCase
             'owners' => 200,
             'difficulty' => 'Hard',
             'status' => 1,
+            'psnprofiles_id' => null,
             'rarity_points' => 123,
         ]);
 
@@ -252,21 +255,32 @@ final class GameRecentPlayersServiceTest extends TestCase
             CREATE TABLE trophy_title (
                 id INTEGER PRIMARY KEY,
                 name TEXT,
+                detail TEXT,
                 np_communication_id TEXT,
-                parent_np_communication_id TEXT,
                 platform TEXT,
                 icon_url TEXT,
                 set_version TEXT,
-                region TEXT,
-                message TEXT,
                 platinum INTEGER,
                 gold INTEGER,
                 silver INTEGER,
-                bronze INTEGER,
+                bronze INTEGER
+            )
+            SQL
+        );
+
+        $this->pdo->exec(
+            <<<SQL
+            CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                parent_np_communication_id TEXT,
+                region TEXT,
+                message TEXT,
+                recent_players INTEGER,
                 owners_completed INTEGER,
                 owners INTEGER,
                 difficulty TEXT,
                 status INTEGER,
+                psnprofiles_id INTEGER,
                 rarity_points INTEGER
             )
             SQL
@@ -316,68 +330,91 @@ final class GameRecentPlayersServiceTest extends TestCase
      */
     private function insertTrophyTitle(array $values): void
     {
-        $statement = $this->pdo->prepare(
+        $titleStatement = $this->pdo->prepare(
             <<<SQL
             INSERT INTO trophy_title (
                 id,
                 name,
+                detail,
                 np_communication_id,
-                parent_np_communication_id,
                 platform,
                 icon_url,
                 set_version,
-                region,
-                message,
                 platinum,
                 gold,
                 silver,
-                bronze,
+                bronze
+            ) VALUES (
+                :id,
+                :name,
+                :detail,
+                :np_communication_id,
+                :platform,
+                :icon_url,
+                :set_version,
+                :platinum,
+                :gold,
+                :silver,
+                :bronze
+            )
+            SQL
+        );
+
+        $titleStatement->execute([
+            ':id' => $values['id'],
+            ':name' => $values['name'],
+            ':detail' => $values['detail'],
+            ':np_communication_id' => $values['np_communication_id'],
+            ':platform' => $values['platform'],
+            ':icon_url' => $values['icon_url'],
+            ':set_version' => $values['set_version'],
+            ':platinum' => $values['platinum'],
+            ':gold' => $values['gold'],
+            ':silver' => $values['silver'],
+            ':bronze' => $values['bronze'],
+        ]);
+
+        $metaStatement = $this->pdo->prepare(
+            <<<SQL
+            INSERT INTO trophy_title_meta (
+                np_communication_id,
+                parent_np_communication_id,
+                region,
+                message,
+                recent_players,
                 owners_completed,
                 owners,
                 difficulty,
                 status,
+                psnprofiles_id,
                 rarity_points
             ) VALUES (
-                :id,
-                :name,
                 :np_communication_id,
                 :parent_np_communication_id,
-                :platform,
-                :icon_url,
-                :set_version,
                 :region,
                 :message,
-                :platinum,
-                :gold,
-                :silver,
-                :bronze,
+                :recent_players,
                 :owners_completed,
                 :owners,
                 :difficulty,
                 :status,
+                :psnprofiles_id,
                 :rarity_points
             )
             SQL
         );
 
-        $statement->execute([
-            ':id' => $values['id'],
-            ':name' => $values['name'],
+        $metaStatement->execute([
             ':np_communication_id' => $values['np_communication_id'],
             ':parent_np_communication_id' => $values['parent_np_communication_id'],
-            ':platform' => $values['platform'],
-            ':icon_url' => $values['icon_url'],
-            ':set_version' => $values['set_version'],
             ':region' => $values['region'],
             ':message' => $values['message'],
-            ':platinum' => $values['platinum'],
-            ':gold' => $values['gold'],
-            ':silver' => $values['silver'],
-            ':bronze' => $values['bronze'],
+            ':recent_players' => $values['recent_players'],
             ':owners_completed' => $values['owners_completed'],
             ':owners' => $values['owners'],
             ':difficulty' => $values['difficulty'],
             ':status' => $values['status'],
+            ':psnprofiles_id' => $values['psnprofiles_id'],
             ':rarity_points' => $values['rarity_points'],
         ]);
     }

--- a/tests/GameStatusServiceTest.php
+++ b/tests/GameStatusServiceTest.php
@@ -14,9 +14,11 @@ final class GameStatusServiceTest extends TestCase
         $this->database = new PDO('sqlite::memory:');
         $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-        $this->database->exec('CREATE TABLE trophy_title (id INTEGER PRIMARY KEY, status INTEGER NOT NULL)');
+        $this->database->exec('CREATE TABLE trophy_title (id INTEGER PRIMARY KEY, np_communication_id TEXT NOT NULL)');
+        $this->database->exec('CREATE TABLE trophy_title_meta (np_communication_id TEXT PRIMARY KEY, status INTEGER NOT NULL)');
         $this->database->exec('CREATE TABLE psn100_change (change_type TEXT NOT NULL, param_1 INTEGER NOT NULL)');
-        $this->database->exec('INSERT INTO trophy_title (id, status) VALUES (1, 0)');
+        $this->database->exec("INSERT INTO trophy_title (id, np_communication_id) VALUES (1, 'NPWR-1')");
+        $this->database->exec("INSERT INTO trophy_title_meta (np_communication_id, status) VALUES ('NPWR-1', 0)");
 
         $this->service = new GameStatusService($this->database);
     }
@@ -28,7 +30,7 @@ final class GameStatusServiceTest extends TestCase
         $this->assertSame('delisted', $statusText);
 
         $status = $this->database
-            ->query('SELECT status FROM trophy_title WHERE id = 1')
+            ->query('SELECT status FROM trophy_title_meta WHERE np_communication_id = "NPWR-1"')
             ->fetchColumn();
         $this->assertSame(1, (int) $status);
 
@@ -62,7 +64,7 @@ final class GameStatusServiceTest extends TestCase
         }
 
         $status = $this->database
-            ->query('SELECT status FROM trophy_title WHERE id = 1')
+            ->query('SELECT status FROM trophy_title_meta WHERE np_communication_id = "NPWR-1"')
             ->fetchColumn();
         $this->assertSame(0, (int) $status);
 

--- a/tests/HomepageContentServiceTest.php
+++ b/tests/HomepageContentServiceTest.php
@@ -26,12 +26,28 @@ final class HomepageContentServiceTest extends TestCase
                 name TEXT,
                 icon_url TEXT,
                 platform TEXT,
-                status INTEGER,
                 platinum INTEGER,
                 gold INTEGER,
                 silver INTEGER,
-                bronze INTEGER,
-                recent_players INTEGER
+                bronze INTEGER
+            )
+            SQL
+        );
+
+        $this->pdo->exec(
+            <<<SQL
+            CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                owners INTEGER DEFAULT 0,
+                difficulty REAL DEFAULT 0,
+                message TEXT DEFAULT NULL,
+                status INTEGER NOT NULL,
+                recent_players INTEGER DEFAULT 0,
+                owners_completed INTEGER DEFAULT 0,
+                psnprofiles_id INTEGER DEFAULT NULL,
+                parent_np_communication_id TEXT DEFAULT NULL,
+                region TEXT DEFAULT NULL,
+                rarity_points INTEGER DEFAULT 0
             )
             SQL
         );
@@ -58,10 +74,17 @@ final class HomepageContentServiceTest extends TestCase
     {
         $this->pdo->exec(
             "INSERT INTO trophy_title " .
-            "(id, np_communication_id, name, icon_url, platform, status, platinum, gold, silver, bronze, recent_players) VALUES" .
-            " (1, 'NPWR001', 'First Game', 'first.png', 'PS4', 0, 1, 2, 3, 4, 10)," .
-            " (2, 'NPWR002', 'Hidden Game', 'hidden.png', 'PS5', 2, 5, 5, 5, 5, 5)," .
-            " (3, 'NPWR003', 'Latest Game', 'latest.png', 'PS5', 0, 0, 1, 1, 1, 20)"
+            "(id, np_communication_id, name, icon_url, platform, platinum, gold, silver, bronze) VALUES" .
+            " (1, 'NPWR001', 'First Game', 'first.png', 'PS4', 1, 2, 3, 4)," .
+            " (2, 'NPWR002', 'Hidden Game', 'hidden.png', 'PS5', 5, 5, 5, 5)," .
+            " (3, 'NPWR003', 'Latest Game', 'latest.png', 'PS5', 0, 1, 1, 1)"
+        );
+
+        $this->pdo->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status, recent_players) VALUES" .
+            " ('NPWR001', 0, 10)," .
+            " ('NPWR002', 2, 5)," .
+            " ('NPWR003', 0, 20)"
         );
 
         $games = $this->service->getNewGames(2);
@@ -81,9 +104,15 @@ final class HomepageContentServiceTest extends TestCase
     {
         $this->pdo->exec(
             "INSERT INTO trophy_title " .
-            "(id, np_communication_id, name, icon_url, platform, status, platinum, gold, silver, bronze, recent_players) VALUES" .
-            " (1, 'NPWR100', 'Visible Game', 'visible.png', 'PS5', 0, 0, 0, 0, 0, 100)," .
-            " (2, 'NPWR200', 'Hidden Game', 'hidden.png', 'PS4', 2, 0, 0, 0, 0, 10)"
+            "(id, np_communication_id, name, icon_url, platform, platinum, gold, silver, bronze) VALUES" .
+            " (1, 'NPWR100', 'Visible Game', 'visible.png', 'PS5', 0, 0, 0, 0)," .
+            " (2, 'NPWR200', 'Hidden Game', 'hidden.png', 'PS4', 0, 0, 0, 0)"
+        );
+
+        $this->pdo->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status, recent_players) VALUES" .
+            " ('NPWR100', 0, 100)," .
+            " ('NPWR200', 2, 10)"
         );
 
         $this->pdo->exec(
@@ -113,10 +142,17 @@ final class HomepageContentServiceTest extends TestCase
     {
         $this->pdo->exec(
             "INSERT INTO trophy_title " .
-            "(id, np_communication_id, name, icon_url, platform, status, platinum, gold, silver, bronze, recent_players) VALUES" .
-            " (1, 'NPWR300', 'Moderate Game', 'moderate.png', 'PS4', 0, 0, 0, 0, 0, 500)," .
-            " (2, 'NPWR400', 'Hidden Game', 'hidden.png', 'PS5', 2, 0, 0, 0, 0, 1000)," .
-            " (3, 'NPWR500', 'Popular Game', 'popular.png', 'PS5', 0, 0, 0, 0, 0, 1500)"
+            "(id, np_communication_id, name, icon_url, platform, platinum, gold, silver, bronze) VALUES" .
+            " (1, 'NPWR300', 'Moderate Game', 'moderate.png', 'PS4', 0, 0, 0, 0)," .
+            " (2, 'NPWR400', 'Hidden Game', 'hidden.png', 'PS5', 0, 0, 0, 0)," .
+            " (3, 'NPWR500', 'Popular Game', 'popular.png', 'PS5', 0, 0, 0, 0)"
+        );
+
+        $this->pdo->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status, recent_players) VALUES" .
+            " ('NPWR300', 0, 500)," .
+            " ('NPWR400', 2, 1000)," .
+            " ('NPWR500', 0, 1500)"
         );
 
         $popularGames = $this->service->getPopularGames(2);

--- a/tests/PlayerAdvisorServiceTest.php
+++ b/tests/PlayerAdvisorServiceTest.php
@@ -24,8 +24,23 @@ final class PlayerAdvisorServiceTest extends TestCase
                 np_communication_id TEXT NOT NULL,
                 name TEXT NOT NULL,
                 icon_url TEXT NOT NULL,
-                platform TEXT NOT NULL,
-                status INTEGER NOT NULL
+                platform TEXT NOT NULL
+            )'
+        );
+
+        $this->database->exec(
+            'CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                owners INTEGER DEFAULT 0,
+                difficulty REAL DEFAULT 0,
+                message TEXT DEFAULT NULL,
+                status INTEGER NOT NULL,
+                recent_players INTEGER DEFAULT 0,
+                owners_completed INTEGER DEFAULT 0,
+                psnprofiles_id INTEGER DEFAULT NULL,
+                parent_np_communication_id TEXT DEFAULT NULL,
+                region TEXT DEFAULT NULL,
+                rarity_points INTEGER DEFAULT 0
             )'
         );
 
@@ -70,10 +85,17 @@ final class PlayerAdvisorServiceTest extends TestCase
     public function testCountAdvisableTrophiesIgnoresEarnedAndUnselectedPlatforms(): void
     {
         $this->database->exec(
-            "INSERT INTO trophy_title (np_communication_id, name, icon_url, platform, status) VALUES\n" .
-            "('NPWR-PS5-1', 'Game PS5', 'game-ps5.png', 'PS5', 0),\n" .
-            "('NPWR-PS5-2', 'Game PS5 Earned', 'game-ps5-earned.png', 'PS5', 0),\n" .
-            "('NPWR-PS4-1', 'Game PS4', 'game-ps4.png', 'PS4', 0)"
+            "INSERT INTO trophy_title (np_communication_id, name, icon_url, platform) VALUES\n" .
+            "('NPWR-PS5-1', 'Game PS5', 'game-ps5.png', 'PS5'),\n" .
+            "('NPWR-PS5-2', 'Game PS5 Earned', 'game-ps5-earned.png', 'PS5'),\n" .
+            "('NPWR-PS4-1', 'Game PS4', 'game-ps4.png', 'PS4')"
+        );
+
+        $this->database->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status) VALUES\n" .
+            "('NPWR-PS5-1', 0),\n" .
+            "('NPWR-PS5-2', 0),\n" .
+            "('NPWR-PS4-1', 0)"
         );
 
         $this->database->exec(
@@ -105,10 +127,17 @@ final class PlayerAdvisorServiceTest extends TestCase
     public function testGetAdvisableTrophiesReturnsOrderedTrophyCollection(): void
     {
         $this->database->exec(
-            "INSERT INTO trophy_title (np_communication_id, name, icon_url, platform, status) VALUES\n" .
-            "('NPWR-1', 'First Game', 'game-1.png', 'PS4', 0),\n" .
-            "('NPWR-2', 'Second Game', 'game-2.png', 'PS4', 0),\n" .
-            "('NPWR-3', 'Third Game', 'game-3.png', 'PS4', 0)"
+            "INSERT INTO trophy_title (np_communication_id, name, icon_url, platform) VALUES\n" .
+            "('NPWR-1', 'First Game', 'game-1.png', 'PS4'),\n" .
+            "('NPWR-2', 'Second Game', 'game-2.png', 'PS4'),\n" .
+            "('NPWR-3', 'Third Game', 'game-3.png', 'PS4')"
+        );
+
+        $this->database->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status) VALUES\n" .
+            "('NPWR-1', 0),\n" .
+            "('NPWR-2', 0),\n" .
+            "('NPWR-3', 0)"
         );
 
         $this->database->exec(

--- a/tests/PlayerGamesServiceTest.php
+++ b/tests/PlayerGamesServiceTest.php
@@ -24,7 +24,15 @@ final class PlayerGamesServiceTest extends TestCase
                 np_communication_id TEXT NOT NULL,
                 name TEXT NOT NULL,
                 icon_url TEXT,
-                platform TEXT,
+                platform TEXT
+            )
+            SQL
+        );
+
+        $this->pdo->exec(
+            <<<SQL
+            CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
                 status INTEGER,
                 rarity_points INTEGER
             )
@@ -182,8 +190,8 @@ final class PlayerGamesServiceTest extends TestCase
         int $maxRarityPoints = 0
     ): void {
         $statement = $this->pdo->prepare(
-            'INSERT INTO trophy_title (id, np_communication_id, name, icon_url, platform, status, rarity_points) '
-            . 'VALUES (:id, :np, :name, :icon, :platform, :status, :rarity)'
+            'INSERT INTO trophy_title (id, np_communication_id, name, icon_url, platform) '
+            . 'VALUES (:id, :np, :name, :icon, :platform)'
         );
         $statement->execute([
             ':id' => $id,
@@ -191,6 +199,14 @@ final class PlayerGamesServiceTest extends TestCase
             ':name' => $name,
             ':icon' => 'icon.png',
             ':platform' => $platform,
+        ]);
+
+        $statement = $this->pdo->prepare(
+            'INSERT INTO trophy_title_meta (np_communication_id, status, rarity_points) '
+            . 'VALUES (:np, :status, :rarity)'
+        );
+        $statement->execute([
+            ':np' => $npCommunicationId,
             ':status' => $status,
             ':rarity' => $maxRarityPoints,
         ]);

--- a/tests/PlayerSummaryServiceTest.php
+++ b/tests/PlayerSummaryServiceTest.php
@@ -18,11 +18,17 @@ final class PlayerSummaryServiceTest extends TestCase
         $this->database->exec(
             'CREATE TABLE trophy_title (
                 np_communication_id TEXT PRIMARY KEY,
-                status INTEGER NOT NULL,
                 bronze INTEGER NOT NULL,
                 silver INTEGER NOT NULL,
                 gold INTEGER NOT NULL,
                 platinum INTEGER NOT NULL
+            )'
+        );
+
+        $this->database->exec(
+            'CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                status INTEGER NOT NULL
             )'
         );
 
@@ -44,10 +50,17 @@ final class PlayerSummaryServiceTest extends TestCase
     public function testGetSummaryAggregatesPlayerStatistics(): void
     {
         $this->database->exec(
-            "INSERT INTO trophy_title (np_communication_id, status, bronze, silver, gold, platinum) VALUES\n" .
-            "('NPWR001', 0, 10, 5, 3, 1),\n" .
-            "('NPWR002', 0, 5, 2, 1, 0),\n" .
-            "('NPWR003', 1, 1, 1, 1, 0)"
+            "INSERT INTO trophy_title (np_communication_id, bronze, silver, gold, platinum) VALUES\n" .
+            "('NPWR001', 10, 5, 3, 1),\n" .
+            "('NPWR002', 5, 2, 1, 0),\n" .
+            "('NPWR003', 1, 1, 1, 0)"
+        );
+
+        $this->database->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status) VALUES\n" .
+            "('NPWR001', 0),\n" .
+            "('NPWR002', 0),\n" .
+            "('NPWR003', 1)"
         );
 
         $this->database->exec(
@@ -69,8 +82,12 @@ final class PlayerSummaryServiceTest extends TestCase
     public function testGetSummaryReturnsEmptySummaryWhenPlayerHasNoVisibleGames(): void
     {
         $this->database->exec(
-            "INSERT INTO trophy_title (np_communication_id, status, bronze, silver, gold, platinum) VALUES\n" .
-            "('NPWR010', 1, 2, 2, 1, 0)"
+            "INSERT INTO trophy_title (np_communication_id, bronze, silver, gold, platinum) VALUES\n" .
+            "('NPWR010', 2, 2, 1, 0)"
+        );
+
+        $this->database->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status) VALUES ('NPWR010', 1)"
         );
 
         $this->database->exec(

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -62,15 +62,16 @@ class DailyCronJob implements CronJobInterface
             UPDATE trophy t
             JOIN rarity r USING(order_id)
             JOIN trophy_title tt USING(np_communication_id)
+            JOIN trophy_title_meta ttm USING (np_communication_id)
             SET
                 t.rarity_percent = r.rarity_percent,
                 t.rarity_point = IF(
-                    t.status = 0 AND tt.status = 0,
+                    t.status = 0 AND ttm.status = 0,
                     IF(r.rarity_percent = 0, 99999, FLOOR(1 / (r.rarity_percent / 100) - 1)),
                     0
                 ),
                 t.rarity_name = CASE
-                    WHEN t.status != 0 OR tt.status != 0 THEN 'NONE'
+                    WHEN t.status != 0 OR ttm.status != 0 THEN 'NONE'
                     WHEN r.rarity_percent > 10 THEN 'COMMON'
                     WHEN r.rarity_percent > 2 THEN 'UNCOMMON'
                     WHEN r.rarity_percent > 0.2 THEN 'RARE'
@@ -100,9 +101,9 @@ class DailyCronJob implements CronJobInterface
                 WHERE `status` = 0
                 GROUP BY np_communication_id
             )
-            UPDATE trophy_title tt
+            UPDATE trophy_title_meta ttm
             JOIN rarity r USING(np_communication_id)
-            SET tt.rarity_points = r.rarity_sum"
+            SET ttm.rarity_points = r.rarity_sum"
         );
 
         $query->execute();

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -19,13 +19,13 @@ class HourlyCronJob implements CronJobInterface
             GROUP BY
                 ttp.np_communication_id
         )
-        UPDATE trophy_title tt
-        JOIN game g ON tt.np_communication_id = g.np_communication_id
+        UPDATE trophy_title_meta ttm
+        JOIN game g ON ttm.np_communication_id = g.np_communication_id
         SET
-            tt.owners = g.owners,
-            tt.owners_completed = g.owners_completed,
-            tt.recent_players = g.recent_players,
-            tt.difficulty = IF(g.owners = 0, 0, (g.owners_completed / g.owners) * 100)
+            ttm.owners = g.owners,
+            ttm.owners_completed = g.owners_completed,
+            ttm.recent_players = g.recent_players,
+            ttm.difficulty = IF(g.owners = 0, 0, (g.owners_completed / g.owners) * 100)
         SQL;
 
     private PDO $database;

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -911,16 +911,16 @@ class ThirtyMinuteCronJob implements CronJobInterface
                         foreach ($playerGames as $playerGame) {
                             $game = $playerGame["np_communication_id"];
                             if (!in_array($game, $scannedGames)) {
-                                $query = $this->database->prepare("SELECT tt.parent_np_communication_id
-                                    FROM   trophy_title tt
-                                    WHERE  tt.np_communication_id = :np_communication_id");
+                                $query = $this->database->prepare("SELECT ttm.parent_np_communication_id
+                                    FROM   trophy_title_meta ttm
+                                    WHERE  ttm.np_communication_id = :np_communication_id");
                                 $query->bindValue(":np_communication_id", $game, PDO::PARAM_STR);
                                 $query->execute();
                                 $mergedGame = $query->fetchColumn(); // MERGE_...
                                 if ($mergedGame) {
-                                    $query = $this->database->prepare("SELECT tt.np_communication_id
-                                        FROM   trophy_title tt
-                                        WHERE  tt.parent_np_communication_id = :parent_np_communication_id AND tt.np_communication_id != :np_communication_id");
+                                    $query = $this->database->prepare("SELECT ttm.np_communication_id
+                                        FROM   trophy_title_meta ttm
+                                        WHERE  ttm.parent_np_communication_id = :parent_np_communication_id AND ttm.np_communication_id != :np_communication_id");
                                     $query->bindValue(":parent_np_communication_id", $mergedGame, PDO::PARAM_STR);
                                     $query->bindValue(":np_communication_id", $game, PDO::PARAM_STR);
                                     $query->execute();
@@ -987,7 +987,8 @@ class ThirtyMinuteCronJob implements CronJobInterface
                             Ifnull(Sum(ttp.platinum), 0) AS platinum
                         FROM   trophy_title_player ttp
                             JOIN trophy_title tt USING (np_communication_id)
-                        WHERE  tt.status = 0
+                            JOIN trophy_title_meta ttm USING (np_communication_id)
+                        WHERE  ttm.status = 0
                             AND ttp.account_id = :account_id ");
                     $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
                     $query->execute();

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -73,18 +73,19 @@ class GameHeaderService
         $query = $this->database->prepare(
             <<<'SQL'
             SELECT
-                id,
-                `name`,
-                platform,
-                region
+                tt.id,
+                tt.`name`,
+                tt.platform,
+                ttm.region
             FROM
-                trophy_title
+                trophy_title tt
+                JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             WHERE
-                parent_np_communication_id = :parent_np_communication_id
+                ttm.parent_np_communication_id = :parent_np_communication_id
             ORDER BY
-                `name`,
-                platform,
-                region
+                tt.`name`,
+                tt.platform,
+                ttm.region
             SQL
         );
         $query->bindValue(':parent_np_communication_id', $npCommunicationId, PDO::PARAM_STR);

--- a/wwwroot/classes/GameLeaderboardService.php
+++ b/wwwroot/classes/GameLeaderboardService.php
@@ -21,11 +21,32 @@ class GameLeaderboardService
         $query = $this->database->prepare(
             <<<'SQL'
             SELECT
-                *
+                tt.id,
+                tt.np_communication_id,
+                tt.name,
+                tt.detail,
+                tt.icon_url,
+                tt.platform,
+                tt.bronze,
+                tt.silver,
+                tt.gold,
+                tt.platinum,
+                tt.set_version,
+                ttm.message,
+                ttm.status,
+                ttm.recent_players,
+                ttm.owners_completed,
+                ttm.owners,
+                ttm.difficulty,
+                ttm.psnprofiles_id,
+                ttm.parent_np_communication_id,
+                ttm.region,
+                ttm.rarity_points
             FROM
-                trophy_title
+                trophy_title tt
+                JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             WHERE
-                id = :id
+                tt.id = :id
             SQL
         );
         $query->bindValue(':id', $gameId, PDO::PARAM_INT);

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -126,6 +126,7 @@ class GameListService
                 COUNT(*)
             FROM
                 trophy_title tt
+                JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             LEFT JOIN player p ON p.online_id = :online_id
             LEFT JOIN trophy_title_player ttp ON
                 ttp.np_communication_id = tt.np_communication_id
@@ -144,16 +145,16 @@ class GameListService
             'tt.np_communication_id',
             'tt.id',
             'tt.name',
-            'tt.status',
+            'ttm.status AS status',
             'tt.icon_url',
             'tt.platform',
-            'tt.owners',
-            'tt.difficulty',
+            'ttm.owners AS owners',
+            'ttm.difficulty AS difficulty',
             'tt.platinum',
             'tt.gold',
             'tt.silver',
             'tt.bronze',
-            'tt.rarity_points',
+            'ttm.rarity_points AS rarity_points',
             'ttp.progress',
         ];
 
@@ -173,6 +174,7 @@ class GameListService
                 %s
             FROM
                 trophy_title tt
+                JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             LEFT JOIN player p ON p.online_id = :online_id
             LEFT JOIN trophy_title_player ttp ON
                 ttp.np_communication_id = tt.np_communication_id
@@ -196,13 +198,13 @@ class GameListService
 
         switch ($filter->getSort()) {
             case GameListFilter::SORT_COMPLETION:
-                $conditions[] = "tt.status = 0 AND (tt.bronze + tt.silver + tt.gold + tt.platinum) != 0";
+                $conditions[] = "ttm.status = 0 AND (tt.bronze + tt.silver + tt.gold + tt.platinum) != 0";
                 break;
             case GameListFilter::SORT_RARITY:
-                $conditions[] = 'tt.status = 0';
+                $conditions[] = 'ttm.status = 0';
                 break;
             default:
-                $conditions[] = 'tt.status != 2';
+                $conditions[] = 'ttm.status != 2';
                 break;
         }
 

--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -23,11 +23,32 @@ class GameRecentPlayersService
         $query = $this->database->prepare(
             <<<'SQL'
             SELECT
-                *
+                tt.id,
+                tt.np_communication_id,
+                tt.name,
+                tt.detail,
+                tt.icon_url,
+                tt.platform,
+                tt.bronze,
+                tt.silver,
+                tt.gold,
+                tt.platinum,
+                tt.set_version,
+                ttm.message,
+                ttm.status,
+                ttm.recent_players,
+                ttm.owners_completed,
+                ttm.owners,
+                ttm.difficulty,
+                ttm.psnprofiles_id,
+                ttm.parent_np_communication_id,
+                ttm.region,
+                ttm.rarity_points
             FROM
-                trophy_title
+                trophy_title tt
+                JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             WHERE
-                id = :id
+                tt.id = :id
             SQL
         );
         $query->bindValue(':id', $gameId, PDO::PARAM_INT);

--- a/wwwroot/classes/GameResetService.php
+++ b/wwwroot/classes/GameResetService.php
@@ -52,8 +52,8 @@ class GameResetService
                 'DELETE FROM trophy_earned WHERE np_communication_id = :np_communication_id',
                 'DELETE FROM trophy_group_player WHERE np_communication_id = :np_communication_id',
                 'DELETE FROM trophy_title_player WHERE np_communication_id = :np_communication_id',
-                'UPDATE trophy_title SET owners = 0, owners_completed = 0 WHERE np_communication_id = :np_communication_id',
-                'UPDATE trophy_title SET parent_np_communication_id = NULL WHERE parent_np_communication_id = :np_communication_id',
+                'UPDATE trophy_title_meta SET owners = 0, owners_completed = 0 WHERE np_communication_id = :np_communication_id',
+                'UPDATE trophy_title_meta SET parent_np_communication_id = NULL WHERE parent_np_communication_id = :np_communication_id',
             ];
 
             foreach ($statements as $sql) {
@@ -79,7 +79,7 @@ class GameResetService
                 'DELETE FROM trophy_title_player WHERE np_communication_id = :np_communication_id',
                 'DELETE FROM trophy_group WHERE np_communication_id = :np_communication_id',
                 'DELETE FROM trophy_title WHERE np_communication_id = :np_communication_id',
-                'UPDATE trophy_title SET parent_np_communication_id = NULL WHERE parent_np_communication_id = :np_communication_id',
+                'UPDATE trophy_title_meta SET parent_np_communication_id = NULL WHERE parent_np_communication_id = :np_communication_id',
             ];
 
             foreach ($statements as $sql) {

--- a/wwwroot/classes/GameService.php
+++ b/wwwroot/classes/GameService.php
@@ -19,11 +19,32 @@ class GameService
         $query = $this->database->prepare(
             <<<'SQL'
             SELECT
-                *
+                tt.id,
+                tt.np_communication_id,
+                tt.name,
+                tt.detail,
+                tt.icon_url,
+                tt.platform,
+                tt.bronze,
+                tt.silver,
+                tt.gold,
+                tt.platinum,
+                tt.set_version,
+                ttm.message,
+                ttm.status,
+                ttm.recent_players,
+                ttm.owners_completed,
+                ttm.owners,
+                ttm.difficulty,
+                ttm.psnprofiles_id,
+                ttm.parent_np_communication_id,
+                ttm.region,
+                ttm.rarity_points
             FROM
-                trophy_title
+                trophy_title tt
+                JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             WHERE
-                id = :id
+                tt.id = :id
             SQL
         );
         $query->bindValue(':id', $gameId, PDO::PARAM_INT);

--- a/wwwroot/classes/GameStatusService.php
+++ b/wwwroot/classes/GameStatusService.php
@@ -36,11 +36,23 @@ class GameStatusService
 
     private function updateStatus(int $gameId, int $status): void
     {
+        $npCommunicationIdQuery = $this->database->prepare(
+            'SELECT np_communication_id FROM trophy_title WHERE id = :game_id'
+        );
+        $npCommunicationIdQuery->bindValue(':game_id', $gameId, PDO::PARAM_INT);
+        $npCommunicationIdQuery->execute();
+
+        $npCommunicationId = $npCommunicationIdQuery->fetchColumn();
+
+        if ($npCommunicationId === false) {
+            return;
+        }
+
         $query = $this->database->prepare(
-            'UPDATE trophy_title SET status = :status WHERE id = :game_id'
+            'UPDATE trophy_title_meta SET status = :status WHERE np_communication_id = :np_communication_id'
         );
         $query->bindValue(':status', $status, PDO::PARAM_INT);
-        $query->bindValue(':game_id', $gameId, PDO::PARAM_INT);
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->execute();
     }
 

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -29,13 +29,21 @@ class HomepageContentService
         $query = $this->database->prepare(
             <<<'SQL'
             SELECT
-                *
+                tt.id,
+                tt.name,
+                tt.icon_url,
+                tt.platform,
+                tt.platinum,
+                tt.gold,
+                tt.silver,
+                tt.bronze
             FROM
-                trophy_title
+                trophy_title tt
+                JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             WHERE
-                `status` != 2
+                ttm.status != 2
             ORDER BY
-                id DESC
+                tt.id DESC
             LIMIT
                 :limit
             SQL
@@ -71,8 +79,9 @@ class HomepageContentService
             FROM
                 trophy_group tg
                 JOIN trophy_title tt USING (np_communication_id)
+                JOIN trophy_title_meta ttm USING (np_communication_id)
             WHERE
-                tt.status != 2
+                ttm.status != 2
                 AND tg.group_id != 'default'
             ORDER BY
                 tg.id DESC
@@ -99,17 +108,18 @@ class HomepageContentService
         $query = $this->database->prepare(
             <<<'SQL'
             SELECT
-                id,
-                icon_url,
-                platform,
-                `name`,
-                recent_players
+                tt.id,
+                tt.icon_url,
+                tt.platform,
+                tt.`name`,
+                ttm.recent_players
             FROM
-                trophy_title
+                trophy_title tt
+                JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             WHERE
-                `status` != 2
+                ttm.status != 2
             ORDER BY
-                recent_players DESC
+                ttm.recent_players DESC
             LIMIT
                 :limit
             SQL

--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -35,6 +35,7 @@ class PlayerAdvisorService
             SELECT COUNT(*)
             FROM trophy t
             JOIN trophy_title tt USING (np_communication_id)
+            JOIN trophy_title_meta ttm USING (np_communication_id)
             JOIN trophy_title_player ttp ON
                 t.np_communication_id = ttp.np_communication_id
                 AND ttp.account_id = :account_id
@@ -44,7 +45,7 @@ class PlayerAdvisorService
                 AND te_completed.account_id = :account_id
                 AND te_completed.earned = 1
             WHERE te_completed.account_id IS NULL
-                AND tt.status = 0
+                AND ttm.status = 0
                 AND t.status = 0
         SQL;
 
@@ -80,6 +81,7 @@ class PlayerAdvisorService
                 te_progress.progress
             FROM trophy t
             JOIN trophy_title tt USING (np_communication_id)
+            JOIN trophy_title_meta ttm USING (np_communication_id)
             LEFT JOIN trophy_earned te_progress ON
                 t.np_communication_id = te_progress.np_communication_id
                 AND t.order_id = te_progress.order_id
@@ -94,7 +96,7 @@ class PlayerAdvisorService
                 AND te_completed.account_id = :account_id
                 AND te_completed.earned = 1
             WHERE te_completed.account_id IS NULL
-                AND tt.status = 0
+                AND ttm.status = 0
                 AND t.status = 0
         SQL;
 

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -34,6 +34,7 @@ class PlayerGamesService
             'SELECT COUNT(*)
             FROM trophy_title_player ttp
                 JOIN trophy_title tt USING (np_communication_id)
+                JOIN trophy_title_meta ttm USING (np_communication_id)
                 JOIN trophy_group_player tgp USING (account_id, np_communication_id)
             WHERE %s',
             $this->buildWhereClause($filter, true)
@@ -59,8 +60,8 @@ class PlayerGamesService
             'tt.name',
             'tt.icon_url',
             'tt.platform',
-            'tt.status',
-            'tt.rarity_points AS max_rarity_points',
+            'ttm.status AS status',
+            'ttm.rarity_points AS max_rarity_points',
             'ttp.bronze',
             'ttp.silver',
             'ttp.gold',
@@ -81,6 +82,7 @@ class PlayerGamesService
             'SELECT %s
             FROM trophy_title_player ttp
                 JOIN trophy_title tt USING (np_communication_id)
+                JOIN trophy_title_meta ttm USING (np_communication_id)
                 JOIN trophy_group_player tgp USING (account_id, np_communication_id)
             WHERE %s
             %s
@@ -116,7 +118,7 @@ class PlayerGamesService
     private function buildWhereClause(PlayerGamesFilter $filter, bool $forCount): string
     {
         $conditions = [
-            'tt.status != 2',
+            'ttm.status != 2',
             'ttp.account_id = :account_id',
             "tgp.group_id = 'default'",
         ];

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -31,7 +31,8 @@ class PlayerLogService
             SELECT COUNT(*)
             FROM trophy_earned te
             JOIN trophy_title tt USING (np_communication_id)
-            WHERE tt.status != 2
+            JOIN trophy_title_meta ttm USING (np_communication_id)
+            WHERE ttm.status != 2
                 AND te.account_id = :account_id
                 AND te.earned = 1
         SQL;
@@ -65,13 +66,14 @@ class PlayerLogService
                 t.reward_image_url,
                 tt.id AS game_id,
                 tt.name AS game_name,
-                tt.status AS game_status,
+                ttm.status AS game_status,
                 tt.icon_url AS game_icon,
                 tt.platform
             FROM trophy_earned te
             LEFT JOIN trophy t USING (np_communication_id, order_id)
             LEFT JOIN trophy_title tt USING (np_communication_id)
-            WHERE tt.status != 2
+            LEFT JOIN trophy_title_meta ttm USING (np_communication_id)
+            WHERE ttm.status != 2
                 AND te.account_id = :account_id
                 AND te.earned = 1
         SQL;

--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -108,13 +108,13 @@ class PlayerRandomGamesService
                 tt.name,
                 tt.icon_url,
                 tt.platform,
-                tt.owners,
-                tt.difficulty,
+                ttm.owners,
+                ttm.difficulty,
                 tt.platinum,
                 tt.gold,
                 tt.silver,
                 tt.bronze,
-                tt.rarity_points,
+                ttm.rarity_points,
                 ttp.progress
             SQL
             . $this->buildBaseQuery($filter);
@@ -124,11 +124,12 @@ class PlayerRandomGamesService
     {
         $sql = <<<'SQL'
              FROM trophy_title tt
+            JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             LEFT JOIN trophy_title_player ttp ON
                 ttp.np_communication_id = tt.np_communication_id
                 AND ttp.account_id = :account_id
             WHERE
-                tt.status = 0
+                ttm.status = 0
                 AND (ttp.progress IS NULL OR ttp.progress < 100)
         SQL;
 

--- a/wwwroot/classes/PlayerSummaryService.php
+++ b/wwwroot/classes/PlayerSummaryService.php
@@ -43,8 +43,9 @@ class PlayerSummaryService
             FROM
                 trophy_title_player ttp
                 INNER JOIN trophy_title tt ON tt.np_communication_id = ttp.np_communication_id
+                INNER JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             WHERE
-                tt.status = 0
+                ttm.status = 0
                 AND ttp.account_id = :account_id
             SQL
         );

--- a/wwwroot/classes/TrophyListService.php
+++ b/wwwroot/classes/TrophyListService.php
@@ -21,7 +21,8 @@ class TrophyListService
             'SELECT COUNT(*)
             FROM trophy t
             JOIN trophy_title tt USING (np_communication_id)
-            WHERE t.status = 0 AND tt.status = 0'
+            JOIN trophy_title_meta ttm USING (np_communication_id)
+            WHERE t.status = 0 AND ttm.status = 0'
         );
 
         $query->execute();
@@ -55,7 +56,8 @@ class TrophyListService
                 tt.platform
             FROM trophy t
             JOIN trophy_title tt USING(np_communication_id)
-            WHERE t.status = 0 AND tt.status = 0
+            JOIN trophy_title_meta ttm USING (np_communication_id)
+            WHERE t.status = 0 AND ttm.status = 0
             ORDER BY t.rarity_percent DESC
             LIMIT :offset, :limit'
         );


### PR DESCRIPTION
## Summary
- join the new trophy_title_meta table across services and DTO tests so PSN100-specific fields come from the companion table
- expand SQLite test schemas and stubs to expose the meta columns expected by the updated queries
- update GameStatusService to resolve the trophy set identifier before updating trophy_title_meta for better SQLite compatibility

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6902b381721c832f9fa4c3750e2ddcdc