### PR TITLE
Fix parent trophy group matching return type casting

### DIFF
--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -462,7 +462,7 @@ class GameCopyService
 
         $usedParentGroups = [];
         foreach ($existingGroupMappings as $parentGroupId) {
-            $usedParentGroups[$parentGroupId] = true;
+            $usedParentGroups[(string) $parentGroupId] = true;
         }
 
         $groupOffset = $this->determineGroupOffset($existingGroupIds);
@@ -511,7 +511,7 @@ class GameCopyService
 
                 $groupIdMapping[$groupId] = $targetGroupId;
                 $existingGroupIds[$targetGroupId] = true;
-                $usedParentGroups[$targetGroupId] = true;
+                $usedParentGroups[(string) $targetGroupId] = true;
                 $parentGroupTrophyNames[$targetGroupId] = $childGroupTrophyNames[$groupId] ?? [];
                 $select->closeCursor();
                 continue;
@@ -561,7 +561,7 @@ class GameCopyService
 
             $groupIdMapping[$groupId] = $targetGroupId;
             $existingGroupIds[$targetGroupId] = true;
-            $usedParentGroups[$targetGroupId] = true;
+            $usedParentGroups[(string) $targetGroupId] = true;
             $parentGroupTrophyNames[$targetGroupId] = $childGroupTrophyNames[$groupId] ?? [];
 
             $select->closeCursor();
@@ -956,16 +956,18 @@ class GameCopyService
         }
 
         foreach ($parentGroupTrophyNames as $parentGroupId => $parentNames) {
-            if ($parentGroupId === $childGroupId) {
+            $parentGroupIdString = (string) $parentGroupId;
+
+            if ($parentGroupIdString === $childGroupId) {
                 continue;
             }
 
-            if (isset($usedParentGroups[$parentGroupId])) {
+            if (isset($usedParentGroups[$parentGroupIdString])) {
                 continue;
             }
 
             if ($parentNames === $childNames) {
-                return $parentGroupId;
+                return $parentGroupIdString;
             }
         }
 


### PR DESCRIPTION
## Summary
- cast parent trophy group identifiers to strings before comparison and return in GameCopyService
- ensure used parent group tracking stores identifiers as strings to avoid type mismatches

## Testing
- php -l wwwroot/classes/Admin/GameCopyService.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a73c5b6c832fae6317b38415f2fe)