### PR TITLE
Render game history changes as unified diffs

### DIFF
--- a/tests/GameHistoryPageTest.php
+++ b/tests/GameHistoryPageTest.php
@@ -114,27 +114,45 @@ final class GameHistoryPageTest extends TestCase
         $this->assertTrue($latestEntry['hasTitleChanges']);
         $this->assertTrue($latestEntry['titleHighlights']['set_version']);
         $this->assertFalse($latestEntry['titleHighlights']['detail']);
+        $this->assertTrue(isset($latestEntry['titleDiffs']['set_version']));
+        $this->assertStringContainsString('-01.05', $latestEntry['titleDiffs']['set_version']);
+        $this->assertStringContainsString('+01.10', $latestEntry['titleDiffs']['set_version']);
+        $this->assertSame('01.05', $latestEntry['titlePrevious']['set_version']);
         $this->assertSame([], $latestEntry['groups']);
         $this->assertCount(1, $latestEntry['trophies']);
         $this->assertTrue($latestEntry['trophies'][0]['changedFields']['progress_target_value']);
+        $this->assertTrue(isset($latestEntry['trophies'][0]['diffs']['progress_target_value']));
+        $this->assertStringContainsString('-50', $latestEntry['trophies'][0]['diffs']['progress_target_value']);
+        $this->assertStringContainsString('+100', $latestEntry['trophies'][0]['diffs']['progress_target_value']);
+        $this->assertSame(50, $latestEntry['trophies'][0]['previousValues']['progress_target_value']);
 
         $midEntry = $entries[1];
         $this->assertTrue($midEntry['hasTitleChanges']);
         $this->assertTrue($midEntry['titleHighlights']['set_version']);
         $this->assertCount(1, $midEntry['groups']);
         $this->assertTrue($midEntry['groups'][0]['isNewRow']);
+        $this->assertStringContainsString('+Expansion', $midEntry['groups'][0]['diffs']['name']);
+        $this->assertTrue(($midEntry['groups'][0]['previousValues']['name'] ?? null) === null);
         $this->assertCount(1, $midEntry['trophies']);
         $this->assertTrue($midEntry['trophies'][0]['isNewRow']);
         $this->assertTrue($midEntry['trophies'][0]['is_unobtainable']);
+        $this->assertStringContainsString('+Challenger', $midEntry['trophies'][0]['diffs']['name']);
+        $this->assertStringContainsString('+Reach level 5', $midEntry['trophies'][0]['diffs']['detail']);
+        $this->assertStringContainsString('+50', $midEntry['trophies'][0]['diffs']['progress_target_value']);
+        $this->assertTrue(($midEntry['trophies'][0]['previousValues']['progress_target_value'] ?? null) === null);
 
         $earliestEntry = $entries[2];
         $this->assertTrue($earliestEntry['hasTitleChanges']);
         $this->assertTrue($earliestEntry['titleHighlights']['icon_url']);
         $this->assertTrue($earliestEntry['titleHighlights']['detail']);
+        $this->assertStringContainsString('+Initial detail', $earliestEntry['titleDiffs']['detail']);
+        $this->assertStringContainsString('+icon-a.png', $earliestEntry['titleDiffs']['icon_url']);
         $this->assertCount(1, $earliestEntry['groups']);
         $this->assertTrue($earliestEntry['groups'][0]['isNewRow']);
+        $this->assertStringContainsString('+Base', $earliestEntry['groups'][0]['diffs']['name']);
         $this->assertCount(1, $earliestEntry['trophies']);
         $this->assertTrue($earliestEntry['trophies'][0]['isNewRow']);
         $this->assertFalse($earliestEntry['trophies'][0]['is_unobtainable']);
+        $this->assertStringContainsString('+First Trophy', $earliestEntry['trophies'][0]['diffs']['name']);
     }
 }

--- a/wwwroot/classes/GameHistoryPage.php
+++ b/wwwroot/classes/GameHistoryPage.php
@@ -97,8 +97,33 @@ final class GameHistoryPage
      *     historyId: int,
      *     discoveredAt: DateTimeImmutable,
      *     title: ?array{detail: ?string, icon_url: ?string, set_version: ?string},
-     *     groups: array<int, array{group_id: string, name: ?string, detail: ?string, icon_url: ?string}>,
-     *     trophies: array<int, array{group_id: string, order_id: int, name: ?string, detail: ?string, icon_url: ?string, progress_target_value: ?int, is_unobtainable: bool}>
+     *     titleHighlights: array{detail: bool, icon_url: bool, set_version: bool},
+     *     titleDiffs?: array{detail: ?string, icon_url: ?string, set_version: ?string},
+     *     titlePrevious?: array{detail: ?string, icon_url: ?string, set_version: ?string},
+     *     hasTitleChanges: bool,
+     *     groups: array<int, array{
+     *         group_id: string,
+     *         name: ?string,
+     *         detail: ?string,
+     *         icon_url: ?string,
+     *         changedFields: array{name: bool, detail: bool, icon_url: bool},
+     *         diffs?: array{name: ?string, detail: ?string, icon_url: ?string},
+     *         previousValues?: array{name: ?string, detail: ?string, icon_url: ?string},
+     *         isNewRow: bool
+     *     }>,
+     *     trophies: array<int, array{
+     *         group_id: string,
+     *         order_id: int,
+     *         name: ?string,
+     *         detail: ?string,
+     *         icon_url: ?string,
+     *         progress_target_value: ?int,
+     *         is_unobtainable: bool,
+     *         changedFields: array{name: bool, detail: bool, icon_url: bool, progress_target_value: bool},
+     *         diffs?: array{name: ?string, detail: ?string, icon_url: ?string, progress_target_value: ?string},
+     *         previousValues?: array{name: ?string, detail: ?string, icon_url: ?string, progress_target_value: ?int},
+     *         isNewRow: bool
+     *     }>
      * }>
      */
     public function getHistoryEntries(): array
@@ -124,6 +149,8 @@ final class GameHistoryPage
      *     discoveredAt: DateTimeImmutable,
      *     title: ?array{detail: ?string, icon_url: ?string, set_version: ?string},
      *     titleHighlights: array{detail: bool, icon_url: bool, set_version: bool},
+     *     titleDiffs?: array{detail: ?string, icon_url: ?string, set_version: ?string},
+     *     titlePrevious?: array{detail: ?string, icon_url: ?string, set_version: ?string},
      *     hasTitleChanges: bool,
      *     groups: array<int, array{
      *         group_id: string,
@@ -131,6 +158,8 @@ final class GameHistoryPage
      *         detail: ?string,
      *         icon_url: ?string,
      *         changedFields: array{name: bool, detail: bool, icon_url: bool},
+     *         diffs?: array{name: ?string, detail: ?string, icon_url: ?string},
+     *         previousValues?: array{name: ?string, detail: ?string, icon_url: ?string},
      *         isNewRow: bool
      *     }>,
      *     trophies: array<int, array{
@@ -142,6 +171,8 @@ final class GameHistoryPage
      *         progress_target_value: ?int,
      *         is_unobtainable: bool,
      *         changedFields: array{name: bool, detail: bool, icon_url: bool, progress_target_value: bool},
+     *         diffs?: array{name: ?string, detail: ?string, icon_url: ?string, progress_target_value: ?string},
+     *         previousValues?: array{name: ?string, detail: ?string, icon_url: ?string, progress_target_value: ?int},
      *         isNewRow: bool
      *     }>
      * }>
@@ -176,6 +207,12 @@ final class GameHistoryPage
                 'set_version' => false,
             ];
             $hasTitleChanges = false;
+            $titlePreviousForDiff = $previousTitle;
+            $titleDiffs = [
+                'detail' => null,
+                'icon_url' => null,
+                'set_version' => null,
+            ];
 
             if ($titleChange !== null) {
                 $titleHighlights['detail'] = $this->isNewNonEmptyString($titleChange['detail'] ?? null, $previousTitle['detail']);
@@ -183,12 +220,25 @@ final class GameHistoryPage
                 $titleHighlights['set_version'] = $this->isNewNonEmptyString($titleChange['set_version'] ?? null, $previousTitle['set_version']);
 
                 $hasTitleChanges = in_array(true, $titleHighlights, true);
+
+                if ($titleHighlights['detail']) {
+                    $titleDiffs['detail'] = $this->createUnifiedDiff($previousTitle['detail'], $titleChange['detail'] ?? null);
+                }
+
+                if ($titleHighlights['icon_url']) {
+                    $titleDiffs['icon_url'] = $this->createUnifiedDiff($previousTitle['icon_url'], $titleChange['icon_url'] ?? null);
+                }
+
+                if ($titleHighlights['set_version']) {
+                    $titleDiffs['set_version'] = $this->createUnifiedDiff($previousTitle['set_version'], $titleChange['set_version'] ?? null);
+                }
             }
 
             $filteredGroups = [];
             foreach ($entry['groups'] as $groupChange) {
                 $groupId = $groupChange['group_id'];
                 $previousGroup = $previousGroups[$groupId] ?? ['name' => null, 'detail' => null, 'icon_url' => null];
+                $groupPreviousForDiff = $previousGroup;
 
                 $changedFields = [
                     'name' => $this->isNewNonEmptyString($groupChange['name'] ?? null, $previousGroup['name']),
@@ -210,6 +260,12 @@ final class GameHistoryPage
 
                 if ($hasRowChanges) {
                     $groupChange['changedFields'] = $changedFields;
+                    $groupChange['previousValues'] = $groupPreviousForDiff;
+                    $groupChange['diffs'] = [
+                        'name' => $changedFields['name'] ? $this->createUnifiedDiff($groupPreviousForDiff['name'], $groupChange['name'] ?? null) : null,
+                        'detail' => $changedFields['detail'] ? $this->createUnifiedDiff($groupPreviousForDiff['detail'], $groupChange['detail'] ?? null) : null,
+                        'icon_url' => $changedFields['icon_url'] ? $this->createUnifiedDiff($groupPreviousForDiff['icon_url'], $groupChange['icon_url'] ?? null) : null,
+                    ];
                     $groupChange['isNewRow'] = $isNewRow;
                     $filteredGroups[] = $groupChange;
                 }
@@ -230,6 +286,7 @@ final class GameHistoryPage
                     'icon_url' => null,
                     'progress_target_value' => null,
                 ];
+                $trophyPreviousForDiff = $previousTrophy;
 
                 $changedFields = [
                     'name' => $this->isNewNonEmptyString($trophyChange['name'] ?? null, $previousTrophy['name']),
@@ -258,6 +315,18 @@ final class GameHistoryPage
 
                 if ($hasRowChanges) {
                     $trophyChange['changedFields'] = $changedFields;
+                    $trophyChange['previousValues'] = $trophyPreviousForDiff;
+                    $trophyChange['diffs'] = [
+                        'name' => $changedFields['name'] ? $this->createUnifiedDiff($trophyPreviousForDiff['name'], $trophyChange['name'] ?? null) : null,
+                        'detail' => $changedFields['detail'] ? $this->createUnifiedDiff($trophyPreviousForDiff['detail'], $trophyChange['detail'] ?? null) : null,
+                        'icon_url' => $changedFields['icon_url'] ? $this->createUnifiedDiff($trophyPreviousForDiff['icon_url'], $trophyChange['icon_url'] ?? null) : null,
+                        'progress_target_value' => $changedFields['progress_target_value']
+                            ? $this->createUnifiedDiff(
+                                $trophyPreviousForDiff['progress_target_value'] === null ? null : (string) $trophyPreviousForDiff['progress_target_value'],
+                                $trophyChange['progress_target_value'] === null ? null : (string) $trophyChange['progress_target_value']
+                            )
+                            : null,
+                    ];
                     $trophyChange['isNewRow'] = $isNewRow;
                     $filteredTrophies[] = $trophyChange;
                 }
@@ -275,6 +344,10 @@ final class GameHistoryPage
             if ($entryHasChanges) {
                 $entry['titleHighlights'] = $titleHighlights;
                 $entry['hasTitleChanges'] = $hasTitleChanges;
+                if ($hasTitleChanges) {
+                    $entry['titleDiffs'] = $titleDiffs;
+                    $entry['titlePrevious'] = $titlePreviousForDiff;
+                }
                 $entry['groups'] = $filteredGroups;
                 $entry['trophies'] = $filteredTrophies;
 
@@ -325,6 +398,131 @@ final class GameHistoryPage
         }
 
         return $value !== $previous;
+    }
+
+    private function createUnifiedDiff(?string $previous, ?string $current): ?string
+    {
+        $previousString = $previous ?? '';
+        $currentString = $current ?? '';
+
+        if ($previousString === $currentString) {
+            return null;
+        }
+
+        $previousLines = $this->splitIntoLines($previousString);
+        $currentLines = $this->splitIntoLines($currentString);
+
+        $diffBody = $this->calculateDiffBody($previousLines, $currentLines);
+
+        if ($diffBody === []) {
+            return null;
+        }
+
+        $diffLines = ['--- Previous', '+++ Current', '@@'];
+
+        foreach ($diffBody as $diffLine) {
+            [$prefix, $line] = $diffLine;
+            $diffLines[] = $prefix . $line;
+        }
+
+        return implode("\n", $diffLines);
+    }
+
+    /**
+     * @param array<int, string> $previousLines
+     * @param array<int, string> $currentLines
+     * @return array<int, array{0: string, 1: string}>
+     */
+    private function calculateDiffBody(array $previousLines, array $currentLines): array
+    {
+        $diffBody = $this->buildFullDiff($previousLines, $currentLines);
+
+        $start = 0;
+        $end = count($diffBody);
+
+        while ($start < $end && $diffBody[$start][0] === ' ') {
+            $start++;
+        }
+
+        while ($end > $start && $diffBody[$end - 1][0] === ' ') {
+            $end--;
+        }
+
+        return array_slice($diffBody, $start, $end - $start);
+    }
+
+    /**
+     * @param array<int, string> $previousLines
+     * @param array<int, string> $currentLines
+     * @return array<int, array{0: string, 1: string}>
+     */
+    private function buildFullDiff(array $previousLines, array $currentLines): array
+    {
+        $previousCount = count($previousLines);
+        $currentCount = count($currentLines);
+
+        $lengthMatrix = [];
+
+        for ($i = 0; $i <= $previousCount; $i++) {
+            $lengthMatrix[$i] = array_fill(0, $currentCount + 1, 0);
+        }
+
+        for ($i = $previousCount - 1; $i >= 0; $i--) {
+            for ($j = $currentCount - 1; $j >= 0; $j--) {
+                if ($previousLines[$i] === $currentLines[$j]) {
+                    $lengthMatrix[$i][$j] = $lengthMatrix[$i + 1][$j + 1] + 1;
+                } else {
+                    $lengthMatrix[$i][$j] = max($lengthMatrix[$i + 1][$j], $lengthMatrix[$i][$j + 1]);
+                }
+            }
+        }
+
+        $diffBody = [];
+        $i = 0;
+        $j = 0;
+
+        while ($i < $previousCount && $j < $currentCount) {
+            if ($previousLines[$i] === $currentLines[$j]) {
+                $diffBody[] = [' ', $previousLines[$i]];
+                $i++;
+                $j++;
+                continue;
+            }
+
+            if ($lengthMatrix[$i + 1][$j] >= $lengthMatrix[$i][$j + 1]) {
+                $diffBody[] = ['-', $previousLines[$i]];
+                $i++;
+            } else {
+                $diffBody[] = ['+', $currentLines[$j]];
+                $j++;
+            }
+        }
+
+        while ($i < $previousCount) {
+            $diffBody[] = ['-', $previousLines[$i]];
+            $i++;
+        }
+
+        while ($j < $currentCount) {
+            $diffBody[] = ['+', $currentLines[$j]];
+            $j++;
+        }
+
+        return $diffBody;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function splitIntoLines(string $value): array
+    {
+        $normalized = str_replace(["\r\n", "\r"], "\n", $value);
+
+        if ($normalized === '') {
+            return [];
+        }
+
+        return explode("\n", $normalized);
     }
 
     public function createMetaData(): PageMetaData

--- a/wwwroot/game_history.php
+++ b/wwwroot/game_history.php
@@ -32,10 +32,107 @@ $metaData = $gameHistoryPage->createMetaData();
 $title = $gameHistoryPage->getPageTitle();
 
 require_once 'header.php';
+
+$renderDiffBlock = static function (?string $diff): string {
+    if ($diff === null || $diff === '') {
+        return '';
+    }
+
+    $lines = explode("\n", $diff);
+    $htmlLines = [];
+
+    foreach ($lines as $line) {
+        $class = 'diff-line';
+
+        if (str_starts_with($line, '+++')) {
+            $class .= ' diff-line-file diff-line-add';
+        } elseif (str_starts_with($line, '---')) {
+            $class .= ' diff-line-file diff-line-remove';
+        } elseif (str_starts_with($line, '@@')) {
+            $class .= ' diff-line-hunk';
+        } elseif ($line !== '' && $line[0] === '+') {
+            $class .= ' diff-line-add';
+        } elseif ($line !== '' && $line[0] === '-') {
+            $class .= ' diff-line-remove';
+        } elseif ($line !== '' && $line[0] === ' ') {
+            $class .= ' diff-line-context';
+        } else {
+            $class .= ' diff-line-other';
+        }
+
+        $htmlLines[] = '<span class="' . $class . '">' . htmlentities($line, ENT_QUOTES, 'UTF-8') . '</span>';
+    }
+
+    return '<pre class="diff-block bg-body-secondary-subtle small p-3 rounded mb-0">' . implode("\n", $htmlLines) . '</pre>';
+};
+
+$resolveTitleIconPath = static function (?string $iconUrl) use ($game): ?string {
+    if ($iconUrl === null || $iconUrl === '') {
+        return null;
+    }
+
+    if ($iconUrl === '.png') {
+        if (str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2')) {
+            return '../missing-ps5-game-and-trophy.png';
+        }
+
+        return '../missing-ps4-game.png';
+    }
+
+    return $iconUrl;
+};
+
+$resolveGroupIconPath = static function (?string $iconUrl) use ($resolveTitleIconPath): ?string {
+    return $resolveTitleIconPath($iconUrl);
+};
+
+$resolveTrophyIconPath = static function (?string $iconUrl) use ($game): ?string {
+    if ($iconUrl === null || $iconUrl === '') {
+        return null;
+    }
+
+    if ($iconUrl === '.png') {
+        if (str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2')) {
+            return '../missing-ps5-game-and-trophy.png';
+        }
+
+        return '../missing-ps4-trophy.png';
+    }
+
+    return $iconUrl;
+};
 ?>
 
 <main class="container">
     <?php require_once 'game_header.php'; ?>
+
+    <style>
+        .diff-block {
+            font-family: var(--bs-font-monospace, monospace);
+            white-space: pre-wrap;
+        }
+
+        .diff-line-add {
+            color: var(--bs-success-text-emphasis);
+        }
+
+        .diff-line-remove {
+            color: var(--bs-danger-text-emphasis);
+        }
+
+        .diff-line-hunk {
+            color: var(--bs-primary-text-emphasis);
+            font-weight: 600;
+        }
+
+        .diff-line-file {
+            font-weight: 600;
+        }
+
+        .diff-line-context {
+            color: var(--bs-secondary-color);
+        }
+    </style>
 
     <div class="p-3">
         <div class="row">
@@ -84,26 +181,49 @@ require_once 'header.php';
                             </time>
                         </div>
                         <div class="card-body">
-                            <?php if ($titleChange !== null && $hasTitleChanges && (($titleHighlights['detail'] ?? false) || ($titleHighlights['icon_url'] ?? false))) { ?>
-                                <div class="row g-3 align-items-center mb-3">
-                                    <?php if ($titleHighlights['icon_url'] ?? false) { ?>
-                                        <div class="col-12 col-md-2 text-center text-md-start">
-                                            <?php
-                                            $iconUrl = $titleChange['icon_url'] ?? '';
-                                            $iconPath = ($iconUrl === '.png')
-                                                ? ((str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2'))
-                                                    ? '../missing-ps5-game-and-trophy.png'
-                                                    : '../missing-ps4-game.png')
-                                                : $iconUrl;
-                                            ?>
-                                            <img class="object-fit-scale border border-success border-2 rounded" style="height: 5.5rem;" src="/img/title/<?= htmlentities($iconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($game->getName(), ENT_QUOTES, 'UTF-8'); ?>">
+                            <?php $titleDiffs = $entry['titleDiffs'] ?? ['detail' => null, 'icon_url' => null, 'set_version' => null]; ?>
+                            <?php if ($hasTitleChanges) { ?>
+                                <div class="mb-4">
+                                    <h2 class="h5">Title Changes</h2>
+
+                                    <?php if (($titleDiffs['set_version'] ?? null) !== null) { ?>
+                                        <div class="mb-3">
+                                            <div class="text-uppercase small text-body-secondary fw-semibold mb-1">Version</div>
+                                            <?= $renderDiffBlock($titleDiffs['set_version']); ?>
                                         </div>
                                     <?php } ?>
-                                    <?php if ($titleHighlights['detail'] ?? false) { ?>
-                                        <div class="col-12 <?= ($titleHighlights['icon_url'] ?? false) ? 'col-md-10' : 'col-md-12'; ?>">
-                                            <div class="p-2 border border-success rounded bg-success-subtle text-success-emphasis">
-                                                <?= nl2br(htmlentities((string) $titleChange['detail'], ENT_QUOTES, 'UTF-8')); ?>
-                                            </div>
+
+                                    <?php if (($titleDiffs['detail'] ?? null) !== null) { ?>
+                                        <div class="mb-3">
+                                            <div class="text-uppercase small text-body-secondary fw-semibold mb-1">Detail</div>
+                                            <?= $renderDiffBlock($titleDiffs['detail']); ?>
+                                        </div>
+                                    <?php } ?>
+
+                                    <?php if (($titleDiffs['icon_url'] ?? null) !== null) { ?>
+                                        <div class="mb-3">
+                                            <div class="text-uppercase small text-body-secondary fw-semibold mb-2">Icon</div>
+                                            <?php
+                                            $previousIconPath = $resolveTitleIconPath($entry['titlePrevious']['icon_url'] ?? null);
+                                            $currentIconPath = $resolveTitleIconPath($titleChange['icon_url'] ?? null);
+                                            ?>
+                                            <?php if ($previousIconPath !== null || $currentIconPath !== null) { ?>
+                                                <div class="d-flex flex-wrap gap-3 align-items-start mb-2">
+                                                    <?php if ($previousIconPath !== null) { ?>
+                                                        <div class="text-center">
+                                                            <div class="small text-body-secondary mb-1">Previous</div>
+                                                            <img class="object-fit-scale border rounded" style="height: 5.5rem;" src="/img/title/<?= htmlentities($previousIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="Previous icon for <?= htmlentities($game->getName(), ENT_QUOTES, 'UTF-8'); ?>">
+                                                        </div>
+                                                    <?php } ?>
+                                                    <?php if ($currentIconPath !== null) { ?>
+                                                        <div class="text-center">
+                                                            <div class="small text-body-secondary mb-1">Current</div>
+                                                            <img class="object-fit-scale border border-success border-2 rounded" style="height: 5.5rem;" src="/img/title/<?= htmlentities($currentIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="Current icon for <?= htmlentities($game->getName(), ENT_QUOTES, 'UTF-8'); ?>">
+                                                        </div>
+                                                    <?php } ?>
+                                                </div>
+                                            <?php } ?>
+                                            <?= $renderDiffBlock($titleDiffs['icon_url']); ?>
                                         </div>
                                     <?php } ?>
                                 </div>
@@ -111,46 +231,67 @@ require_once 'header.php';
 
                             <?php $groupChanges = $entry['groups'] ?? []; ?>
                             <?php if ($groupChanges !== []) { ?>
-                                <div class="mb-3">
+                                <div class="mb-4">
                                     <h2 class="h5">Trophy Groups</h2>
-                                    <div class="table-responsive">
-                                        <table class="table table-sm align-middle mb-0">
-                                            <thead>
-                                                <tr>
-                                                    <th scope="col">Group</th>
-                                                    <th scope="col">Name</th>
-                                                    <th scope="col">Detail</th>
-                                                    <th scope="col" class="text-center">Icon</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                <?php foreach ($groupChanges as $groupChange) { ?>
-                                                    <?php $groupChangedFields = $groupChange['changedFields'] ?? ['name' => false, 'detail' => false, 'icon_url' => false]; ?>
-                                                    <tr class="<?= ($groupChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
-                                                        <td class="<?= ($groupChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
-                                                            <span class="badge text-bg-secondary"><?= htmlentities($groupChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span>
-                                                        </td>
-                                                        <td class="<?= (($groupChange['isNewRow'] ?? false) || ($groupChangedFields['name'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?= htmlentities($groupChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
-                                                        </td>
-                                                        <td class="<?= (($groupChange['isNewRow'] ?? false) || ($groupChangedFields['detail'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?= nl2br(htmlentities($groupChange['detail'] ?? '', ENT_QUOTES, 'UTF-8')); ?>
-                                                        </td>
-                                                        <td class="text-center <?= (($groupChange['isNewRow'] ?? false) || ($groupChangedFields['icon_url'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?php
-                                                            $groupIconUrl = $groupChange['icon_url'] ?? '';
-                                                            $groupIconPath = ($groupIconUrl === '.png')
-                                                                ? ((str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2'))
-                                                                    ? '../missing-ps5-game-and-trophy.png'
-                                                                    : '../missing-ps4-game.png')
-                                                                : $groupIconUrl;
-                                                            ?>
-                                                            <img class="object-fit-cover <?= (($groupChange['isNewRow'] ?? false) || ($groupChangedFields['icon_url'] ?? false)) ? 'border border-success border-2 rounded' : ''; ?>" style="height: 3.5rem;" src="/img/group/<?= htmlentities($groupIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($groupChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
-                                                        </td>
-                                                    </tr>
+                                    <div class="vstack gap-3">
+                                        <?php foreach ($groupChanges as $groupChange) { ?>
+                                            <?php $groupDiffs = $groupChange['diffs'] ?? ['name' => null, 'detail' => null, 'icon_url' => null]; ?>
+                                            <?php $groupPrevious = $groupChange['previousValues'] ?? ['name' => null, 'detail' => null, 'icon_url' => null]; ?>
+                                            <div class="border rounded p-3">
+                                                <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+                                                    <div class="d-flex align-items-center gap-2">
+                                                        <span class="badge text-bg-secondary"><?= htmlentities($groupChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span>
+                                                        <span class="small text-body-secondary text-uppercase">Group</span>
+                                                    </div>
+                                                    <div class="d-flex gap-2">
+                                                        <?php if ($groupChange['isNewRow'] ?? false) { ?>
+                                                            <span class="badge text-bg-success">New</span>
+                                                        <?php } ?>
+                                                    </div>
+                                                </div>
+
+                                                <?php if (($groupDiffs['name'] ?? null) !== null) { ?>
+                                                    <div class="mb-3">
+                                                        <div class="text-uppercase small text-body-secondary fw-semibold mb-1">Name</div>
+                                                        <?= $renderDiffBlock($groupDiffs['name']); ?>
+                                                    </div>
                                                 <?php } ?>
-                                            </tbody>
-                                        </table>
+
+                                                <?php if (($groupDiffs['detail'] ?? null) !== null) { ?>
+                                                    <div class="mb-3">
+                                                        <div class="text-uppercase small text-body-secondary fw-semibold mb-1">Detail</div>
+                                                        <?= $renderDiffBlock($groupDiffs['detail']); ?>
+                                                    </div>
+                                                <?php } ?>
+
+                                                <?php if (($groupDiffs['icon_url'] ?? null) !== null) { ?>
+                                                    <div class="mb-3">
+                                                        <div class="text-uppercase small text-body-secondary fw-semibold mb-2">Icon</div>
+                                                        <?php
+                                                        $previousGroupIconPath = $resolveGroupIconPath($groupPrevious['icon_url'] ?? null);
+                                                        $currentGroupIconPath = $resolveGroupIconPath($groupChange['icon_url'] ?? null);
+                                                        ?>
+                                                        <?php if ($previousGroupIconPath !== null || $currentGroupIconPath !== null) { ?>
+                                                            <div class="d-flex flex-wrap gap-3 align-items-start mb-2">
+                                                                <?php if ($previousGroupIconPath !== null) { ?>
+                                                                    <div class="text-center">
+                                                                        <div class="small text-body-secondary mb-1">Previous</div>
+                                                                        <img class="object-fit-cover border rounded" style="height: 3.5rem;" src="/img/group/<?= htmlentities($previousGroupIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($groupPrevious['name'] ?? 'Previous group icon', ENT_QUOTES, 'UTF-8'); ?>">
+                                                                    </div>
+                                                                <?php } ?>
+                                                                <?php if ($currentGroupIconPath !== null) { ?>
+                                                                    <div class="text-center">
+                                                                        <div class="small text-body-secondary mb-1">Current</div>
+                                                                        <img class="object-fit-cover border border-success border-2 rounded" style="height: 3.5rem;" src="/img/group/<?= htmlentities($currentGroupIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($groupChange['name'] ?? 'Current group icon', ENT_QUOTES, 'UTF-8'); ?>">
+                                                                    </div>
+                                                                <?php } ?>
+                                                            </div>
+                                                        <?php } ?>
+                                                        <?= $renderDiffBlock($groupDiffs['icon_url']); ?>
+                                                    </div>
+                                                <?php } ?>
+                                            </div>
+                                        <?php } ?>
                                     </div>
                                 </div>
                             <?php } ?>
@@ -159,56 +300,75 @@ require_once 'header.php';
                             <?php if ($trophyChanges !== []) { ?>
                                 <div>
                                     <h2 class="h5">Trophies</h2>
-                                    <div class="table-responsive">
-                                        <table class="table table-sm align-middle mb-0">
-                                            <thead>
-                                                <tr>
-                                                    <th scope="col">Group</th>
-                                                    <th scope="col">#</th>
-                                                    <th scope="col">Name</th>
-                                                    <th scope="col">Detail</th>
-                                                    <th scope="col">Target</th>
-                                                    <th scope="col" class="text-center">Icon</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                <?php foreach ($trophyChanges as $trophyChange) { ?>
-                                                    <?php $trophyChangedFields = $trophyChange['changedFields'] ?? ['name' => false, 'detail' => false, 'icon_url' => false, 'progress_target_value' => false]; ?>
-                                                    <tr class="<?= ($trophyChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
-                                                        <td class="<?= ($trophyChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
-                                                            <span class="badge text-bg-secondary"><?= htmlentities($trophyChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span>
-                                                        </td>
-                                                        <td class="<?= ($trophyChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
-                                                            <?php if ($trophyChange['is_unobtainable'] ?? false) { ?>
-                                                                <span class="badge text-bg-warning" title="This trophy is unobtainable and not accounted for on any leaderboard."><?= (int) $trophyChange['order_id']; ?></span>
-                                                            <?php } else { ?>
-                                                                <?= (int) $trophyChange['order_id']; ?>
-                                                            <?php } ?>
-                                                        </td>
-                                                        <td class="<?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['name'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?= htmlentities($trophyChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
-                                                        </td>
-                                                        <td class="<?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['detail'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?= nl2br(htmlentities($trophyChange['detail'] ?? '', ENT_QUOTES, 'UTF-8')); ?>
-                                                        </td>
-                                                        <td class="<?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['progress_target_value'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?= $trophyChange['progress_target_value'] === null ? '&mdash;' : htmlentities((string) $trophyChange['progress_target_value'], ENT_QUOTES, 'UTF-8'); ?>
-                                                        </td>
-                                                        <td class="text-center <?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['icon_url'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?php
-                                                            $trophyIconUrl = $trophyChange['icon_url'] ?? '';
-                                                            $trophyIconPath = ($trophyIconUrl === '.png')
-                                                                ? ((str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2'))
-                                                                    ? '../missing-ps5-game-and-trophy.png'
-                                                                    : '../missing-ps4-trophy.png')
-                                                                : $trophyIconUrl;
-                                                            ?>
-                                                            <img class="object-fit-scale <?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['icon_url'] ?? false)) ? 'border border-success border-2 rounded' : ''; ?>" style="height: 3.5rem;" src="/img/trophy/<?= htmlentities($trophyIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophyChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
-                                                        </td>
-                                                    </tr>
+                                    <div class="vstack gap-3">
+                                        <?php foreach ($trophyChanges as $trophyChange) { ?>
+                                            <?php $trophyDiffs = $trophyChange['diffs'] ?? ['name' => null, 'detail' => null, 'icon_url' => null, 'progress_target_value' => null]; ?>
+                                            <?php $trophyPrevious = $trophyChange['previousValues'] ?? ['name' => null, 'detail' => null, 'icon_url' => null, 'progress_target_value' => null]; ?>
+                                            <div class="border rounded p-3">
+                                                <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+                                                    <div class="d-flex flex-wrap align-items-center gap-2">
+                                                        <span class="badge text-bg-secondary"><?= htmlentities($trophyChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span>
+                                                        <span class="badge text-bg-primary">#<?= (int) $trophyChange['order_id']; ?></span>
+                                                    </div>
+                                                    <div class="d-flex gap-2">
+                                                        <?php if ($trophyChange['isNewRow'] ?? false) { ?>
+                                                            <span class="badge text-bg-success">New</span>
+                                                        <?php } ?>
+                                                        <?php if ($trophyChange['is_unobtainable'] ?? false) { ?>
+                                                            <span class="badge text-bg-warning" title="This trophy is unobtainable and not accounted for on any leaderboard.">Unobtainable</span>
+                                                        <?php } ?>
+                                                    </div>
+                                                </div>
+
+                                                <?php if (($trophyDiffs['name'] ?? null) !== null) { ?>
+                                                    <div class="mb-3">
+                                                        <div class="text-uppercase small text-body-secondary fw-semibold mb-1">Name</div>
+                                                        <?= $renderDiffBlock($trophyDiffs['name']); ?>
+                                                    </div>
                                                 <?php } ?>
-                                            </tbody>
-                                        </table>
+
+                                                <?php if (($trophyDiffs['detail'] ?? null) !== null) { ?>
+                                                    <div class="mb-3">
+                                                        <div class="text-uppercase small text-body-secondary fw-semibold mb-1">Detail</div>
+                                                        <?= $renderDiffBlock($trophyDiffs['detail']); ?>
+                                                    </div>
+                                                <?php } ?>
+
+                                                <?php if (($trophyDiffs['progress_target_value'] ?? null) !== null) { ?>
+                                                    <div class="mb-3">
+                                                        <div class="text-uppercase small text-body-secondary fw-semibold mb-1">Target</div>
+                                                        <?= $renderDiffBlock($trophyDiffs['progress_target_value']); ?>
+                                                    </div>
+                                                <?php } ?>
+
+                                                <?php if (($trophyDiffs['icon_url'] ?? null) !== null) { ?>
+                                                    <div class="mb-3">
+                                                        <div class="text-uppercase small text-body-secondary fw-semibold mb-2">Icon</div>
+                                                        <?php
+                                                        $previousTrophyIconPath = $resolveTrophyIconPath($trophyPrevious['icon_url'] ?? null);
+                                                        $currentTrophyIconPath = $resolveTrophyIconPath($trophyChange['icon_url'] ?? null);
+                                                        ?>
+                                                        <?php if ($previousTrophyIconPath !== null || $currentTrophyIconPath !== null) { ?>
+                                                            <div class="d-flex flex-wrap gap-3 align-items-start mb-2">
+                                                                <?php if ($previousTrophyIconPath !== null) { ?>
+                                                                    <div class="text-center">
+                                                                        <div class="small text-body-secondary mb-1">Previous</div>
+                                                                        <img class="object-fit-scale border rounded" style="height: 3.5rem;" src="/img/trophy/<?= htmlentities($previousTrophyIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophyPrevious['name'] ?? 'Previous trophy icon', ENT_QUOTES, 'UTF-8'); ?>">
+                                                                    </div>
+                                                                <?php } ?>
+                                                                <?php if ($currentTrophyIconPath !== null) { ?>
+                                                                    <div class="text-center">
+                                                                        <div class="small text-body-secondary mb-1">Current</div>
+                                                                        <img class="object-fit-scale border border-success border-2 rounded" style="height: 3.5rem;" src="/img/trophy/<?= htmlentities($currentTrophyIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophyChange['name'] ?? 'Current trophy icon', ENT_QUOTES, 'UTF-8'); ?>">
+                                                                    </div>
+                                                                <?php } ?>
+                                                            </div>
+                                                        <?php } ?>
+                                                        <?= $renderDiffBlock($trophyDiffs['icon_url']); ?>
+                                                    </div>
+                                                <?php } ?>
+                                            </div>
+                                        <?php } ?>
                                     </div>
                                 </div>
                             <?php } ?>


### PR DESCRIPTION
## Summary
- extend the game history backend to track previous values and compute unified diff strings for title, group, and trophy changes
- rework the history page UI to render diff blocks with styling and icon comparisons instead of tabular highlights
- expand the GameHistoryPage test coverage to assert the new diff metadata for titles, groups, and trophies

## Testing
- php -l wwwroot/game_history.php
- php -l wwwroot/classes/GameHistoryPage.php
- php -l tests/GameHistoryPageTest.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6909d077f310832f933b3db394af61c6