### PR TITLE
Refactor player notices into reusable class

### DIFF
--- a/tests/PlayerQueueResponseFactoryTest.php
+++ b/tests/PlayerQueueResponseFactoryTest.php
@@ -49,13 +49,13 @@ final class PlayerQueueResponseFactoryTest extends TestCase
         $message = $response->getMessage();
         $this->assertStringContainsString("Player '<a class=\"link-underline link-underline-opacity-0 link-underline-opacity-100-hover\" href=\"/player/Bad%20User\">Bad User</a>' is tagged as a cheater and won't be scanned.", $message);
         $this->assertStringContainsString('Dispute</a>?', $message);
-        $this->assertStringContainsString('https://github.com/Ragowit/psn100/issues?q=label%3Acheater+Bad%20User+OR+Account%2F123', $message);
+        $this->assertStringContainsString('https://github.com/Ragowit/psn100/issues?q=label%3Acheater%20Bad%20User%20OR%20Account%2F123', $message);
 
         $this->assertSame(
             [
                 'Bad User',
                 '/player/Bad%20User',
-                'https://github.com/Ragowit/psn100/issues?q=label%3Acheater+Bad%20User+OR+Account%2F123',
+                'https://github.com/Ragowit/psn100/issues?q=label%3Acheater%20Bad%20User%20OR%20Account%2F123',
             ],
             $service->getEscapedValues()
         );

--- a/wwwroot/classes/PlayerHeaderViewModel.php
+++ b/wwwroot/classes/PlayerHeaderViewModel.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/Utility.php';
 require_once __DIR__ . '/PlayerLeaderboardRank.php';
 require_once __DIR__ . '/PlayerLeaderboardRankChange.php';
+require_once __DIR__ . '/PlayerStatusNotice.php';
 
 class PlayerHeaderViewModel
 {
@@ -91,14 +92,12 @@ class PlayerHeaderViewModel
 
         switch ($status) {
             case 1:
-                $alerts[] = sprintf(
-                    "This player has some funny looking trophy data. This doesn't necessarily mean cheating, but all data from this player will be excluded from site statistics and leaderboards. <a href=\"https://github.com/Ragowit/psn100/issues?q=label%%3Acheater+%s+OR+%d\">Dispute</a>?",
-                    rawurlencode($onlineId),
-                    $accountId
-                );
+                $notice = PlayerStatusNotice::flagged($onlineId, (string) $accountId);
+                $alerts[] = $notice->getMessage();
                 break;
             case 3:
-                $alerts[] = "This player seems to have a <a class=\"link-underline link-underline-opacity-0 link-underline-opacity-100-hover\" href=\"https://www.playstation.com/en-us/support/account/privacy-settings-psn/\">private</a> profile. Make sure this player is no longer private, and then issue a new scan of the profile on the front page.";
+                $notice = PlayerStatusNotice::privateProfile();
+                $alerts[] = $notice->getMessage() . ' Make sure this player is no longer private, and then issue a new scan of the profile on the front page.';
                 break;
             case 4:
                 $alerts[] = 'This player has not played a game in over a year and is considered inactive by this site. All data from this player will be excluded from site statistics and leaderboards.';

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerQueueService.php';
 require_once __DIR__ . '/PlayerQueueResponse.php';
+require_once __DIR__ . '/PlayerStatusNotice.php';
 
 final class PlayerQueueResponseFactory
 {
@@ -157,10 +158,7 @@ final class PlayerQueueResponseFactory
     private function createCheaterMessage(string $playerName, ?string $accountId): string
     {
         $playerLink = $this->createPlayerLink($playerName);
-        $accountIdValue = $accountId ?? '';
-        $playerQuery = rawurlencode($playerName);
-        $accountQuery = rawurlencode((string) $accountIdValue);
-        $disputeUrl = 'https://github.com/Ragowit/psn100/issues?q=label%3Acheater+' . $playerQuery . '+OR+' . $accountQuery;
+        $disputeUrl = PlayerStatusNotice::createDisputeUrl($playerName, $accountId);
         $disputeLink = '<a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="'
             . $this->service->escapeHtml($disputeUrl) . '">Dispute</a>';
 

--- a/wwwroot/classes/PlayerStatusNotice.php
+++ b/wwwroot/classes/PlayerStatusNotice.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+final class PlayerStatusNotice
+{
+    private const TYPE_FLAGGED = 'flagged';
+    private const TYPE_PRIVATE = 'private';
+    private const DISPUTE_BASE_URL = 'https://github.com/Ragowit/psn100/issues';
+    private const PRIVATE_PROFILE_URL = 'https://www.playstation.com/en-us/support/account/privacy-settings-psn/';
+
+    private string $type;
+
+    private string $message;
+
+    private function __construct(string $type, string $message)
+    {
+        $this->type = $type;
+        $this->message = $message;
+    }
+
+    public static function flagged(string $onlineId, ?string $accountId): self
+    {
+        $disputeUrl = self::createDisputeUrl($onlineId, $accountId);
+        $message = sprintf(
+            "This player has some funny looking trophy data. This doesn't necessarily mean cheating, but all data from this player will be excluded from site statistics and leaderboards. <a href=\"%s\">Dispute</a>?",
+            htmlspecialchars($disputeUrl, ENT_QUOTES, 'UTF-8')
+        );
+
+        return new self(self::TYPE_FLAGGED, $message);
+    }
+
+    public static function privateProfile(): self
+    {
+        $message = sprintf(
+            'This player seems to have a <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="%s">private</a> profile.',
+            htmlspecialchars(self::PRIVATE_PROFILE_URL, ENT_QUOTES, 'UTF-8')
+        );
+
+        return new self(self::TYPE_PRIVATE, $message);
+    }
+
+    public static function createDisputeUrl(string $onlineId, ?string $accountId): string
+    {
+        $query = ['q' => self::buildDisputeQuery($onlineId, $accountId)];
+
+        return self::DISPUTE_BASE_URL . '?' . http_build_query($query, '', '&', PHP_QUERY_RFC3986);
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function isFlagged(): bool
+    {
+        return $this->type === self::TYPE_FLAGGED;
+    }
+
+    public function isPrivateProfile(): bool
+    {
+        return $this->type === self::TYPE_PRIVATE;
+    }
+
+    private static function buildDisputeQuery(string $onlineId, ?string $accountId): string
+    {
+        $accountSegment = '';
+
+        if ($accountId !== null && $accountId !== '') {
+            $accountSegment = sprintf(' OR %s', $accountId);
+        }
+
+        return sprintf('label:cheater %s%s', $onlineId, $accountSegment);
+    }
+}

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerGamesPageContext.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
+require_once __DIR__ . '/classes/PlayerStatusNotice.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -27,6 +28,13 @@ $platformFilterOptions = $pageContext->getPlatformFilterOptions();
 $platformFilterRenderer = PlayerPlatformFilterRenderer::createDefault();
 $playerOnlineId = $pageContext->getPlayerOnlineId();
 $playerAccountId = $pageContext->getPlayerAccountId();
+$playerStatusNotice = null;
+
+if ($pageContext->isPlayerFlagged()) {
+    $playerStatusNotice = PlayerStatusNotice::flagged($playerOnlineId, (string) $playerAccountId);
+} elseif ($pageContext->isPlayerPrivate()) {
+    $playerStatusNotice = PlayerStatusNotice::privateProfile();
+}
 $title = $pageContext->getTitle();
 require_once("header.php");
 ?>
@@ -110,20 +118,11 @@ require_once("header.php");
 
                         <tbody>
                             <?php
-                            if (!$pageContext->shouldDisplayGames()) {
+                            if ($playerStatusNotice !== null) {
                                 ?>
                                 <tr>
                                     <td colspan="4" class="text-center">
-                                        <?php if ($pageContext->isPlayerFlagged()) { ?>
-                                            <h3>
-                                                This player has some funny looking trophy data. This doesn't necessarily mean cheating, but all data from this player will be excluded from site statistics and leaderboards.
-                                                <a href="https://github.com/Ragowit/psn100/issues?q=label%3Acheater+<?= htmlspecialchars($playerOnlineId, ENT_QUOTES, 'UTF-8'); ?>+OR+<?= htmlspecialchars((string) $playerAccountId, ENT_QUOTES, 'UTF-8'); ?>">Dispute</a>?
-                                            </h3>
-                                        <?php } elseif ($pageContext->isPlayerPrivate()) { ?>
-                                            <h3>
-                                                This player seems to have a <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="https://www.playstation.com/en-us/support/account/privacy-settings-psn/">private</a> profile.
-                                            </h3>
-                                        <?php } ?>
+                                        <h3><?= $playerStatusNotice->getMessage(); ?></h3>
                                     </td>
                                 </tr>
                                 <?php

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
 require_once __DIR__ . '/classes/PlayerNavigation.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterOptions.php';
+require_once __DIR__ . '/classes/PlayerStatusNotice.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -41,6 +42,19 @@ $platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
     static fn (string $platform): bool => $playerAdvisorFilter->isPlatformSelected($platform)
 );
 $platformFilterRenderer = PlayerPlatformFilterRenderer::createDefault();
+$playerStatusNotice = null;
+
+if (!$shouldDisplayAdvisor) {
+    $status = (int) ($player['status'] ?? 0);
+    if ($status === 1) {
+        $playerStatusNotice = PlayerStatusNotice::flagged(
+            (string) $player['online_id'],
+            isset($player['account_id']) ? (string) $player['account_id'] : null
+        );
+    } elseif ($status === 3) {
+        $playerStatusNotice = PlayerStatusNotice::privateProfile();
+    }
+}
 
 $title = $player["online_id"] . "'s Trophy Advisor ~ PSN 100%";
 require_once("header.php");
@@ -84,20 +98,12 @@ require_once("header.php");
 
                         <tbody>
                             <?php
-                            if (!$shouldDisplayAdvisor) {
-                                if ($player["status"] == 1) {
+                            if ($playerStatusNotice !== null) {
                                 ?>
                                 <tr>
-                                    <td colspan="5" class="text-center"><h3>This player have some funny looking trophy data. This doesn't necessarily means cheating, but all data from this player will not be in any of the site statistics or leaderboards. <a href="https://github.com/Ragowit/psn100/issues?q=label%3Acheater+<?= $player["online_id"]; ?>+OR+<?= $player["account_id"]; ?>">Dispute</a>?</h3></td>
+                                    <td colspan="5" class="text-center"><h3><?= $playerStatusNotice->getMessage(); ?></h3></td>
                                 </tr>
                                 <?php
-                                } elseif ($player["status"] == 3) {
-                                ?>
-                                <tr>
-                                    <td colspan="5" class="text-center"><h3>This player seems to have a <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="https://www.playstation.com/en-us/support/account/privacy-settings-psn/">private</a> profile.</h3></td>
-                                </tr>
-                                <?php
-                                }
                             } else {
                                 foreach ($advisableTrophies as $trophy) {
                                     $gameLink = $trophy->getGameLink($player['online_id']);

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerLogPageContext.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
+require_once __DIR__ . '/classes/PlayerStatusNotice.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -26,6 +27,13 @@ $platformFilterRenderer = PlayerPlatformFilterRenderer::createDefault();
 
 $playerOnlineId = $pageContext->getPlayerOnlineId();
 $playerAccountId = $pageContext->getPlayerAccountId();
+$playerStatusNotice = null;
+
+if ($pageContext->isPlayerFlagged()) {
+    $playerStatusNotice = PlayerStatusNotice::flagged($playerOnlineId, (string) $playerAccountId);
+} elseif ($pageContext->isPlayerPrivate()) {
+    $playerStatusNotice = PlayerStatusNotice::privateProfile();
+}
 
 $title = $pageContext->getTitle();
 require_once("header.php");
@@ -79,16 +87,10 @@ require_once("header.php");
 
                         <tbody>
                             <?php
-                            if ($pageContext->isPlayerFlagged()) {
+                            if ($playerStatusNotice !== null && !$pageContext->shouldDisplayLog()) {
                                 ?>
                                 <tr>
-                                    <td colspan="5" class="text-center"><h3>This player have some funny looking trophy data. This doesn't necessarily means cheating, but all data from this player will not be in any of the site statistics or leaderboards. <a href="https://github.com/Ragowit/psn100/issues?q=label%3Acheater+<?= $playerOnlineId; ?>+OR+<?= $playerAccountId; ?>">Dispute</a>?</h3></td>
-                                </tr>
-                                <?php
-                            } elseif ($pageContext->isPlayerPrivate()) {
-                                ?>
-                                <tr>
-                                    <td colspan="5" class="text-center"><h3>This player seems to have a <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="https://www.playstation.com/en-us/support/account/privacy-settings-psn/">private</a> profile.</h3></td>
+                                    <td colspan="5" class="text-center"><h3><?= $playerStatusNotice->getMessage(); ?></h3></td>
                                 </tr>
                                 <?php
                             } elseif ($pageContext->shouldDisplayLog()) {


### PR DESCRIPTION
## Summary
- introduce a PlayerStatusNotice helper to generate consistent flag/private messaging and dispute links
- update the various player pages plus the header view model to rely on the notice instead of inlining strings
- reuse the new dispute link builder inside the player queue response factory and adjust the corresponding unit test

## Testing
- `php -l wwwroot/classes/PlayerStatusNotice.php wwwroot/player.php wwwroot/player_log.php wwwroot/player_random.php wwwroot/player_advisor.php wwwroot/classes/PlayerHeaderViewModel.php wwwroot/classes/PlayerQueueResponseFactory.php tests/PlayerQueueResponseFactoryTest.php`
- `php tests/run.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ec332d20832fa10fd918ea18aecb)