### PR TITLE
Use GraphQL endpoint for admin player search

### DIFF
--- a/wwwroot/admin/psn-player-search.php
+++ b/wwwroot/admin/psn-player-search.php
@@ -54,7 +54,7 @@ $errorMessage = $handledRequest['errorMessage'];
                                 <th scope="col">#</th>
                                 <th scope="col">Online ID</th>
                                 <th scope="col">Account ID</th>
-                                <th scope="col">Country</th>
+                                <th scope="col">Languages</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -63,7 +63,7 @@ $errorMessage = $handledRequest['errorMessage'];
                                     <th scope="row"><?= $index + 1; ?></th>
                                     <td><?= htmlentities($result->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></td>
                                     <td><?= htmlentities($result->getAccountId(), ENT_QUOTES, 'UTF-8'); ?></td>
-                                    <td><?= htmlentities($result->getCountry(), ENT_QUOTES, 'UTF-8'); ?></td>
+                                    <td><?= htmlentities($result->getLanguages(), ENT_QUOTES, 'UTF-8'); ?></td>
                                 </tr>
                             <?php } ?>
                         </tbody>

--- a/wwwroot/classes/Admin/PsnPlayerSearchResult.php
+++ b/wwwroot/classes/Admin/PsnPlayerSearchResult.php
@@ -8,22 +8,50 @@ final class PsnPlayerSearchResult
 
     private string $accountId;
 
-    private string $country;
+    private string $languages;
 
-    public function __construct(string $onlineId, string $accountId, string $country)
+    public function __construct(string $onlineId, string $accountId, string $languages)
     {
         $this->onlineId = $onlineId;
         $this->accountId = $accountId;
-        $this->country = $country;
+        $this->languages = $languages;
     }
 
     public static function fromUserSearchResult(object $userSearchResult): self
     {
         $onlineId = method_exists($userSearchResult, 'onlineId') ? (string) $userSearchResult->onlineId() : '';
         $accountId = method_exists($userSearchResult, 'accountId') ? (string) $userSearchResult->accountId() : '';
-        $country = method_exists($userSearchResult, 'country') ? (string) $userSearchResult->country() : '';
+        $languages = '';
 
-        return new self($onlineId, $accountId, $country);
+        if (method_exists($userSearchResult, 'languages')) {
+            $languagesValue = $userSearchResult->languages();
+
+            if (is_array($languagesValue)) {
+                $normalized = [];
+
+                foreach ($languagesValue as $language) {
+                    if (!is_string($language)) {
+                        continue;
+                    }
+
+                    $language = trim($language);
+
+                    if ($language === '') {
+                        continue;
+                    }
+
+                    if (!in_array($language, $normalized, true)) {
+                        $normalized[] = $language;
+                    }
+                }
+
+                $languages = implode(', ', $normalized);
+            } elseif (is_string($languagesValue)) {
+                $languages = trim($languagesValue);
+            }
+        }
+
+        return new self($onlineId, $accountId, $languages);
     }
 
     public function getOnlineId(): string
@@ -36,8 +64,8 @@ final class PsnPlayerSearchResult
         return $this->accountId;
     }
 
-    public function getCountry(): string
+    public function getLanguages(): string
     {
-        return $this->country;
+        return $this->languages;
     }
 }


### PR DESCRIPTION
## Summary
- replace the admin PSN player search with GraphQL context/domain search requests
- add helpers to parse GraphQL payloads, paginate for up to 50 results, and extract country metadata
- update the player search service tests to stub the GraphQL responses and rate limit scenarios

## Testing
- php -l wwwroot/classes/Admin/PsnPlayerSearchService.php
- php -l tests/PsnPlayerSearchServiceTest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110b1cf5ec832f9679aedd1424b357)