### PR TITLE
Clamp unearned trophy calculation to non-negative values

### DIFF
--- a/tests/PlayerSummaryServiceTest.php
+++ b/tests/PlayerSummaryServiceTest.php
@@ -103,4 +103,25 @@ final class PlayerSummaryServiceTest extends TestCase
         $this->assertSame(null, $summary->getAverageProgress());
         $this->assertSame(0, $summary->getUnearnedTrophies());
     }
+
+    public function testGetSummaryDoesNotAllowNegativeUnearnedTrophies(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, bronze, silver, gold, platinum) VALUES\n" .
+            "('NPWR020', 1, 0, 0, 0)"
+        );
+
+        $this->database->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status) VALUES ('NPWR020', 0)"
+        );
+
+        $this->database->exec(
+            "INSERT INTO trophy_title_player (np_communication_id, account_id, progress, bronze, silver, gold, platinum) VALUES\n" .
+            "('NPWR020', 42, 100, 5, 0, 0, 0)"
+        );
+
+        $summary = $this->service->getSummary(42);
+
+        $this->assertSame(0, $summary->getUnearnedTrophies());
+    }
 }

--- a/wwwroot/classes/PlayerSummaryService.php
+++ b/wwwroot/classes/PlayerSummaryService.php
@@ -35,10 +35,10 @@ class PlayerSummaryService
                 SUM(CASE WHEN ttp.progress = 100 THEN 1 ELSE 0 END)       AS number_of_completed_games,
                 ROUND(AVG(ttp.progress), 2)                               AS average_progress,
                 SUM(
-                    tt.bronze - ttp.bronze +
-                    tt.silver - ttp.silver +
-                    tt.gold - ttp.gold +
-                    tt.platinum - ttp.platinum
+                    CASE WHEN tt.bronze > ttp.bronze THEN tt.bronze - ttp.bronze ELSE 0 END +
+                    CASE WHEN tt.silver > ttp.silver THEN tt.silver - ttp.silver ELSE 0 END +
+                    CASE WHEN tt.gold > ttp.gold THEN tt.gold - ttp.gold ELSE 0 END +
+                    CASE WHEN tt.platinum > ttp.platinum THEN tt.platinum - ttp.platinum ELSE 0 END
                 )                                                         AS unearned_trophies
             FROM
                 trophy_title_player ttp


### PR DESCRIPTION
## Summary
- clamp each per-trophy difference in `PlayerSummaryService` so the SUM never produces a negative value that can underflow unsigned MySQL columns
- add a regression test to ensure the unearned trophy count stays at zero when the stored player progress exceeds the configured totals

## Testing
- `php -l wwwroot/classes/PlayerSummaryService.php`
- `php -l tests/PlayerSummaryServiceTest.php`
- `php tests/run.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69158a62e9c4832f9af6fee68c525549)