### PR TITLE
Copy trophy title meta when cloning games

### DIFF
--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -228,8 +228,14 @@ SQL
             if ($metaInsert->rowCount() === 0) {
                 $defaultMetaInsert = $this->database->prepare(
                     <<<'SQL'
-                    INSERT INTO trophy_title_meta (np_communication_id)
-                    VALUES (:np_communication_id)
+                    INSERT INTO trophy_title_meta (
+                        np_communication_id,
+                        message
+                    )
+                    VALUES (
+                        :np_communication_id,
+                        ''
+                    )
 SQL
                 );
                 $defaultMetaInsert->bindValue(':np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);


### PR DESCRIPTION
## Summary
- ensure cloned trophy titles copy metadata from the source game
- create a default metadata row when the source game lacks one

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_690363090c3c832f9377658567877cb8