### PR TITLE
Fix NP ID parsing in admin player search

### DIFF
--- a/tests/PsnPlayerSearchServiceTest.php
+++ b/tests/PsnPlayerSearchServiceTest.php
@@ -90,14 +90,14 @@ final class PsnPlayerSearchServiceTest extends TestCase
                         $onlineId = rawurldecode($matches[1]);
 
                         if ($onlineId === 'Player1') {
-                            return (object) ['npId' => base64_encode('player1@a6.us')];
+                            return (object) ['profile' => (object) ['npId' => base64_encode('player1@a6.us')]];
                         }
 
                         if ($onlineId === 'Player2') {
-                            return (object) ['npId' => base64_encode('player2@a6.jp')];
+                            return (object) ['profile' => (object) ['npId' => base64_encode('player2@a6.jp')]];
                         }
 
-                        return (object) ['npId' => base64_encode(strtolower($onlineId) . '@a6.us')];
+                        return (object) ['profile' => (object) ['npId' => base64_encode(strtolower($onlineId) . '@a6.us')]];
                     }
 
                     return (object) [];
@@ -142,7 +142,7 @@ final class PsnPlayerSearchServiceTest extends TestCase
                 $onlineId = rawurldecode($matches[1]);
 
                 if ($onlineId === 'Hunter') {
-                    return (object) ['npId' => base64_encode('hunter@a6.gb')];
+                    return (object) ['profile' => (object) ['npId' => base64_encode('hunter@a6.gb')]];
                 }
             }
 

--- a/wwwroot/classes/Admin/PsnPlayerSearchResult.php
+++ b/wwwroot/classes/Admin/PsnPlayerSearchResult.php
@@ -42,13 +42,22 @@ final class PsnPlayerSearchResult
         $encodedNpId = null;
 
         if (is_object($profile)) {
-            $npIdValue = $profile->npId ?? null;
+            $npIdValue = self::extractNpIdFromProfile($profile);
             $encodedNpId = is_string($npIdValue) ? $npIdValue : null;
         }
 
         [$npId, $country] = self::normalizeNpId($encodedNpId);
 
         return new self($onlineId, $accountId, $npId, $country);
+    }
+
+    private static function extractNpIdFromProfile(object $profile): mixed
+    {
+        if (property_exists($profile, 'profile') && is_object($profile->profile)) {
+            return $profile->profile->npId ?? null;
+        }
+
+        return $profile->npId ?? null;
     }
 
     public function getOnlineId(): string


### PR DESCRIPTION
## Summary
- update PSN player search result parsing to read NP ID values from nested profile responses
- adjust player search service tests to reflect the nested profile response structure

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691229f237d4832f94335423a504511e)