### PR TITLE
Add clone game field to admin merge form

### DIFF
--- a/wwwroot/admin/merge.php
+++ b/wwwroot/admin/merge.php
@@ -55,6 +55,10 @@ $message = $requestHandler->handle($_POST ?? []);
                     <label class="form-label" for="merge-trophy-child">Trophy Child ID</label>
                     <input type="text" class="form-control" id="merge-trophy-child" name="trophychild">
                 </div>
+                <div class="col-12 col-md-6 col-xl-4">
+                    <label class="form-label" for="merge-clone">Clone Game ID</label>
+                    <input type="number" class="form-control" id="merge-clone" name="clone" inputmode="numeric">
+                </div>
                 <div class="col-12 align-self-end">
                     <button type="submit" class="btn btn-primary" id="merge-submit">Submit</button>
                 </div>
@@ -80,6 +84,7 @@ $message = $requestHandler->handle($_POST ?? []);
                     methodSelectId,
                     trophyChildInputId,
                     trophyParentInputId,
+                    cloneInputId,
                     submitButtonId,
                     progressWrapperId,
                     progressBarId,
@@ -92,6 +97,7 @@ $message = $requestHandler->handle($_POST ?? []);
                     this.methodSelect = document.getElementById(methodSelectId);
                     this.trophyChildInput = document.getElementById(trophyChildInputId);
                     this.trophyParentInput = document.getElementById(trophyParentInputId);
+                    this.cloneInput = document.getElementById(cloneInputId);
                     this.submitButton = document.getElementById(submitButtonId);
                     this.progressWrapper = document.getElementById(progressWrapperId);
                     this.progressBar = document.getElementById(progressBarId);
@@ -117,6 +123,7 @@ $message = $requestHandler->handle($_POST ?? []);
                         this.progressBar,
                         this.progressMessage,
                         this.resultContainer,
+                        this.cloneInput,
                     ].every((element) => element instanceof HTMLElement);
                 }
 
@@ -149,6 +156,11 @@ $message = $requestHandler->handle($_POST ?? []);
                     const parentValue = (this.parentInput?.value || '').trim();
                     const trophyParentValue = (this.trophyParentInput?.value || '').trim();
                     const trophyChildValue = (this.trophyChildInput?.value || '').trim();
+                    const cloneValue = (this.cloneInput?.value || '').trim();
+
+                    if (cloneValue !== '') {
+                        return false;
+                    }
 
                     if (trophyParentValue !== '' || trophyChildValue !== '') {
                         return false;
@@ -473,6 +485,7 @@ $message = $requestHandler->handle($_POST ?? []);
                 methodSelectId: 'merge-method',
                 trophyChildInputId: 'merge-trophy-child',
                 trophyParentInputId: 'merge-trophy-parent',
+                cloneInputId: 'merge-clone',
                 submitButtonId: 'merge-submit',
                 progressWrapperId: 'merge-progress-wrapper',
                 progressBarId: 'merge-progress-bar',

--- a/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
+++ b/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
@@ -24,12 +24,12 @@ class TrophyMergeRequestHandler
                 return $this->handleSpecificTrophyMerge($postData);
             }
 
-            if ($this->isGameMerge($postData)) {
-                return $this->handleGameMerge($postData);
-            }
-
             if ($this->isCloneRequest($postData)) {
                 return $this->handleCloneRequest($postData);
+            }
+
+            if ($this->isGameMerge($postData)) {
+                return $this->handleGameMerge($postData);
             }
         } catch (InvalidArgumentException | RuntimeException $exception) {
             return $exception->getMessage();
@@ -115,14 +115,14 @@ class TrophyMergeRequestHandler
 
     private function isCloneRequest(array $postData): bool
     {
-        return $this->isNumericValueFromArray($postData, 'child');
+        return $this->isNumericValueFromArray($postData, 'clone');
     }
 
     private function handleCloneRequest(array $postData): string
     {
-        $childId = (int) $postData['child'];
+        $cloneId = (int) $postData['clone'];
 
-        return $this->trophyMergeService->cloneGame($childId);
+        return $this->trophyMergeService->cloneGame($cloneId);
     }
 
     private function isNumericValueFromArray(array $values, string $key): bool


### PR DESCRIPTION
## Summary
- add a dedicated Clone Game ID field to the admin merge form
- update the merge form controller to skip async processing when the clone field is used
- adjust the merge request handler to read clone requests from the new field

## Testing
- php -l wwwroot/admin/merge.php
- php -l wwwroot/classes/Admin/TrophyMergeRequestHandler.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_690561f93834832fa9d0579aff56c57b