### PR TITLE
Refactor PSN player lookup handler to return result object

### DIFF
--- a/tests/PsnPlayerLookupServiceTest.php
+++ b/tests/PsnPlayerLookupServiceTest.php
@@ -147,11 +147,11 @@ final class PsnPlayerLookupServiceTest extends TestCase
 
         $handled = PsnPlayerLookupRequestHandler::handle($service, '   ');
 
-        $this->assertSame('', $handled['normalizedOnlineId']);
-        $this->assertSame(null, $handled['result']);
-        $this->assertSame(null, $handled['errorMessage']);
-        $this->assertSame(null, $handled['decodedNpId']);
-        $this->assertSame(null, $handled['npCountry']);
+        $this->assertSame('', $handled->getNormalizedOnlineId());
+        $this->assertSame(null, $handled->getResult());
+        $this->assertSame(null, $handled->getErrorMessage());
+        $this->assertSame(null, $handled->getDecodedNpId());
+        $this->assertSame(null, $handled->getNpCountry());
     }
 
     public function testRequestHandlerReturnsLookupErrorMessage(): void
@@ -171,11 +171,11 @@ final class PsnPlayerLookupServiceTest extends TestCase
 
         $handled = PsnPlayerLookupRequestHandler::handle($service, 'missing');
 
-        $this->assertSame('missing', $handled['normalizedOnlineId']);
-        $this->assertSame(null, $handled['result']);
-        $this->assertSame('Player "missing" was not found.', $handled['errorMessage']);
-        $this->assertSame(null, $handled['decodedNpId']);
-        $this->assertSame(null, $handled['npCountry']);
+        $this->assertSame('missing', $handled->getNormalizedOnlineId());
+        $this->assertSame(null, $handled->getResult());
+        $this->assertSame('Player "missing" was not found.', $handled->getErrorMessage());
+        $this->assertSame(null, $handled->getDecodedNpId());
+        $this->assertSame(null, $handled->getNpCountry());
     }
 
     public function testRequestHandlerReturnsFallbackMessageForUnexpectedErrors(): void
@@ -189,14 +189,14 @@ final class PsnPlayerLookupServiceTest extends TestCase
 
         $handled = PsnPlayerLookupRequestHandler::handle($service, 'example');
 
-        $this->assertSame('example', $handled['normalizedOnlineId']);
-        $this->assertSame(null, $handled['result']);
+        $this->assertSame('example', $handled->getNormalizedOnlineId());
+        $this->assertSame(null, $handled->getResult());
         $this->assertSame(
             'An unexpected error occurred while looking up the player. Please try again later.',
-            $handled['errorMessage']
+            $handled->getErrorMessage()
         );
-        $this->assertSame(null, $handled['decodedNpId']);
-        $this->assertSame(null, $handled['npCountry']);
+        $this->assertSame(null, $handled->getDecodedNpId());
+        $this->assertSame(null, $handled->getNpCountry());
     }
 
     public function testRequestHandlerIncludesNpIdMetadataWhenAvailable(): void
@@ -219,11 +219,11 @@ final class PsnPlayerLookupServiceTest extends TestCase
 
         $handled = PsnPlayerLookupRequestHandler::handle($service, 'Example');
 
-        $this->assertSame('Example', $handled['normalizedOnlineId']);
-        $this->assertTrue(is_array($handled['result']), 'Expected lookup result to be an array.');
-        $this->assertSame(null, $handled['errorMessage']);
-        $this->assertSame('example@a6.us', $handled['decodedNpId']);
-        $this->assertSame('US', $handled['npCountry']);
+        $this->assertSame('Example', $handled->getNormalizedOnlineId());
+        $this->assertTrue(is_array($handled->getResult()), 'Expected lookup result to be an array.');
+        $this->assertSame(null, $handled->getErrorMessage());
+        $this->assertSame('example@a6.us', $handled->getDecodedNpId());
+        $this->assertSame('US', $handled->getNpCountry());
     }
 }
 

--- a/wwwroot/admin/psn-player-lookup.php
+++ b/wwwroot/admin/psn-player-lookup.php
@@ -10,11 +10,11 @@ $onlineId = isset($_GET['onlineId']) ? (string) $_GET['onlineId'] : '';
 $lookupService = PsnPlayerLookupService::fromDatabase($database);
 $handledRequest = PsnPlayerLookupRequestHandler::handle($lookupService, $onlineId);
 
-$normalizedOnlineId = $handledRequest['normalizedOnlineId'];
-$result = $handledRequest['result'];
-$errorMessage = $handledRequest['errorMessage'];
-$decodedNpId = $handledRequest['decodedNpId'];
-$npCountry = $handledRequest['npCountry'];
+$normalizedOnlineId = $handledRequest->getNormalizedOnlineId();
+$result = $handledRequest->getResult();
+$errorMessage = $handledRequest->getErrorMessage();
+$decodedNpId = $handledRequest->getDecodedNpId();
+$npCountry = $handledRequest->getNpCountry();
 ?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">

--- a/wwwroot/classes/Admin/PsnPlayerLookupRequestHandler.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupRequestHandler.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PsnPlayerLookupService.php';
 require_once __DIR__ . '/PsnPlayerLookupException.php';
+require_once __DIR__ . '/PsnPlayerLookupRequestResult.php';
 
 final class PsnPlayerLookupRequestHandler
 {
-    /**
-     * @return array{normalizedOnlineId: string, result: ?array, errorMessage: ?string}
-     */
-    public static function handle(PsnPlayerLookupService $lookupService, string $onlineId): array
+    public static function handle(PsnPlayerLookupService $lookupService, string $onlineId): PsnPlayerLookupRequestResult
     {
         $normalizedOnlineId = trim($onlineId);
         $result = null;
@@ -35,13 +33,13 @@ final class PsnPlayerLookupRequestHandler
             }
         }
 
-        return [
-            'normalizedOnlineId' => $normalizedOnlineId,
-            'result' => $result,
-            'errorMessage' => $errorMessage,
-            'decodedNpId' => $decodedNpId,
-            'npCountry' => $npCountry,
-        ];
+        return new PsnPlayerLookupRequestResult(
+            $normalizedOnlineId,
+            $result,
+            $errorMessage,
+            $decodedNpId,
+            $npCountry
+        );
     }
 
     /**

--- a/wwwroot/classes/Admin/PsnPlayerLookupRequestResult.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupRequestResult.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+final class PsnPlayerLookupRequestResult
+{
+    private string $normalizedOnlineId;
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    private ?array $result;
+
+    private ?string $errorMessage;
+
+    private ?string $decodedNpId;
+
+    private ?string $npCountry;
+
+    /**
+     * @param array<string, mixed>|null $result
+     */
+    public function __construct(
+        string $normalizedOnlineId,
+        ?array $result,
+        ?string $errorMessage,
+        ?string $decodedNpId,
+        ?string $npCountry
+    ) {
+        $this->normalizedOnlineId = $normalizedOnlineId;
+        $this->result = $result;
+        $this->errorMessage = $errorMessage;
+        $this->decodedNpId = $decodedNpId;
+        $this->npCountry = $npCountry;
+    }
+
+    public function getNormalizedOnlineId(): string
+    {
+        return $this->normalizedOnlineId;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getResult(): ?array
+    {
+        return $this->result;
+    }
+
+    public function hasResult(): bool
+    {
+        return $this->result !== null;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+
+    public function hasError(): bool
+    {
+        return $this->errorMessage !== null;
+    }
+
+    public function getDecodedNpId(): ?string
+    {
+        return $this->decodedNpId;
+    }
+
+    public function getNpCountry(): ?string
+    {
+        return $this->npCountry;
+    }
+}


### PR DESCRIPTION
## Summary
- add `PsnPlayerLookupRequestResult` to represent the PSN player lookup response in an object-oriented way
- update the request handler, admin PSN lookup page, and tests to consume the new value object API

## Testing
- php tests/run.php
- php -l wwwroot/classes/Admin/PsnPlayerLookupRequestResult.php
- php -l wwwroot/classes/Admin/PsnPlayerLookupRequestHandler.php
- php -l wwwroot/admin/psn-player-lookup.php
- php -l tests/PsnPlayerLookupServiceTest.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d34310e0832fa5a623cb647bc070)