### PR TITLE
Update admin player search with NP ID and country

### DIFF
--- a/tests/PsnPlayerSearchServiceTest.php
+++ b/tests/PsnPlayerSearchServiceTest.php
@@ -86,18 +86,18 @@ final class PsnPlayerSearchServiceTest extends TestCase
                         return (object) [];
                     }
 
-                    if (str_starts_with($path, 'userProfile/v1/internal/users/')) {
-                        if (preg_match('~/users/([^/]+)/profiles$~', $path, $matches) !== 1) {
-                            return (object) [];
+                    if (preg_match('~^userProfile/v1/users/([^/]+)/profile2$~', $path, $matches) === 1) {
+                        $onlineId = rawurldecode($matches[1]);
+
+                        if ($onlineId === 'Player1') {
+                            return (object) ['npId' => base64_encode('player1@a6.us')];
                         }
 
-                        $accountId = $matches[1];
-
-                        if ($accountId === '1') {
-                            return (object) ['languages' => ['en-US', 'fr-FR']];
+                        if ($onlineId === 'Player2') {
+                            return (object) ['npId' => base64_encode('player2@a6.jp')];
                         }
 
-                        return (object) ['languages' => ['ja-JP']];
+                        return (object) ['npId' => base64_encode(strtolower($onlineId) . '@a6.us')];
                     }
 
                     return (object) [];
@@ -112,8 +112,10 @@ final class PsnPlayerSearchServiceTest extends TestCase
         $this->assertCount(50, $results);
         $this->assertSame('Player1', $results[0]->getOnlineId());
         $this->assertSame('Player50', $results[49]->getOnlineId());
-        $this->assertSame('en-US, fr-FR', $results[0]->getLanguages());
-        $this->assertSame('ja-JP', $results[1]->getLanguages());
+        $this->assertSame('player1@a6.us', $results[0]->getNpId());
+        $this->assertSame('US', $results[0]->getCountry());
+        $this->assertSame('player2@a6.jp', $results[1]->getNpId());
+        $this->assertSame('JP', $results[1]->getCountry());
     }
 
     public function testSearchSkipsWorkersThatFailToLogin(): void
@@ -136,8 +138,12 @@ final class PsnPlayerSearchServiceTest extends TestCase
                 ]);
             }
 
-            if (preg_match('~/users/([^/]+)/profiles$~', $path, $matches) === 1 && $matches[1] === '42') {
-                return (object) ['languages' => ['en-GB']];
+            if (preg_match('~^userProfile/v1/users/([^/]+)/profile2$~', $path, $matches) === 1) {
+                $onlineId = rawurldecode($matches[1]);
+
+                if ($onlineId === 'Hunter') {
+                    return (object) ['npId' => base64_encode('hunter@a6.gb')];
+                }
             }
 
             return (object) [];
@@ -170,7 +176,8 @@ final class PsnPlayerSearchServiceTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertSame('Hunter', $results[0]->getOnlineId());
-        $this->assertSame('en-GB', $results[0]->getLanguages());
+        $this->assertSame('hunter@a6.gb', $results[0]->getNpId());
+        $this->assertSame('GB', $results[0]->getCountry());
     }
 
     public function testSearchThrowsWhenNoWorkersCanAuthenticate(): void

--- a/wwwroot/admin/psn-player-search.php
+++ b/wwwroot/admin/psn-player-search.php
@@ -54,7 +54,8 @@ $errorMessage = $handledRequest['errorMessage'];
                                 <th scope="col">#</th>
                                 <th scope="col">Online ID</th>
                                 <th scope="col">Account ID</th>
-                                <th scope="col">Languages</th>
+                                <th scope="col">NP ID</th>
+                                <th scope="col">Country</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -63,7 +64,8 @@ $errorMessage = $handledRequest['errorMessage'];
                                     <th scope="row"><?= $index + 1; ?></th>
                                     <td><?= htmlentities($result->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></td>
                                     <td><?= htmlentities($result->getAccountId(), ENT_QUOTES, 'UTF-8'); ?></td>
-                                    <td><?= htmlentities($result->getLanguages(), ENT_QUOTES, 'UTF-8'); ?></td>
+                                    <td><?= htmlentities($result->getNpId(), ENT_QUOTES, 'UTF-8'); ?></td>
+                                    <td><?= htmlentities($result->getCountry(), ENT_QUOTES, 'UTF-8'); ?></td>
                                 </tr>
                             <?php } ?>
                         </tbody>

--- a/wwwroot/classes/Admin/PsnPlayerSearchResult.php
+++ b/wwwroot/classes/Admin/PsnPlayerSearchResult.php
@@ -8,50 +8,47 @@ final class PsnPlayerSearchResult
 
     private string $accountId;
 
-    private string $languages;
+    private string $npId;
 
-    public function __construct(string $onlineId, string $accountId, string $languages)
+    private string $country;
+
+    public function __construct(string $onlineId, string $accountId, string $npId, string $country)
     {
         $this->onlineId = $onlineId;
         $this->accountId = $accountId;
-        $this->languages = $languages;
+        $this->npId = $npId;
+        $this->country = $country;
     }
 
     public static function fromUserSearchResult(object $userSearchResult): self
     {
         $onlineId = method_exists($userSearchResult, 'onlineId') ? (string) $userSearchResult->onlineId() : '';
         $accountId = method_exists($userSearchResult, 'accountId') ? (string) $userSearchResult->accountId() : '';
-        $languages = '';
 
-        if (method_exists($userSearchResult, 'languages')) {
-            $languagesValue = $userSearchResult->languages();
+        $encodedNpId = null;
 
-            if (is_array($languagesValue)) {
-                $normalized = [];
-
-                foreach ($languagesValue as $language) {
-                    if (!is_string($language)) {
-                        continue;
-                    }
-
-                    $language = trim($language);
-
-                    if ($language === '') {
-                        continue;
-                    }
-
-                    if (!in_array($language, $normalized, true)) {
-                        $normalized[] = $language;
-                    }
-                }
-
-                $languages = implode(', ', $normalized);
-            } elseif (is_string($languagesValue)) {
-                $languages = trim($languagesValue);
-            }
+        if (method_exists($userSearchResult, 'npId')) {
+            $npIdValue = $userSearchResult->npId();
+            $encodedNpId = is_string($npIdValue) ? $npIdValue : null;
         }
 
-        return new self($onlineId, $accountId, $languages);
+        [$npId, $country] = self::normalizeNpId($encodedNpId);
+
+        return new self($onlineId, $accountId, $npId, $country);
+    }
+
+    public static function fromProfileData(string $onlineId, string $accountId, ?object $profile): self
+    {
+        $encodedNpId = null;
+
+        if (is_object($profile)) {
+            $npIdValue = $profile->npId ?? null;
+            $encodedNpId = is_string($npIdValue) ? $npIdValue : null;
+        }
+
+        [$npId, $country] = self::normalizeNpId($encodedNpId);
+
+        return new self($onlineId, $accountId, $npId, $country);
     }
 
     public function getOnlineId(): string
@@ -64,8 +61,87 @@ final class PsnPlayerSearchResult
         return $this->accountId;
     }
 
-    public function getLanguages(): string
+    public function getNpId(): string
     {
-        return $this->languages;
+        return $this->npId;
+    }
+
+    public function getCountry(): string
+    {
+        return $this->country;
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private static function normalizeNpId(?string $encodedNpId): array
+    {
+        if ($encodedNpId === null) {
+            return ['', ''];
+        }
+
+        $decoded = self::decodeNpId($encodedNpId);
+
+        if ($decoded === null || $decoded === '') {
+            return ['', ''];
+        }
+
+        return [$decoded, self::extractCountryFromNpId($decoded)];
+    }
+
+    private static function decodeNpId(string $encodedNpId): ?string
+    {
+        $normalized = trim($encodedNpId);
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        $normalized = str_replace(['-', '_'], ['+', '/'], $normalized);
+
+        $remainder = strlen($normalized) % 4;
+
+        if ($remainder !== 0) {
+            $normalized .= str_repeat('=', 4 - $remainder);
+        }
+
+        $decoded = base64_decode($normalized, true);
+
+        if ($decoded === false) {
+            return null;
+        }
+
+        return $decoded;
+    }
+
+    private static function extractCountryFromNpId(string $npId): string
+    {
+        $atPosition = strrpos($npId, '@');
+
+        if ($atPosition === false) {
+            return '';
+        }
+
+        $domain = substr($npId, $atPosition + 1);
+
+        if ($domain === false) {
+            return '';
+        }
+
+        $domain = trim($domain);
+
+        if ($domain === '') {
+            return '';
+        }
+
+        $parts = array_values(array_filter(explode('.', $domain), static fn (string $part): bool => $part !== ''));
+
+        if ($parts === []) {
+            return '';
+        }
+
+        $country = strtoupper((string) array_pop($parts));
+
+        return $country;
     }
 }


### PR DESCRIPTION
## Summary
- replace the admin player search language column with decoded NP ID and derived country information
- update the PSN player search service to call the profile2 endpoint, decode NP IDs, and populate country metadata
- adjust service tests to cover the new data extraction logic

## Testing
- php -l wwwroot/classes/Admin/PsnPlayerSearchResult.php
- php -l wwwroot/classes/Admin/PsnPlayerSearchService.php
- php -l wwwroot/admin/psn-player-search.php
- php -l tests/PsnPlayerSearchServiceTest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691225432928832f90bee93864f2f5f2)