### PR TITLE
Add admin workers management page

### DIFF
--- a/tests/AdminWorkerServiceTest.php
+++ b/tests/AdminWorkerServiceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerService.php';
+
+final class AdminWorkerServiceTest extends TestCase
+{
+    public function testFetchWorkersOrdersByScanStart(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY AUTOINCREMENT, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_start TEXT)');
+
+        $database->exec("INSERT INTO setting (refresh_token, npsso, scanning, scan_start) VALUES ('token-2', 'npsso-2', 'player-two', '2024-01-02 10:00:00')");
+        $database->exec("INSERT INTO setting (refresh_token, npsso, scanning, scan_start) VALUES ('token-1', 'npsso-1', 'player-one', '2024-01-01 09:00:00')");
+        $database->exec("INSERT INTO setting (refresh_token, npsso, scanning, scan_start) VALUES ('token-3', 'npsso-3', '', '2024-01-03 08:00:00')");
+
+        $service = new WorkerService($database);
+        $workers = $service->fetchWorkers();
+
+        $this->assertCount(3, $workers);
+        $this->assertSame('token-1', $workers[0]->getRefreshToken());
+        $this->assertSame('token-2', $workers[1]->getRefreshToken());
+        $this->assertSame('token-3', $workers[2]->getRefreshToken());
+        $this->assertSame('player-one', $workers[0]->getScanning());
+        $this->assertSame('2024-01-01 09:00:00', $workers[0]->getScanStart()->format('Y-m-d H:i:s'));
+    }
+
+    public function testUpdateWorkerNpssoReturnsTrueWhenRowUpdated(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY AUTOINCREMENT, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_start TEXT)');
+        $database->exec("INSERT INTO setting (refresh_token, npsso, scanning, scan_start) VALUES ('token-1', 'old-npsso', 'player-one', '2024-01-01 09:00:00')");
+
+        $service = new WorkerService($database);
+        $this->assertTrue($service->updateWorkerNpsso(1, 'new-npsso'));
+
+        $statement = $database->query('SELECT npsso FROM setting WHERE id = 1');
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertSame('new-npsso', $row['npsso']);
+    }
+
+    public function testUpdateWorkerNpssoReturnsFalseWhenRowMissing(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY AUTOINCREMENT, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_start TEXT)');
+
+        $service = new WorkerService($database);
+        $this->assertFalse($service->updateWorkerNpsso(42, 'does-not-exist'));
+    }
+}

--- a/wwwroot/admin/workers.php
+++ b/wwwroot/admin/workers.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+require_once '../init.php';
+require_once '../classes/Admin/AdminRequest.php';
+require_once '../classes/Admin/WorkerService.php';
+
+$workerService = new WorkerService($database);
+$request = AdminRequest::fromGlobals($_SERVER ?? [], $_POST ?? []);
+
+$successMessage = null;
+$errorMessage = null;
+
+if ($request->isPost()) {
+    $workerId = $request->getPostPositiveInt('worker_id');
+    $npsso = $request->getPostString('npsso');
+
+    if ($workerId === null) {
+        $errorMessage = 'Invalid worker selected.';
+    } elseif ($npsso === '') {
+        $errorMessage = 'The NPSSO value cannot be empty.';
+    } elseif (strlen($npsso) > 64) {
+        $errorMessage = 'The NPSSO value must be 64 characters or fewer.';
+    } else {
+        try {
+            $updated = $workerService->updateWorkerNpsso($workerId, $npsso);
+
+            if ($updated) {
+                $successMessage = 'Worker NPSSO updated successfully.';
+            } else {
+                $errorMessage = 'Unable to update NPSSO. Please verify the worker still exists.';
+            }
+        } catch (Throwable $exception) {
+            $errorMessage = 'An unexpected error occurred while updating the NPSSO value.';
+        }
+    }
+}
+
+$workers = $workerService->fetchWorkers();
+?>
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <link
+            href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+            rel="stylesheet"
+            integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
+            crossorigin="anonymous"
+        >
+        <title>Admin ~ Workers</title>
+    </head>
+    <body>
+        <div class="container py-4">
+            <div class="mb-3">
+                <a href="/admin/">Back</a>
+            </div>
+
+            <?php if ($successMessage !== null) { ?>
+                <div class="alert alert-success" role="alert">
+                    <?= htmlspecialchars($successMessage, ENT_QUOTES, 'UTF-8'); ?>
+                </div>
+            <?php } ?>
+
+            <?php if ($errorMessage !== null) { ?>
+                <div class="alert alert-danger" role="alert">
+                    <?= htmlspecialchars($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
+                </div>
+            <?php } ?>
+
+            <?php if ($workers === []) { ?>
+                <div class="alert alert-info" role="alert">No workers were found.</div>
+            <?php } else { ?>
+                <div class="table-responsive">
+                    <table class="table table-striped table-bordered align-middle">
+                        <thead>
+                            <tr>
+                                <th scope="col" style="width: 4rem;">ID</th>
+                                <th scope="col">Refresh Token</th>
+                                <th scope="col" style="width: 18rem;">NPSSO</th>
+                                <th scope="col" style="width: 16rem;">Scanning</th>
+                                <th scope="col" style="width: 16rem;">Scan Start</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($workers as $worker) { ?>
+                                <?php
+                                $scanStart = $worker->getScanStart();
+                                $scanStartFormatted = htmlspecialchars($scanStart->format('Y-m-d H:i:s'), ENT_QUOTES, 'UTF-8');
+                                $scanning = $worker->getScanning();
+                                $scanningDisplay = htmlspecialchars($scanning, ENT_QUOTES, 'UTF-8');
+                                $scanningLink = $scanning !== '' ? '/player/' . rawurlencode($scanning) : null;
+                                ?>
+                                <tr>
+                                    <td class="text-nowrap">#<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?></td>
+                                    <td class="text-nowrap">
+                                        <code><?= htmlspecialchars($worker->getRefreshToken(), ENT_QUOTES, 'UTF-8'); ?></code>
+                                    </td>
+                                    <td>
+                                        <form method="post" class="d-flex gap-2 align-items-center" autocomplete="off">
+                                            <input type="hidden" name="worker_id" value="<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
+                                            <input
+                                                type="text"
+                                                name="npsso"
+                                                class="form-control form-control-sm"
+                                                value="<?= htmlspecialchars($worker->getNpsso(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                maxlength="64"
+                                            >
+                                            <button type="submit" class="btn btn-sm btn-primary">Save</button>
+                                        </form>
+                                    </td>
+                                    <td class="text-nowrap">
+                                        <?php if ($scanningLink !== null) { ?>
+                                            <a href="<?= htmlspecialchars($scanningLink, ENT_QUOTES, 'UTF-8'); ?>">
+                                                <?= $scanningDisplay; ?>
+                                            </a>
+                                        <?php } else { ?>
+                                            <span class="text-body-secondary">Idle</span>
+                                        <?php } ?>
+                                    </td>
+                                    <td class="text-nowrap">
+                                        <time datetime="<?= htmlspecialchars($scanStart->format(DATE_ATOM), ENT_QUOTES, 'UTF-8'); ?>">
+                                            <?= $scanStartFormatted; ?>
+                                        </time>
+                                    </td>
+                                </tr>
+                            <?php } ?>
+                        </tbody>
+                    </table>
+                </div>
+            <?php } ?>
+        </div>
+    </body>
+</html>

--- a/wwwroot/classes/Admin/AdminNavigation.php
+++ b/wwwroot/classes/Admin/AdminNavigation.php
@@ -74,6 +74,7 @@ class AdminNavigation
             new AdminNavigationItem('Reported Players', '/admin/report.php'),
             new AdminNavigationItem('Rescan Game', '/admin/rescan.php'),
             new AdminNavigationItem('Reset Trophy Data or Delete Merged Game', '/admin/reset.php'),
+            new AdminNavigationItem('Workers', '/admin/workers.php'),
             new AdminNavigationItem('Unobtainable trophy', '/admin/unobtainable.php'),
         ];
     }

--- a/wwwroot/classes/Admin/Worker.php
+++ b/wwwroot/classes/Admin/Worker.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+final class Worker
+{
+    private int $id;
+
+    private string $refreshToken;
+
+    private string $npsso;
+
+    private string $scanning;
+
+    private DateTimeImmutable $scanStart;
+
+    public function __construct(
+        int $id,
+        string $refreshToken,
+        string $npsso,
+        string $scanning,
+        DateTimeImmutable $scanStart
+    ) {
+        $this->id = $id;
+        $this->refreshToken = $refreshToken;
+        $this->npsso = $npsso;
+        $this->scanning = $scanning;
+        $this->scanStart = $scanStart;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getRefreshToken(): string
+    {
+        return $this->refreshToken;
+    }
+
+    public function getNpsso(): string
+    {
+        return $this->npsso;
+    }
+
+    public function getScanning(): string
+    {
+        return $this->scanning;
+    }
+
+    public function getScanStart(): DateTimeImmutable
+    {
+        return $this->scanStart;
+    }
+}

--- a/wwwroot/classes/Admin/WorkerService.php
+++ b/wwwroot/classes/Admin/WorkerService.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Worker.php';
+
+final class WorkerService
+{
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    /**
+     * @return list<Worker>
+     */
+    public function fetchWorkers(): array
+    {
+        $statement = $this->database->query(
+            'SELECT id, refresh_token, npsso, scanning, scan_start FROM setting ORDER BY scan_start ASC'
+        );
+
+        if ($statement === false) {
+            return [];
+        }
+
+        $workers = [];
+
+        while (($row = $statement->fetch(PDO::FETCH_ASSOC)) !== false) {
+            $id = isset($row['id']) ? (int) $row['id'] : 0;
+            $refreshToken = (string) ($row['refresh_token'] ?? '');
+            $npsso = (string) ($row['npsso'] ?? '');
+            $scanning = (string) ($row['scanning'] ?? '');
+            $scanStartRaw = (string) ($row['scan_start'] ?? '');
+
+            try {
+                $scanStart = new DateTimeImmutable($scanStartRaw ?: '1970-01-01 00:00:00');
+            } catch (Exception $exception) {
+                $scanStart = new DateTimeImmutable('1970-01-01 00:00:00');
+            }
+
+            $workers[] = new Worker($id, $refreshToken, $npsso, $scanning, $scanStart);
+        }
+
+        return $workers;
+    }
+
+    public function updateWorkerNpsso(int $workerId, string $npsso): bool
+    {
+        $statement = $this->database->prepare('UPDATE setting SET npsso = :npsso WHERE id = :id');
+
+        if ($statement === false) {
+            return false;
+        }
+
+        $statement->bindValue(':npsso', $npsso, PDO::PARAM_STR);
+        $statement->bindValue(':id', $workerId, PDO::PARAM_INT);
+
+        $statement->execute();
+
+        return $statement->rowCount() > 0;
+    }
+}


### PR DESCRIPTION
## Summary
- add a Workers admin page that lists the worker rows and allows updating NPSSO tokens
- introduce Worker and WorkerService classes plus navigation entry for the new page
- cover the WorkerService with new unit tests

## Testing
- php -l wwwroot/classes/Admin/Worker.php
- php -l wwwroot/classes/Admin/WorkerService.php
- php -l wwwroot/admin/workers.php
- php tests/run.php


------
https://chatgpt.com/codex/tasks/task_e_69085e780cfc832fb4a505c17336218c