### PR TITLE
Refactor image hashing into service

### DIFF
--- a/tests/ImageHashCalculatorTest.php
+++ b/tests/ImageHashCalculatorTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/ImageProcessor.php';
+require_once __DIR__ . '/../wwwroot/classes/ImageHashCalculator.php';
+
+final class ImageHashCalculatorTest extends TestCase
+{
+    public function testCalculateReturnsNullWhenContentsEmpty(): void
+    {
+        $calculator = new ImageHashCalculator(new FakeImageProcessor());
+
+        $this->assertSame(null, $calculator->calculate(''));
+    }
+
+    public function testCalculateReturnsNullWhenProcessorUnsupported(): void
+    {
+        $calculator = new ImageHashCalculator(new FakeImageProcessor(supported: false));
+
+        $this->assertSame(null, $calculator->calculate('image-data'));
+    }
+
+    public function testCalculateReturnsNullWhenImageCreationFails(): void
+    {
+        $calculator = new ImageHashCalculator(new FakeImageProcessor(createSucceeds: false));
+
+        $this->assertSame(null, $calculator->calculate('image-data'));
+    }
+
+    public function testCalculateReturnsHashForOpaqueImage(): void
+    {
+        $pixels = [
+            [
+                ['red' => 0, 'green' => 1, 'blue' => 2, 'alpha' => 0],
+                ['red' => 3, 'green' => 4, 'blue' => 5, 'alpha' => 0],
+            ],
+        ];
+        $calculator = new ImageHashCalculator(new FakeImageProcessor(pixels: $pixels));
+
+        $buffer = '';
+        foreach ($pixels as $row) {
+            foreach ($row as $pixel) {
+                $buffer .= chr($pixel['red']);
+                $buffer .= chr($pixel['green']);
+                $buffer .= chr($pixel['blue']);
+            }
+        }
+
+        $this->assertSame(md5($buffer), $calculator->calculate('image-data'));
+    }
+
+    public function testCalculateIncludesAlphaWhenTransparencyDetected(): void
+    {
+        $pixels = [
+            [
+                ['red' => 10, 'green' => 20, 'blue' => 30, 'alpha' => 5],
+                ['red' => 40, 'green' => 50, 'blue' => 60, 'alpha' => 0],
+            ],
+        ];
+        $calculator = new ImageHashCalculator(new FakeImageProcessor(pixels: $pixels));
+
+        $buffer = '';
+        foreach ($pixels as $row) {
+            foreach ($row as $pixel) {
+                $buffer .= chr($pixel['red']);
+                $buffer .= chr($pixel['green']);
+                $buffer .= chr($pixel['blue']);
+
+                $alpha = (int) round(($pixel['alpha'] ?? 0) * 255 / 127);
+                $alpha = max(0, min(255, $alpha));
+                $buffer .= chr($alpha);
+            }
+        }
+
+        $this->assertSame(md5($buffer), $calculator->calculate('image-data'));
+    }
+}
+
+final class FakeImageProcessor implements ImageProcessorInterface
+{
+    private bool $supported;
+
+    private bool $createSucceeds;
+
+    private int $width;
+
+    private int $height;
+
+    private array $pixels;
+
+    private bool $trueColor;
+
+    private object $imageHandle;
+
+    public function __construct(
+        bool $supported = true,
+        bool $createSucceeds = true,
+        int $width = 1,
+        int $height = 1,
+        array $pixels = [],
+        bool $trueColor = true
+    ) {
+        $this->supported = $supported;
+        $this->createSucceeds = $createSucceeds;
+        $this->trueColor = $trueColor;
+        $this->imageHandle = new stdClass();
+
+        if ($pixels !== []) {
+            $this->pixels = $pixels;
+            $this->height = count($pixels);
+            $this->width = count($pixels[0]);
+        } else {
+            $this->pixels = [];
+            $this->width = $width;
+            $this->height = $height;
+        }
+    }
+
+    public function isSupported(): bool
+    {
+        return $this->supported;
+    }
+
+    public function createImageFromString(string $contents): mixed
+    {
+        if (!$this->createSucceeds) {
+            return null;
+        }
+
+        return $this->imageHandle;
+    }
+
+    public function destroyImage(mixed $image): void
+    {
+        // Nothing to clean up in the fake processor.
+    }
+
+    public function getWidth(mixed $image): int
+    {
+        return $this->width;
+    }
+
+    public function getHeight(mixed $image): int
+    {
+        return $this->height;
+    }
+
+    public function isTrueColor(mixed $image): bool
+    {
+        return $this->trueColor;
+    }
+
+    public function convertPaletteToTrueColor(mixed $image): void
+    {
+        $this->trueColor = true;
+    }
+
+    public function getColorAt(mixed $image, int $x, int $y): int
+    {
+        return $y * max(1, $this->width) + $x;
+    }
+
+    public function getColorComponents(mixed $image, int $color): array
+    {
+        if ($this->pixels === []) {
+            return ['red' => 0, 'green' => 0, 'blue' => 0, 'alpha' => 0];
+        }
+
+        $width = max(1, $this->width);
+        $y = intdiv($color, $width);
+        $x = $color % $width;
+
+        return $this->pixels[$y][$x];
+    }
+}

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -27,17 +27,25 @@ class GameRescanService
 
     private TrophyHistoryRecorder $historyRecorder;
 
+    private ImageHashCalculator $imageHashCalculator;
+
     /**
      * @var callable(string):void|null
      */
     private $logListener = null;
 
-    public function __construct(PDO $database, TrophyCalculator $trophyCalculator, ?TrophyHistoryRecorder $historyRecorder = null)
+    public function __construct(
+        PDO $database,
+        TrophyCalculator $trophyCalculator,
+        ?TrophyHistoryRecorder $historyRecorder = null,
+        ?ImageHashCalculator $imageHashCalculator = null
+    )
     {
         $this->database = $database;
         $this->trophyCalculator = $trophyCalculator;
         $this->historyRecorder = $historyRecorder ?? new TrophyHistoryRecorder($database);
         $this->trophyMetaRepository = new TrophyMetaRepository($database);
+        $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
     }
 
     /**
@@ -1016,7 +1024,7 @@ class GameRescanService
 
     private function buildFilename(string $url, string $contents): string
     {
-        $hash = ImageHashCalculator::calculate($contents);
+        $hash = $this->imageHashCalculator->calculate($contents);
         if ($hash === null) {
             $hash = md5($contents);
         }

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -34,12 +34,15 @@ class ThirtyMinuteCronJob implements CronJobInterface
 
     private AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService;
 
+    private ImageHashCalculator $imageHashCalculator;
+
     public function __construct(
         PDO $database,
         TrophyCalculator $trophyCalculator,
         Psn100Logger $logger,
         TrophyHistoryRecorder $historyRecorder,
-        int $workerId
+        int $workerId,
+        ?ImageHashCalculator $imageHashCalculator = null
     )
     {
         $this->database = $database;
@@ -52,6 +55,7 @@ class ThirtyMinuteCronJob implements CronJobInterface
             $database,
             new TrophyMergeService($database)
         );
+        $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
     }
 
     /**
@@ -521,7 +525,7 @@ class ThirtyMinuteCronJob implements CronJobInterface
                         continue;
                     }
 
-                    $md5Hash = ImageHashCalculator::calculate($avatarContents);
+                    $md5Hash = $this->imageHashCalculator->calculate($avatarContents);
                     if ($md5Hash === null) {
                         $md5Hash = md5($avatarContents);
                     }
@@ -2036,7 +2040,7 @@ class ThirtyMinuteCronJob implements CronJobInterface
 
     private function buildFilename(string $url, string $contents): string
     {
-        $hash = ImageHashCalculator::calculate($contents);
+        $hash = $this->imageHashCalculator->calculate($contents);
         if ($hash === null) {
             $hash = md5($contents);
         }

--- a/wwwroot/classes/ImageProcessor.php
+++ b/wwwroot/classes/ImageProcessor.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+interface ImageProcessorInterface
+{
+    public function isSupported(): bool;
+
+    /**
+     * @return mixed|null
+     */
+    public function createImageFromString(string $contents);
+
+    public function destroyImage(mixed $image): void;
+
+    public function getWidth(mixed $image): int;
+
+    public function getHeight(mixed $image): int;
+
+    public function isTrueColor(mixed $image): bool;
+
+    public function convertPaletteToTrueColor(mixed $image): void;
+
+    public function getColorAt(mixed $image, int $x, int $y): int;
+
+    /**
+     * @return array<string, int>
+     */
+    public function getColorComponents(mixed $image, int $color): array;
+}
+
+final class GdImageProcessor implements ImageProcessorInterface
+{
+    public function isSupported(): bool
+    {
+        return extension_loaded('gd');
+    }
+
+    public function createImageFromString(string $contents): mixed
+    {
+        try {
+            $image = @imagecreatefromstring($contents);
+        } catch (\ValueError) {
+            return null;
+        }
+
+        if ($image === false) {
+            return null;
+        }
+
+        return $image;
+    }
+
+    public function destroyImage(mixed $image): void
+    {
+        if (is_resource($image) || $image instanceof \GdImage) {
+            imagedestroy($image);
+        }
+    }
+
+    public function getWidth(mixed $image): int
+    {
+        return imagesx($image);
+    }
+
+    public function getHeight(mixed $image): int
+    {
+        return imagesy($image);
+    }
+
+    public function isTrueColor(mixed $image): bool
+    {
+        return imageistruecolor($image);
+    }
+
+    public function convertPaletteToTrueColor(mixed $image): void
+    {
+        @imagepalettetotruecolor($image);
+    }
+
+    public function getColorAt(mixed $image, int $x, int $y): int
+    {
+        return imagecolorat($image, $x, $y);
+    }
+
+    public function getColorComponents(mixed $image, int $color): array
+    {
+        return imagecolorsforindex($image, $color);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the static image hashing helper with an `ImageHashCalculator` service that accepts a pluggable `ImageProcessorInterface`, making the logic injectable and easier to test
- inject the calculator into `GameRescanService` and `ThirtyMinuteCronJob` so they reuse a single instance when downloading artwork
- add unit coverage for the calculator using a fake processor to verify success, failure, and transparency scenarios

## Testing
- php -l wwwroot/classes/ImageProcessor.php
- php -l wwwroot/classes/ImageHashCalculator.php
- php -l wwwroot/classes/Admin/GameRescanService.php
- php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php
- php -l tests/ImageHashCalculatorTest.php
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d34310e0832fa5a623cb647bc070)