### PR TITLE
Remove refresh token field from admin workers list

### DIFF
--- a/tests/AdminWorkerServiceTest.php
+++ b/tests/AdminWorkerServiceTest.php
@@ -20,9 +20,6 @@ final class AdminWorkerServiceTest extends TestCase
         $workers = $service->fetchWorkers();
 
         $this->assertCount(3, $workers);
-        $this->assertSame('token-1', $workers[0]->getRefreshToken());
-        $this->assertSame('token-2', $workers[1]->getRefreshToken());
-        $this->assertSame('token-3', $workers[2]->getRefreshToken());
         $this->assertSame('player-one', $workers[0]->getScanning());
         $this->assertSame('2024-01-01 09:00:00', $workers[0]->getScanStart()->format('Y-m-d H:i:s'));
     }

--- a/wwwroot/classes/Admin/Worker.php
+++ b/wwwroot/classes/Admin/Worker.php
@@ -6,8 +6,6 @@ final class Worker
 {
     private int $id;
 
-    private string $refreshToken;
-
     private string $npsso;
 
     private string $scanning;
@@ -16,13 +14,11 @@ final class Worker
 
     public function __construct(
         int $id,
-        string $refreshToken,
         string $npsso,
         string $scanning,
         DateTimeImmutable $scanStart
     ) {
         $this->id = $id;
-        $this->refreshToken = $refreshToken;
         $this->npsso = $npsso;
         $this->scanning = $scanning;
         $this->scanStart = $scanStart;
@@ -31,11 +27,6 @@ final class Worker
     public function getId(): int
     {
         return $this->id;
-    }
-
-    public function getRefreshToken(): string
-    {
-        return $this->refreshToken;
     }
 
     public function getNpsso(): string

--- a/wwwroot/classes/Admin/WorkerService.php
+++ b/wwwroot/classes/Admin/WorkerService.php
@@ -19,7 +19,7 @@ final class WorkerService
     public function fetchWorkers(): array
     {
         $statement = $this->database->query(
-            'SELECT id, refresh_token, npsso, scanning, scan_start FROM setting ORDER BY scan_start ASC'
+            'SELECT id, npsso, scanning, scan_start FROM setting ORDER BY scan_start ASC'
         );
 
         if ($statement === false) {
@@ -30,7 +30,6 @@ final class WorkerService
 
         while (($row = $statement->fetch(PDO::FETCH_ASSOC)) !== false) {
             $id = isset($row['id']) ? (int) $row['id'] : 0;
-            $refreshToken = (string) ($row['refresh_token'] ?? '');
             $npsso = (string) ($row['npsso'] ?? '');
             $scanning = (string) ($row['scanning'] ?? '');
             $scanStartRaw = (string) ($row['scan_start'] ?? '');
@@ -41,7 +40,7 @@ final class WorkerService
                 $scanStart = new DateTimeImmutable('1970-01-01 00:00:00');
             }
 
-            $workers[] = new Worker($id, $refreshToken, $npsso, $scanning, $scanStart);
+            $workers[] = new Worker($id, $npsso, $scanning, $scanStart);
         }
 
         return $workers;


### PR DESCRIPTION
## Summary
- remove the refresh token column from the admin workers table and underlying Worker model
- update the workers page to localize scan start timestamps in the viewer's timezone
- adjust the admin worker service test expectations now that refresh tokens are no longer exposed

## Testing
- php tests/run.php
- php -l wwwroot/classes/Admin/Worker.php
- php -l wwwroot/classes/Admin/WorkerService.php
- php -l wwwroot/admin/workers.php
- php -l tests/AdminWorkerServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_690861e984bc832f90435fe39f6ff0c3