### PR TITLE
Handle empty PSN player search errors

### DIFF
--- a/wwwroot/admin/psn-player-search.php
+++ b/wwwroot/admin/psn-player-search.php
@@ -15,7 +15,13 @@ if ($normalizedSearchTerm !== '') {
         $searchService = PsnPlayerSearchService::fromDatabase($database);
         $results = $searchService->search($normalizedSearchTerm);
     } catch (Throwable $exception) {
-        $errorMessage = $exception->getMessage();
+        $message = trim($exception->getMessage());
+
+        if ($message === '') {
+            $message = 'An unexpected error occurred while searching for players. Please try again later.';
+        }
+
+        $errorMessage = $message;
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- ensure the admin PSN player search page shows a helpful message when an exception lacks a description

## Testing
- php -l wwwroot/admin/psn-player-search.php
- php tests/run.php *(fails: PsnPlayerSearchServiceTest::__construct signature mismatch in Worker test stub)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e6e3b63e0832fbba78ec213d20f4d)