### PR TITLE
Render game history entries as unified diffs

### DIFF
--- a/tests/GameHistoryPageTest.php
+++ b/tests/GameHistoryPageTest.php
@@ -114,18 +114,23 @@ final class GameHistoryPageTest extends TestCase
         $this->assertTrue($latestEntry['hasTitleChanges']);
         $this->assertTrue($latestEntry['titleHighlights']['set_version']);
         $this->assertFalse($latestEntry['titleHighlights']['detail']);
+        $this->assertSame('01.05', $latestEntry['previousTitle']['set_version']);
         $this->assertSame([], $latestEntry['groups']);
         $this->assertCount(1, $latestEntry['trophies']);
         $this->assertTrue($latestEntry['trophies'][0]['changedFields']['progress_target_value']);
+        $this->assertSame(50, $latestEntry['trophies'][0]['previous']['progress_target_value']);
 
         $midEntry = $entries[1];
         $this->assertTrue($midEntry['hasTitleChanges']);
         $this->assertTrue($midEntry['titleHighlights']['set_version']);
+        $this->assertSame('01.00', $midEntry['previousTitle']['set_version']);
         $this->assertCount(1, $midEntry['groups']);
         $this->assertTrue($midEntry['groups'][0]['isNewRow']);
+        $this->assertSame(null, $midEntry['groups'][0]['previous']['name']);
         $this->assertCount(1, $midEntry['trophies']);
         $this->assertTrue($midEntry['trophies'][0]['isNewRow']);
         $this->assertTrue($midEntry['trophies'][0]['is_unobtainable']);
+        $this->assertSame(null, $midEntry['trophies'][0]['previous']['progress_target_value']);
 
         $earliestEntry = $entries[2];
         $this->assertTrue($earliestEntry['hasTitleChanges']);

--- a/wwwroot/classes/GameHistoryPage.php
+++ b/wwwroot/classes/GameHistoryPage.php
@@ -30,6 +30,7 @@ final class GameHistoryPage
      *     historyId: int,
      *     discoveredAt: DateTimeImmutable,
      *     title: ?array{detail: ?string, icon_url: ?string, set_version: ?string},
+     *     previousTitle: array{detail: ?string, icon_url: ?string, set_version: ?string},
      *     titleHighlights: array{detail: bool, icon_url: bool, set_version: bool},
      *     hasTitleChanges: bool,
      *     groups: array<int, array{
@@ -38,6 +39,7 @@ final class GameHistoryPage
      *         detail: ?string,
      *         icon_url: ?string,
      *         changedFields: array{name: bool, detail: bool, icon_url: bool},
+     *         previous: array{name: ?string, detail: ?string, icon_url: ?string},
      *         isNewRow: bool
      *     }>,
      *     trophies: array<int, array{
@@ -49,6 +51,7 @@ final class GameHistoryPage
      *         progress_target_value: ?int,
      *         is_unobtainable: bool,
      *         changedFields: array{name: bool, detail: bool, icon_url: bool, progress_target_value: bool},
+     *         previous: array{name: ?string, detail: ?string, icon_url: ?string, progress_target_value: ?int},
      *         isNewRow: bool
      *     }>
      * }>|null
@@ -123,6 +126,7 @@ final class GameHistoryPage
      *     historyId: int,
      *     discoveredAt: DateTimeImmutable,
      *     title: ?array{detail: ?string, icon_url: ?string, set_version: ?string},
+     *     previousTitle: array{detail: ?string, icon_url: ?string, set_version: ?string},
      *     titleHighlights: array{detail: bool, icon_url: bool, set_version: bool},
      *     hasTitleChanges: bool,
      *     groups: array<int, array{
@@ -131,6 +135,7 @@ final class GameHistoryPage
      *         detail: ?string,
      *         icon_url: ?string,
      *         changedFields: array{name: bool, detail: bool, icon_url: bool},
+     *         previous: array{name: ?string, detail: ?string, icon_url: ?string},
      *         isNewRow: bool
      *     }>,
      *     trophies: array<int, array{
@@ -142,6 +147,7 @@ final class GameHistoryPage
      *         progress_target_value: ?int,
      *         is_unobtainable: bool,
      *         changedFields: array{name: bool, detail: bool, icon_url: bool, progress_target_value: bool},
+     *         previous: array{name: ?string, detail: ?string, icon_url: ?string, progress_target_value: ?int},
      *         isNewRow: bool
      *     }>
      * }>
@@ -210,6 +216,7 @@ final class GameHistoryPage
 
                 if ($hasRowChanges) {
                     $groupChange['changedFields'] = $changedFields;
+                    $groupChange['previous'] = $previousGroup;
                     $groupChange['isNewRow'] = $isNewRow;
                     $filteredGroups[] = $groupChange;
                 }
@@ -258,6 +265,7 @@ final class GameHistoryPage
 
                 if ($hasRowChanges) {
                     $trophyChange['changedFields'] = $changedFields;
+                    $trophyChange['previous'] = $previousTrophy;
                     $trophyChange['isNewRow'] = $isNewRow;
                     $filteredTrophies[] = $trophyChange;
                 }
@@ -275,6 +283,7 @@ final class GameHistoryPage
             if ($entryHasChanges) {
                 $entry['titleHighlights'] = $titleHighlights;
                 $entry['hasTitleChanges'] = $hasTitleChanges;
+                $entry['previousTitle'] = $previousTitle;
                 $entry['groups'] = $filteredGroups;
                 $entry['trophies'] = $filteredTrophies;
 


### PR DESCRIPTION
## Summary
- render game history entries using a unified diff layout with dedicated helpers and styles
- capture previous values for title, group, and trophy changes when preparing history entries
- extend the game history page test suite to cover the new diff metadata

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6909d6d4915c832faf64bc67aeda9b7c