### PR TITLE
Refactor game trophy rows to objects

### DIFF
--- a/tests/GameTrophyFilterTest.php
+++ b/tests/GameTrophyFilterTest.php
@@ -75,6 +75,46 @@ final class GameTrophyFilterTest extends TestCase
         $this->assertTrue($filter->shouldDisplayTrophy([]));
     }
 
+    public function testShouldDisplayTrophySupportsViewModelInstances(): void
+    {
+        $filter = GameTrophyFilter::fromQueryParameters(['unearned' => true], true);
+
+        $utility = new Utility();
+        $pendingTrophy = GameTrophyRow::fromArray(
+            [
+                'id' => 1,
+                'order_id' => 1,
+                'type' => 'bronze',
+                'name' => 'Pending Trophy',
+                'detail' => 'Detail',
+                'icon_url' => 'icon.png',
+                'rarity_percent' => 10,
+                'status' => 0,
+            ],
+            $utility,
+            false
+        );
+
+        $earnedTrophy = GameTrophyRow::fromArray(
+            [
+                'id' => 2,
+                'order_id' => 2,
+                'type' => 'silver',
+                'name' => 'Earned Trophy',
+                'detail' => 'Detail',
+                'icon_url' => 'icon.png',
+                'rarity_percent' => 5,
+                'status' => 0,
+                'earned' => 1,
+            ],
+            $utility,
+            false
+        );
+
+        $this->assertTrue($filter->shouldDisplayTrophy($pendingTrophy));
+        $this->assertFalse($filter->shouldDisplayTrophy($earnedTrophy));
+    }
+
     public function testFromQueryParametersTreatsUnexpectedTypesAsTruthy(): void
     {
         $filter = GameTrophyFilter::fromQueryParameters(['unearned' => ['unexpected']], true);

--- a/tests/GameTrophyRowTest.php
+++ b/tests/GameTrophyRowTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/Game/GameTrophyRow.php';
+
+final class GameTrophyRowTest extends TestCase
+{
+    private function createRow(array $data, bool $usesPlayStation5Assets = false): GameTrophyRow
+    {
+        $defaults = [
+            'id' => 1,
+            'order_id' => 1,
+            'type' => 'bronze',
+            'name' => 'Example Trophy',
+            'detail' => 'Complete the tutorial.',
+            'icon_url' => 'icon.png',
+            'rarity_percent' => 12.5,
+            'status' => 0,
+        ];
+
+        return GameTrophyRow::fromArray($data + $defaults, new Utility(), $usesPlayStation5Assets);
+    }
+
+    public function testGetIconPathUsesPlatformSpecificPlaceholder(): void
+    {
+        $ps5Row = $this->createRow(['icon_url' => '.png'], true);
+        $ps4Row = $this->createRow(['icon_url' => '.png'], false);
+
+        $this->assertSame('../missing-ps5-game-and-trophy.png', $ps5Row->getIconPath());
+        $this->assertSame('../missing-ps4-trophy.png', $ps4Row->getIconPath());
+    }
+
+    public function testRowAttributesIncludeWarningForUnobtainableTrophy(): void
+    {
+        $row = $this->createRow(['status' => 1]);
+
+        $attributes = $row->getRowAttributes(null);
+
+        $this->assertStringContainsString('class="table-warning"', $attributes);
+        $this->assertStringContainsString('title="', $attributes);
+    }
+
+    public function testRowAttributesIncludeSuccessForEarnedTrophy(): void
+    {
+        $row = $this->createRow(['earned' => 1]);
+
+        $attributes = $row->getRowAttributes(123);
+
+        $this->assertSame(' class="table-success"', $attributes);
+    }
+
+    public function testTimestampHelpersDetectMissingTimestamp(): void
+    {
+        $row = $this->createRow(['earned' => 1, 'earned_date' => 'No Timestamp']);
+
+        $this->assertFalse($row->hasRecordedEarnedDate());
+        $this->assertTrue($row->shouldDisplayNoTimestampMessage());
+    }
+
+    public function testProgressDisplayUsesZeroWhenProgressMissing(): void
+    {
+        $row = $this->createRow(['progress_target_value' => 25]);
+
+        $this->assertSame('0/25', $row->getProgressDisplay());
+    }
+
+    public function testProgressDisplayUsesTargetWhenEarnedWithoutProgress(): void
+    {
+        $row = $this->createRow(['progress_target_value' => 15, 'earned' => 1]);
+
+        $this->assertSame('15/15', $row->getProgressDisplay());
+    }
+}

--- a/wwwroot/classes/Game/GameTrophyRow.php
+++ b/wwwroot/classes/Game/GameTrophyRow.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../Utility.php';
+
+final class GameTrophyRow
+{
+    private const TROPHY_TYPE_COLORS = [
+        'bronze' => '#c46438',
+        'silver' => '#777777',
+        'gold' => '#c2903e',
+        'platinum' => '#667fb2',
+    ];
+
+    private const UNOBTAINABLE_STATUS = 1;
+    private const UNOBTAINABLE_TITLE = 'This trophy is unobtainable and not accounted for on any leaderboard.';
+
+    private int $id;
+    private int $orderId;
+    private string $type;
+    private string $name;
+    private string $detail;
+    private string $iconUrl;
+    private float $rarityPercent;
+    private int $status;
+    private ?int $progressTargetValue;
+    private ?int $progress;
+    private ?string $rewardName;
+    private ?string $rewardImageUrl;
+    private ?string $earnedDate;
+    private bool $hasRecordedEarnedTimestamp;
+    private bool $hasExplicitNoTimestamp;
+    private bool $isEarned;
+    private bool $usesPlayStation5Assets;
+    private Utility $utility;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data, Utility $utility, bool $usesPlayStation5Assets): self
+    {
+        return new self($data, $utility, $usesPlayStation5Assets);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function __construct(array $data, Utility $utility, bool $usesPlayStation5Assets)
+    {
+        $this->id = (int) ($data['id'] ?? 0);
+        $this->orderId = (int) ($data['order_id'] ?? 0);
+        $this->type = (string) ($data['type'] ?? '');
+        $this->name = (string) ($data['name'] ?? '');
+        $this->detail = (string) ($data['detail'] ?? '');
+        $this->iconUrl = (string) ($data['icon_url'] ?? '');
+        $this->rarityPercent = isset($data['rarity_percent']) ? (float) $data['rarity_percent'] : 0.0;
+        $this->status = isset($data['status']) ? (int) $data['status'] : 0;
+        $this->progressTargetValue = isset($data['progress_target_value'])
+            ? (int) $data['progress_target_value']
+            : null;
+        $this->progress = isset($data['progress']) ? (int) $data['progress'] : null;
+        $this->rewardName = isset($data['reward_name']) ? (string) $data['reward_name'] : null;
+        $this->rewardImageUrl = isset($data['reward_image_url']) ? (string) $data['reward_image_url'] : null;
+        $this->utility = $utility;
+        $this->usesPlayStation5Assets = $usesPlayStation5Assets;
+
+        $rawEarnedDate = isset($data['earned_date']) ? (string) $data['earned_date'] : null;
+        $this->hasExplicitNoTimestamp = $rawEarnedDate === 'No Timestamp';
+        $this->hasRecordedEarnedTimestamp = $rawEarnedDate !== null
+            && $rawEarnedDate !== ''
+            && $rawEarnedDate !== 'No Timestamp';
+        $this->earnedDate = $this->hasRecordedEarnedTimestamp ? $rawEarnedDate : null;
+
+        $earnedValue = isset($data['earned']) ? (int) $data['earned'] : 0;
+        $this->isEarned = $earnedValue === 1;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getOrderId(): int
+    {
+        return $this->orderId;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDetail(): string
+    {
+        return $this->detail;
+    }
+
+    public function getIconPath(): string
+    {
+        if ($this->iconUrl === '.png') {
+            return $this->usesPlayStation5Assets
+                ? '../missing-ps5-game-and-trophy.png'
+                : '../missing-ps4-trophy.png';
+        }
+
+        return $this->iconUrl;
+    }
+
+    public function getProgressDisplay(): ?string
+    {
+        if ($this->progressTargetValue === null) {
+            return null;
+        }
+
+        $progress = $this->progress;
+
+        if ($progress === null && $this->isEarned) {
+            $progress = $this->progressTargetValue;
+        }
+
+        $progressValue = $progress ?? 0;
+
+        return $progressValue . '/' . $this->progressTargetValue;
+    }
+
+    public function hasReward(): bool
+    {
+        return $this->rewardName !== null && $this->rewardImageUrl !== null;
+    }
+
+    public function getRewardName(): ?string
+    {
+        return $this->rewardName;
+    }
+
+    public function getRewardImageUrl(): ?string
+    {
+        return $this->rewardImageUrl;
+    }
+
+    public function isEarned(): bool
+    {
+        return $this->isEarned;
+    }
+
+    public function hasRecordedEarnedDate(): bool
+    {
+        return $this->hasRecordedEarnedTimestamp;
+    }
+
+    public function shouldDisplayNoTimestampMessage(): bool
+    {
+        return $this->isEarned && !$this->hasRecordedEarnedTimestamp && $this->hasExplicitNoTimestamp;
+    }
+
+    public function getEarnedDate(): ?string
+    {
+        return $this->earnedDate;
+    }
+
+    public function getEarnedElementId(): string
+    {
+        return 'earned' . $this->orderId;
+    }
+
+    public function getRarityPercent(): float
+    {
+        return $this->rarityPercent;
+    }
+
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+
+    public function getTrophyLink(?string $playerOnlineId = null): string
+    {
+        $slug = $this->utility->slugify($this->name);
+        $playerSegment = ($playerOnlineId !== null && $playerOnlineId !== '')
+            ? '/' . $playerOnlineId
+            : '';
+
+        return '/trophy/' . $this->id . '-' . $slug . $playerSegment;
+    }
+
+    public function getTypeColor(): string
+    {
+        return self::TROPHY_TYPE_COLORS[$this->type] ?? self::TROPHY_TYPE_COLORS['bronze'];
+    }
+
+    public function getRowAttributes(?int $accountId): string
+    {
+        $attributes = [];
+
+        if ($this->isUnobtainable()) {
+            $attributes[] = 'class="table-warning"';
+            $attributes[] = 'title="' . htmlspecialchars(self::UNOBTAINABLE_TITLE, ENT_QUOTES, 'UTF-8') . '"';
+        } elseif ($accountId !== null && $this->isEarned) {
+            $attributes[] = 'class="table-success"';
+        }
+
+        if ($attributes === []) {
+            return '';
+        }
+
+        return ' ' . implode(' ', $attributes);
+    }
+
+    private function isUnobtainable(): bool
+    {
+        return $this->status === self::UNOBTAINABLE_STATUS;
+    }
+}

--- a/wwwroot/classes/GamePage.php
+++ b/wwwroot/classes/GamePage.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
 require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/Game/GamePlayerProgress.php';
 require_once __DIR__ . '/Game/GameHeaderData.php';
+require_once __DIR__ . '/Game/GameTrophyRow.php';
 require_once __DIR__ . '/PageMetaData.php';
 require_once __DIR__ . '/Utility.php';
 
@@ -175,6 +176,23 @@ class GamePage
         return $this->trophiesByGroup[$groupId];
     }
 
+    /**
+     * @return GameTrophyRow[]
+     */
+    public function getTrophyRows(string $groupId): array
+    {
+        $usesPlayStation5Assets = $this->usesPlayStation5Assets();
+
+        return array_map(
+            fn (array $trophy): GameTrophyRow => GameTrophyRow::fromArray(
+                $trophy,
+                $this->utility,
+                $usesPlayStation5Assets
+            ),
+            $this->getTrophies($groupId)
+        );
+    }
+
     public function createMetaData(): PageMetaData
     {
         return (new PageMetaData())
@@ -197,5 +215,12 @@ class GamePage
     public function getGameSlug(): string
     {
         return $this->utility->slugify($this->game->getName());
+    }
+
+    private function usesPlayStation5Assets(): bool
+    {
+        $platform = $this->game->getPlatform();
+
+        return str_contains($platform, 'PS5') || str_contains($platform, 'PSVR2');
     }
 }

--- a/wwwroot/classes/GameTrophyFilter.php
+++ b/wwwroot/classes/GameTrophyFilter.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Game/GameTrophyRow.php';
+
 class GameTrophyFilter
 {
     private bool $unearnedOnly;
@@ -45,12 +47,16 @@ class GameTrophyFilter
     }
 
     /**
-     * @param array<string, mixed> $trophy
+     * @param array<string, mixed>|GameTrophyRow $trophy
      */
-    public function shouldDisplayTrophy(array $trophy): bool
+    public function shouldDisplayTrophy(array|GameTrophyRow $trophy): bool
     {
         if (!$this->unearnedOnly) {
             return true;
+        }
+
+        if ($trophy instanceof GameTrophyRow) {
+            return !$trophy->isEarned();
         }
 
         $earned = isset($trophy['earned']) ? (int) $trophy['earned'] : 0;


### PR DESCRIPTION
## Summary
- add a `GameTrophyRow` view model to encapsulate trophy presentation details and replace the array heavy logic inside `game.php`
- update `GamePage`/`GameTrophyFilter` to work with the new object oriented flow and ensure the filter can receive either arrays or view models
- expand automated coverage with dedicated tests for the new row model plus a filter test that exercises the OOP path

## Testing
- php -l wwwroot/classes/Game/GameTrophyRow.php
- php -l wwwroot/classes/GamePage.php
- php -l wwwroot/classes/GameTrophyFilter.php
- php -l wwwroot/game.php
- php -l tests/GameTrophyFilterTest.php
- php -l tests/GameTrophyRowTest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918db4087a0832faec4204fa89952e8)