### PR TITLE
Handle spaced punctuation in admin log formatter

### DIFF
--- a/tests/AdminLogEntryFormatterTest.php
+++ b/tests/AdminLogEntryFormatterTest.php
@@ -43,6 +43,17 @@ final class AdminLogEntryFormatterTest extends TestCase
         $this->assertStringContainsString('/game/59688-food-truck-kingdom#default', $formatted);
     }
 
+    public function testFormatsSetVersionMessageWithSpacesAroundPeriod(): void
+    {
+        $this->database->exec("INSERT INTO trophy_title (id, np_communication_id, name) VALUES (7777, 'NPWR53360_00', 'Cazzarion: Shellfish Frenzy')");
+
+        $message = 'SET VERSION for Cazzarion: Shellfish Frenzy . NPWR53360_00, default, Cazzarion: Shellfish Frenzy';
+        $formatted = $this->formatter->format($message);
+
+        $this->assertStringContainsString('/game/7777-cazzarion-shellfish-frenzy', $formatted);
+        $this->assertStringContainsString('/game/7777-cazzarion-shellfish-frenzy#default', $formatted);
+    }
+
     public function testFormatsNewTrophiesMessageWithLinks(): void
     {
         $this->database->exec("INSERT INTO trophy_title (id, np_communication_id, name) VALUES (1234, 'NPWR99999_00', 'Sample Game')");

--- a/wwwroot/classes/Admin/LogEntryFormatter.php
+++ b/wwwroot/classes/Admin/LogEntryFormatter.php
@@ -70,7 +70,7 @@ final class LogEntryFormatter
 
     private function formatSetVersionMessage(string $message): ?string
     {
-        if (!preg_match('/^SET VERSION for (.+)\. ([A-Z0-9_]+), ([^,]+), (.+)$/', $message, $matches, PREG_OFFSET_CAPTURE)) {
+        if (!preg_match('/^SET VERSION for (.+)\s*\.\s*([A-Z0-9_]+),\s*([^,]+),\s*(.+)$/', $message, $matches, PREG_OFFSET_CAPTURE)) {
             return null;
         }
 
@@ -101,7 +101,7 @@ final class LogEntryFormatter
 
     private function formatNewTrophiesAddedMessage(string $message): ?string
     {
-        if (!preg_match('/^New trophies added for (.+)\. ([A-Z0-9_]+), ([^,]+), (.+)$/', $message, $matches, PREG_OFFSET_CAPTURE)) {
+        if (!preg_match('/^New trophies added for (.+)\s*\.\s*([A-Z0-9_]+),\s*([^,]+),\s*(.+)$/', $message, $matches, PREG_OFFSET_CAPTURE)) {
             return null;
         }
 


### PR DESCRIPTION
## Summary
- allow admin log formatter to match SET VERSION and new trophy messages even when punctuation is surrounded by spaces
- add regression test covering spaced SET VERSION logs to ensure links are generated

## Testing
- php -d detect_unicode=0 tests/run.php
- php -l wwwroot/classes/Admin/LogEntryFormatter.php
- php -l tests/AdminLogEntryFormatterTest.php

------
https://chatgpt.com/codex/tasks/task_e_690860528e78832fa6d29d128c0cd954