### PR TITLE
Add admin delete player tool

### DIFF
--- a/tests/DeletePlayerRequestHandlerTest.php
+++ b/tests/DeletePlayerRequestHandlerTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/Admin/DeletePlayerRequestHandler.php';
+
+final class DeletePlayerRequestHandlerTest extends TestCase
+{
+    private PDO $database;
+
+    private DeletePlayerRequestHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->createTables();
+
+        $service = new DeletePlayerService($this->database);
+        $this->handler = new DeletePlayerRequestHandler($service);
+    }
+
+    public function testHandleRequestReturnsEmptyResultForGet(): void
+    {
+        $request = new AdminRequest('GET', []);
+
+        $result = $this->handler->handleRequest($request);
+
+        $this->assertSame(null, $result->getSuccessMessage());
+        $this->assertSame(null, $result->getErrorMessage());
+    }
+
+    public function testHandleRequestReturnsErrorWhenNoIdentifiersProvided(): void
+    {
+        $request = new AdminRequest('POST', [
+            'account_id' => '',
+            'online_id' => '',
+        ]);
+
+        $result = $this->handler->handleRequest($request);
+
+        $this->assertSame('<p>Please provide an account ID or an online ID.</p>', $result->getErrorMessage());
+    }
+
+    public function testHandleRequestReturnsErrorForInvalidAccountId(): void
+    {
+        $request = new AdminRequest('POST', [
+            'account_id' => '12ab',
+        ]);
+
+        $result = $this->handler->handleRequest($request);
+
+        $this->assertSame('<p>Please provide a numeric account ID.</p>', $result->getErrorMessage());
+    }
+
+    public function testHandleRequestReturnsErrorWhenOnlineIdNotFound(): void
+    {
+        $request = new AdminRequest('POST', [
+            'account_id' => '',
+            'online_id' => 'MissingUser',
+        ]);
+
+        $result = $this->handler->handleRequest($request);
+
+        $this->assertSame('<p>No player was found with that online ID.</p>', $result->getErrorMessage());
+    }
+
+    public function testHandleRequestDeletesPlayerByAccountId(): void
+    {
+        $this->insertPlayerData('5005', 'DeleteById');
+
+        $request = new AdminRequest('POST', [
+            'account_id' => '5005',
+            'online_id' => '',
+        ]);
+
+        $result = $this->handler->handleRequest($request);
+
+        $this->assertSame(null, $result->getErrorMessage());
+
+        $success = $result->getSuccessMessage();
+        $this->assertTrue($success !== null);
+        $this->assertStringContainsString('Deleted data for account ID 5005.', $success);
+        $this->assertStringContainsString('trophy_earned: 2 rows deleted', $success);
+        $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM player WHERE account_id = '5005'")->fetchColumn());
+    }
+
+    public function testHandleRequestDeletesPlayerByOnlineId(): void
+    {
+        $this->insertPlayerData('6006', 'DeleteByOnline');
+
+        $request = new AdminRequest('POST', [
+            'account_id' => '',
+            'online_id' => 'DeleteByOnline',
+        ]);
+
+        $result = $this->handler->handleRequest($request);
+
+        $this->assertSame(null, $result->getErrorMessage());
+
+        $success = $result->getSuccessMessage();
+        $this->assertTrue($success !== null);
+        $this->assertStringContainsString('Deleted data for account ID 6006.', $success);
+        $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM player WHERE account_id = '6006'")->fetchColumn());
+    }
+
+    private function createTables(): void
+    {
+        $this->database->exec('CREATE TABLE trophy_earned (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_id TEXT NOT NULL
+        )');
+        $this->database->exec('CREATE TABLE trophy_group_player (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_id TEXT NOT NULL
+        )');
+        $this->database->exec('CREATE TABLE trophy_title_player (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_id TEXT NOT NULL
+        )');
+        $this->database->exec('CREATE TABLE player (
+            account_id TEXT PRIMARY KEY,
+            online_id TEXT
+        )');
+        $this->database->exec('CREATE TABLE log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            message TEXT
+        )');
+    }
+
+    private function insertPlayerData(string $accountId, string $onlineId): void
+    {
+        $this->database->exec(sprintf(
+            "INSERT INTO player (account_id, online_id) VALUES ('%s', '%s')",
+            $accountId,
+            $onlineId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO trophy_group_player (account_id) VALUES ('%s')",
+            $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO trophy_title_player (account_id) VALUES ('%s')",
+            $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO log (message) VALUES ('Player (%s) deleted')",
+            $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO trophy_earned (account_id) VALUES ('%s')",
+            $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO trophy_earned (account_id) VALUES ('%s')",
+            $accountId
+        ));
+    }
+}

--- a/tests/DeletePlayerServiceTest.php
+++ b/tests/DeletePlayerServiceTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/Admin/DeletePlayerService.php';
+
+final class DeletePlayerServiceTest extends TestCase
+{
+    private PDO $database;
+
+    private DeletePlayerService $service;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->createTables();
+
+        $this->service = new DeletePlayerService($this->database);
+    }
+
+    public function testFindAccountIdByOnlineIdReturnsAccountId(): void
+    {
+        $this->database->exec("INSERT INTO player (account_id, online_id) VALUES ('1001', 'ExampleUser')");
+
+        $accountId = $this->service->findAccountIdByOnlineId('ExampleUser');
+
+        $this->assertSame('1001', $accountId);
+    }
+
+    public function testFindAccountIdByOnlineIdReturnsNullWhenNotFound(): void
+    {
+        $accountId = $this->service->findAccountIdByOnlineId('MissingUser');
+
+        $this->assertSame(null, $accountId);
+    }
+
+    public function testDeletePlayerByAccountIdDeletesData(): void
+    {
+        $this->insertPlayerData('2002', 'PlayerOne');
+        $this->insertPlayerData('3003', 'PlayerTwo');
+
+        $counts = $this->service->deletePlayerByAccountId('2002');
+
+        $this->assertSame(
+            [
+                'trophy_earned' => 2,
+                'trophy_group_player' => 1,
+                'trophy_title_player' => 1,
+                'player' => 1,
+                'log' => 1,
+            ],
+            $counts
+        );
+
+        $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM trophy_earned WHERE account_id = '2002'")->fetchColumn());
+        $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM trophy_group_player WHERE account_id = '2002'")->fetchColumn());
+        $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM trophy_title_player WHERE account_id = '2002'")->fetchColumn());
+        $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM player WHERE account_id = '2002'")->fetchColumn());
+        $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM log WHERE message LIKE '%2002%'")->fetchColumn());
+
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM player WHERE account_id = '3003'")->fetchColumn());
+    }
+
+    public function testDeletePlayerByAccountIdRollsBackOnFailure(): void
+    {
+        $this->insertPlayerData('4004', 'FailureUser');
+
+        $this->database->exec('CREATE TRIGGER trigger_fail_delete BEFORE DELETE ON trophy_group_player
+            BEGIN
+                SELECT RAISE(ABORT, "delete failure");
+            END;');
+
+        try {
+            $this->service->deletePlayerByAccountId('4004');
+            $this->fail('Expected RuntimeException was not thrown.');
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString('Failed to delete player data.', $exception->getMessage());
+        }
+
+        $this->assertSame(2, (int) $this->database->query("SELECT COUNT(*) FROM trophy_earned WHERE account_id = '4004'")->fetchColumn());
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM trophy_group_player WHERE account_id = '4004'")->fetchColumn());
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM trophy_title_player WHERE account_id = '4004'")->fetchColumn());
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM player WHERE account_id = '4004'")->fetchColumn());
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM log WHERE message LIKE '%4004%'")->fetchColumn());
+    }
+
+    private function createTables(): void
+    {
+        $this->database->exec('CREATE TABLE trophy_earned (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_id TEXT NOT NULL
+        )');
+        $this->database->exec('CREATE TABLE trophy_group_player (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_id TEXT NOT NULL
+        )');
+        $this->database->exec('CREATE TABLE trophy_title_player (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_id TEXT NOT NULL
+        )');
+        $this->database->exec('CREATE TABLE player (
+            account_id TEXT PRIMARY KEY,
+            online_id TEXT
+        )');
+        $this->database->exec('CREATE TABLE log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            message TEXT
+        )');
+    }
+
+    private function insertPlayerData(string $accountId, string $onlineId): void
+    {
+        $this->database->exec(sprintf(
+            "INSERT INTO player (account_id, online_id) VALUES ('%s', '%s')",
+            $accountId,
+            $onlineId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO trophy_group_player (account_id) VALUES ('%s')",
+            $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO trophy_title_player (account_id) VALUES ('%s')",
+            $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO log (message) VALUES ('Player (%s) deleted')",
+            $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO trophy_earned (account_id) VALUES ('%s')",
+            $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO trophy_earned (account_id) VALUES ('%s')",
+            $accountId
+        ));
+    }
+}

--- a/wwwroot/admin/delete-player.php
+++ b/wwwroot/admin/delete-player.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+require_once '../init.php';
+require_once '../classes/Admin/DeletePlayerService.php';
+require_once '../classes/Admin/DeletePlayerRequestHandler.php';
+
+$service = new DeletePlayerService($database);
+$requestHandler = new DeletePlayerRequestHandler($service);
+
+$request = AdminRequest::fromGlobals($_SERVER ?? [], $_POST ?? []);
+$result = $requestHandler->handleRequest($request);
+$success = $result->getSuccessMessage();
+$error = $result->getErrorMessage();
+
+?>
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+    <head>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+        <title>Admin ~ Delete Player</title>
+    </head>
+    <body>
+        <div class="p-4">
+            <a href="/admin/">Back</a><br><br>
+            <form method="post" autocomplete="off" class="mb-4">
+                <div class="mb-3">
+                    <label for="account-id" class="form-label">Account ID</label>
+                    <input type="text" id="account-id" name="account_id" class="form-control" value="<?= htmlspecialchars($_POST['account_id'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                    <div class="form-text">Provide the numeric account ID for the player.</div>
+                </div>
+                <div class="mb-3">
+                    <label for="online-id" class="form-label">Online ID</label>
+                    <input type="text" id="online-id" name="online_id" class="form-control" value="<?= htmlspecialchars($_POST['online_id'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                    <div class="form-text">If the account ID is unknown, provide the online ID instead.</div>
+                </div>
+                <p class="text-muted">Enter either an account ID or an online ID. Only one is required.</p>
+                <button type="submit" class="btn btn-danger">Delete Player</button>
+            </form>
+
+            <?php if ($error !== null) { ?>
+                <div class="alert alert-danger" role="alert">
+                    <?= $error; ?>
+                </div>
+            <?php } ?>
+
+            <?php if ($success !== null) { ?>
+                <div class="alert alert-success" role="alert">
+                    <?= $success; ?>
+                </div>
+            <?php } ?>
+        </div>
+    </body>
+</html>

--- a/wwwroot/classes/Admin/AdminNavigation.php
+++ b/wwwroot/classes/Admin/AdminNavigation.php
@@ -65,6 +65,7 @@ class AdminNavigation
         return [
             new AdminNavigationItem('Cheater', '/admin/cheater.php'),
             new AdminNavigationItem('Copy group and trophy data', '/admin/copy.php'),
+            new AdminNavigationItem('Delete Player', '/admin/delete-player.php'),
             new AdminNavigationItem('Game Details', '/admin/detail.php'),
             new AdminNavigationItem('Game Merge', '/admin/merge.php'),
             new AdminNavigationItem('Possible Cheaters', '/admin/possible.php'),

--- a/wwwroot/classes/Admin/DeletePlayerRequestHandler.php
+++ b/wwwroot/classes/Admin/DeletePlayerRequestHandler.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/AdminRequest.php';
+require_once __DIR__ . '/DeletePlayerRequestResult.php';
+require_once __DIR__ . '/DeletePlayerService.php';
+
+final class DeletePlayerRequestHandler
+{
+    private DeletePlayerService $service;
+
+    public function __construct(DeletePlayerService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function handleRequest(AdminRequest $request): DeletePlayerRequestResult
+    {
+        if (!$request->isPost()) {
+            return DeletePlayerRequestResult::empty();
+        }
+
+        $accountIdInput = $request->getPostString('account_id');
+        $onlineId = $request->getPostString('online_id');
+
+        if ($accountIdInput === '' && $onlineId === '') {
+            return DeletePlayerRequestResult::error('<p>Please provide an account ID or an online ID.</p>');
+        }
+
+        if ($accountIdInput !== '') {
+            if (!$this->isValidAccountId($accountIdInput)) {
+                return DeletePlayerRequestResult::error('<p>Please provide a numeric account ID.</p>');
+            }
+
+            $accountId = $accountIdInput;
+        } else {
+            $accountId = $this->service->findAccountIdByOnlineId($onlineId);
+
+            if ($accountId === null) {
+                return DeletePlayerRequestResult::error('<p>No player was found with that online ID.</p>');
+            }
+        }
+
+        try {
+            $counts = $this->service->deletePlayerByAccountId($accountId);
+        } catch (Throwable $exception) {
+            return DeletePlayerRequestResult::error('<p>Failed to delete player data. Please try again.</p>');
+        }
+
+        $escapedAccountId = $this->escape($accountId);
+        $items = '';
+
+        foreach ($counts as $table => $count) {
+            $items .= sprintf('<li>%s: %d rows deleted</li>', $this->escape((string) $table), $count);
+        }
+
+        $message = sprintf(
+            '<p>Deleted data for account ID %s.</p><ul>%s</ul>',
+            $escapedAccountId,
+            $items
+        );
+
+        return DeletePlayerRequestResult::success($message);
+    }
+
+    private function isValidAccountId(string $accountId): bool
+    {
+        return $accountId !== '' && preg_match('/^\\d+$/', $accountId) === 1;
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/wwwroot/classes/Admin/DeletePlayerRequestResult.php
+++ b/wwwroot/classes/Admin/DeletePlayerRequestResult.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+final class DeletePlayerRequestResult
+{
+    private ?string $successMessage;
+
+    private ?string $errorMessage;
+
+    private function __construct(?string $successMessage, ?string $errorMessage)
+    {
+        $this->successMessage = $successMessage;
+        $this->errorMessage = $errorMessage;
+    }
+
+    public static function empty(): self
+    {
+        return new self(null, null);
+    }
+
+    public static function success(string $message): self
+    {
+        return new self($message, null);
+    }
+
+    public static function error(string $message): self
+    {
+        return new self(null, $message);
+    }
+
+    public function getSuccessMessage(): ?string
+    {
+        return $this->successMessage;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+}

--- a/wwwroot/classes/Admin/DeletePlayerService.php
+++ b/wwwroot/classes/Admin/DeletePlayerService.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+final class DeletePlayerService
+{
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function findAccountIdByOnlineId(string $onlineId): ?string
+    {
+        $query = $this->database->prepare('SELECT account_id FROM player WHERE online_id = :online_id');
+        $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
+        $query->execute();
+
+        $accountId = $query->fetchColumn();
+
+        return $accountId === false ? null : (string) $accountId;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function deletePlayerByAccountId(string $accountId): array
+    {
+        if (!$this->database->beginTransaction()) {
+            throw new RuntimeException('Failed to start database transaction.');
+        }
+
+        try {
+            $counts = [];
+            $counts['trophy_earned'] = $this->deleteByAccountId(
+                'DELETE FROM trophy_earned WHERE account_id = :account_id',
+                $accountId
+            );
+            $counts['trophy_group_player'] = $this->deleteByAccountId(
+                'DELETE FROM trophy_group_player WHERE account_id = :account_id',
+                $accountId
+            );
+            $counts['trophy_title_player'] = $this->deleteByAccountId(
+                'DELETE FROM trophy_title_player WHERE account_id = :account_id',
+                $accountId
+            );
+            $counts['player'] = $this->deleteByAccountId(
+                'DELETE FROM player WHERE account_id = :account_id',
+                $accountId
+            );
+
+            $logStatement = $this->database->prepare('DELETE FROM log WHERE message LIKE :message');
+            $logStatement->bindValue(':message', '%' . $accountId . '%', PDO::PARAM_STR);
+            $logStatement->execute();
+            $counts['log'] = (int) $logStatement->rowCount();
+
+            $this->database->commit();
+
+            return $counts;
+        } catch (Throwable $exception) {
+            if ($this->database->inTransaction()) {
+                $this->database->rollBack();
+            }
+
+            throw new RuntimeException('Failed to delete player data.', 0, $exception);
+        }
+    }
+
+    private function deleteByAccountId(string $sql, string $accountId): int
+    {
+        $statement = $this->database->prepare($sql);
+        $statement->bindValue(':account_id', $accountId, PDO::PARAM_STR);
+        $statement->execute();
+
+        return (int) $statement->rowCount();
+    }
+}


### PR DESCRIPTION
## Summary
- add a Delete Player admin page that accepts either an account ID or an online ID
- implement a transactional deletion service and request handler that remove player data across related tables
- register the page in the admin navigation and cover the new logic with unit tests

## Testing
- php -l wwwroot/classes/Admin/DeletePlayerRequestResult.php
- php -l wwwroot/classes/Admin/DeletePlayerService.php
- php -l wwwroot/classes/Admin/DeletePlayerRequestHandler.php
- php -l wwwroot/admin/delete-player.php
- php -l tests/DeletePlayerServiceTest.php
- php -l tests/DeletePlayerRequestHandlerTest.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6903dd44958c832fad82cebd20e19f17