### PR TITLE
Increase cron job memory limit to prevent stream exhaustion

### DIFF
--- a/tests/CronJobRunnerTest.php
+++ b/tests/CronJobRunnerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/CronJobRunner.php';
+
+final class CronJobRunnerTest extends TestCase
+{
+    private string|false $originalMemoryLimit;
+
+    private string|false $originalMaxExecutionTime;
+
+    private string|false $originalMysqlConnectTimeout;
+
+    protected function setUp(): void
+    {
+        $this->originalMemoryLimit = ini_get('memory_limit');
+        $this->originalMaxExecutionTime = ini_get('max_execution_time');
+        $this->originalMysqlConnectTimeout = ini_get('mysql.connect_timeout');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalMemoryLimit !== false) {
+            ini_set('memory_limit', (string) $this->originalMemoryLimit);
+        }
+
+        if ($this->originalMaxExecutionTime !== false) {
+            ini_set('max_execution_time', (string) $this->originalMaxExecutionTime);
+        }
+
+        if ($this->originalMysqlConnectTimeout !== false) {
+            ini_set('mysql.connect_timeout', (string) $this->originalMysqlConnectTimeout);
+        }
+    }
+
+    public function testConfigureEnvironmentRaisesLowMemoryLimit(): void
+    {
+        ini_set('memory_limit', '128M');
+        ini_set('max_execution_time', '30');
+        ini_set('mysql.connect_timeout', '15');
+
+        $runner = CronJobRunner::create();
+        $runner->configureEnvironment();
+
+        $this->assertSame('512M', ini_get('memory_limit'));
+
+        $maxExecutionTime = ini_get('max_execution_time');
+        if ($maxExecutionTime !== false) {
+            $this->assertSame('0', $maxExecutionTime);
+        }
+
+        $mysqlConnectTimeout = ini_get('mysql.connect_timeout');
+        if ($mysqlConnectTimeout !== false) {
+            $this->assertSame('0', $mysqlConnectTimeout);
+        }
+    }
+
+    public function testConfigureEnvironmentKeepsHigherMemoryLimit(): void
+    {
+        ini_set('memory_limit', '1024M');
+
+        $runner = CronJobRunner::create();
+        $runner->configureEnvironment();
+
+        $this->assertSame('1024M', ini_get('memory_limit'));
+    }
+}

--- a/wwwroot/classes/Cron/CronJobRunner.php
+++ b/wwwroot/classes/Cron/CronJobRunner.php
@@ -6,6 +6,9 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final class CronJobRunner
 {
+    private const MINIMUM_MEMORY_LIMIT = '512M';
+    private const MINIMUM_MEMORY_LIMIT_BYTES = 536870912; // 512 MiB
+
     private bool $environmentConfigured = false;
 
     public static function create(): self
@@ -30,6 +33,7 @@ final class CronJobRunner
             return;
         }
 
+        $this->increaseMemoryLimitIfNeeded();
         $this->applyIniSetting('max_execution_time', '0');
         $this->applyIniSetting('mysql.connect_timeout', '0');
 
@@ -45,5 +49,69 @@ final class CronJobRunner
         if (function_exists('ini_set')) {
             @ini_set($option, $value);
         }
+    }
+
+    private function increaseMemoryLimitIfNeeded(): void
+    {
+        if (function_exists('ini_get')) {
+            $currentLimit = ini_get('memory_limit');
+
+            if ($currentLimit === false || $currentLimit === '' || $currentLimit === '-1') {
+                return;
+            }
+
+            $currentBytes = $this->parseIniSizeToBytes($currentLimit);
+
+            if ($currentBytes !== null && $currentBytes >= self::MINIMUM_MEMORY_LIMIT_BYTES) {
+                return;
+            }
+        }
+
+        $this->applyIniSetting('memory_limit', self::MINIMUM_MEMORY_LIMIT);
+    }
+
+    private function parseIniSizeToBytes(string $value): ?int
+    {
+        $trimmed = trim($value);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (is_numeric($trimmed)) {
+            return (int) $trimmed;
+        }
+
+        if (str_ends_with($trimmed, 'B') || str_ends_with($trimmed, 'b')) {
+            $trimmed = substr($trimmed, 0, -1);
+            $trimmed = trim($trimmed);
+        }
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        $unit = strtolower(substr($trimmed, -1));
+        $numberPart = substr($trimmed, 0, -1);
+
+        if ($numberPart === '' || !is_numeric($numberPart)) {
+            return null;
+        }
+
+        $number = (float) $numberPart;
+
+        switch ($unit) {
+            case 'g':
+                $number *= 1024;
+                // no break intentionally
+            case 'm':
+                $number *= 1024;
+                // no break intentionally
+            case 'k':
+                $number *= 1024;
+                return (int) round($number);
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- ensure the cron runner raises PHP's memory limit to at least 512M to prevent stream exhaustion during large PSN responses
- add regression tests covering the cron runner's environment configuration helpers

## Testing
- php tests/run.php
- php -l wwwroot/classes/Cron/CronJobRunner.php
- php -l tests/CronJobRunnerTest.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e64e7e784832fbd4270282f9bfe6c)