### PR TITLE
Remove obsolete trophy_title indexes

### DIFF
--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -451,12 +451,7 @@ ALTER TABLE `trophy_merge`
 --
 ALTER TABLE `trophy_title`
   ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `u_np_communication_id` (`np_communication_id`),
-  ADD KEY `idx_npcid_status` (`np_communication_id`,`status`),
-  ADD KEY `idx_status` (`status`),
-  ADD KEY `idx_parent_np_communication_id` (`parent_np_communication_id`),
-  ADD KEY `idx_psnprofiles_id` (`psnprofiles_id`),
-  ADD KEY `trophy_title_idx_np_id_owners` (`np_communication_id`,`owners`);
+  ADD UNIQUE KEY `u_np_communication_id` (`np_communication_id`);
 ALTER TABLE `trophy_title` ADD FULLTEXT KEY `idx_name` (`name`);
 
 --


### PR DESCRIPTION
## Summary
- remove outdated trophy_title indexes that referenced columns now stored in trophy_title_meta

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6903711d2d54832f89de4fd59dce0be9