### PR TITLE
Add unified diff styling to game history tables

### DIFF
--- a/tests/GameHistoryPageTest.php
+++ b/tests/GameHistoryPageTest.php
@@ -117,6 +117,9 @@ final class GameHistoryPageTest extends TestCase
         $this->assertSame([], $latestEntry['groups']);
         $this->assertCount(1, $latestEntry['trophies']);
         $this->assertTrue($latestEntry['trophies'][0]['changedFields']['progress_target_value']);
+        $this->assertTrue(array_key_exists('previousValues', $latestEntry['trophies'][0]));
+        $this->assertSame(50, $latestEntry['trophies'][0]['previousValues']['progress_target_value']);
+        $this->assertSame('Challenger', $latestEntry['trophies'][0]['previousValues']['name']);
 
         $midEntry = $entries[1];
         $this->assertTrue($midEntry['hasTitleChanges']);
@@ -126,6 +129,7 @@ final class GameHistoryPageTest extends TestCase
         $this->assertCount(1, $midEntry['trophies']);
         $this->assertTrue($midEntry['trophies'][0]['isNewRow']);
         $this->assertTrue($midEntry['trophies'][0]['is_unobtainable']);
+        $this->assertFalse(array_key_exists('previousValues', $midEntry['trophies'][0]));
 
         $earliestEntry = $entries[2];
         $this->assertTrue($earliestEntry['hasTitleChanges']);

--- a/wwwroot/classes/GameHistoryPage.php
+++ b/wwwroot/classes/GameHistoryPage.php
@@ -38,7 +38,8 @@ final class GameHistoryPage
      *         detail: ?string,
      *         icon_url: ?string,
      *         changedFields: array{name: bool, detail: bool, icon_url: bool},
-     *         isNewRow: bool
+     *         isNewRow: bool,
+     *         previousValues?: array{name: ?string, detail: ?string, icon_url: ?string}
      *     }>,
      *     trophies: array<int, array{
      *         group_id: string,
@@ -49,7 +50,13 @@ final class GameHistoryPage
      *         progress_target_value: ?int,
      *         is_unobtainable: bool,
      *         changedFields: array{name: bool, detail: bool, icon_url: bool, progress_target_value: bool},
-     *         isNewRow: bool
+     *         isNewRow: bool,
+     *         previousValues?: array{
+     *             name: ?string,
+     *             detail: ?string,
+     *             icon_url: ?string,
+     *             progress_target_value: ?int
+     *         }
      *     }>
      * }>|null
      */
@@ -131,7 +138,8 @@ final class GameHistoryPage
      *         detail: ?string,
      *         icon_url: ?string,
      *         changedFields: array{name: bool, detail: bool, icon_url: bool},
-     *         isNewRow: bool
+     *         isNewRow: bool,
+     *         previousValues?: array{name: ?string, detail: ?string, icon_url: ?string}
      *     }>,
      *     trophies: array<int, array{
      *         group_id: string,
@@ -142,7 +150,13 @@ final class GameHistoryPage
      *         progress_target_value: ?int,
      *         is_unobtainable: bool,
      *         changedFields: array{name: bool, detail: bool, icon_url: bool, progress_target_value: bool},
-     *         isNewRow: bool
+     *         isNewRow: bool,
+     *         previousValues?: array{
+     *             name: ?string,
+     *             detail: ?string,
+     *             icon_url: ?string,
+     *             progress_target_value: ?int
+     *         }
      *     }>
      * }>
      */
@@ -197,6 +211,7 @@ final class GameHistoryPage
                 ];
 
                 $isNewRow = !array_key_exists($groupId, $previousGroups);
+                $hasFieldChanges = in_array(true, $changedFields, true);
 
                 if ($isNewRow) {
                     foreach (array_keys($changedFields) as $field) {
@@ -204,9 +219,11 @@ final class GameHistoryPage
                             $changedFields[$field] = true;
                         }
                     }
+                } elseif ($hasFieldChanges) {
+                    $groupChange['previousValues'] = $previousGroup;
                 }
 
-                $hasRowChanges = $isNewRow || in_array(true, $changedFields, true);
+                $hasRowChanges = $isNewRow || $hasFieldChanges;
 
                 if ($hasRowChanges) {
                     $groupChange['changedFields'] = $changedFields;
@@ -239,6 +256,7 @@ final class GameHistoryPage
                 ];
 
                 $isNewRow = !array_key_exists($trophyKey, $previousTrophies);
+                $hasFieldChanges = in_array(true, $changedFields, true);
 
                 if ($isNewRow) {
                     foreach (array_keys($changedFields) as $field) {
@@ -252,9 +270,11 @@ final class GameHistoryPage
                             }
                         }
                     }
+                } elseif ($hasFieldChanges) {
+                    $trophyChange['previousValues'] = $previousTrophy;
                 }
 
-                $hasRowChanges = $isNewRow || in_array(true, $changedFields, true);
+                $hasRowChanges = $isNewRow || $hasFieldChanges;
 
                 if ($hasRowChanges) {
                     $trophyChange['changedFields'] = $changedFields;

--- a/wwwroot/game_history.php
+++ b/wwwroot/game_history.php
@@ -125,27 +125,67 @@ require_once 'header.php';
                                             </thead>
                                             <tbody>
                                                 <?php foreach ($groupChanges as $groupChange) { ?>
-                                                    <?php $groupChangedFields = $groupChange['changedFields'] ?? ['name' => false, 'detail' => false, 'icon_url' => false]; ?>
-                                                    <tr class="<?= ($groupChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
-                                                        <td class="<?= ($groupChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
+                                                    <?php
+                                                    $groupChangedFields = $groupChange['changedFields'] ?? ['name' => false, 'detail' => false, 'icon_url' => false];
+                                                    $previousGroupValues = $groupChange['previousValues'] ?? null;
+                                                    $hasGroupFieldChanges = in_array(true, $groupChangedFields, true);
+                                                    $isNewGroupRow = $groupChange['isNewRow'] ?? false;
+                                                    $showPreviousGroupRow = is_array($previousGroupValues) && $hasGroupFieldChanges;
+                                                    ?>
+
+                                                    <?php if ($showPreviousGroupRow) { ?>
+                                                        <?php
+                                                        $previousGroupIconUrl = $previousGroupValues['icon_url'] ?? '';
+                                                        $previousGroupIconPath = ($previousGroupIconUrl === '.png')
+                                                            ? ((str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2'))
+                                                                ? '../missing-ps5-game-and-trophy.png'
+                                                                : '../missing-ps4-game.png')
+                                                            : $previousGroupIconUrl;
+                                                        ?>
+                                                        <tr class="diff-row diff-row-removed">
+                                                            <td>
+                                                                <span class="badge text-bg-secondary"><?= htmlentities($groupChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span>
+                                                            </td>
+                                                            <td class="diff-cell diff-cell-removed <?= ($groupChangedFields['name'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                                <div class="diff-cell-content"><span class="visually-hidden">Previous value: </span><?= htmlentities($previousGroupValues['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?></div>
+                                                            </td>
+                                                            <td class="diff-cell diff-cell-removed <?= ($groupChangedFields['detail'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                                <div class="diff-cell-content"><span class="visually-hidden">Previous value: </span><?= nl2br(htmlentities($previousGroupValues['detail'] ?? '', ENT_QUOTES, 'UTF-8')); ?></div>
+                                                            </td>
+                                                            <td class="text-center diff-cell diff-cell-removed diff-cell-icon <?= ($groupChangedFields['icon_url'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                                <div class="diff-cell-content">
+                                                                    <span class="visually-hidden">Previous value: </span>
+                                                                    <img class="object-fit-cover diff-icon" style="height: 3.5rem;" src="/img/group/<?= htmlentities($previousGroupIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($previousGroupValues['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    <?php } ?>
+
+                                                    <?php
+                                                    $groupIconUrl = $groupChange['icon_url'] ?? '';
+                                                    $groupIconPath = ($groupIconUrl === '.png')
+                                                        ? ((str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2'))
+                                                            ? '../missing-ps5-game-and-trophy.png'
+                                                            : '../missing-ps4-game.png')
+                                                        : $groupIconUrl;
+                                                    $groupRowClass = ($isNewGroupRow || $hasGroupFieldChanges) ? 'diff-row diff-row-added' : '';
+                                                    $groupRowClassAttribute = $groupRowClass === '' ? '' : ' class="' . $groupRowClass . '"';
+                                                    ?>
+                                                    <tr<?= $groupRowClassAttribute; ?>>
+                                                        <td>
                                                             <span class="badge text-bg-secondary"><?= htmlentities($groupChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span>
                                                         </td>
-                                                        <td class="<?= (($groupChange['isNewRow'] ?? false) || ($groupChangedFields['name'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?= htmlentities($groupChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                                                        <td class="diff-cell <?= ($isNewGroupRow || $hasGroupFieldChanges) ? 'diff-cell-added' : ''; ?> <?= ($groupChangedFields['name'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                            <div class="diff-cell-content"><span class="visually-hidden">Updated value: </span><?= htmlentities($groupChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?></div>
                                                         </td>
-                                                        <td class="<?= (($groupChange['isNewRow'] ?? false) || ($groupChangedFields['detail'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?= nl2br(htmlentities($groupChange['detail'] ?? '', ENT_QUOTES, 'UTF-8')); ?>
+                                                        <td class="diff-cell <?= ($isNewGroupRow || $hasGroupFieldChanges) ? 'diff-cell-added' : ''; ?> <?= ($groupChangedFields['detail'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                            <div class="diff-cell-content"><span class="visually-hidden">Updated value: </span><?= nl2br(htmlentities($groupChange['detail'] ?? '', ENT_QUOTES, 'UTF-8')); ?></div>
                                                         </td>
-                                                        <td class="text-center <?= (($groupChange['isNewRow'] ?? false) || ($groupChangedFields['icon_url'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?php
-                                                            $groupIconUrl = $groupChange['icon_url'] ?? '';
-                                                            $groupIconPath = ($groupIconUrl === '.png')
-                                                                ? ((str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2'))
-                                                                    ? '../missing-ps5-game-and-trophy.png'
-                                                                    : '../missing-ps4-game.png')
-                                                                : $groupIconUrl;
-                                                            ?>
-                                                            <img class="object-fit-cover <?= (($groupChange['isNewRow'] ?? false) || ($groupChangedFields['icon_url'] ?? false)) ? 'border border-success border-2 rounded' : ''; ?>" style="height: 3.5rem;" src="/img/group/<?= htmlentities($groupIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($groupChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                                                        <td class="text-center diff-cell diff-cell-icon <?= ($isNewGroupRow || $hasGroupFieldChanges) ? 'diff-cell-added' : ''; ?> <?= ($groupChangedFields['icon_url'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                            <div class="diff-cell-content">
+                                                                <span class="visually-hidden">Updated value: </span>
+                                                                <img class="object-fit-cover diff-icon" style="height: 3.5rem;" src="/img/group/<?= htmlentities($groupIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($groupChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                                                            </div>
                                                         </td>
                                                     </tr>
                                                 <?php } ?>
@@ -173,37 +213,88 @@ require_once 'header.php';
                                             </thead>
                                             <tbody>
                                                 <?php foreach ($trophyChanges as $trophyChange) { ?>
-                                                    <?php $trophyChangedFields = $trophyChange['changedFields'] ?? ['name' => false, 'detail' => false, 'icon_url' => false, 'progress_target_value' => false]; ?>
-                                                    <tr class="<?= ($trophyChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
-                                                        <td class="<?= ($trophyChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
+                                                    <?php
+                                                    $trophyChangedFields = $trophyChange['changedFields'] ?? ['name' => false, 'detail' => false, 'icon_url' => false, 'progress_target_value' => false];
+                                                    $previousTrophyValues = $trophyChange['previousValues'] ?? null;
+                                                    $hasFieldChanges = in_array(true, $trophyChangedFields, true);
+                                                    $isNewTrophyRow = $trophyChange['isNewRow'] ?? false;
+                                                    $showPreviousTrophyRow = is_array($previousTrophyValues) && $hasFieldChanges;
+                                                    ?>
+
+                                                    <?php if ($showPreviousTrophyRow) { ?>
+                                                        <?php
+                                                        $previousTargetValue = $previousTrophyValues['progress_target_value'] ?? null;
+                                                        $previousIconUrl = $previousTrophyValues['icon_url'] ?? '';
+                                                        $previousIconPath = ($previousIconUrl === '.png')
+                                                            ? ((str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2'))
+                                                                ? '../missing-ps5-game-and-trophy.png'
+                                                                : '../missing-ps4-trophy.png')
+                                                            : $previousIconUrl;
+                                                        ?>
+                                                        <tr class="diff-row diff-row-removed">
+                                                            <td>
+                                                                <span class="badge text-bg-secondary"><?= htmlentities($trophyChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span>
+                                                            </td>
+                                                            <td>
+                                                                <?php if ($trophyChange['is_unobtainable'] ?? false) { ?>
+                                                                    <span class="badge text-bg-warning" title="This trophy is unobtainable and not accounted for on any leaderboard."><?= (int) $trophyChange['order_id']; ?></span>
+                                                                <?php } else { ?>
+                                                                    <?= (int) $trophyChange['order_id']; ?>
+                                                                <?php } ?>
+                                                            </td>
+                                                            <td class="diff-cell diff-cell-removed <?= ($trophyChangedFields['name'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                                <div class="diff-cell-content"><span class="visually-hidden">Previous value: </span><?= htmlentities($previousTrophyValues['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?></div>
+                                                            </td>
+                                                            <td class="diff-cell diff-cell-removed <?= ($trophyChangedFields['detail'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                                <div class="diff-cell-content"><span class="visually-hidden">Previous value: </span><?= nl2br(htmlentities($previousTrophyValues['detail'] ?? '', ENT_QUOTES, 'UTF-8')); ?></div>
+                                                            </td>
+                                                            <td class="diff-cell diff-cell-removed <?= ($trophyChangedFields['progress_target_value'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                                <div class="diff-cell-content"><span class="visually-hidden">Previous value: </span><?= $previousTargetValue === null ? '&mdash;' : htmlentities((string) $previousTargetValue, ENT_QUOTES, 'UTF-8'); ?></div>
+                                                            </td>
+                                                            <td class="text-center diff-cell diff-cell-removed diff-cell-icon <?= ($trophyChangedFields['icon_url'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                                <div class="diff-cell-content">
+                                                                    <span class="visually-hidden">Previous value: </span>
+                                                                    <img class="object-fit-scale diff-icon" style="height: 3.5rem;" src="/img/trophy/<?= htmlentities($previousIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($previousTrophyValues['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    <?php } ?>
+
+                                                    <?php
+                                                    $trophyIconUrl = $trophyChange['icon_url'] ?? '';
+                                                    $trophyIconPath = ($trophyIconUrl === '.png')
+                                                        ? ((str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2'))
+                                                            ? '../missing-ps5-game-and-trophy.png'
+                                                            : '../missing-ps4-trophy.png')
+                                                        : $trophyIconUrl;
+                                                    $newRowClass = ($isNewTrophyRow || $hasFieldChanges) ? 'diff-row diff-row-added' : '';
+                                                    $newRowClassAttribute = $newRowClass === '' ? '' : ' class="' . $newRowClass . '"';
+                                                    ?>
+                                                    <tr<?= $newRowClassAttribute; ?>>
+                                                        <td>
                                                             <span class="badge text-bg-secondary"><?= htmlentities($trophyChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span>
                                                         </td>
-                                                        <td class="<?= ($trophyChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
+                                                        <td>
                                                             <?php if ($trophyChange['is_unobtainable'] ?? false) { ?>
                                                                 <span class="badge text-bg-warning" title="This trophy is unobtainable and not accounted for on any leaderboard."><?= (int) $trophyChange['order_id']; ?></span>
                                                             <?php } else { ?>
                                                                 <?= (int) $trophyChange['order_id']; ?>
                                                             <?php } ?>
                                                         </td>
-                                                        <td class="<?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['name'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?= htmlentities($trophyChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                                                        <td class="diff-cell <?= ($isNewTrophyRow || $hasFieldChanges) ? 'diff-cell-added' : ''; ?> <?= ($trophyChangedFields['name'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                            <div class="diff-cell-content"><span class="visually-hidden">Updated value: </span><?= htmlentities($trophyChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?></div>
                                                         </td>
-                                                        <td class="<?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['detail'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?= nl2br(htmlentities($trophyChange['detail'] ?? '', ENT_QUOTES, 'UTF-8')); ?>
+                                                        <td class="diff-cell <?= ($isNewTrophyRow || $hasFieldChanges) ? 'diff-cell-added' : ''; ?> <?= ($trophyChangedFields['detail'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                            <div class="diff-cell-content"><span class="visually-hidden">Updated value: </span><?= nl2br(htmlentities($trophyChange['detail'] ?? '', ENT_QUOTES, 'UTF-8')); ?></div>
                                                         </td>
-                                                        <td class="<?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['progress_target_value'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?= $trophyChange['progress_target_value'] === null ? '&mdash;' : htmlentities((string) $trophyChange['progress_target_value'], ENT_QUOTES, 'UTF-8'); ?>
+                                                        <td class="diff-cell <?= ($isNewTrophyRow || $hasFieldChanges) ? 'diff-cell-added' : ''; ?> <?= ($trophyChangedFields['progress_target_value'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                            <div class="diff-cell-content"><span class="visually-hidden">Updated value: </span><?= $trophyChange['progress_target_value'] === null ? '&mdash;' : htmlentities((string) $trophyChange['progress_target_value'], ENT_QUOTES, 'UTF-8'); ?></div>
                                                         </td>
-                                                        <td class="text-center <?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['icon_url'] ?? false)) ? 'table-success' : ''; ?>">
-                                                            <?php
-                                                            $trophyIconUrl = $trophyChange['icon_url'] ?? '';
-                                                            $trophyIconPath = ($trophyIconUrl === '.png')
-                                                                ? ((str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2'))
-                                                                    ? '../missing-ps5-game-and-trophy.png'
-                                                                    : '../missing-ps4-trophy.png')
-                                                                : $trophyIconUrl;
-                                                            ?>
-                                                            <img class="object-fit-scale <?= (($trophyChange['isNewRow'] ?? false) || ($trophyChangedFields['icon_url'] ?? false)) ? 'border border-success border-2 rounded' : ''; ?>" style="height: 3.5rem;" src="/img/trophy/<?= htmlentities($trophyIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophyChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                                                        <td class="text-center diff-cell diff-cell-icon <?= ($isNewTrophyRow || $hasFieldChanges) ? 'diff-cell-added' : ''; ?> <?= ($trophyChangedFields['icon_url'] ?? false) ? 'diff-cell-highlight' : ''; ?>">
+                                                            <div class="diff-cell-content">
+                                                                <span class="visually-hidden">Updated value: </span>
+                                                                <img class="object-fit-scale diff-icon" style="height: 3.5rem;" src="/img/trophy/<?= htmlentities($trophyIconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophyChange['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+                                                            </div>
                                                         </td>
                                                     </tr>
                                                 <?php } ?>

--- a/wwwroot/header.php
+++ b/wwwroot/header.php
@@ -126,6 +126,103 @@ if (isset($metaData) && $metaData instanceof PageMetaData) {
             .table-warning a:hover {
                 text-decoration-color: var(--bs-warning-text-emphasis) !important;
             }
+
+            .diff-row {
+                position: relative;
+            }
+
+            .diff-row.diff-row-added::before,
+            .diff-row.diff-row-removed::before {
+                content: '';
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                left: 0.25rem;
+                width: 0.2rem;
+                border-radius: 0.2rem;
+                opacity: 0.7;
+            }
+
+            .diff-row.diff-row-added::before {
+                background-color: rgba(63, 185, 80, 0.6);
+            }
+
+            .diff-row.diff-row-removed::before {
+                background-color: rgba(248, 81, 73, 0.6);
+            }
+
+            .diff-cell {
+                position: relative;
+                overflow: hidden;
+            }
+
+            .diff-cell::after {
+                content: '';
+                position: absolute;
+                inset: 0;
+                border-radius: 0.35rem;
+                background-color: transparent;
+                pointer-events: none;
+                transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+                z-index: 0;
+            }
+
+            .diff-cell-content {
+                position: relative;
+                z-index: 1;
+                display: block;
+            }
+
+            .diff-cell-added::after {
+                background-color: rgba(63, 185, 80, 0.18);
+            }
+
+            .diff-cell-removed::after {
+                background-color: rgba(248, 81, 73, 0.2);
+            }
+
+            .diff-cell.diff-cell-highlight::after {
+                inset: 0.15rem 0.35rem;
+            }
+
+            .diff-cell-added.diff-cell-highlight::after {
+                background-color: rgba(63, 185, 80, 0.35);
+                box-shadow: 0 0 0 1px rgba(46, 160, 67, 0.4);
+            }
+
+            .diff-cell-removed.diff-cell-highlight::after {
+                background-color: rgba(248, 81, 73, 0.38);
+                box-shadow: 0 0 0 1px rgba(248, 81, 73, 0.45);
+            }
+
+            .diff-cell-icon .diff-cell-content {
+                display: flex;
+                justify-content: center;
+            }
+
+            .diff-icon {
+                border-radius: 0.5rem;
+                border: 2px solid transparent;
+                background-color: rgba(0, 0, 0, 0.25);
+            }
+
+            .diff-cell-added.diff-cell-icon .diff-icon {
+                border-color: rgba(63, 185, 80, 0.55);
+                background-color: rgba(46, 160, 67, 0.2);
+            }
+
+            .diff-cell-added.diff-cell-icon.diff-cell-highlight .diff-icon {
+                border-color: rgba(63, 185, 80, 0.85);
+            }
+
+            .diff-cell-removed.diff-cell-icon .diff-icon {
+                border-color: rgba(248, 81, 73, 0.55);
+                background-color: rgba(248, 81, 73, 0.22);
+            }
+
+            .diff-cell-removed.diff-cell-icon.diff-cell-highlight .diff-icon {
+                border-color: rgba(248, 81, 73, 0.85);
+            }
         </style>
 
         <title><?= $title; ?></title>


### PR DESCRIPTION
## Summary
- track previous field values when computing game history changes
- render trophy group and trophy changes in a unified diff-style layout with added CSS helpers
- extend game history tests to cover the new previous value metadata

## Testing
- php -l wwwroot/classes/GameHistoryPage.php
- php -l wwwroot/game_history.php
- php -l wwwroot/header.php
- php -l tests/GameHistoryPageTest.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_6909dbb6bea4832f9aa9ff3eb96a7d21