### PR TITLE
Refactor player filters to renderer

### DIFF
--- a/tests/PlayerPlatformFilterRendererTest.php
+++ b/tests/PlayerPlatformFilterRendererTest.php
@@ -46,4 +46,35 @@ final class PlayerPlatformFilterRendererTest extends TestCase
             );
         }
     }
+
+    public function testRenderDropdownControlsDoesNotWrapInForm(): void
+    {
+        $options = PlayerPlatformFilterOptions::fromSelectionCallback(static fn (): bool => false);
+        $renderer = PlayerPlatformFilterRenderer::createDefault();
+
+        $controls = $renderer->renderDropdownControls($options);
+
+        $this->assertStringContainsString('<button', $controls);
+        $this->assertStringContainsString('<ul class="dropdown-menu', $controls);
+        $this->assertFalse(str_contains($controls, '<form'));
+    }
+
+    public function testRenderOptionItemsOutputsListItems(): void
+    {
+        $options = PlayerPlatformFilterOptions::fromSelectionCallback(static fn (): bool => false);
+        $renderer = PlayerPlatformFilterRenderer::createDefault();
+
+        $items = $renderer->renderOptionItems($options);
+
+        foreach ($options->getOptions() as $option) {
+            $this->assertStringContainsString(
+                htmlspecialchars($option->getInputId(), ENT_QUOTES, 'UTF-8'),
+                $items
+            );
+            $this->assertStringContainsString(
+                htmlspecialchars($option->getLabel(), ENT_QUOTES, 'UTF-8'),
+                $items
+            );
+        }
+    }
 }

--- a/wwwroot/classes/PlayerPlatformFilterRenderer.php
+++ b/wwwroot/classes/PlayerPlatformFilterRenderer.php
@@ -20,23 +20,40 @@ final class PlayerPlatformFilterRenderer
 
     public function render(PlayerPlatformFilterOptions $options): string
     {
-        $buttonLabel = htmlspecialchars($this->buttonLabel, ENT_QUOTES, 'UTF-8');
-        $optionItems = array_map(
-            fn (PlayerPlatformFilterOption $option): string => $this->renderOption($option),
-            $options->getOptions()
-        );
-        $optionsHtml = implode(PHP_EOL, $optionItems);
+        $dropdownControls = $this->renderDropdownControls($options);
 
         return <<<HTML
 <form>
     <div class="input-group d-flex justify-content-end">
-        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">{$buttonLabel}</button>
-        <ul class="dropdown-menu p-2">
-{$optionsHtml}
-        </ul>
+        {$dropdownControls}
     </div>
 </form>
 HTML;
+    }
+
+    public function renderDropdownControls(PlayerPlatformFilterOptions $options): string
+    {
+        $buttonLabel = htmlspecialchars($this->buttonLabel, ENT_QUOTES, 'UTF-8');
+        $optionItems = $this->renderOptionItems($options);
+
+        return <<<HTML
+        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+            {$buttonLabel}
+        </button>
+        <ul class="dropdown-menu p-2">
+{$optionItems}
+        </ul>
+HTML;
+    }
+
+    public function renderOptionItems(PlayerPlatformFilterOptions $options): string
+    {
+        $optionItems = array_map(
+            fn (PlayerPlatformFilterOption $option): string => $this->renderOption($option),
+            $options->getOptions()
+        );
+
+        return implode(PHP_EOL, $optionItems);
     }
 
     private function renderOption(PlayerPlatformFilterOption $option): string

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerGamesPageContext.php';
+require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -23,6 +24,7 @@ $playerSearch = $pageContext->getSearch();
 $sort = $pageContext->getSort();
 $playerNavigation = $pageContext->getPlayerNavigation();
 $platformFilterOptions = $pageContext->getPlatformFilterOptions();
+$platformFilterRenderer = PlayerPlatformFilterRenderer::createDefault();
 $playerOnlineId = $pageContext->getPlayerOnlineId();
 $playerAccountId = $pageContext->getPlayerAccountId();
 $title = $pageContext->getTitle();
@@ -67,24 +69,7 @@ require_once("header.php");
                                     </label>
                                 </div>
                             </li>
-                            <?php foreach ($platformFilterOptions->getOptions() as $platformOption) { ?>
-                                <li>
-                                    <div class="form-check">
-                                        <?php $inputId = htmlspecialchars($platformOption->getInputId(), ENT_QUOTES, 'UTF-8'); ?>
-                                        <input
-                                            class="form-check-input"
-                                            type="checkbox"<?= $platformOption->isSelected() ? ' checked' : ''; ?>
-                                            value="true"
-                                            onChange="this.form.submit()"
-                                            id="<?= $inputId; ?>"
-                                            name="<?= htmlspecialchars($platformOption->getInputName(), ENT_QUOTES, 'UTF-8'); ?>"
-                                        >
-                                        <label class="form-check-label" for="<?= $inputId; ?>">
-                                            <?= htmlspecialchars($platformOption->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
-                                        </label>
-                                    </div>
-                                </li>
-                            <?php } ?>
+                            <?= $platformFilterRenderer->renderOptionItems($platformFilterOptions); ?>
                             <li>
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox"<?= ($playerGamesFilter->isUncompletedSelected() ? " checked" : "") ?> value="true" onChange="this.form.submit()" id="filterUncompletedGames" name="uncompleted">

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerLogPageContext.php';
+require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -21,6 +22,7 @@ $trophiesLog = $pageContext->getTrophies();
 $trophyRarityFormatter = $pageContext->getTrophyRarityFormatter();
 $playerNavigation = $pageContext->getPlayerNavigation();
 $platformFilterOptions = $pageContext->getPlatformFilterOptions();
+$platformFilterRenderer = PlayerPlatformFilterRenderer::createDefault();
 
 $playerOnlineId = $pageContext->getPlayerOnlineId();
 $playerAccountId = $pageContext->getPlayerAccountId();
@@ -47,27 +49,7 @@ require_once("header.php");
             <div class="col-12 col-lg-3 mb-3">
                 <form>
                     <div class="input-group d-flex justify-content-end">
-                        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Filter</button>
-                        <ul class="dropdown-menu p-2">
-                            <?php foreach ($platformFilterOptions->getOptions() as $platformOption) { ?>
-                                <li>
-                                    <div class="form-check">
-                                        <?php $inputId = htmlspecialchars($platformOption->getInputId(), ENT_QUOTES, 'UTF-8'); ?>
-                                        <input
-                                            class="form-check-input"
-                                            type="checkbox"<?= $platformOption->isSelected() ? ' checked' : ''; ?>
-                                            value="true"
-                                            onChange="this.form.submit()"
-                                            id="<?= $inputId; ?>"
-                                            name="<?= htmlspecialchars($platformOption->getInputName(), ENT_QUOTES, 'UTF-8'); ?>"
-                                        >
-                                        <label class="form-check-label" for="<?= $inputId; ?>">
-                                            <?= htmlspecialchars($platformOption->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
-                                        </label>
-                                    </div>
-                                </li>
-                            <?php } ?>
-                        </ul>
+                        <?= $platformFilterRenderer->renderDropdownControls($platformFilterOptions); ?>
 
                         <select class="form-select" name="sort" onChange="this.form.submit()">
                             <option disabled>Sort by...</option>


### PR DESCRIPTION
## Summary
- expose reusable helpers on `PlayerPlatformFilterRenderer` so pages can embed the dropdown controls inside more complex forms
- update the player games and player log pages to consume the renderer instead of duplicating checkbox markup
- extend the renderer test suite to cover the new public helpers

## Testing
- `php tests/run.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918db4087a0832faec4204fa89952e8)