### PR TITLE
Refactor platform filter dropdown rendering

### DIFF
--- a/tests/PlayerPlatformFilterRendererTest.php
+++ b/tests/PlayerPlatformFilterRendererTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerPlatformFilterRenderer.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerPlatformFilterOptions.php';
+
+final class PlayerPlatformFilterRendererTest extends TestCase
+{
+    public function testRenderIncludesCheckedAttributeForSelectedPlatforms(): void
+    {
+        $options = PlayerPlatformFilterOptions::fromSelectionCallback(
+            static fn (string $platform): bool => $platform === 'ps5'
+        );
+        $renderer = new PlayerPlatformFilterRenderer();
+
+        $html = $renderer->render($options);
+
+        $this->assertStringContainsString('name="ps5"', $html);
+        $this->assertStringContainsString('id="filterPS5"', $html);
+        $this->assertStringContainsString('type="checkbox" checked', $html);
+    }
+
+    public function testRenderEscapesButtonLabel(): void
+    {
+        $options = PlayerPlatformFilterOptions::fromSelectionCallback(static fn (): bool => false);
+        $renderer = new PlayerPlatformFilterRenderer('<Filter>');
+
+        $html = $renderer->render($options);
+
+        $this->assertStringContainsString('&lt;Filter&gt;', $html);
+    }
+
+    public function testRenderIncludesAllPlatformLabels(): void
+    {
+        $options = PlayerPlatformFilterOptions::fromSelectionCallback(static fn (): bool => false);
+        $renderer = PlayerPlatformFilterRenderer::createDefault();
+
+        $html = $renderer->render($options);
+
+        foreach ($options->getOptions() as $option) {
+            $this->assertStringContainsString(
+                htmlspecialchars($option->getLabel(), ENT_QUOTES, 'UTF-8'),
+                $html
+            );
+        }
+    }
+}

--- a/wwwroot/classes/PlayerPlatformFilterRenderer.php
+++ b/wwwroot/classes/PlayerPlatformFilterRenderer.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
+
+final class PlayerPlatformFilterRenderer
+{
+    private string $buttonLabel;
+
+    public function __construct(string $buttonLabel = 'Filter')
+    {
+        $this->buttonLabel = $buttonLabel;
+    }
+
+    public static function createDefault(): self
+    {
+        return new self('Filter');
+    }
+
+    public function render(PlayerPlatformFilterOptions $options): string
+    {
+        $buttonLabel = htmlspecialchars($this->buttonLabel, ENT_QUOTES, 'UTF-8');
+        $optionItems = array_map(
+            fn (PlayerPlatformFilterOption $option): string => $this->renderOption($option),
+            $options->getOptions()
+        );
+        $optionsHtml = implode(PHP_EOL, $optionItems);
+
+        return <<<HTML
+<form>
+    <div class="input-group d-flex justify-content-end">
+        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">{$buttonLabel}</button>
+        <ul class="dropdown-menu p-2">
+{$optionsHtml}
+        </ul>
+    </div>
+</form>
+HTML;
+    }
+
+    private function renderOption(PlayerPlatformFilterOption $option): string
+    {
+        $inputId = htmlspecialchars($option->getInputId(), ENT_QUOTES, 'UTF-8');
+        $inputName = htmlspecialchars($option->getInputName(), ENT_QUOTES, 'UTF-8');
+        $label = htmlspecialchars($option->getLabel(), ENT_QUOTES, 'UTF-8');
+        $checkedAttribute = $option->isSelected() ? ' checked' : '';
+
+        return <<<HTML
+            <li>
+                <div class="form-check">
+                    <input
+                        class="form-check-input"
+                        type="checkbox"{$checkedAttribute}
+                        value="true"
+                        onChange="this.form.submit()"
+                        id="{$inputId}"
+                        name="{$inputName}"
+                    >
+                    <label class="form-check-label" for="{$inputId}">
+                        {$label}
+                    </label>
+                </div>
+            </li>
+HTML;
+    }
+}

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
 require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
 require_once __DIR__ . '/classes/PlayerNavigation.php';
+require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterOptions.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
@@ -39,6 +40,7 @@ $playerNavigation = PlayerNavigation::forSection((string) $player['online_id'], 
 $platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
     static fn (string $platform): bool => $playerAdvisorFilter->isPlatformSelected($platform)
 );
+$platformFilterRenderer = PlayerPlatformFilterRenderer::createDefault();
 
 $title = $player["online_id"] . "'s Trophy Advisor ~ PSN 100%";
 require_once("header.php");
@@ -60,31 +62,7 @@ require_once("header.php");
             </div>
 
             <div class="col-12 col-lg-3 mb-3">
-                <form>
-                    <div class="input-group d-flex justify-content-end">
-                        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Filter</button>
-                        <ul class="dropdown-menu p-2">
-                            <?php foreach ($platformFilterOptions->getOptions() as $platformOption) { ?>
-                                <li>
-                                    <div class="form-check">
-                                        <?php $inputId = htmlspecialchars($platformOption->getInputId(), ENT_QUOTES, 'UTF-8'); ?>
-                                        <input
-                                            class="form-check-input"
-                                            type="checkbox"<?= $platformOption->isSelected() ? ' checked' : ''; ?>
-                                            value="true"
-                                            onChange="this.form.submit()"
-                                            id="<?= $inputId; ?>"
-                                            name="<?= htmlspecialchars($platformOption->getInputName(), ENT_QUOTES, 'UTF-8'); ?>"
-                                        >
-                                        <label class="form-check-label" for="<?= $inputId; ?>">
-                                            <?= htmlspecialchars($platformOption->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
-                                        </label>
-                                    </div>
-                                </li>
-                            <?php } ?>
-                        </ul>
-                    </div>
-                </form>
+                <?= $platformFilterRenderer->render($platformFilterOptions); ?>
             </div>
         </div>
     </div>

--- a/wwwroot/player_random.php
+++ b/wwwroot/player_random.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerRandomGamesPageContext.php';
+require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -20,6 +21,7 @@ $playerSummary = $context->getPlayerSummary();
 $randomGames = $context->getRandomGames();
 $playerNavigation = $context->getPlayerNavigation();
 $platformFilterOptions = $context->getPlatformFilterOptions();
+$platformFilterRenderer = PlayerPlatformFilterRenderer::createDefault();
 
 $title = $context->getTitle();
 require_once("header.php");
@@ -41,31 +43,7 @@ require_once("header.php");
             </div>
 
             <div class="col-12 col-lg-3 mb-3">
-            <form>
-                    <div class="input-group d-flex justify-content-end">
-                        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Filter</button>
-                        <ul class="dropdown-menu p-2">
-                            <?php foreach ($platformFilterOptions->getOptions() as $platformOption) { ?>
-                                <li>
-                                    <div class="form-check">
-                                        <?php $inputId = htmlspecialchars($platformOption->getInputId(), ENT_QUOTES, 'UTF-8'); ?>
-                                        <input
-                                            class="form-check-input"
-                                            type="checkbox"<?= $platformOption->isSelected() ? ' checked' : ''; ?>
-                                            value="true"
-                                            onChange="this.form.submit()"
-                                            id="<?= $inputId; ?>"
-                                            name="<?= htmlspecialchars($platformOption->getInputName(), ENT_QUOTES, 'UTF-8'); ?>"
-                                        >
-                                        <label class="form-check-label" for="<?= $inputId; ?>">
-                                            <?= htmlspecialchars($platformOption->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
-                                        </label>
-                                    </div>
-                                </li>
-                            <?php } ?>
-                        </ul>
-                    </div>
-                </form>
+                <?= $platformFilterRenderer->render($platformFilterOptions); ?>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add `PlayerPlatformFilterRenderer` to encapsulate the repeated trophy platform filter dropdown markup and centralize HTML escaping
- update the trophy advisor and random games pages to reuse the new renderer so their UI stays consistent
- cover the renderer with new tests to ensure it produces the expected markup

## Testing
- php -l wwwroot/classes/PlayerPlatformFilterRenderer.php
- php -l wwwroot/player_advisor.php
- php -l wwwroot/player_random.php
- php -l tests/PlayerPlatformFilterRendererTest.php
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d34310e0832fa5a623cb647bc070)