### PR TITLE
Retry current trophy title when icon missing

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -677,6 +677,13 @@ class ThirtyMinuteCronJob implements CronJobInterface
 
                         // Look through each and every game
                         foreach ($trophyTitles as $index => $trophyTitle) {
+                            $npid = $trophyTitle->npCommunicationId();
+                            array_push($scannedGames, $npid);
+
+                            if ($index < $scanStartIndex) {
+                                continue;
+                            }
+
                             $trophyTitle = $this->ensureTrophyTitleIcon(
                                 $user,
                                 $trophyTitle,
@@ -691,13 +698,6 @@ class ThirtyMinuteCronJob implements CronJobInterface
                                 $restartScan = true;
 
                                 break;
-                            }
-
-                            $npid = $trophyTitle->npCommunicationId();
-                            array_push($scannedGames, $npid);
-
-                            if ($index < $scanStartIndex) {
-                                continue;
                             }
 
                             if ($totalGamesToProcess > 0) {


### PR DESCRIPTION
## Summary
- replace the pre-scan icon validation with a helper that retries fetching only the current trophy title when its icon URL is missing
- abort the scan immediately when a trophy title still lacks an icon after the retry so the cron job restarts cleanly

## Testing
- `php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php`
- `php tests/run.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691596759d4c832f99f15b6bab5224db)