### PR TITLE
Avoid copying trophy rarity metadata when duplicating games

### DIFF
--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -162,11 +162,13 @@ class GameCopyService
         INSERT INTO
             trophy_meta (
                 trophy_id,
-                status
+                status,
+                rarity_name
             )
         SELECT
             parent.id,
-            tm.status
+            tm.status,
+            'NONE'
         FROM
             trophy parent
             INNER JOIN trophy t ON t.np_communication_id = :child_np_communication_id


### PR DESCRIPTION
## Summary
- stop copying rarity percentage, points, owners, and rarity name when mirroring trophy metadata
- leave status updates intact while relying on defaults for new trophy meta rows

## Testing
- php -l wwwroot/classes/Admin/GameCopyService.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6907db3dd030832fa75ffb33f8a4ca41