### PR TITLE
Add sorting controls to admin workers list

### DIFF
--- a/tests/AdminWorkerServiceTest.php
+++ b/tests/AdminWorkerServiceTest.php
@@ -36,6 +36,23 @@ SQL
         );
     }
 
+    public function testFetchWorkersCanOrderByIdDescending(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY AUTOINCREMENT, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_start TEXT, scan_progress TEXT)');
+
+        $database->exec("INSERT INTO setting (id, refresh_token, npsso, scanning, scan_start) VALUES (1, 'token-1', 'npsso-1', '', '2024-01-01 09:00:00')");
+        $database->exec("INSERT INTO setting (id, refresh_token, npsso, scanning, scan_start) VALUES (2, 'token-2', 'npsso-2', '', '2024-01-02 09:00:00')");
+
+        $service = new WorkerService($database);
+        $workers = $service->fetchWorkers('id', 'DESC');
+
+        $this->assertCount(2, $workers);
+        $this->assertSame(2, $workers[0]->getId());
+        $this->assertSame(1, $workers[1]->getId());
+    }
+
     public function testUpdateWorkerNpssoReturnsTrueWhenRowUpdated(): void
     {
         $database = new PDO('sqlite::memory:');

--- a/wwwroot/classes/Admin/WorkerService.php
+++ b/wwwroot/classes/Admin/WorkerService.php
@@ -16,11 +16,20 @@ final class WorkerService
     /**
      * @return list<Worker>
      */
-    public function fetchWorkers(): array
+    public function fetchWorkers(string $orderBy = 'scan_start', string $direction = 'ASC'): array
     {
-        $statement = $this->database->query(
-            'SELECT id, npsso, scanning, scan_start, scan_progress FROM setting ORDER BY scan_start ASC'
-        );
+        $orderColumn = match (strtolower($orderBy)) {
+            'id' => 'id',
+            default => 'scan_start',
+        };
+
+        $orderDirection = strtoupper($direction) === 'DESC' ? 'DESC' : 'ASC';
+
+        $statement = $this->database->query(sprintf(
+            'SELECT id, npsso, scanning, scan_start, scan_progress FROM setting ORDER BY %s %s',
+            $orderColumn,
+            $orderDirection
+        ));
 
         if ($statement === false) {
             return [];


### PR DESCRIPTION
## Summary
- add server-side support for ordering workers by ID or scan start
- expose sorting controls in the admin workers table and drop the timezone suffix from localized timestamps
- cover the new ordering capability with a dedicated service test

## Testing
- php -l wwwroot/admin/workers.php
- php -l wwwroot/classes/Admin/WorkerService.php
- php -l tests/AdminWorkerServiceTest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691438eea3cc832fbd52c5d38430691a)