### PR TITLE
Handle zero max score when calculating merged trophy progress

### DIFF
--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -591,9 +591,9 @@ SQL
                                 GREATEST(
                                     FLOOR(
                                         IF(
-                                            (player.score / tg.max_score) * 100 = 100 AND tg.platinum = 1 AND player.platinum = 0,
+                                            (player.score / NULLIF(tg.max_score, 0)) * 100 = 100 AND tg.platinum = 1 AND player.platinum = 0,
                                             99,
-                                            (player.score / tg.max_score) * 100
+                                            (player.score / NULLIF(tg.max_score, 0)) * 100
                                         )
                                     ),
                                     1


### PR DESCRIPTION
## Summary
- avoid division by zero when calculating merged trophy progress by using NULLIF on the max score divisor

## Testing
- php tests/run.php
- php -l wwwroot/classes/TrophyMergeService.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a57f8058832f9bf1b90c55bd11a3)