### PR TITLE
Update cron job image hash naming

### DIFF
--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/GameRescanProgressListener.php';
 require_once __DIR__ . '/GameRescanDifferenceTracker.php';
 require_once __DIR__ . '/GameRescanResult.php';
+require_once __DIR__ . '/../ImageHashCalculator.php';
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../TrophyMetaRepository.php';
 
@@ -1004,7 +1005,10 @@ class GameRescanService
 
     private function buildFilename(string $url, string $contents): string
     {
-        $hash = md5($contents);
+        $hash = ImageHashCalculator::calculate($contents);
+        if ($hash === null) {
+            $hash = md5($contents);
+        }
         $extensionPosition = strrpos($url, '.');
         $extension = $extensionPosition === false ? '' : strtolower(substr($url, $extensionPosition));
 

--- a/wwwroot/classes/ImageHashCalculator.php
+++ b/wwwroot/classes/ImageHashCalculator.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+class ImageHashCalculator
+{
+    public static function calculate(string $contents): ?string
+    {
+        if ($contents === '') {
+            return null;
+        }
+
+        if (!extension_loaded('gd')) {
+            return null;
+        }
+
+        try {
+            $image = @imagecreatefromstring($contents);
+        } catch (\ValueError $exception) {
+            return null;
+        }
+
+        if ($image === false) {
+            return null;
+        }
+
+        $width = imagesx($image);
+        $height = imagesy($image);
+
+        if ($width <= 0 || $height <= 0) {
+            imagedestroy($image);
+
+            return null;
+        }
+
+        if (!imageistruecolor($image)) {
+            @imagepalettetotruecolor($image);
+        }
+
+        $hasTransparency = false;
+
+        for ($y = 0; $y < $height && !$hasTransparency; $y++) {
+            for ($x = 0; $x < $width; $x++) {
+                $color = imagecolorat($image, $x, $y);
+                $components = imagecolorsforindex($image, $color);
+
+                if (($components['alpha'] ?? 0) > 0) {
+                    $hasTransparency = true;
+                    break;
+                }
+            }
+        }
+
+        $buffer = '';
+
+        for ($y = 0; $y < $height; $y++) {
+            for ($x = 0; $x < $width; $x++) {
+                $color = imagecolorat($image, $x, $y);
+                $components = imagecolorsforindex($image, $color);
+
+                $buffer .= chr($components['red']);
+                $buffer .= chr($components['green']);
+                $buffer .= chr($components['blue']);
+
+                if ($hasTransparency) {
+                    $alpha = (int) round(($components['alpha'] ?? 0) * 255 / 127);
+                    if ($alpha < 0) {
+                        $alpha = 0;
+                    } elseif ($alpha > 255) {
+                        $alpha = 255;
+                    }
+
+                    $buffer .= chr($alpha);
+                }
+            }
+        }
+
+        imagedestroy($image);
+
+        if ($buffer === '') {
+            return null;
+        }
+
+        return md5($buffer);
+    }
+}


### PR DESCRIPTION
## Summary
- make the thirty-minute cron job reuse the pixel-based hash when naming cached images

## Testing
- php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_690624506a68832faf25e3582ea3570c