### PR TITLE
Show trophy title history diffs on game history page

### DIFF
--- a/tests/GameHistoryPageTest.php
+++ b/tests/GameHistoryPageTest.php
@@ -114,6 +114,12 @@ final class GameHistoryPageTest extends TestCase
         $this->assertTrue($latestEntry['hasTitleChanges']);
         $this->assertTrue($latestEntry['titleHighlights']['set_version']);
         $this->assertFalse($latestEntry['titleHighlights']['detail']);
+        $this->assertSame([
+            'set_version' => [
+                'previous' => '01.05',
+                'current' => '01.10',
+            ],
+        ], $latestEntry['titleFieldDiffs']);
         $this->assertSame([], $latestEntry['groups']);
         $this->assertCount(1, $latestEntry['trophies']);
         $this->assertTrue($latestEntry['trophies'][0]['changedFields']['progress_target_value']);
@@ -121,6 +127,12 @@ final class GameHistoryPageTest extends TestCase
         $midEntry = $entries[1];
         $this->assertTrue($midEntry['hasTitleChanges']);
         $this->assertTrue($midEntry['titleHighlights']['set_version']);
+        $this->assertSame([
+            'set_version' => [
+                'previous' => '01.00',
+                'current' => '01.05',
+            ],
+        ], $midEntry['titleFieldDiffs']);
         $this->assertCount(1, $midEntry['groups']);
         $this->assertTrue($midEntry['groups'][0]['isNewRow']);
         $this->assertCount(1, $midEntry['trophies']);
@@ -131,6 +143,20 @@ final class GameHistoryPageTest extends TestCase
         $this->assertTrue($earliestEntry['hasTitleChanges']);
         $this->assertTrue($earliestEntry['titleHighlights']['icon_url']);
         $this->assertTrue($earliestEntry['titleHighlights']['detail']);
+        $this->assertSame([
+            'detail' => [
+                'previous' => null,
+                'current' => 'Initial detail',
+            ],
+            'icon_url' => [
+                'previous' => null,
+                'current' => 'icon-a.png',
+            ],
+            'set_version' => [
+                'previous' => null,
+                'current' => '01.00',
+            ],
+        ], $earliestEntry['titleFieldDiffs']);
         $this->assertCount(1, $earliestEntry['groups']);
         $this->assertTrue($earliestEntry['groups'][0]['isNewRow']);
         $this->assertCount(1, $earliestEntry['trophies']);

--- a/wwwroot/classes/GameHistoryPage.php
+++ b/wwwroot/classes/GameHistoryPage.php
@@ -31,6 +31,7 @@ final class GameHistoryPage
      *     discoveredAt: DateTimeImmutable,
      *     title: ?array{detail: ?string, icon_url: ?string, set_version: ?string},
      *     titleHighlights: array{detail: bool, icon_url: bool, set_version: bool},
+     *     titleFieldDiffs?: array<string, array{previous: mixed, current: mixed}>,
      *     hasTitleChanges: bool,
      *     groups: array<int, array{
      *         group_id: string,
@@ -126,6 +127,7 @@ final class GameHistoryPage
      *     discoveredAt: DateTimeImmutable,
      *     title: ?array{detail: ?string, icon_url: ?string, set_version: ?string},
      *     titleHighlights: array{detail: bool, icon_url: bool, set_version: bool},
+     *     titleFieldDiffs?: array<string, array{previous: mixed, current: mixed}>,
      *     hasTitleChanges: bool,
      *     groups: array<int, array{
      *         group_id: string,
@@ -181,12 +183,24 @@ final class GameHistoryPage
             ];
             $hasTitleChanges = false;
 
+            $titleFieldDiffs = [];
+
             if ($titleChange !== null) {
                 $titleHighlights['detail'] = $this->isNewNonEmptyString($titleChange['detail'] ?? null, $previousTitle['detail']);
                 $titleHighlights['icon_url'] = $this->isNewNonEmptyString($titleChange['icon_url'] ?? null, $previousTitle['icon_url']);
                 $titleHighlights['set_version'] = $this->isNewNonEmptyString($titleChange['set_version'] ?? null, $previousTitle['set_version']);
 
                 $hasTitleChanges = in_array(true, $titleHighlights, true);
+
+                foreach (['detail', 'icon_url', 'set_version'] as $field) {
+                    if ($titleHighlights[$field]) {
+                        $currentValue = $this->normalizeString($titleChange[$field] ?? null);
+                        $titleFieldDiffs[$field] = [
+                            'previous' => $previousTitle[$field] ?? null,
+                            'current' => $currentValue,
+                        ];
+                    }
+                }
             }
 
             $filteredGroups = [];
@@ -316,6 +330,9 @@ final class GameHistoryPage
 
             if ($entryHasChanges) {
                 $entry['titleHighlights'] = $titleHighlights;
+                if ($titleFieldDiffs !== []) {
+                    $entry['titleFieldDiffs'] = $titleFieldDiffs;
+                }
                 $entry['hasTitleChanges'] = $hasTitleChanges;
                 $entry['groups'] = $filteredGroups;
                 $entry['trophies'] = $filteredTrophies;


### PR DESCRIPTION
## Summary
- show previous and current trophy title details and icons alongside history entries
- extend the shared icon renderer to handle title assets and surface set version changes
- cover the new title diff data in the GameHistoryPage unit test

## Testing
- php -l wwwroot/game_history.php
- php -l wwwroot/classes/GameHistoryPage.php
- php -l tests/GameHistoryPageTest.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_690b41222620832f9058e7a9f88d7253