### PR TITLE
Display worker scan progress in admin panel

### DIFF
--- a/wwwroot/admin/workers.php
+++ b/wwwroot/admin/workers.php
@@ -81,6 +81,7 @@ $workers = $workerService->fetchWorkers();
                                 <th scope="col" style="width: 18rem;">NPSSO</th>
                                 <th scope="col" style="width: 16rem;">Scanning</th>
                                 <th scope="col" style="width: 16rem;">Scan Start</th>
+                                <th scope="col" style="width: 20rem;">Scan Progress</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -90,6 +91,7 @@ $workers = $workerService->fetchWorkers();
                                 $scanning = $worker->getScanning();
                                 $scanningDisplay = htmlspecialchars($scanning, ENT_QUOTES, 'UTF-8');
                                 $scanningLink = $scanning !== '' ? '/player/' . rawurlencode($scanning) : null;
+                                $scanProgress = $worker->getScanProgress();
                                 ?>
                                 <tr>
                                     <td class="text-nowrap">#<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?></td>
@@ -122,6 +124,52 @@ $workers = $workerService->fetchWorkers();
                                         >
                                             <?= htmlspecialchars($scanStart->format('Y-m-d H:i:s T'), ENT_QUOTES, 'UTF-8'); ?>
                                         </time>
+                                    </td>
+                                    <td>
+                                        <?php if ($scanning === '') { ?>
+                                            <span class="text-body-secondary">—</span>
+                                        <?php } elseif ($scanProgress === null) { ?>
+                                            <span class="text-body-secondary">Not reported</span>
+                                        <?php } else { ?>
+                                            <div class="small">
+                                                <?php if (array_key_exists('title', $scanProgress)) { ?>
+                                                    <div>
+                                                        <strong>Title:</strong>
+                                                        <?= htmlspecialchars((string) $scanProgress['title'], ENT_QUOTES, 'UTF-8'); ?>
+                                                    </div>
+                                                <?php } ?>
+                                                <?php
+                                                $current = $scanProgress['current'] ?? null;
+                                                $total = $scanProgress['total'] ?? null;
+                                                $progressSummary = null;
+                                                $percentage = null;
+
+                                                if (is_int($current) && is_int($total) && $total > 0) {
+                                                    $progressSummary = sprintf('%d / %d', $current, $total);
+                                                    $percentage = round(($current / $total) * 100, 1);
+                                                } elseif (is_int($current) && $total === null) {
+                                                    $progressSummary = (string) $current;
+                                                } elseif (is_int($total) && $current === null) {
+                                                    $progressSummary = '0 / ' . $total;
+                                                }
+                                                ?>
+                                                <?php if ($progressSummary !== null) { ?>
+                                                    <div>
+                                                        <strong>Progress:</strong>
+                                                        <?= htmlspecialchars($progressSummary, ENT_QUOTES, 'UTF-8'); ?>
+                                                        <?php if ($percentage !== null) { ?>
+                                                            (<?= htmlspecialchars(number_format($percentage, 1), ENT_QUOTES, 'UTF-8'); ?>%)
+                                                        <?php } ?>
+                                                    </div>
+                                                <?php } ?>
+                                                <?php if (array_key_exists('npCommunicationId', $scanProgress)) { ?>
+                                                    <div>
+                                                        <strong>NP Communication ID:</strong>
+                                                        <?= htmlspecialchars((string) $scanProgress['npCommunicationId'], ENT_QUOTES, 'UTF-8'); ?>
+                                                    </div>
+                                                <?php } ?>
+                                            </div>
+                                        <?php } ?>
                                     </td>
                                 </tr>
                             <?php } ?>

--- a/wwwroot/classes/Admin/Worker.php
+++ b/wwwroot/classes/Admin/Worker.php
@@ -12,16 +12,23 @@ final class Worker
 
     private DateTimeImmutable $scanStart;
 
+    /**
+     * @var array{current?: int, total?: int, title?: string, npCommunicationId?: string}|null
+     */
+    private ?array $scanProgress;
+
     public function __construct(
         int $id,
         string $npsso,
         string $scanning,
-        DateTimeImmutable $scanStart
+        DateTimeImmutable $scanStart,
+        ?array $scanProgress
     ) {
         $this->id = $id;
         $this->npsso = $npsso;
         $this->scanning = $scanning;
         $this->scanStart = $scanStart;
+        $this->scanProgress = $scanProgress;
     }
 
     public function getId(): int
@@ -42,5 +49,13 @@ final class Worker
     public function getScanStart(): DateTimeImmutable
     {
         return $this->scanStart;
+    }
+
+    /**
+     * @return array{current?: int, total?: int, title?: string, npCommunicationId?: string}|null
+     */
+    public function getScanProgress(): ?array
+    {
+        return $this->scanProgress;
     }
 }


### PR DESCRIPTION
## Summary
- add scan progress data to the admin worker entity and service, decoding JSON payloads when present
- surface worker scan progress details in the admin workers table with friendly formatting
- expand worker service tests to cover scan progress handling

## Testing
- php -l wwwroot/classes/Admin/Worker.php
- php -l wwwroot/classes/Admin/WorkerService.php
- php -l wwwroot/admin/workers.php
- php -l tests/AdminWorkerServiceTest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e6b7dfd44832f9c522b748f5c7453)