### PR TITLE
Ensure trophy merge creates missing trophy meta records

### DIFF
--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -1033,11 +1033,13 @@ SQL
                     INSERT INTO trophy_title_meta (
                         np_communication_id,
                         message,
-                        parent_np_communication_id
+                        parent_np_communication_id,
+                        status
                     ) VALUES (
                         :np_communication_id,
                         '',
-                        :parent_np_communication_id
+                        :parent_np_communication_id,
+                        2
                     )
 SQL
                 );


### PR DESCRIPTION
## Summary
- ensure trophy merge process creates a trophy_title_meta row when a child title is missing metadata before updating its parent relationship

## Testing
- php tests/run.php *(fails: PsnPlayerSearchServiceTest requires five Worker constructor arguments)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fd22d9774832faf198706639e1fb7)