### PR TITLE
Refactor worker scan progress handling

### DIFF
--- a/tests/AdminWorkerScanProgressTest.php
+++ b/tests/AdminWorkerScanProgressTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerScanProgress.php';
+
+final class AdminWorkerScanProgressTest extends TestCase
+{
+    public function testFromJsonParsesValidPayload(): void
+    {
+        $progress = WorkerScanProgress::fromJson('{"current": 3, "total": 5, "title": "Example", "npCommunicationId": "foo"}');
+
+        $this->assertTrue($progress instanceof WorkerScanProgress, 'Progress data should decode into value object.');
+        $this->assertSame(3, $progress->getCurrent());
+        $this->assertSame(5, $progress->getTotal());
+        $this->assertSame('Example', $progress->getTitle());
+        $this->assertSame('foo', $progress->getNpCommunicationId());
+        $this->assertSame('3 / 5', $progress->getProgressSummary());
+        $this->assertSame(60.0, $progress->getPercentage());
+    }
+
+    public function testFromJsonReturnsNullWhenNoData(): void
+    {
+        $this->assertSame(null, WorkerScanProgress::fromJson('{}'));
+        $this->assertSame(null, WorkerScanProgress::fromJson(null));
+    }
+}

--- a/tests/AdminWorkerServiceTest.php
+++ b/tests/AdminWorkerServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerService.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerScanProgress.php';
 
 final class AdminWorkerServiceTest extends TestCase
 {
@@ -26,14 +27,11 @@ SQL
         $this->assertCount(3, $workers);
         $this->assertSame('player-one', $workers[0]->getScanning());
         $this->assertSame('2024-01-01 09:00:00', $workers[0]->getScanStart()->format('Y-m-d H:i:s'));
-        $this->assertSame(
-            [
-                'current' => 5,
-                'total' => 10,
-                'title' => 'Example',
-            ],
-            $workers[0]->getScanProgress()
-        );
+        $scanProgress = $workers[0]->getScanProgress();
+        $this->assertTrue($scanProgress instanceof WorkerScanProgress, 'Scan progress should be a value object.');
+        $this->assertSame(5, $scanProgress->getCurrent());
+        $this->assertSame(10, $scanProgress->getTotal());
+        $this->assertSame('Example', $scanProgress->getTitle());
     }
 
     public function testFetchWorkersCanOrderByIdDescending(): void

--- a/wwwroot/admin/workers.php
+++ b/wwwroot/admin/workers.php
@@ -144,26 +144,16 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                             <span class="text-body-secondary">Not reported</span>
                                         <?php } else { ?>
                                             <div class="small">
-                                                <?php if (array_key_exists('title', $scanProgress)) { ?>
+                                                <?php $title = $scanProgress->getTitle(); ?>
+                                                <?php if ($title !== null) { ?>
                                                     <div>
                                                         <strong>Title:</strong>
-                                                        <?= htmlspecialchars((string) $scanProgress['title'], ENT_QUOTES, 'UTF-8'); ?>
+                                                        <?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?>
                                                     </div>
                                                 <?php } ?>
                                                 <?php
-                                                $current = $scanProgress['current'] ?? null;
-                                                $total = $scanProgress['total'] ?? null;
-                                                $progressSummary = null;
-                                                $percentage = null;
-
-                                                if (is_int($current) && is_int($total) && $total > 0) {
-                                                    $progressSummary = sprintf('%d / %d', $current, $total);
-                                                    $percentage = round(($current / $total) * 100, 1);
-                                                } elseif (is_int($current) && $total === null) {
-                                                    $progressSummary = (string) $current;
-                                                } elseif (is_int($total) && $current === null) {
-                                                    $progressSummary = '0 / ' . $total;
-                                                }
+                                                $progressSummary = $scanProgress->getProgressSummary();
+                                                $percentage = $scanProgress->getPercentage();
                                                 ?>
                                                 <?php if ($progressSummary !== null) { ?>
                                                     <div>
@@ -174,10 +164,11 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                                         <?php } ?>
                                                     </div>
                                                 <?php } ?>
-                                                <?php if (array_key_exists('npCommunicationId', $scanProgress)) { ?>
+                                                <?php $npCommunicationId = $scanProgress->getNpCommunicationId(); ?>
+                                                <?php if ($npCommunicationId !== null) { ?>
                                                     <div>
                                                         <strong>NP Communication ID:</strong>
-                                                        <?= htmlspecialchars((string) $scanProgress['npCommunicationId'], ENT_QUOTES, 'UTF-8'); ?>
+                                                        <?= htmlspecialchars($npCommunicationId, ENT_QUOTES, 'UTF-8'); ?>
                                                     </div>
                                                 <?php } ?>
                                             </div>

--- a/wwwroot/classes/Admin/Worker.php
+++ b/wwwroot/classes/Admin/Worker.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/WorkerScanProgress.php';
+
 final class Worker
 {
     private int $id;
@@ -12,17 +14,14 @@ final class Worker
 
     private DateTimeImmutable $scanStart;
 
-    /**
-     * @var array{current?: int, total?: int, title?: string, npCommunicationId?: string}|null
-     */
-    private ?array $scanProgress;
+    private ?WorkerScanProgress $scanProgress;
 
     public function __construct(
         int $id,
         string $npsso,
         string $scanning,
         DateTimeImmutable $scanStart,
-        ?array $scanProgress
+        ?WorkerScanProgress $scanProgress
     ) {
         $this->id = $id;
         $this->npsso = $npsso;
@@ -51,10 +50,7 @@ final class Worker
         return $this->scanStart;
     }
 
-    /**
-     * @return array{current?: int, total?: int, title?: string, npCommunicationId?: string}|null
-     */
-    public function getScanProgress(): ?array
+    public function getScanProgress(): ?WorkerScanProgress
     {
         return $this->scanProgress;
     }

--- a/wwwroot/classes/Admin/WorkerScanProgress.php
+++ b/wwwroot/classes/Admin/WorkerScanProgress.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+final class WorkerScanProgress
+{
+    private ?int $current;
+
+    private ?int $total;
+
+    private ?string $title;
+
+    private ?string $npCommunicationId;
+
+    private function __construct(
+        ?int $current,
+        ?int $total,
+        ?string $title,
+        ?string $npCommunicationId
+    ) {
+        $this->current = $current;
+        $this->total = $total;
+        $this->title = $title;
+        $this->npCommunicationId = $npCommunicationId;
+    }
+
+    public static function fromJson(?string $value): ?self
+    {
+        if ($value === null || trim($value) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        return self::fromArray($decoded);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): ?self
+    {
+        $current = array_key_exists('current', $data) && is_numeric($data['current'])
+            ? max(0, (int) $data['current'])
+            : null;
+
+        $total = array_key_exists('total', $data) && is_numeric($data['total'])
+            ? max(0, (int) $data['total'])
+            : null;
+
+        $title = array_key_exists('title', $data) && is_string($data['title']) && $data['title'] !== ''
+            ? $data['title']
+            : null;
+
+        $npCommunicationId = array_key_exists('npCommunicationId', $data)
+            && is_string($data['npCommunicationId'])
+            && $data['npCommunicationId'] !== ''
+            ? $data['npCommunicationId']
+            : null;
+
+        if ($current === null && $total === null && $title === null && $npCommunicationId === null) {
+            return null;
+        }
+
+        return new self($current, $total, $title, $npCommunicationId);
+    }
+
+    public function getCurrent(): ?int
+    {
+        return $this->current;
+    }
+
+    public function getTotal(): ?int
+    {
+        return $this->total;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function getNpCommunicationId(): ?string
+    {
+        return $this->npCommunicationId;
+    }
+
+    public function getProgressSummary(): ?string
+    {
+        if ($this->current !== null && $this->total !== null) {
+            if ($this->total > 0) {
+                return sprintf('%d / %d', $this->current, $this->total);
+            }
+
+            return null;
+        }
+
+        if ($this->current !== null && $this->total === null) {
+            return (string) $this->current;
+        }
+
+        if ($this->total !== null && $this->current === null) {
+            return sprintf('0 / %d', $this->total);
+        }
+
+        return null;
+    }
+
+    public function getPercentage(): ?float
+    {
+        if ($this->current === null || $this->total === null || $this->total <= 0) {
+            return null;
+        }
+
+        return round(($this->current / $this->total) * 100, 1);
+    }
+}

--- a/wwwroot/classes/Admin/WorkerService.php
+++ b/wwwroot/classes/Admin/WorkerService.php
@@ -70,40 +70,9 @@ final class WorkerService
         return $workers;
     }
 
-    /**
-     * @return array{current?: int, total?: int, title?: string, npCommunicationId?: string}|null
-     */
-    private function decodeScanProgress(?string $value): ?array
+    private function decodeScanProgress(?string $value): ?WorkerScanProgress
     {
-        if ($value === null || $value === '') {
-            return null;
-        }
-
-        $decoded = json_decode($value, true);
-
-        if (!is_array($decoded)) {
-            return null;
-        }
-
-        $progress = [];
-
-        if (array_key_exists('current', $decoded) && is_numeric($decoded['current'])) {
-            $progress['current'] = max(0, (int) $decoded['current']);
-        }
-
-        if (array_key_exists('total', $decoded) && is_numeric($decoded['total'])) {
-            $progress['total'] = max(0, (int) $decoded['total']);
-        }
-
-        if (array_key_exists('title', $decoded) && is_string($decoded['title'])) {
-            $progress['title'] = $decoded['title'];
-        }
-
-        if (array_key_exists('npCommunicationId', $decoded) && is_string($decoded['npCommunicationId'])) {
-            $progress['npCommunicationId'] = $decoded['npCommunicationId'];
-        }
-
-        return $progress === [] ? null : $progress;
+        return WorkerScanProgress::fromJson($value);
     }
 
     public function updateWorkerNpsso(int $workerId, string $npsso): bool


### PR DESCRIPTION
## Summary
- add a `WorkerScanProgress` value object to decode and expose worker progress payloads in an object-oriented way
- update the worker entity, service, and admin UI to depend on the new value object for rendering summaries and metadata
- cover the new behavior with additional unit tests for the value object and existing service

## Testing
- `php tests/run.php`
- `php -l wwwroot/classes/Admin/WorkerScanProgress.php`
- `php -l wwwroot/classes/Admin/Worker.php`
- `php -l wwwroot/classes/Admin/WorkerService.php`
- `php -l wwwroot/admin/workers.php`
- `php -l tests/AdminWorkerServiceTest.php`
- `php -l tests/AdminWorkerScanProgressTest.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ec332d20832fa10fd918ea18aecb)