### PR TITLE
Set message field when inserting trophy title metadata

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -573,15 +573,18 @@ class ThirtyMinuteCronJob implements CronJobInterface
                         }
 
                         $metaQuery = $this->database->prepare("INSERT INTO trophy_title_meta (
-                                np_communication_id
+                                np_communication_id,
+                                message
                             )
                             VALUES (
-                                :np_communication_id
+                                :np_communication_id,
+                                :message
                             ) AS new
                             ON DUPLICATE KEY
                             UPDATE
                                 np_communication_id = new.np_communication_id");
                         $metaQuery->bindValue(":np_communication_id", $npid, PDO::PARAM_STR);
+                        $metaQuery->bindValue(":message", '', PDO::PARAM_STR);
                         $metaQuery->execute();
 
                         // Get "groups" (game and DLCs)


### PR DESCRIPTION
## Summary
- include the message column when inserting trophy_title_meta records so new rows satisfy the NOT NULL constraint
- bind an empty message for new records, relying on later updates to populate real content

## Testing
- php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6903db32c6d4832f8db65b95acadae52