### PR TITLE
Add About page context object

### DIFF
--- a/tests/AboutPageContextTest.php
+++ b/tests/AboutPageContextTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/AboutPageContext.php';
+require_once __DIR__ . '/../wwwroot/classes/AboutPagePlayer.php';
+require_once __DIR__ . '/../wwwroot/classes/AboutPageScanSummary.php';
+require_once __DIR__ . '/../wwwroot/classes/Utility.php';
+
+final class AboutPageDataProviderStub implements AboutPageDataProviderInterface
+{
+    private AboutPageScanSummary $summary;
+
+    /**
+     * @var list<AboutPagePlayer>
+     */
+    private array $players;
+
+    /**
+     * @param list<AboutPagePlayer> $players
+     */
+    public function __construct(AboutPageScanSummary $summary, array $players)
+    {
+        $this->summary = $summary;
+        $this->players = $players;
+    }
+
+    public function getScanSummary(): AboutPageScanSummary
+    {
+        return $this->summary;
+    }
+
+    public function getScanLogPlayers(int $limit): array
+    {
+        return array_slice($this->players, 0, $limit);
+    }
+}
+
+final class AboutPageContextTest extends TestCase
+{
+    public function testCreateBuildsInitialPlayerListUsingLimits(): void
+    {
+        $summary = new AboutPageScanSummary(100, 25);
+        $players = $this->createPlayers(['Alice', 'Bob', 'Carol']);
+        $dataProvider = new AboutPageDataProviderStub($summary, $players);
+
+        $context = AboutPageContext::create($dataProvider, 2, 1, 'Custom Title');
+
+        $this->assertSame($summary, $context->getScanSummary());
+        $this->assertSame('Custom Title', $context->getTitle());
+        $this->assertSame(2, $context->getScanLogLimit());
+        $this->assertSame(1, $context->getMaxInitialDisplayCount());
+        $this->assertSame(1, $context->getInitialDisplayCount());
+        $this->assertCount(1, $context->getInitialScanLogPlayers());
+        $this->assertSame('Alice', $context->getInitialScanLogPlayers()[0]->getOnlineId());
+    }
+
+    public function testGetScanLogPlayersDataSerializesPlayers(): void
+    {
+        $summary = new AboutPageScanSummary(10, 5);
+        $players = $this->createPlayers(['Alpha', 'Beta']);
+        $dataProvider = new AboutPageDataProviderStub($summary, $players);
+
+        $context = AboutPageContext::create($dataProvider, 5, 5);
+        $serializedPlayers = $context->getScanLogPlayersData();
+
+        $this->assertCount(2, $serializedPlayers);
+        $this->assertSame('Alpha', $serializedPlayers[0]['onlineId']);
+        $this->assertSame('Beta', $serializedPlayers[1]['onlineId']);
+    }
+
+    /**
+     * @param list<string> $names
+     * @return list<AboutPagePlayer>
+     */
+    private function createPlayers(array $names): array
+    {
+        $utility = new Utility();
+        $players = [];
+
+        foreach ($names as $name) {
+            $players[] = new AboutPagePlayer(
+                $utility,
+                $name,
+                'SE',
+                'avatar.png',
+                '2024-01-01 00:00:00',
+                100,
+                '50',
+                0,
+                0,
+                1,
+                1,
+                1
+            );
+        }
+
+        return $players;
+    }
+}

--- a/wwwroot/about.php
+++ b/wwwroot/about.php
@@ -1,16 +1,17 @@
 <?php
 require_once __DIR__ . '/classes/AboutPageService.php';
-require_once __DIR__ . '/classes/AboutPagePlayerArraySerializer.php';
+require_once __DIR__ . '/classes/AboutPageContext.php';
 
 $aboutPageService = new AboutPageService($database, $utility);
-$scanSummary = $aboutPageService->getScanSummary();
-$scanLogPlayers = $aboutPageService->getScanLogPlayers(30);
-$maxScanLogDisplayCount = 10;
-$initialDisplayCount = min($maxScanLogDisplayCount, count($scanLogPlayers));
-$initialScanLogPlayers = array_slice($scanLogPlayers, 0, $initialDisplayCount);
-$scanLogPlayersData = AboutPagePlayerArraySerializer::serializeCollection($scanLogPlayers);
+$aboutPageContext = AboutPageContext::create($aboutPageService);
 
-$title = "About ~ PSN 100%";
+$scanSummary = $aboutPageContext->getScanSummary();
+$initialScanLogPlayers = $aboutPageContext->getInitialScanLogPlayers();
+$scanLogPlayersData = $aboutPageContext->getScanLogPlayersData();
+$initialDisplayCount = $aboutPageContext->getInitialDisplayCount();
+$maxScanLogDisplayCount = $aboutPageContext->getMaxInitialDisplayCount();
+
+$title = $aboutPageContext->getTitle();
 require_once("header.php");
 ?>
 

--- a/wwwroot/classes/AboutPageContext.php
+++ b/wwwroot/classes/AboutPageContext.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/AboutPageDataProviderInterface.php';
+require_once __DIR__ . '/AboutPagePlayerArraySerializer.php';
+
+final class AboutPageContext
+{
+    private const DEFAULT_SCAN_LOG_LIMIT = 30;
+    private const DEFAULT_MAX_INITIAL_DISPLAY_COUNT = 10;
+    private const DEFAULT_TITLE = 'About ~ PSN 100%';
+
+    private AboutPageScanSummary $scanSummary;
+
+    /**
+     * @var list<AboutPagePlayer>
+     */
+    private array $scanLogPlayers;
+
+    /**
+     * @var list<AboutPagePlayer>
+     */
+    private array $initialScanLogPlayers;
+
+    /**
+     * @var list<array<string, mixed>>
+     */
+    private array $serializedScanLogPlayers;
+
+    private int $scanLogLimit;
+
+    private int $initialDisplayCount;
+
+    private int $maxInitialDisplayCount;
+
+    private string $title;
+
+    /**
+     * @param list<AboutPagePlayer> $scanLogPlayers
+     * @param list<AboutPagePlayer> $initialScanLogPlayers
+     * @param list<array<string, mixed>> $serializedScanLogPlayers
+     */
+    private function __construct(
+        AboutPageScanSummary $scanSummary,
+        array $scanLogPlayers,
+        array $initialScanLogPlayers,
+        array $serializedScanLogPlayers,
+        int $scanLogLimit,
+        int $initialDisplayCount,
+        int $maxInitialDisplayCount,
+        string $title
+    ) {
+        $this->scanSummary = $scanSummary;
+        $this->scanLogPlayers = $scanLogPlayers;
+        $this->initialScanLogPlayers = $initialScanLogPlayers;
+        $this->serializedScanLogPlayers = $serializedScanLogPlayers;
+        $this->scanLogLimit = $scanLogLimit;
+        $this->initialDisplayCount = $initialDisplayCount;
+        $this->maxInitialDisplayCount = $maxInitialDisplayCount;
+        $this->title = $title;
+    }
+
+    public static function create(
+        AboutPageDataProviderInterface $dataProvider,
+        int $scanLogLimit = self::DEFAULT_SCAN_LOG_LIMIT,
+        int $maxInitialDisplayCount = self::DEFAULT_MAX_INITIAL_DISPLAY_COUNT,
+        string $title = self::DEFAULT_TITLE
+    ): self {
+        $scanSummary = $dataProvider->getScanSummary();
+        $scanLogPlayers = $dataProvider->getScanLogPlayers($scanLogLimit);
+        $initialDisplayCount = min($maxInitialDisplayCount, count($scanLogPlayers));
+        $initialScanLogPlayers = array_slice($scanLogPlayers, 0, $initialDisplayCount);
+        $serializedScanLogPlayers = AboutPagePlayerArraySerializer::serializeCollection($scanLogPlayers);
+
+        return new self(
+            $scanSummary,
+            $scanLogPlayers,
+            $initialScanLogPlayers,
+            $serializedScanLogPlayers,
+            $scanLogLimit,
+            $initialDisplayCount,
+            $maxInitialDisplayCount,
+            $title
+        );
+    }
+
+    public function getScanSummary(): AboutPageScanSummary
+    {
+        return $this->scanSummary;
+    }
+
+    /**
+     * @return list<AboutPagePlayer>
+     */
+    public function getInitialScanLogPlayers(): array
+    {
+        return $this->initialScanLogPlayers;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function getScanLogPlayersData(): array
+    {
+        return $this->serializedScanLogPlayers;
+    }
+
+    public function getInitialDisplayCount(): int
+    {
+        return $this->initialDisplayCount;
+    }
+
+    public function getMaxInitialDisplayCount(): int
+    {
+        return $this->maxInitialDisplayCount;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getScanLogLimit(): int
+    {
+        return $this->scanLogLimit;
+    }
+}

--- a/wwwroot/classes/AboutPageDataProviderInterface.php
+++ b/wwwroot/classes/AboutPageDataProviderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/AboutPagePlayer.php';
+require_once __DIR__ . '/AboutPageScanSummary.php';
+
+interface AboutPageDataProviderInterface
+{
+    public function getScanSummary(): AboutPageScanSummary;
+
+    /**
+     * @return list<AboutPagePlayer>
+     */
+    public function getScanLogPlayers(int $limit): array;
+}

--- a/wwwroot/classes/AboutPageService.php
+++ b/wwwroot/classes/AboutPageService.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/AboutPageDataProviderInterface.php';
 require_once __DIR__ . '/AboutPagePlayer.php';
 require_once __DIR__ . '/AboutPageScanSummary.php';
 
-class AboutPageService
+class AboutPageService implements AboutPageDataProviderInterface
 {
     private const DEFAULT_SCAN_LOG_LIMIT = 10;
 
@@ -36,6 +37,9 @@ class AboutPageService
         );
     }
 
+    /**
+     * @return list<AboutPagePlayer>
+     */
     public function getScanLogPlayers(int $limit = self::DEFAULT_SCAN_LOG_LIMIT): array
     {
         $query = $this->database->prepare(


### PR DESCRIPTION
## Summary
- add an `AboutPageDataProviderInterface` and `AboutPageContext` to prepare About page data in an object-oriented way
- update `AboutPageService` to implement the new interface and adjust `about.php` to consume the context instead of inline logic
- add dedicated tests that exercise the new context helper

## Testing
- `php tests/run.php`
- `php -l wwwroot/classes/AboutPageDataProviderInterface.php`
- `php -l wwwroot/classes/AboutPageContext.php`
- `php -l wwwroot/classes/AboutPageService.php`
- `php -l wwwroot/about.php`
- `php -l tests/AboutPageContextTest.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918db4087a0832faec4204fa89952e8)