### PR TITLE
Add game history navigation link across game pages

### DIFF
--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -58,6 +58,7 @@ require_once("header.php");
                     <a class="btn btn-primary active" href="/game/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Trophies</a>
                     <a class="btn btn-outline-primary" href="/game-leaderboard/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Leaderboard</a>
                     <a class="btn btn-outline-primary" href="/game-recent-players/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Recent Players</a>
+                    <a class="btn btn-outline-primary" href="/game-history/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?>">History</a>
                 </div>
             </div>
 

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -124,12 +124,8 @@ require_once __DIR__ . '/classes/Game/GamePlayerProgress.php';
                 <div>
                     <?php
                     $region = $game->getRegion();
-                    $historyUrl = '/game-history/' . $game->getId() . '-' . $utility->slugify($game->getName());
                     ?>
-                    Version:
-                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlentities($historyUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                        <?= htmlentities($game->getSetVersion(), ENT_QUOTES, 'UTF-8'); ?>
-                    </a>
+                    Version: <?= htmlentities($game->getSetVersion(), ENT_QUOTES, 'UTF-8'); ?>
                     <?= ($region === null ? '' : " <span class=\"badge rounded-pill text-bg-primary\">" . htmlentities($region, ENT_QUOTES, 'UTF-8') . '</span>') ?>
                 </div>
 

--- a/wwwroot/game_leaderboard.php
+++ b/wwwroot/game_leaderboard.php
@@ -47,6 +47,7 @@ require_once("header.php");
                     <a class="btn btn-outline-primary" href="/game/<?= $gameSlug; ?><?= (isset($player) ? '/' . $player : ''); ?>">Trophies</a>
                     <a class="btn btn-primary active" href="/game-leaderboard/<?= $gameSlug; ?><?= (isset($player) ? '/' . $player : ''); ?>">Leaderboard</a>
                     <a class="btn btn-outline-primary" href="/game-recent-players/<?= $gameSlug; ?><?= (isset($player) ? '/' . $player : ''); ?>">Recent Players</a>
+                    <a class="btn btn-outline-primary" href="/game-history/<?= $gameSlug; ?>">History</a>
                 </div>
             </div>
 

--- a/wwwroot/game_recent_players.php
+++ b/wwwroot/game_recent_players.php
@@ -44,6 +44,7 @@ require_once("header.php");
                     <a class="btn btn-outline-primary" href="/game/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Trophies</a>
                     <a class="btn btn-outline-primary" href="/game-leaderboard/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Leaderboard</a>
                     <a class="btn btn-primary active" href="/game-recent-players/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Recent Players</a>
+                    <a class="btn btn-outline-primary" href="/game-history/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?>">History</a>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- add a History button to the game navigation bar on the trophies, leaderboard, and recent players views
- keep the version number static in the game header now that the history link lives in navigation

## Testing
- php -l wwwroot/game_header.php
- php -l wwwroot/game.php
- php -l wwwroot/game_leaderboard.php
- php -l wwwroot/game_recent_players.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6905d47f0f0c832faaca27836257e7b1