### PR TITLE
Filter game history to show only new information

### DIFF
--- a/tests/GameHistoryPageTest.php
+++ b/tests/GameHistoryPageTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/GameHistoryPage.php';
+
+final class GameHistoryPageTest extends TestCase
+{
+    public function testGetHistoryEntriesOmitsUnchangedRowsAndHighlightsDifferences(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $database->exec('CREATE TABLE trophy_title_history (id INTEGER PRIMARY KEY AUTOINCREMENT, trophy_title_id INTEGER, detail TEXT, icon_url TEXT, set_version TEXT, discovered_at TEXT)');
+        $database->exec('CREATE TABLE trophy_group_history (title_history_id INTEGER, group_id TEXT, name TEXT, detail TEXT, icon_url TEXT)');
+        $database->exec('CREATE TABLE trophy_history (title_history_id INTEGER, group_id TEXT, order_id INTEGER, name TEXT, detail TEXT, icon_url TEXT, progress_target_value INTEGER)');
+
+        $database->exec("INSERT INTO trophy_title_history (id, trophy_title_id, detail, icon_url, set_version, discovered_at) VALUES (1, 42, 'Initial detail', 'icon-a.png', '01.00', '2024-01-01 00:00:00')");
+        $database->exec("INSERT INTO trophy_title_history (id, trophy_title_id, detail, icon_url, set_version, discovered_at) VALUES (2, 42, NULL, NULL, '01.05', '2024-02-01 00:00:00')");
+        $database->exec("INSERT INTO trophy_title_history (id, trophy_title_id, detail, icon_url, set_version, discovered_at) VALUES (3, 42, NULL, NULL, '01.10', '2024-03-05 00:00:00')");
+        $database->exec("INSERT INTO trophy_title_history (id, trophy_title_id, detail, icon_url, set_version, discovered_at) VALUES (4, 42, NULL, NULL, '01.10', '2024-04-01 00:00:00')");
+
+        $database->exec("INSERT INTO trophy_group_history (title_history_id, group_id, name, detail, icon_url) VALUES (1, 'default', 'Base', 'Base detail', 'group-a.png')");
+        $database->exec("INSERT INTO trophy_group_history (title_history_id, group_id, name, detail, icon_url) VALUES (2, 'default', 'Base', 'Base detail', 'group-a.png')");
+        $database->exec("INSERT INTO trophy_group_history (title_history_id, group_id, name, detail, icon_url) VALUES (2, '001', 'Expansion', 'Expansion detail', '.png')");
+        $database->exec("INSERT INTO trophy_group_history (title_history_id, group_id, name, detail, icon_url) VALUES (3, 'default', 'Base', 'Base detail', 'group-a.png')");
+        $database->exec("INSERT INTO trophy_group_history (title_history_id, group_id, name, detail, icon_url) VALUES (3, '001', 'Expansion', 'Expansion detail', '.png')");
+        $database->exec("INSERT INTO trophy_group_history (title_history_id, group_id, name, detail, icon_url) VALUES (4, 'default', 'Base', 'Base detail', 'group-a.png')");
+        $database->exec("INSERT INTO trophy_group_history (title_history_id, group_id, name, detail, icon_url) VALUES (4, '001', 'Expansion', 'Expansion detail', '.png')");
+
+        $database->exec("INSERT INTO trophy_history (title_history_id, group_id, order_id, name, detail, icon_url, progress_target_value) VALUES (1, 'default', 1, 'First Trophy', 'Earn it', 'trophy-a.png', NULL)");
+        $database->exec("INSERT INTO trophy_history (title_history_id, group_id, order_id, name, detail, icon_url, progress_target_value) VALUES (2, 'default', 1, 'First Trophy', 'Earn it', 'trophy-a.png', NULL)");
+        $database->exec("INSERT INTO trophy_history (title_history_id, group_id, order_id, name, detail, icon_url, progress_target_value) VALUES (2, '001', 5, 'Challenger', 'Reach level 5', '.png', 50)");
+        $database->exec("INSERT INTO trophy_history (title_history_id, group_id, order_id, name, detail, icon_url, progress_target_value) VALUES (3, 'default', 1, 'First Trophy', 'Earn it', 'trophy-a.png', NULL)");
+        $database->exec("INSERT INTO trophy_history (title_history_id, group_id, order_id, name, detail, icon_url, progress_target_value) VALUES (3, '001', 5, 'Challenger', 'Reach level 5', '.png', 100)");
+        $database->exec("INSERT INTO trophy_history (title_history_id, group_id, order_id, name, detail, icon_url, progress_target_value) VALUES (4, 'default', 1, 'First Trophy', 'Earn it', 'trophy-a.png', NULL)");
+        $database->exec("INSERT INTO trophy_history (title_history_id, group_id, order_id, name, detail, icon_url, progress_target_value) VALUES (4, '001', 5, 'Challenger', 'Reach level 5', '.png', 100)");
+
+        $game = GameDetails::fromArray([
+            'id' => 42,
+            'name' => 'Example Game',
+            'np_communication_id' => 'NPWR12345_00',
+            'detail' => 'Detail',
+            'icon_url' => 'icon.png',
+            'platform' => 'PS5',
+            'bronze' => 10,
+            'silver' => 5,
+            'gold' => 2,
+            'platinum' => 1,
+            'set_version' => '01.00',
+            'message' => null,
+            'status' => 0,
+            'recent_players' => 0,
+            'owners_completed' => 0,
+            'owners' => 0,
+            'difficulty' => '0',
+            'psnprofiles_id' => null,
+            'parent_np_communication_id' => null,
+            'region' => null,
+            'rarity_points' => 0,
+        ]);
+
+        $gameService = new class ($game) extends GameService {
+            private GameDetails $game;
+
+            public function __construct(GameDetails $game)
+            {
+                $this->game = $game;
+            }
+
+            public function getGame(int $gameId): ?GameDetails
+            {
+                return $this->game;
+            }
+        };
+
+        $historyService = new GameHistoryService($database);
+
+        $headerService = new class extends GameHeaderService {
+            public function __construct()
+            {
+            }
+
+            public function buildHeaderData(GameDetails $game): GameHeaderData
+            {
+                return new GameHeaderData(null, [], 0);
+            }
+        };
+
+        $page = new GameHistoryPage(
+            $gameService,
+            $historyService,
+            $headerService,
+            new Utility(),
+            42
+        );
+
+        $entries = $page->getHistoryEntries();
+
+        $this->assertCount(3, $entries);
+        $this->assertSame([3, 2, 1], array_column($entries, 'historyId'));
+
+        $latestEntry = $entries[0];
+        $this->assertTrue($latestEntry['hasTitleChanges']);
+        $this->assertTrue($latestEntry['titleHighlights']['set_version']);
+        $this->assertFalse($latestEntry['titleHighlights']['detail']);
+        $this->assertSame([], $latestEntry['groups']);
+        $this->assertCount(1, $latestEntry['trophies']);
+        $this->assertTrue($latestEntry['trophies'][0]['changedFields']['progress_target_value']);
+
+        $midEntry = $entries[1];
+        $this->assertTrue($midEntry['hasTitleChanges']);
+        $this->assertTrue($midEntry['titleHighlights']['set_version']);
+        $this->assertCount(1, $midEntry['groups']);
+        $this->assertTrue($midEntry['groups'][0]['isNewRow']);
+        $this->assertCount(1, $midEntry['trophies']);
+        $this->assertTrue($midEntry['trophies'][0]['isNewRow']);
+
+        $earliestEntry = $entries[2];
+        $this->assertTrue($earliestEntry['hasTitleChanges']);
+        $this->assertTrue($earliestEntry['titleHighlights']['icon_url']);
+        $this->assertTrue($earliestEntry['titleHighlights']['detail']);
+        $this->assertCount(1, $earliestEntry['groups']);
+        $this->assertTrue($earliestEntry['groups'][0]['isNewRow']);
+        $this->assertCount(1, $earliestEntry['trophies']);
+        $this->assertTrue($earliestEntry['trophies'][0]['isNewRow']);
+    }
+}

--- a/wwwroot/game_history.php
+++ b/wwwroot/game_history.php
@@ -67,35 +67,44 @@ require_once 'header.php';
                             <div>
                                 <?php
                                 $titleChange = $entry['title'] ?? null;
+                                $titleHighlights = $entry['titleHighlights'] ?? ['detail' => false, 'icon_url' => false, 'set_version' => false];
+                                $hasTitleChanges = $entry['hasTitleChanges'] ?? false;
                                 $setVersion = $titleChange['set_version'] ?? null;
                                 ?>
-                                <span class="fw-semibold">Version <?= htmlentities($setVersion ?? 'Unknown', ENT_QUOTES, 'UTF-8'); ?></span>
+                                <span class="fw-semibold">
+                                    Version <?= htmlentities($setVersion ?? 'Unknown', ENT_QUOTES, 'UTF-8'); ?>
+                                    <?php if ($titleHighlights['set_version'] ?? false) { ?>
+                                        <span class="badge text-bg-success ms-2">New</span>
+                                    <?php } ?>
+                                </span>
                             </div>
                             <div class="text-body-secondary small">
                                 <?= htmlentities($entry['discoveredAt']->format('Y-m-d H:i:s'), ENT_QUOTES, 'UTF-8'); ?> UTC
                             </div>
                         </div>
                         <div class="card-body">
-                            <?php if ($titleChange !== null) { ?>
+                            <?php if ($titleChange !== null && $hasTitleChanges && (($titleHighlights['detail'] ?? false) || ($titleHighlights['icon_url'] ?? false))) { ?>
                                 <div class="row g-3 align-items-center mb-3">
-                                    <div class="col-12 col-md-2 text-center text-md-start">
-                                        <?php
-                                        $iconUrl = $titleChange['icon_url'] ?? '';
-                                        $iconPath = ($iconUrl === '.png')
-                                            ? ((str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2'))
-                                                ? '../missing-ps5-game-and-trophy.png'
-                                                : '../missing-ps4-game.png')
-                                            : $iconUrl;
-                                        ?>
-                                        <img class="object-fit-scale" style="height: 5.5rem;" src="/img/title/<?= htmlentities($iconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($game->getName(), ENT_QUOTES, 'UTF-8'); ?>">
-                                    </div>
-                                    <div class="col-12 col-md-10">
-                                        <?php if (($titleChange['detail'] ?? '') !== '') { ?>
-                                            <div><?= nl2br(htmlentities((string) $titleChange['detail'], ENT_QUOTES, 'UTF-8')); ?></div>
-                                        <?php } else { ?>
-                                            <div class="text-body-secondary"><em>No title detail provided.</em></div>
-                                        <?php } ?>
-                                    </div>
+                                    <?php if ($titleHighlights['icon_url'] ?? false) { ?>
+                                        <div class="col-12 col-md-2 text-center text-md-start">
+                                            <?php
+                                            $iconUrl = $titleChange['icon_url'] ?? '';
+                                            $iconPath = ($iconUrl === '.png')
+                                                ? ((str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2'))
+                                                    ? '../missing-ps5-game-and-trophy.png'
+                                                    : '../missing-ps4-game.png')
+                                                : $iconUrl;
+                                            ?>
+                                            <img class="object-fit-scale border border-success border-2 rounded" style="height: 5.5rem;" src="/img/title/<?= htmlentities($iconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($game->getName(), ENT_QUOTES, 'UTF-8'); ?>">
+                                        </div>
+                                    <?php } ?>
+                                    <?php if ($titleHighlights['detail'] ?? false) { ?>
+                                        <div class="col-12 <?= ($titleHighlights['icon_url'] ?? false) ? 'col-md-10' : 'col-md-12'; ?>">
+                                            <div class="p-2 border border-success rounded bg-success-subtle text-success-emphasis">
+                                                <?= nl2br(htmlentities((string) $titleChange['detail'], ENT_QUOTES, 'UTF-8')); ?>
+                                            </div>
+                                        </div>
+                                    <?php } ?>
                                 </div>
                             <?php } ?>
 
@@ -115,11 +124,18 @@ require_once 'header.php';
                                             </thead>
                                             <tbody>
                                                 <?php foreach ($groupChanges as $groupChange) { ?>
-                                                    <tr>
-                                                        <td><span class="badge text-bg-secondary"><?= htmlentities($groupChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span></td>
-                                                        <td><?= htmlentities($groupChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
-                                                        <td><?= nl2br(htmlentities($groupChange['detail'] ?? '', ENT_QUOTES, 'UTF-8')); ?></td>
-                                                        <td class="text-center">
+                                                    <?php $groupChangedFields = $groupChange['changedFields'] ?? ['name' => false, 'detail' => false, 'icon_url' => false]; ?>
+                                                    <tr class="<?= ($groupChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
+                                                        <td class="<?= ($groupChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
+                                                            <span class="badge text-bg-secondary"><?= htmlentities($groupChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span>
+                                                        </td>
+                                                        <td class="<?= (($groupChange['isNewRow'] ?? false) || ($groupChangedFields['name'] ?? false)) ? 'table-success' : ''; ?>">
+                                                            <?= htmlentities($groupChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                                                        </td>
+                                                        <td class="<?= (($groupChange['isNewRow'] ?? false) || ($groupChangedFields['detail'] ?? false)) ? 'table-success' : ''; ?>">
+                                                            <?= nl2br(htmlentities($groupChange['detail'] ?? '', ENT_QUOTES, 'UTF-8')); ?>
+                                                        </td>
+                                                        <td class="text-center <?= (($groupChange['isNewRow'] ?? false) || ($groupChangedFields['icon_url'] ?? false)) ? 'table-success' : ''; ?>">
                                                             <?php
                                                             $groupIconUrl = $groupChange['icon_url'] ?? '';
                                                             $groupIconPath = ($groupIconUrl === '.png')
@@ -128,7 +144,7 @@ require_once 'header.php';
                                                                     : '../missing-ps4-game.png')
                                                                 : $groupIconUrl;
                                                             ?>
-                                                            <img class="object-fit-cover" style="height: 3.5rem;" src="/img/group/<?= htmlentities($groupIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($groupChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                                                            <img class="object-fit-cover <?= (($groupChange['isNewRow'] ?? false) || ($groupChangedFields['icon_url'] ?? false)) ? 'border border-success border-2 rounded' : ''; ?>" style="height: 3.5rem;" src="/img/group/<?= htmlentities($groupIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($groupChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
                                                         </td>
                                                     </tr>
                                                 <?php } ?>
@@ -156,13 +172,22 @@ require_once 'header.php';
                                             </thead>
                                             <tbody>
                                                 <?php foreach ($trophyChanges as $trophyChange) { ?>
-                                                    <tr>
-                                                        <td><span class="badge text-bg-secondary"><?= htmlentities($trophyChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span></td>
-                                                        <td><?= (int) $trophyChange['order_id']; ?></td>
-                                                        <td><?= htmlentities($trophyChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
-                                                        <td><?= nl2br(htmlentities($trophyChange['detail'] ?? '', ENT_QUOTES, 'UTF-8')); ?></td>
-                                                        <td><?= $trophyChange['progress_target_value'] === null ? '&mdash;' : htmlentities((string) $trophyChange['progress_target_value'], ENT_QUOTES, 'UTF-8'); ?></td>
-                                                        <td class="text-center">
+                                                    <?php $trophyChangedFields = $trophyChange['changedFields'] ?? ['name' => false, 'detail' => false, 'icon_url' => false, 'progress_target_value' => false]; ?>
+                                                    <tr class="<?= ($trophyChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
+                                                        <td class="<?= ($trophyChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
+                                                            <span class="badge text-bg-secondary"><?= htmlentities($trophyChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span>
+                                                        </td>
+                                                        <td class="<?= ($trophyChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>"><?= (int) $trophyChange['order_id']; ?></td>
+                                                        <td class="<?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['name'] ?? false)) ? 'table-success' : ''; ?>">
+                                                            <?= htmlentities($trophyChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                                                        </td>
+                                                        <td class="<?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['detail'] ?? false)) ? 'table-success' : ''; ?>">
+                                                            <?= nl2br(htmlentities($trophyChange['detail'] ?? '', ENT_QUOTES, 'UTF-8')); ?>
+                                                        </td>
+                                                        <td class="<?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['progress_target_value'] ?? false)) ? 'table-success' : ''; ?>">
+                                                            <?= $trophyChange['progress_target_value'] === null ? '&mdash;' : htmlentities((string) $trophyChange['progress_target_value'], ENT_QUOTES, 'UTF-8'); ?>
+                                                        </td>
+                                                        <td class="text-center <?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['icon_url'] ?? false)) ? 'table-success' : ''; ?>">
                                                             <?php
                                                             $trophyIconUrl = $trophyChange['icon_url'] ?? '';
                                                             $trophyIconPath = ($trophyIconUrl === '.png')
@@ -171,7 +196,7 @@ require_once 'header.php';
                                                                     : '../missing-ps4-trophy.png')
                                                                 : $trophyIconUrl;
                                                             ?>
-                                                            <img class="object-fit-scale" style="height: 3.5rem;" src="/img/trophy/<?= htmlentities($trophyIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophyChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                                                            <img class="object-fit-scale <?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['icon_url'] ?? false)) ? 'border border-success border-2 rounded' : ''; ?>" style="height: 3.5rem;" src="/img/trophy/<?= htmlentities($trophyIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophyChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
                                                         </td>
                                                     </tr>
                                                 <?php } ?>


### PR DESCRIPTION
## Summary
- filter game history entries to only include cards with new trophy data
- highlight changed title, group, and trophy fields when rendering the history page
- add a regression test to cover the filtering and highlighting logic

## Testing
- php tests/run.php
- php -l wwwroot/classes/GameHistoryPage.php
- php -l wwwroot/game_history.php
- php -l tests/GameHistoryPageTest.php

------
https://chatgpt.com/codex/tasks/task_e_6905c62a9fbc832fb2fb7929d847c8e7