### PR TITLE
Fix unobtainable trophy counting query

### DIFF
--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -110,10 +110,11 @@ class GameHeaderService
             SELECT
                 COUNT(*)
             FROM
-                trophy
+                trophy t
+                JOIN trophy_meta tm ON tm.trophy_id = t.id
             WHERE
-                `status` = 1
-                AND np_communication_id = :np_communication_id
+                tm.status = 1
+                AND t.np_communication_id = :np_communication_id
             SQL
         );
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);


### PR DESCRIPTION
## Summary
- join the trophy_meta table when counting unobtainable trophies so the status column exists
- update the GameHeaderService test fixtures to include the trophy_meta table and populate status values

## Testing
- php -l wwwroot/classes/GameHeaderService.php
- php -l tests/GameHeaderServiceTest.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_690515483bd8832f8f25062612b743ad