### PR TITLE
Handle PSN player search rate limiting

### DIFF
--- a/wwwroot/admin/psn-player-search.php
+++ b/wwwroot/admin/psn-player-search.php
@@ -4,26 +4,15 @@ declare(strict_types=1);
 require_once '../init.php';
 require_once '../vendor/autoload.php';
 require_once '../classes/Admin/PsnPlayerSearchService.php';
+require_once '../classes/Admin/PsnPlayerSearchRequestHandler.php';
 
 $searchTerm = isset($_GET['player']) ? (string) $_GET['player'] : '';
-$normalizedSearchTerm = trim($searchTerm);
-$results = [];
-$errorMessage = null;
+$searchService = PsnPlayerSearchService::fromDatabase($database);
+$handledRequest = PsnPlayerSearchRequestHandler::handle($searchService, $searchTerm);
 
-if ($normalizedSearchTerm !== '') {
-    try {
-        $searchService = PsnPlayerSearchService::fromDatabase($database);
-        $results = $searchService->search($normalizedSearchTerm);
-    } catch (Throwable $exception) {
-        $message = trim($exception->getMessage());
-
-        if ($message === '') {
-            $message = 'An unexpected error occurred while searching for players. Please try again later.';
-        }
-
-        $errorMessage = $message;
-    }
-}
+$normalizedSearchTerm = $handledRequest['normalizedSearchTerm'];
+$results = $handledRequest['results'];
+$errorMessage = $handledRequest['errorMessage'];
 ?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">

--- a/wwwroot/classes/Admin/PsnPlayerSearchRateLimitException.php
+++ b/wwwroot/classes/Admin/PsnPlayerSearchRateLimitException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+final class PsnPlayerSearchRateLimitException extends RuntimeException
+{
+    private ?DateTimeImmutable $retryAt;
+
+    public function __construct(?DateTimeImmutable $retryAt, ?Throwable $previous = null)
+    {
+        $this->retryAt = $retryAt;
+
+        $message = 'The PlayStation Network rate limited the player search request.';
+
+        if ($retryAt !== null) {
+            $message .= sprintf(' Retry available at %s.', $retryAt->format(DateTimeInterface::RFC3339));
+        }
+
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getRetryAt(): ?DateTimeImmutable
+    {
+        return $this->retryAt;
+    }
+}

--- a/wwwroot/classes/Admin/PsnPlayerSearchRequestHandler.php
+++ b/wwwroot/classes/Admin/PsnPlayerSearchRequestHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PsnPlayerSearchRateLimitException.php';
+require_once __DIR__ . '/PsnPlayerSearchService.php';
+
+final class PsnPlayerSearchRequestHandler
+{
+    /**
+     * @return array{normalizedSearchTerm: string, results: list<PsnPlayerSearchResult>, errorMessage: ?string}
+     */
+    public static function handle(PsnPlayerSearchService $searchService, string $searchTerm): array
+    {
+        $normalizedSearchTerm = trim($searchTerm);
+        $results = [];
+        $errorMessage = null;
+
+        if ($normalizedSearchTerm !== '') {
+            try {
+                $results = $searchService->search($normalizedSearchTerm);
+            } catch (PsnPlayerSearchRateLimitException $rateLimitException) {
+                $retryAt = $rateLimitException->getRetryAt();
+
+                $errorMessage = $retryAt === null
+                    ? 'The PlayStation Network rate limited player search. Please try again later.'
+                    : sprintf(
+                        'The PlayStation Network rate limited player search until %s.',
+                        $retryAt->format(DateTimeInterface::RFC3339)
+                    );
+            } catch (Throwable $exception) {
+                $message = trim($exception->getMessage());
+
+                if ($message === '') {
+                    $message = 'An unexpected error occurred while searching for players. Please try again later.';
+                }
+
+                $errorMessage = $message;
+            }
+        }
+
+        return [
+            'normalizedSearchTerm' => $normalizedSearchTerm,
+            'results' => $results,
+            'errorMessage' => $errorMessage,
+        ];
+    }
+}

--- a/wwwroot/classes/Admin/PsnPlayerSearchService.php
+++ b/wwwroot/classes/Admin/PsnPlayerSearchService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/WorkerService.php';
 require_once __DIR__ . '/PsnPlayerSearchResult.php';
+require_once __DIR__ . '/PsnPlayerSearchRateLimitException.php';
 
 use Tustin\PlayStation\Client;
 
@@ -61,16 +62,168 @@ final class PsnPlayerSearchService
         $results = [];
         $count = 0;
 
-        foreach ($client->users()->search($normalizedPlayerName) as $userSearchResult) {
-            $results[] = PsnPlayerSearchResult::fromUserSearchResult($userSearchResult);
-            $count++;
+        try {
+            foreach ($client->users()->search($normalizedPlayerName) as $userSearchResult) {
+                $results[] = PsnPlayerSearchResult::fromUserSearchResult($userSearchResult);
+                $count++;
 
-            if ($count >= self::RESULT_LIMIT) {
-                break;
+                if ($count >= self::RESULT_LIMIT) {
+                    break;
+                }
             }
+        } catch (Throwable $exception) {
+            $rateLimitException = $this->createRateLimitException($exception);
+
+            if ($rateLimitException !== null) {
+                throw $rateLimitException;
+            }
+
+            throw $exception;
         }
 
         return $results;
+    }
+
+    private function createRateLimitException(Throwable $exception): ?PsnPlayerSearchRateLimitException
+    {
+        $response = $this->findResponse($exception);
+
+        if ($response !== null) {
+            $statusCode = $this->extractStatusCodeFromResponse($response);
+
+            if ($statusCode === 429) {
+                $retryAt = $this->extractRetryTimestampFromResponse($response);
+
+                return new PsnPlayerSearchRateLimitException($retryAt, $exception);
+            }
+        }
+
+        $throwableStatusCode = $this->extractStatusCodeFromThrowable($exception);
+
+        if ($throwableStatusCode === 429) {
+            return new PsnPlayerSearchRateLimitException(null, $exception);
+        }
+
+        return null;
+    }
+
+    private function findResponse(Throwable $exception): ?object
+    {
+        if (method_exists($exception, 'getResponse')) {
+            $response = $exception->getResponse();
+
+            if (is_object($response)) {
+                return $response;
+            }
+        }
+
+        $previous = $exception->getPrevious();
+
+        if ($previous instanceof Throwable) {
+            return $this->findResponse($previous);
+        }
+
+        return null;
+    }
+
+    private function extractStatusCodeFromResponse(object $response): ?int
+    {
+        if (method_exists($response, 'getStatusCode')) {
+            $statusCode = $response->getStatusCode();
+
+            if (is_int($statusCode)) {
+                return $statusCode;
+            }
+        }
+
+        if (method_exists($response, 'getStatus')) {
+            $status = $response->getStatus();
+
+            if (is_int($status)) {
+                return $status;
+            }
+        }
+
+        return null;
+    }
+
+    private function extractRetryTimestampFromResponse(object $response): ?DateTimeImmutable
+    {
+        $headerValue = null;
+
+        if (method_exists($response, 'getHeaderLine')) {
+            $headerLine = $response->getHeaderLine('X-RateLimit-Next-Available');
+
+            if (is_string($headerLine)) {
+                $headerLine = trim($headerLine);
+
+                if ($headerLine !== '') {
+                    $headerValue = $headerLine;
+                }
+            }
+        }
+
+        if ($headerValue === null && method_exists($response, 'getHeader')) {
+            $header = $response->getHeader('X-RateLimit-Next-Available');
+
+            if (is_array($header) && $header !== []) {
+                $firstValue = $header[0];
+
+                if (is_string($firstValue)) {
+                    $firstValue = trim($firstValue);
+
+                    if ($firstValue !== '') {
+                        $headerValue = $firstValue;
+                    }
+                }
+            }
+        }
+
+        return $this->parseRetryTimestamp($headerValue);
+    }
+
+    private function parseRetryTimestamp(?string $value): ?DateTimeImmutable
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            $timestamp = (int) $value;
+
+            if ($timestamp > 0) {
+                try {
+                    $dateTime = new DateTimeImmutable('@' . $timestamp);
+
+                    return $dateTime->setTimezone(new DateTimeZone('UTC'));
+                } catch (Exception) {
+                    return null;
+                }
+            }
+        }
+
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    private function extractStatusCodeFromThrowable(Throwable $exception): ?int
+    {
+        $code = $exception->getCode();
+
+        if (is_int($code) && $code > 0) {
+            return $code;
+        }
+
+        $previous = $exception->getPrevious();
+
+        if ($previous instanceof Throwable) {
+            return $this->extractStatusCodeFromThrowable($previous);
+        }
+
+        return null;
     }
 
     private function createAuthenticatedClient(): object


### PR DESCRIPTION
## Summary
- wrap PSN player search iteration to surface rate limit responses as a dedicated exception with retry metadata
- add a request handler to format rate-limit feedback for the admin UI and adjust the controller to use it
- extend the player search tests to cover the new exception flow and rate-limit messaging

## Testing
- php -d detect_unicode=0 tests/run.php
- php -l wwwroot/classes/Admin/PsnPlayerSearchService.php
- php -l wwwroot/classes/Admin/PsnPlayerSearchRateLimitException.php
- php -l wwwroot/classes/Admin/PsnPlayerSearchRequestHandler.php
- php -l wwwroot/admin/psn-player-search.php
- php -l tests/PsnPlayerSearchServiceTest.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fa32fd6c832f8d56682ca43514d4)