### PR TITLE
Handle zero max score in trophy merge progress

### DIFF
--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -748,10 +748,10 @@ SQL
                     player.silver,
                     player.gold,
                     player.platinum,
-                    IF(
-                        player.score = 0,
-                        0,
-                        IFNULL(
+                    CASE
+                        WHEN :max_score = 0 THEN 0
+                        WHEN player.score = 0 THEN 0
+                        ELSE IFNULL(
                             GREATEST(
                                 FLOOR(
                                     IF(
@@ -764,7 +764,7 @@ SQL
                             ),
                             0
                         )
-                    ) AS progress,
+                    END AS progress,
                     player.last_updated_date
                 FROM
                     player


### PR DESCRIPTION
## Summary
- prevent division by zero when recalculating merged trophy progress by returning zero progress if the max score is zero

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69142e93ec10832f9f1ea53e616b136f)