### PR TITLE
Add bulk deletion controls to admin log page

### DIFF
--- a/tests/AdminLogPageTest.php
+++ b/tests/AdminLogPageTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/Admin/LogEntryFormatter.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/LogService.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/LogPage.php';
+require_once __DIR__ . '/../wwwroot/classes/Utility.php';
+
+final class AdminLogPageTest extends TestCase
+{
+    public function testHandleDeletesMultipleLogEntries(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE trophy_title (id INTEGER PRIMARY KEY, np_communication_id TEXT, name TEXT)');
+        $database->exec('CREATE TABLE log (id INTEGER PRIMARY KEY AUTOINCREMENT, time TEXT, message TEXT)');
+
+        $database->exec("INSERT INTO trophy_title (id, np_communication_id, name) VALUES (1, 'NPWR00001_00', 'Example Game')");
+        $database->exec("INSERT INTO log (time, message) VALUES ('2024-05-01 10:00:00', 'First entry for deletion test')");
+        $database->exec("INSERT INTO log (time, message) VALUES ('2024-05-01 11:00:00', 'Second entry for deletion test')");
+        $database->exec("INSERT INTO log (time, message) VALUES ('2024-05-01 12:00:00', 'Third entry for deletion test')");
+
+        $formatter = new LogEntryFormatter($database, new Utility());
+        $service = new LogService($database, $formatter);
+        $page = new LogPage($service, 10);
+
+        $result = $page->handle([], ['delete_ids' => ['1', '2', 'invalid', '2'], 'delete_selected' => '1'], 'POST');
+
+        $this->assertSame('Deleted 2 log entries (IDs: 1, 2).', $result->getSuccessMessage());
+        $this->assertSame(null, $result->getErrorMessage());
+        $this->assertSame(1, $service->countEntries());
+    }
+
+    public function testHandleReportsWhenNoSelectedEntriesAreDeleted(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE trophy_title (id INTEGER PRIMARY KEY, np_communication_id TEXT, name TEXT)');
+        $database->exec('CREATE TABLE log (id INTEGER PRIMARY KEY AUTOINCREMENT, time TEXT, message TEXT)');
+
+        $database->exec("INSERT INTO trophy_title (id, np_communication_id, name) VALUES (5, 'NPWR00005_00', 'Example Game 5')");
+        $database->exec("INSERT INTO log (time, message) VALUES ('2024-05-01 10:00:00', 'Only entry remaining after failed delete')");
+
+        $formatter = new LogEntryFormatter($database, new Utility());
+        $service = new LogService($database, $formatter);
+        $page = new LogPage($service, 10);
+
+        $result = $page->handle([], ['delete_ids' => ['99', '0', 'abc'], 'delete_selected' => '1'], 'POST');
+
+        $this->assertSame('No matching log entries were found for the selected IDs.', $result->getErrorMessage());
+        $this->assertSame(null, $result->getSuccessMessage());
+        $this->assertSame(1, $service->countEntries());
+    }
+}

--- a/wwwroot/admin/log.php
+++ b/wwwroot/admin/log.php
@@ -59,38 +59,62 @@ if ($pageResult->getTotalPages() > 1) {
             <?php if ($pageResult->getEntries() === []) { ?>
                 <div class="alert alert-info">No log entries found.</div>
             <?php } else { ?>
-                <div class="table-responsive">
-                    <table class="table table-striped table-bordered align-middle table-sm">
-                        <thead>
-                            <tr>
-                                <th scope="col" style="width: 6rem;">ID</th>
-                                <th scope="col" style="width: 14rem;">Time</th>
-                                <th scope="col">Message</th>
-                                <th scope="col" class="text-center" style="width: 6rem;">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <?php foreach ($pageResult->getEntries() as $entry) { ?>
+                <form method="post" id="log-entries-form">
+                    <div class="d-flex justify-content-end align-items-center mb-2 gap-2">
+                        <button type="submit" name="delete_selected" value="1" class="btn btn-sm btn-danger" id="delete-selected-button" disabled>
+                            Delete selected
+                        </button>
+                    </div>
+
+                    <div class="table-responsive">
+                        <table class="table table-striped table-bordered align-middle table-sm">
+                            <thead>
                                 <tr>
-                                    <td class="text-nowrap">#<?= htmlspecialchars((string) $entry->getId(), ENT_QUOTES, 'UTF-8'); ?></td>
-                                    <td>
-                                        <?php $time = $entry->getTime(); ?>
-                                        <time class="small text-body-secondary js-localized-datetime" datetime="<?= htmlspecialchars($time->format(DATE_ATOM), ENT_QUOTES, 'UTF-8'); ?>">
-                                            <?= htmlspecialchars($time->format('Y-m-d H:i:s T'), ENT_QUOTES, 'UTF-8'); ?>
-                                        </time>
-                                    </td>
-                                    <td><?= $entry->getFormattedMessage(); ?></td>
-                                    <td class="text-center">
-                                        <form method="post" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this log entry?');">
-                                            <input type="hidden" name="delete_id" value="<?= htmlspecialchars((string) $entry->getId(), ENT_QUOTES, 'UTF-8'); ?>">
-                                            <button type="submit" class="btn btn-sm btn-danger">Delete</button>
-                                        </form>
-                                    </td>
+                                    <th scope="col" class="text-center" style="width: 3rem;">
+                                        <input type="checkbox" class="form-check-input" id="select-all-log-entries">
+                                    </th>
+                                    <th scope="col" style="width: 6rem;">ID</th>
+                                    <th scope="col" style="width: 14rem;">Time</th>
+                                    <th scope="col">Message</th>
+                                    <th scope="col" class="text-center" style="width: 6rem;">Actions</th>
                                 </tr>
-                            <?php } ?>
-                        </tbody>
-                    </table>
-                </div>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($pageResult->getEntries() as $entry) { ?>
+                                    <tr>
+                                        <td class="text-center">
+                                            <input
+                                                type="checkbox"
+                                                class="form-check-input js-log-checkbox"
+                                                name="delete_ids[]"
+                                                value="<?= htmlspecialchars((string) $entry->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                aria-label="Select log entry #<?= htmlspecialchars((string) $entry->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                            >
+                                        </td>
+                                        <td class="text-nowrap">#<?= htmlspecialchars((string) $entry->getId(), ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td>
+                                            <?php $time = $entry->getTime(); ?>
+                                            <time class="small text-body-secondary js-localized-datetime" datetime="<?= htmlspecialchars($time->format(DATE_ATOM), ENT_QUOTES, 'UTF-8'); ?>">
+                                                <?= htmlspecialchars($time->format('Y-m-d H:i:s T'), ENT_QUOTES, 'UTF-8'); ?>
+                                            </time>
+                                        </td>
+                                        <td><?= $entry->getFormattedMessage(); ?></td>
+                                        <td class="text-center">
+                                            <button
+                                                type="submit"
+                                                name="delete_id"
+                                                value="<?= htmlspecialchars((string) $entry->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                class="btn btn-sm btn-danger js-log-delete-button"
+                                            >
+                                                Delete
+                                            </button>
+                                        </td>
+                                    </tr>
+                                <?php } ?>
+                            </tbody>
+                        </table>
+                    </div>
+                </form>
             <?php } ?>
 
             <?php if ($pagination !== '') { ?>
@@ -99,31 +123,106 @@ if ($pageResult->getTotalPages() > 1) {
         </div>
         <script>
             document.addEventListener('DOMContentLoaded', () => {
-                if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat !== 'function') {
+                if (typeof Intl === 'object' && typeof Intl.DateTimeFormat === 'function') {
+                    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? '';
+                    const pad = (value) => value.toString().padStart(2, '0');
+
+                    document.querySelectorAll('.js-localized-datetime').forEach((timeElement) => {
+                        const isoString = timeElement.getAttribute('datetime');
+
+                        if (!isoString) {
+                            return;
+                        }
+
+                        const date = new Date(isoString);
+
+                        if (Number.isNaN(date.getTime())) {
+                            return;
+                        }
+
+                        const formattedDate = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+                        const formattedTime = `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+
+                        timeElement.textContent = `${formattedDate} ${formattedTime}${timeZone ? ` ${timeZone}` : ''}`;
+                        timeElement.setAttribute('data-timezone', timeZone);
+                    });
+                }
+
+                const form = document.getElementById('log-entries-form');
+
+                if (!(form instanceof HTMLFormElement)) {
                     return;
                 }
 
-                const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? '';
-                const pad = (value) => value.toString().padStart(2, '0');
+                const selectAllCheckbox = document.getElementById('select-all-log-entries');
+                const deleteSelectedButton = document.getElementById('delete-selected-button');
+                const logCheckboxes = Array.from(form.querySelectorAll('.js-log-checkbox'))
+                    .filter((element) => element instanceof HTMLInputElement);
 
-                document.querySelectorAll('.js-localized-datetime').forEach((timeElement) => {
-                    const isoString = timeElement.getAttribute('datetime');
-
-                    if (!isoString) {
+                const updateBulkDeleteState = () => {
+                    if (!(deleteSelectedButton instanceof HTMLButtonElement)) {
                         return;
                     }
 
-                    const date = new Date(isoString);
+                    const selectedCount = logCheckboxes.filter((checkbox) => checkbox.checked).length;
 
-                    if (Number.isNaN(date.getTime())) {
-                        return;
+                    deleteSelectedButton.disabled = selectedCount === 0;
+
+                    if (selectAllCheckbox instanceof HTMLInputElement) {
+                        if (logCheckboxes.length === 0) {
+                            selectAllCheckbox.checked = false;
+                            selectAllCheckbox.indeterminate = false;
+                        } else if (selectedCount === 0) {
+                            selectAllCheckbox.checked = false;
+                            selectAllCheckbox.indeterminate = false;
+                        } else if (selectedCount === logCheckboxes.length) {
+                            selectAllCheckbox.checked = true;
+                            selectAllCheckbox.indeterminate = false;
+                        } else {
+                            selectAllCheckbox.checked = false;
+                            selectAllCheckbox.indeterminate = true;
+                        }
                     }
+                };
 
-                    const formattedDate = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
-                    const formattedTime = `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+                if (selectAllCheckbox instanceof HTMLInputElement) {
+                    selectAllCheckbox.addEventListener('change', () => {
+                        logCheckboxes.forEach((checkbox) => {
+                            checkbox.checked = selectAllCheckbox.checked;
+                        });
 
-                    timeElement.textContent = `${formattedDate} ${formattedTime}${timeZone ? ` ${timeZone}` : ''}`;
-                    timeElement.setAttribute('data-timezone', timeZone);
+                        updateBulkDeleteState();
+                    });
+                }
+
+                logCheckboxes.forEach((checkbox) => {
+                    checkbox.addEventListener('change', updateBulkDeleteState);
+                });
+
+                updateBulkDeleteState();
+
+                if (deleteSelectedButton instanceof HTMLButtonElement) {
+                    deleteSelectedButton.addEventListener('click', (event) => {
+                        const hasSelection = logCheckboxes.some((checkbox) => checkbox.checked);
+
+                        if (!hasSelection) {
+                            event.preventDefault();
+
+                            return;
+                        }
+
+                        if (!window.confirm('Are you sure you want to delete the selected log entries?')) {
+                            event.preventDefault();
+                        }
+                    });
+                }
+
+                form.querySelectorAll('.js-log-delete-button').forEach((button) => {
+                    button.addEventListener('click', (event) => {
+                        if (!window.confirm('Are you sure you want to delete this log entry?')) {
+                            event.preventDefault();
+                        }
+                    });
                 });
             });
         </script>


### PR DESCRIPTION
## Summary
- add bulk selection and deletion controls to the admin log table along with supporting client-side behaviour
- extend the admin log page logic and service layer to handle deleting multiple entries safely
- cover the new bulk deletion flow with dedicated tests for the log service and log page

## Testing
- php -l wwwroot/classes/Admin/LogService.php
- php -l wwwroot/classes/Admin/LogPage.php
- php -l wwwroot/admin/log.php
- php -l tests/AdminLogServiceTest.php
- php -l tests/AdminLogPageTest.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6907d1cdd4b4832f99a31b6b1bb09b1b