### PR TITLE
Add game link to admin detail page

### DIFF
--- a/wwwroot/admin/detail.php
+++ b/wwwroot/admin/detail.php
@@ -45,6 +45,16 @@ $requestedNpCommunicationId = isset($_GET['np_communication_id']) ? (string) $_G
             </form>
 
             <?php if ($gameDetail !== null) { ?>
+                <?php
+                $gameSlug = $utility->slugify($gameDetail->getName());
+                $gameUrl = '/game/' . $gameDetail->getId() . '-' . $gameSlug;
+                ?>
+                <p>
+                    Game page:
+                    <a href="<?= htmlentities($gameUrl, ENT_QUOTES, 'UTF-8'); ?>" target="_blank" rel="noopener">
+                        <?= htmlentities($gameUrl, ENT_QUOTES, 'UTF-8'); ?>
+                    </a>
+                </p>
                 <form method="post" autocomplete="off">
                     <input type="hidden" name="action" value="update-detail">
                     <input type="hidden" name="game" value="<?= $gameDetail->getId(); ?>"><br>


### PR DESCRIPTION
## Summary
- show administrators a direct link to the public game page whenever game details are loaded

## Testing
- php -l wwwroot/admin/detail.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691593ff717c832fb9f2a8f47ba89231)