### PR TITLE
Ensure admin copy copies trophy title detail

### DIFF
--- a/tests/FooterViewModelTest.php
+++ b/tests/FooterViewModelTest.php
@@ -54,7 +54,7 @@ final class FooterViewModelTest extends TestCase
         $expectedYearRangeLabel = $currentYear <= 2019 ? '2019' : '2019-' . $currentYear;
 
         $this->assertSame($expectedYearRangeLabel, $viewModel->getYearRangeLabel());
-        $this->assertSame('v7.40', $viewModel->getVersionLabel());
+        $this->assertSame('v7.41', $viewModel->getVersionLabel());
         $this->assertSame('https://github.com/Ragowit/psn100/releases', $viewModel->getReleaseUrl());
         $this->assertSame('/changelog', $viewModel->getChangelogUrl());
         $this->assertSame('https://github.com/Ragowit/psn100/issues', $viewModel->getIssuesUrl());

--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -291,11 +291,7 @@ class GameCopyService
         bool $copyIconUrl,
         bool $copySetVersion
     ): void {
-        if (!$copyIconUrl && !$copySetVersion) {
-            return;
-        }
-
-        $fields = [];
+        $fields = ['parent.detail = child_title.detail'];
 
         if ($copyIconUrl) {
             $fields[] = 'parent.icon_url = child_title.icon_url';
@@ -307,7 +303,7 @@ class GameCopyService
 
         $query = $this->database->prepare(
             'WITH child_title AS (
-                SELECT icon_url, set_version
+                SELECT detail, icon_url, set_version
                 FROM trophy_title
                 WHERE np_communication_id = :child_np_communication_id
             )


### PR DESCRIPTION
## Summary
- ensure the admin game copy service always synchronizes the trophy title detail field from the child list
- update the footer view model test to reflect the current default version label

## Testing
- php -l wwwroot/classes/Admin/GameCopyService.php
- php -l tests/FooterViewModelTest.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_690933efd71c832fb5aef4da66a0556a