### PR TITLE
Log trophy title history insertions

### DIFF
--- a/wwwroot/classes/TrophyHistoryRecorder.php
+++ b/wwwroot/classes/TrophyHistoryRecorder.php
@@ -53,6 +53,14 @@ class TrophyHistoryRecorder
 
             $titleHistoryId = (int) $this->database->lastInsertId();
 
+            if ($this->logger !== null) {
+                $this->logger->log(sprintf(
+                    'Recorded new trophy_title_history entry %d for trophy_title.id %d',
+                    $titleHistoryId,
+                    $titleId
+                ));
+            }
+
             $this->recordHistorySnapshotChange($titleId);
 
             $groupSelect = $this->database->prepare(


### PR DESCRIPTION
## Summary
- add a logger message that records each trophy_title_history insertion, including the associated trophy_title id

## Testing
- php -l wwwroot/classes/TrophyHistoryRecorder.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_690718344720832f99a5590b46688d14