### PR TITLE
Refactor admin workers page into page object

### DIFF
--- a/tests/AdminWorkerPageTest.php
+++ b/tests/AdminWorkerPageTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/AdminRequest.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerPage.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerPageResult.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerPageSortLink.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerService.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/Worker.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/CommandExecutionResult.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/CommandExecutorInterface.php';
+
+final class AdminWorkerPageTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY, npsso TEXT, scanning TEXT, scan_start TEXT, scan_progress TEXT)');
+    }
+
+    public function testHandleReturnsSortedWorkersAndLinks(): void
+    {
+        $this->database->exec("INSERT INTO setting (id, npsso, scanning, scan_start, scan_progress) VALUES (1, 'foo', 'Alpha', '2024-01-01 00:00:00', null)");
+        $this->database->exec("INSERT INTO setting (id, npsso, scanning, scan_start, scan_progress) VALUES (2, 'bar', 'Bravo', '2024-01-02 00:00:00', null)");
+
+        $service = new WorkerService($this->database, new FakeCommandExecutor(new CommandExecutionResult(0, '')));
+        $page = new WorkerPage($service);
+
+        $request = new AdminRequest('GET', []);
+        $result = $page->handle(['sort' => 'id', 'direction' => 'DESC'], $request);
+
+        $workers = $result->getWorkers();
+        $this->assertCount(2, $workers);
+        $this->assertSame(2, $workers[0]->getId());
+        $this->assertSame('id', $result->getSortField());
+        $this->assertSame('desc', $result->getSortDirection());
+
+        $idSortLink = $result->getSortLink('id');
+        $this->assertTrue($idSortLink instanceof WorkerPageSortLink);
+        $this->assertSame('?sort=id&direction=asc', $idSortLink->getUrl());
+        $this->assertSame(' ▼', $idSortLink->getIndicator());
+
+        $scanSortLink = $result->getSortLink('scan_start');
+        $this->assertTrue($scanSortLink instanceof WorkerPageSortLink);
+        $this->assertSame('?sort=scan_start&direction=asc', $scanSortLink->getUrl());
+        $this->assertSame('', $scanSortLink->getIndicator());
+    }
+
+    public function testHandleProcessesUpdateNpssoRequests(): void
+    {
+        $this->database->exec("INSERT INTO setting (id, npsso, scanning, scan_start, scan_progress) VALUES (5, 'old', 'Worker', '2024-01-01 00:00:00', null)");
+
+        $service = new WorkerService($this->database, new FakeCommandExecutor(new CommandExecutionResult(0, '')));
+        $page = new WorkerPage($service);
+
+        $request = new AdminRequest('POST', ['action' => 'update_npsso', 'worker_id' => '5', 'npsso' => 'updated']);
+        $result = $page->handle([], $request);
+
+        $this->assertSame('Worker NPSSO updated successfully.', $result->getSuccessMessage());
+        $this->assertSame(null, $result->getErrorMessage());
+
+        $workers = $result->getWorkers();
+        $this->assertCount(1, $workers);
+        $this->assertSame('updated', $workers[0]->getNpsso());
+    }
+
+    public function testHandleProcessesRestartWorkerRequests(): void
+    {
+        $this->database->exec("INSERT INTO setting (id, npsso, scanning, scan_start, scan_progress) VALUES (3, 'np', 'Worker', '2024-01-01 00:00:00', null)");
+
+        $service = new WorkerService($this->database, new FakeCommandExecutor(new CommandExecutionResult(0, 'Done')));
+        $page = new WorkerPage($service);
+
+        $request = new AdminRequest('POST', ['action' => 'restart_worker', 'worker_id' => '3']);
+        $result = $page->handle([], $request);
+
+        $this->assertSame('Worker #3 restart signal sent successfully. Done', $result->getSuccessMessage());
+        $this->assertSame(null, $result->getErrorMessage());
+    }
+
+    public function testHandleProcessesRestartAllWorkersFailure(): void
+    {
+        $this->database->exec("INSERT INTO setting (id, npsso, scanning, scan_start, scan_progress) VALUES (1, 'np', 'Worker', '2024-01-01 00:00:00', null)");
+
+        $service = new WorkerService($this->database, new FakeCommandExecutor(new CommandExecutionResult(2, 'error')));
+        $page = new WorkerPage($service);
+
+        $request = new AdminRequest('POST', ['action' => 'restart_all_workers']);
+        $result = $page->handle([], $request);
+
+        $this->assertSame(null, $result->getSuccessMessage());
+        $this->assertSame('Unable to restart all workers (exit code 2). error', $result->getErrorMessage());
+    }
+
+    private PDO $database;
+}
+
+final class FakeCommandExecutor implements CommandExecutorInterface
+{
+    private CommandExecutionResult $result;
+
+    public function __construct(CommandExecutionResult $result)
+    {
+        $this->result = $result;
+    }
+
+    public function run(array $command): CommandExecutionResult
+    {
+        return $this->result;
+    }
+}

--- a/wwwroot/classes/Admin/WorkerPage.php
+++ b/wwwroot/classes/Admin/WorkerPage.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/AdminRequest.php';
+require_once __DIR__ . '/WorkerService.php';
+require_once __DIR__ . '/CommandExecutionResult.php';
+require_once __DIR__ . '/WorkerPageSortLink.php';
+require_once __DIR__ . '/WorkerPageResult.php';
+
+final class WorkerPage
+{
+    private WorkerService $workerService;
+
+    public function __construct(WorkerService $workerService)
+    {
+        $this->workerService = $workerService;
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public function handle(array $queryParameters, AdminRequest $request): WorkerPageResult
+    {
+        $sortField = $this->normalizeSortField($queryParameters['sort'] ?? null);
+        $sortDirection = $this->normalizeSortDirection($queryParameters['direction'] ?? null);
+
+        [$successMessage, $errorMessage] = $request->isPost()
+            ? $this->processAction($request)
+            : [null, null];
+
+        $workers = $this->workerService->fetchWorkers($sortField, strtoupper($sortDirection));
+
+        $sortLinks = [
+            'id' => $this->createSortLink('id', $sortField, $sortDirection),
+            'scan_start' => $this->createSortLink('scan_start', $sortField, $sortDirection),
+        ];
+
+        return new WorkerPageResult(
+            $workers,
+            $successMessage,
+            $errorMessage,
+            $sortLinks,
+            $sortField,
+            $sortDirection
+        );
+    }
+
+    /**
+     * @return array{0: ?string, 1: ?string}
+     */
+    private function processAction(AdminRequest $request): array
+    {
+        $action = $request->getPostString('action');
+
+        return match ($action) {
+            'update_npsso' => $this->processUpdateNpsso($request),
+            'restart_worker' => $this->processRestartWorker($request),
+            'restart_all_workers' => $this->processRestartAllWorkers(),
+            default => [null, 'Unsupported action requested.'],
+        };
+    }
+
+    /**
+     * @return array{0: ?string, 1: ?string}
+     */
+    private function processUpdateNpsso(AdminRequest $request): array
+    {
+        $workerId = $request->getPostPositiveInt('worker_id');
+
+        if ($workerId === null) {
+            return [null, 'Invalid worker selected.'];
+        }
+
+        $npsso = $request->getPostString('npsso');
+
+        if ($npsso === '') {
+            return [null, 'The NPSSO value cannot be empty.'];
+        }
+
+        if (strlen($npsso) > 64) {
+            return [null, 'The NPSSO value must be 64 characters or fewer.'];
+        }
+
+        try {
+            $updated = $this->workerService->updateWorkerNpsso($workerId, $npsso);
+        } catch (Throwable $exception) {
+            return [null, 'An unexpected error occurred while updating the NPSSO value.'];
+        }
+
+        if ($updated) {
+            return ['Worker NPSSO updated successfully.', null];
+        }
+
+        return [null, 'Unable to update NPSSO. Please verify the worker still exists.'];
+    }
+
+    /**
+     * @return array{0: ?string, 1: ?string}
+     */
+    private function processRestartWorker(AdminRequest $request): array
+    {
+        $workerId = $request->getPostPositiveInt('worker_id');
+
+        if ($workerId === null) {
+            return [null, 'Invalid worker selected for restart.'];
+        }
+
+        $result = $this->workerService->restartWorker($workerId);
+
+        if ($result->isSuccessful()) {
+            return [$this->appendCommandOutput(
+                sprintf('Worker #%d restart signal sent successfully.', $workerId),
+                $result
+            ), null];
+        }
+
+        if ($result->getExitCode() === 1) {
+            return [null, sprintf(
+                'No running process matched worker #%d. It may already be stopped.',
+                $workerId
+            )];
+        }
+
+        return [null, $this->appendCommandOutput(
+            sprintf('Unable to restart worker #%d (exit code %d).', $workerId, $result->getExitCode()),
+            $result
+        )];
+    }
+
+    /**
+     * @return array{0: ?string, 1: ?string}
+     */
+    private function processRestartAllWorkers(): array
+    {
+        $result = $this->workerService->restartAllWorkers();
+
+        if ($result->isSuccessful()) {
+            return [$this->appendCommandOutput('All workers received the restart signal.', $result), null];
+        }
+
+        if ($result->getExitCode() === 1) {
+            return [null, 'No worker processes matched the restart request. They may already be stopped.'];
+        }
+
+        return [null, $this->appendCommandOutput(
+            sprintf('Unable to restart all workers (exit code %d).', $result->getExitCode()),
+            $result
+        )];
+    }
+
+    private function appendCommandOutput(string $message, CommandExecutionResult $result): string
+    {
+        $output = trim($result->getOutput());
+
+        if ($output === '') {
+            return $message;
+        }
+
+        return $message . ' ' . $output;
+    }
+
+    private function normalizeSortField(mixed $value): string
+    {
+        if (!is_string($value)) {
+            return 'scan_start';
+        }
+
+        $normalized = strtolower(trim($value));
+
+        return $normalized === 'id' ? 'id' : 'scan_start';
+    }
+
+    private function normalizeSortDirection(mixed $value): string
+    {
+        if (!is_string($value)) {
+            return 'asc';
+        }
+
+        $normalized = strtolower(trim($value));
+
+        return in_array($normalized, ['asc', 'desc'], true) ? $normalized : 'asc';
+    }
+
+    private function createSortLink(string $field, string $currentField, string $currentDirection): WorkerPageSortLink
+    {
+        $isActive = $field === $currentField;
+        $indicator = '';
+        $nextDirection = 'asc';
+
+        if ($isActive) {
+            $indicator = $currentDirection === 'asc' ? ' ▲' : ' ▼';
+            $nextDirection = $currentDirection === 'asc' ? 'desc' : 'asc';
+        }
+
+        $query = [
+            'sort' => $field,
+            'direction' => $nextDirection,
+        ];
+
+        return new WorkerPageSortLink($field, '?' . http_build_query($query), $indicator);
+    }
+}

--- a/wwwroot/classes/Admin/WorkerPageResult.php
+++ b/wwwroot/classes/Admin/WorkerPageResult.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Worker.php';
+require_once __DIR__ . '/WorkerPageSortLink.php';
+
+final class WorkerPageResult
+{
+    /**
+     * @var list<Worker>
+     */
+    private array $workers;
+
+    private ?string $successMessage;
+
+    private ?string $errorMessage;
+
+    /**
+     * @var array<string, WorkerPageSortLink>
+     */
+    private array $sortLinks;
+
+    private string $sortField;
+
+    private string $sortDirection;
+
+    /**
+     * @param list<Worker> $workers
+     * @param array<string, WorkerPageSortLink> $sortLinks
+     */
+    public function __construct(
+        array $workers,
+        ?string $successMessage,
+        ?string $errorMessage,
+        array $sortLinks,
+        string $sortField,
+        string $sortDirection
+    ) {
+        $this->workers = array_values($workers);
+        $this->successMessage = $successMessage;
+        $this->errorMessage = $errorMessage;
+        $this->sortLinks = $sortLinks;
+        $this->sortField = $sortField;
+        $this->sortDirection = $sortDirection;
+    }
+
+    /**
+     * @return list<Worker>
+     */
+    public function getWorkers(): array
+    {
+        return $this->workers;
+    }
+
+    public function getSuccessMessage(): ?string
+    {
+        return $this->successMessage;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+
+    /**
+     * @return array<string, WorkerPageSortLink>
+     */
+    public function getSortLinks(): array
+    {
+        return $this->sortLinks;
+    }
+
+    public function getSortLink(string $field): ?WorkerPageSortLink
+    {
+        return $this->sortLinks[$field] ?? null;
+    }
+
+    public function getSortField(): string
+    {
+        return $this->sortField;
+    }
+
+    public function getSortDirection(): string
+    {
+        return $this->sortDirection;
+    }
+}

--- a/wwwroot/classes/Admin/WorkerPageSortLink.php
+++ b/wwwroot/classes/Admin/WorkerPageSortLink.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+final class WorkerPageSortLink
+{
+    private string $field;
+
+    private string $url;
+
+    private string $indicator;
+
+    public function __construct(string $field, string $url, string $indicator)
+    {
+        $this->field = $field;
+        $this->url = $url;
+        $this->indicator = $indicator;
+    }
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getIndicator(): string
+    {
+        return $this->indicator;
+    }
+}


### PR DESCRIPTION
## Summary
- move the admin workers page logic into a dedicated `WorkerPage` class that produces a reusable `WorkerPageResult`
- add a `WorkerPageSortLink` helper so the template can render consistent sort links and indicators
- cover the new page workflow with unit tests and update the admin workers template to consume the page result object

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918db4087a0832faec4204fa89952e8)