### PR TITLE
Reverse scan order and surface progress updates

### DIFF
--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -143,7 +143,8 @@ CREATE TABLE `setting` (
   `refresh_token` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `npsso` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `scanning` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `scan_start` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+  `scan_start` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `scan_progress` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------

--- a/tests/AdminWorkerServiceTest.php
+++ b/tests/AdminWorkerServiceTest.php
@@ -10,7 +10,7 @@ final class AdminWorkerServiceTest extends TestCase
     {
         $database = new PDO('sqlite::memory:');
         $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY AUTOINCREMENT, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_start TEXT)');
+        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY AUTOINCREMENT, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_start TEXT, scan_progress TEXT)');
 
         $database->exec("INSERT INTO setting (refresh_token, npsso, scanning, scan_start) VALUES ('token-2', 'npsso-2', 'player-two', '2024-01-02 10:00:00')");
         $database->exec("INSERT INTO setting (refresh_token, npsso, scanning, scan_start) VALUES ('token-1', 'npsso-1', 'player-one', '2024-01-01 09:00:00')");
@@ -28,7 +28,7 @@ final class AdminWorkerServiceTest extends TestCase
     {
         $database = new PDO('sqlite::memory:');
         $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY AUTOINCREMENT, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_start TEXT)');
+        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY AUTOINCREMENT, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_start TEXT, scan_progress TEXT)');
         $database->exec("INSERT INTO setting (refresh_token, npsso, scanning, scan_start) VALUES ('token-1', 'old-npsso', 'player-one', '2024-01-01 09:00:00')");
 
         $service = new WorkerService($database);
@@ -44,7 +44,7 @@ final class AdminWorkerServiceTest extends TestCase
     {
         $database = new PDO('sqlite::memory:');
         $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY AUTOINCREMENT, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_start TEXT)');
+        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY AUTOINCREMENT, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_start TEXT, scan_progress TEXT)');
 
         $service = new WorkerService($database);
         $this->assertFalse($service->updateWorkerNpsso(42, 'does-not-exist'));

--- a/tests/PlayerQueueResponseFactoryTest.php
+++ b/tests/PlayerQueueResponseFactoryTest.php
@@ -157,4 +157,30 @@ final class PlayerQueueResponseFactoryTest extends TestCase
             $service->getEscapedValues()
         );
     }
+
+    public function testCreateQueuedForScanResponseIncludesProgressDetails(): void
+    {
+        $service = new RecordingPlayerQueueServiceStub();
+        $factory = new PlayerQueueResponseFactory($service);
+
+        $response = $factory->createQueuedForScanResponse('Player <Name>', [
+            'current' => 5,
+            'total' => 34,
+            'title' => 'Game <Title>',
+        ]);
+
+        $this->assertSame('queued', $response->getStatus());
+        $this->assertTrue($response->shouldPoll());
+
+        $message = $response->getMessage();
+        $this->assertStringContainsString('href="/player/Player%20%3CName%3E"', $message);
+        $this->assertStringContainsString('Currently scanning <strong>Game &lt;Title&gt;</strong> (5/34).', $message);
+        $this->assertStringContainsString('class="progress mt-2"', $message);
+        $this->assertStringContainsString('spinner-border', $message);
+
+        $this->assertSame(
+            ['Player <Name>', '/player/Player%20%3CName%3E', 'Game <Title>'],
+            $service->getEscapedValues()
+        );
+    }
 }

--- a/wwwroot/classes/PlayerQueueHandler.php
+++ b/wwwroot/classes/PlayerQueueHandler.php
@@ -62,8 +62,12 @@ class PlayerQueueHandler
             return $this->responseFactory->createCheaterResponse($playerName, $playerData['account_id']);
         }
 
-        if ($this->service->isPlayerBeingScanned($playerName)) {
-            return $this->responseFactory->createQueuedForScanResponse($playerName);
+        $scanStatus = $this->service->getActiveScanStatus($playerName);
+        if ($scanStatus !== null) {
+            return $this->responseFactory->createQueuedForScanResponse(
+                $playerName,
+                $scanStatus['progress'] ?? null
+            );
         }
 
         $position = $this->service->getQueuePosition($playerName);

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -45,9 +45,16 @@ final class PlayerQueueResponseFactory
         return $this->createQueuedResponse($message);
     }
 
-    public function createQueuedForScanResponse(string $playerName): PlayerQueueResponse
+    /**
+     * @param array{current?: int, total?: int, title?: string, npCommunicationId?: string}|null $scanProgress
+     */
+    public function createQueuedForScanResponse(string $playerName, ?array $scanProgress = null): PlayerQueueResponse
     {
         $message = $this->createPlayerLink($playerName) . ' is currently being scanned.';
+
+        if ($scanProgress !== null) {
+            $message .= $this->createScanProgressMessage($scanProgress);
+        }
 
         return $this->createQueuedResponse($message);
     }
@@ -95,6 +102,56 @@ final class PlayerQueueResponseFactory
     {
         return $message
             . "\n<div class=\"spinner-border\" role=\"status\">\n    <span class=\"visually-hidden\">Loading...</span>\n</div>";
+    }
+
+    /**
+     * @param array{current?: int, total?: int, title?: string, npCommunicationId?: string} $progress
+     */
+    private function createScanProgressMessage(array $progress): string
+    {
+        $current = null;
+        $total = null;
+
+        if (array_key_exists('current', $progress) && is_numeric($progress['current'])) {
+            $current = max(0, (int) $progress['current']);
+        }
+
+        if (array_key_exists('total', $progress) && is_numeric($progress['total'])) {
+            $total = max(0, (int) $progress['total']);
+        }
+
+        $parts = [];
+
+        if (array_key_exists('title', $progress) && is_string($progress['title']) && $progress['title'] !== '') {
+            $parts[] = 'Currently scanning <strong>' . $this->service->escapeHtml($progress['title']) . '</strong>';
+        }
+
+        if ($current !== null && $total !== null && $total > 0) {
+            $clampedCurrent = min($current, $total);
+            $parts[] = sprintf('(%d/%d)', $clampedCurrent, $total);
+        }
+
+        if ($parts === []) {
+            return '';
+        }
+
+        $message = ' ' . implode(' ', $parts) . '.';
+
+        if ($current !== null && $total !== null && $total > 0) {
+            $clampedCurrent = min($current, $total);
+            $percentage = $total === 0 ? 0 : (int) round(($clampedCurrent / $total) * 100);
+            $percentage = max(0, min(100, $percentage));
+
+            $message .= sprintf(
+                '<div class="progress mt-2" role="progressbar" aria-valuenow="%d" aria-valuemin="0" aria-valuemax="100">'
+                . '<div class="progress-bar bg-primary" style="width: %d%%;"></div>'
+                . '</div>',
+                $percentage,
+                $percentage
+            );
+        }
+
+        return $message;
     }
 
     private function createCheaterMessage(string $playerName, ?string $accountId): string


### PR DESCRIPTION
## Summary
- sort trophy titles chronologically and track the scan start index so workers process the oldest outstanding games first
- persist per-worker scan progress and surface it through the queue service and response factory with progress messaging
- add the `scan_progress` column to the `setting` schema and expand queue-related tests to cover the new progress data

## Testing
- php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php
- php -l wwwroot/classes/PlayerQueueHandler.php
- php -l wwwroot/classes/PlayerQueueResponseFactory.php
- php -l wwwroot/classes/PlayerQueueService.php
- php -l tests/AdminWorkerServiceTest.php
- php -l tests/PlayerQueueHandlerTest.php
- php -l tests/PlayerQueueResponseFactoryTest.php
- php -l tests/PlayerQueueServiceTest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e4168abb8832f9b30617e879e9a46)