### PR TITLE
Fix delete player confirmation punctuation

### DIFF
--- a/wwwroot/admin/delete-player.php
+++ b/wwwroot/admin/delete-player.php
@@ -78,13 +78,19 @@ $encodedConfirmationDisplayName = htmlspecialchars($confirmationDisplayName, ENT
                 <div class="alert alert-warning" role="alert">
                     <p>
                         Are you sure you want to permanently delete player
-                        <?php if ($encodedConfirmationUrl !== null) { ?>
-                            <a href="<?= $encodedConfirmationUrl; ?>" target="_blank" rel="noopener">
-                                <?= $encodedConfirmationDisplayName; ?>
-                            </a>
-                        <?php } else { ?>
-                            <strong><?= $encodedConfirmationDisplayName; ?></strong>
-                        <?php } ?>?
+                        <?php
+                        if ($encodedConfirmationUrl !== null) {
+                            printf(
+                                '<a href="%s" target="_blank" rel="noopener">%s</a>',
+                                $encodedConfirmationUrl,
+                                $encodedConfirmationDisplayName
+                            );
+                        } else {
+                            printf('<strong>%s</strong>', $encodedConfirmationDisplayName);
+                        }
+
+                        echo '?';
+                        ?>
                     </p>
                     <p class="mb-0">This action cannot be undone.</p>
                 </div>


### PR DESCRIPTION
## Summary
- ensure the delete player confirmation message omits the space before the question mark
- keep the question mark outside of the player name link while maintaining the existing markup

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6904705e3abc832facc52633fdf7a49d