### PR TITLE
Normalize trophy hidden flag handling

### DIFF
--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -440,6 +440,7 @@ class GameRescanService
 
             foreach ($data['trophies'] as $trophy) {
                 $orderId = (int) $trophy->id();
+                $trophyHidden = (int) $trophy->hidden();
                 $existingTrophy = $existingTrophyData[$groupId][$orderId] ?? [
                     'hidden' => null,
                     'type' => null,
@@ -475,7 +476,7 @@ class GameRescanService
                     $trophyContextLabel,
                     'Hidden',
                     $existingTrophy['hidden'],
-                    (int) $trophy->hidden()
+                    $trophyHidden
                 );
                 $differenceTracker->recordTrophyChange(
                     $groupId,
@@ -702,7 +703,7 @@ class GameRescanService
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
         $query->bindValue(':order_id', $trophy->id(), PDO::PARAM_INT);
-        $query->bindValue(':hidden', $trophy->hidden(), PDO::PARAM_INT);
+        $query->bindValue(':hidden', (int) $trophy->hidden(), PDO::PARAM_INT);
         $query->bindValue(':type', $trophy->type()->value, PDO::PARAM_STR);
         $query->bindValue(':name', $trophy->name(), PDO::PARAM_STR);
         $query->bindValue(':detail', $trophy->detail(), PDO::PARAM_STR);

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -710,6 +710,8 @@ class ThirtyMinuteCronJob implements CronJobInterface
                                 $existingTrophyQuery->execute();
                                 $existingTrophy = $existingTrophyQuery->fetch(PDO::FETCH_ASSOC) ?: null;
 
+                                $trophyHidden = (int) $trophy->hidden();
+
                                 $progressTargetValue = $trophy->progressTargetValue() === ''
                                     ? null
                                     : $trophy->progressTargetValue();
@@ -735,7 +737,7 @@ class ThirtyMinuteCronJob implements CronJobInterface
                                 $trophyTypeEnumValue = $trophy->type()->value;
 
                                 $trophyNeedsUpdate = $existingTrophy === null
-                                    || (int) ($existingTrophy['hidden'] ?? -1) !== $trophy->hidden()
+                                    || (int) ($existingTrophy['hidden'] ?? -1) !== $trophyHidden
                                     || ($existingTrophy['type'] ?? '') !== $trophyTypeEnumValue
                                     || ($existingTrophy['name'] ?? '') !== $trophy->name()
                                     || ($existingTrophy['detail'] ?? '') !== $trophy->detail()
@@ -839,7 +841,7 @@ class ThirtyMinuteCronJob implements CronJobInterface
                                     $query->bindValue(":np_communication_id", $npid, PDO::PARAM_STR);
                                     $query->bindValue(":group_id", $trophyGroup->id(), PDO::PARAM_STR);
                                     $query->bindValue(":order_id", $trophy->id(), PDO::PARAM_INT);
-                                    $query->bindValue(":hidden", $trophy->hidden(), PDO::PARAM_INT);
+                                    $query->bindValue(":hidden", $trophyHidden, PDO::PARAM_INT);
                                     $query->bindValue(":type", $trophyTypeEnumValue, PDO::PARAM_STR);
                                     $query->bindValue(":name", $trophy->name(), PDO::PARAM_STR);
                                     $query->bindValue(":detail", $trophy->detail(), PDO::PARAM_STR);


### PR DESCRIPTION
## Summary
- coerce trophy hidden flag values to integers before comparing or binding trophies in the cron worker
- reuse the normalized hidden flag when logging trophy changes during admin rescans

## Testing
- php tests/run.php
- php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php
- php -l wwwroot/classes/Admin/GameRescanService.php

------
https://chatgpt.com/codex/tasks/task_e_690632913a78832fab6303ebf772619c