### PR TITLE
Add confirmation step to admin player deletion

### DIFF
--- a/tests/DeletePlayerServiceTest.php
+++ b/tests/DeletePlayerServiceTest.php
@@ -20,20 +20,42 @@ final class DeletePlayerServiceTest extends TestCase
         $this->service = new DeletePlayerService($this->database);
     }
 
-    public function testFindAccountIdByOnlineIdReturnsAccountId(): void
+    public function testFindPlayerByOnlineIdReturnsPlayer(): void
     {
         $this->database->exec("INSERT INTO player (account_id, online_id) VALUES ('1001', 'ExampleUser')");
 
-        $accountId = $this->service->findAccountIdByOnlineId('ExampleUser');
+        $player = $this->service->findPlayerByOnlineId('ExampleUser');
 
-        $this->assertSame('1001', $accountId);
+        $this->assertSame([
+            'account_id' => '1001',
+            'online_id' => 'ExampleUser',
+        ], $player);
     }
 
-    public function testFindAccountIdByOnlineIdReturnsNullWhenNotFound(): void
+    public function testFindPlayerByOnlineIdReturnsNullWhenNotFound(): void
     {
-        $accountId = $this->service->findAccountIdByOnlineId('MissingUser');
+        $player = $this->service->findPlayerByOnlineId('MissingUser');
 
-        $this->assertSame(null, $accountId);
+        $this->assertSame(null, $player);
+    }
+
+    public function testFindPlayerByAccountIdReturnsPlayer(): void
+    {
+        $this->database->exec("INSERT INTO player (account_id, online_id) VALUES ('2002', 'AccountUser')");
+
+        $player = $this->service->findPlayerByAccountId('2002');
+
+        $this->assertSame([
+            'account_id' => '2002',
+            'online_id' => 'AccountUser',
+        ], $player);
+    }
+
+    public function testFindPlayerByAccountIdReturnsNullWhenNotFound(): void
+    {
+        $player = $this->service->findPlayerByAccountId('9999');
+
+        $this->assertSame(null, $player);
     }
 
     public function testDeletePlayerByAccountIdDeletesData(): void

--- a/wwwroot/admin/delete-player.php
+++ b/wwwroot/admin/delete-player.php
@@ -13,6 +13,38 @@ $request = AdminRequest::fromGlobals($_SERVER ?? [], $_POST ?? []);
 $result = $requestHandler->handleRequest($request);
 $success = $result->getSuccessMessage();
 $error = $result->getErrorMessage();
+$confirmation = $result->getConfirmation();
+
+$accountIdValue = $_POST['account_id'] ?? '';
+
+if (!is_string($accountIdValue)) {
+    $accountIdValue = '';
+}
+
+$onlineIdValue = $_POST['online_id'] ?? '';
+
+if (!is_string($onlineIdValue)) {
+    $onlineIdValue = '';
+}
+
+if ($confirmation !== null) {
+    $accountIdValue = $confirmation->getAccountId();
+    $onlineIdValue = $confirmation->getOnlineId() ?? '';
+}
+
+$encodedAccountIdValue = htmlspecialchars($accountIdValue, ENT_QUOTES, 'UTF-8');
+$encodedOnlineIdValue = htmlspecialchars($onlineIdValue, ENT_QUOTES, 'UTF-8');
+
+$confirmationOnlineId = $confirmation?->getOnlineId();
+$confirmationDisplayName = $confirmationOnlineId ?? $accountIdValue;
+$confirmationUrl = $confirmationOnlineId !== null
+    ? 'https://psn100.net/player/' . rawurlencode($confirmationOnlineId)
+    : null;
+$confirmationAccountId = $confirmation?->getAccountId();
+$encodedConfirmationAccountId = $confirmationAccountId === null ? '' : htmlspecialchars($confirmationAccountId, ENT_QUOTES, 'UTF-8');
+$encodedConfirmationOnlineId = $confirmationOnlineId === null ? '' : htmlspecialchars($confirmationOnlineId, ENT_QUOTES, 'UTF-8');
+$encodedConfirmationUrl = $confirmationUrl === null ? null : htmlspecialchars($confirmationUrl, ENT_QUOTES, 'UTF-8');
+$encodedConfirmationDisplayName = htmlspecialchars($confirmationDisplayName, ENT_QUOTES, 'UTF-8');
 
 ?>
 <!doctype html>
@@ -30,17 +62,39 @@ $error = $result->getErrorMessage();
             <form method="post" autocomplete="off" class="mb-4">
                 <div class="mb-3">
                     <label for="account-id" class="form-label">Account ID</label>
-                    <input type="text" id="account-id" name="account_id" class="form-control" value="<?= htmlspecialchars($_POST['account_id'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                    <input type="text" id="account-id" name="account_id" class="form-control" value="<?= $encodedAccountIdValue; ?>">
                     <div class="form-text">Provide the numeric account ID for the player.</div>
                 </div>
                 <div class="mb-3">
                     <label for="online-id" class="form-label">Online ID</label>
-                    <input type="text" id="online-id" name="online_id" class="form-control" value="<?= htmlspecialchars($_POST['online_id'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                    <input type="text" id="online-id" name="online_id" class="form-control" value="<?= $encodedOnlineIdValue; ?>">
                     <div class="form-text">If the account ID is unknown, provide the online ID instead.</div>
                 </div>
                 <p class="text-muted">Enter either an account ID or an online ID. Only one is required.</p>
                 <button type="submit" class="btn btn-danger">Delete Player</button>
             </form>
+
+            <?php if ($confirmation !== null) { ?>
+                <div class="alert alert-warning" role="alert">
+                    <p>
+                        Are you sure you want to permanently delete player
+                        <?php if ($encodedConfirmationUrl !== null) { ?>
+                            <a href="<?= $encodedConfirmationUrl; ?>" target="_blank" rel="noopener">
+                                <?= $encodedConfirmationDisplayName; ?>
+                            </a>
+                        <?php } else { ?>
+                            <strong><?= $encodedConfirmationDisplayName; ?></strong>
+                        <?php } ?>?
+                    </p>
+                    <p class="mb-0">This action cannot be undone.</p>
+                </div>
+                <form method="post" autocomplete="off" class="mb-4">
+                    <input type="hidden" name="account_id" value="<?= $encodedConfirmationAccountId; ?>">
+                    <input type="hidden" name="online_id" value="<?= $encodedConfirmationOnlineId; ?>">
+                    <input type="hidden" name="confirm_delete" value="1">
+                    <button type="submit" class="btn btn-danger">Confirm Delete</button>
+                </form>
+            <?php } ?>
 
             <?php if ($error !== null) { ?>
                 <div class="alert alert-danger" role="alert">

--- a/wwwroot/classes/Admin/DeletePlayerConfirmation.php
+++ b/wwwroot/classes/Admin/DeletePlayerConfirmation.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+final class DeletePlayerConfirmation
+{
+    private string $accountId;
+
+    private ?string $onlineId;
+
+    public function __construct(string $accountId, ?string $onlineId)
+    {
+        $this->accountId = $accountId;
+        $this->onlineId = $onlineId;
+    }
+
+    public function getAccountId(): string
+    {
+        return $this->accountId;
+    }
+
+    public function getOnlineId(): ?string
+    {
+        return $this->onlineId;
+    }
+}

--- a/wwwroot/classes/Admin/DeletePlayerRequestResult.php
+++ b/wwwroot/classes/Admin/DeletePlayerRequestResult.php
@@ -2,31 +2,41 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/DeletePlayerConfirmation.php';
+
 final class DeletePlayerRequestResult
 {
     private ?string $successMessage;
 
     private ?string $errorMessage;
 
-    private function __construct(?string $successMessage, ?string $errorMessage)
+    private ?DeletePlayerConfirmation $confirmation;
+
+    private function __construct(?string $successMessage, ?string $errorMessage, ?DeletePlayerConfirmation $confirmation)
     {
         $this->successMessage = $successMessage;
         $this->errorMessage = $errorMessage;
+        $this->confirmation = $confirmation;
     }
 
     public static function empty(): self
     {
-        return new self(null, null);
+        return new self(null, null, null);
     }
 
     public static function success(string $message): self
     {
-        return new self($message, null);
+        return new self($message, null, null);
     }
 
     public static function error(string $message): self
     {
-        return new self(null, $message);
+        return new self(null, $message, null);
+    }
+
+    public static function confirmation(DeletePlayerConfirmation $confirmation): self
+    {
+        return new self(null, null, $confirmation);
     }
 
     public function getSuccessMessage(): ?string
@@ -37,5 +47,10 @@ final class DeletePlayerRequestResult
     public function getErrorMessage(): ?string
     {
         return $this->errorMessage;
+    }
+
+    public function getConfirmation(): ?DeletePlayerConfirmation
+    {
+        return $this->confirmation;
     }
 }

--- a/wwwroot/classes/Admin/DeletePlayerService.php
+++ b/wwwroot/classes/Admin/DeletePlayerService.php
@@ -11,15 +11,48 @@ final class DeletePlayerService
         $this->database = $database;
     }
 
-    public function findAccountIdByOnlineId(string $onlineId): ?string
+    /**
+     * @return array{account_id: string, online_id: ?string}|null
+     */
+    public function findPlayerByAccountId(string $accountId): ?array
     {
-        $query = $this->database->prepare('SELECT account_id FROM player WHERE online_id = :online_id');
+        $query = $this->database->prepare('SELECT account_id, online_id FROM player WHERE account_id = :account_id');
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
+        $query->execute();
+
+        /** @var array{account_id?: string, online_id?: string|null}|false $player */
+        $player = $query->fetch(PDO::FETCH_ASSOC);
+
+        if ($player === false) {
+            return null;
+        }
+
+        return [
+            'account_id' => (string) $player['account_id'],
+            'online_id' => array_key_exists('online_id', $player) ? ($player['online_id'] === null ? null : (string) $player['online_id']) : null,
+        ];
+    }
+
+    /**
+     * @return array{account_id: string, online_id: ?string}|null
+     */
+    public function findPlayerByOnlineId(string $onlineId): ?array
+    {
+        $query = $this->database->prepare('SELECT account_id, online_id FROM player WHERE online_id = :online_id');
         $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
         $query->execute();
 
-        $accountId = $query->fetchColumn();
+        /** @var array{account_id?: string, online_id?: string|null}|false $player */
+        $player = $query->fetch(PDO::FETCH_ASSOC);
 
-        return $accountId === false ? null : (string) $accountId;
+        if ($player === false) {
+            return null;
+        }
+
+        return [
+            'account_id' => (string) $player['account_id'],
+            'online_id' => array_key_exists('online_id', $player) ? ($player['online_id'] === null ? null : (string) $player['online_id']) : null,
+        ];
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a confirmation step to the admin delete player page that links to the player profile before the final deletion
- extend the delete player handler/service to look up players for confirmation and expose the state via request results
- update the delete player tests to cover the confirmation flow and the new service lookups

## Testing
- php tests/run.php
- for file in \\    wwwroot/classes/Admin/DeletePlayerConfirmation.php \\    wwwroot/classes/Admin/DeletePlayerRequestResult.php \\    wwwroot/classes/Admin/DeletePlayerRequestHandler.php \\    wwwroot/classes/Admin/DeletePlayerService.php \\    wwwroot/admin/delete-player.php \\    tests/DeletePlayerRequestHandlerTest.php \\    tests/DeletePlayerServiceTest.php; do
    php -l "$file" || exit 1
done


------
https://chatgpt.com/codex/tasks/task_e_69045fa8fae8832fbe0f7454dd4817f1