### PR TITLE
Limit changelog notifications to new trophies

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -837,16 +837,12 @@ class ThirtyMinuteCronJob implements CronJobInterface
                                     $query->execute();
 
                                     $trophyAffectedRows = (int) $query->rowCount();
+
                                     if ($trophyAffectedRows > 0) {
                                         $trophyDataChanged = true;
                                     }
+
                                     if ($trophyAffectedRows === 1) {
-                                        $newTrophies = true;
-                                        $groupNewTrophies = true;
-                                    } elseif ($trophyAffectedRows === 2) {
-                                        // MySQL returns 2 when an ON DUPLICATE KEY UPDATE statement
-                                        // updates an existing row with new data. Treat that as a set
-                                        // revision so downstream change notifications still fire.
                                         $newTrophies = true;
                                         $groupNewTrophies = true;
                                     }


### PR DESCRIPTION
## Summary
- only treat inserted trophies as new content during the thirty-minute cron job
- avoid emitting GAME_VERSION changelog entries when existing trophies are revised

## Testing
- php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6905657fb3ac832f804033eabfd2b2fd