### PR TITLE
Refactor game trophy groups to objects

### DIFF
--- a/tests/GameTrophyGroupTest.php
+++ b/tests/GameTrophyGroupTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/Game/GameTrophyGroup.php';
+
+final class GameTrophyGroupTest extends TestCase
+{
+    private function createGroup(array $data = [], bool $usesPlayStation5Assets = false): GameTrophyGroup
+    {
+        $defaults = [
+            'group_id' => 'default',
+            'name' => 'Base Game',
+            'detail' => 'Contains the core trophies.',
+            'icon_url' => 'group.png',
+            'bronze' => 1,
+            'silver' => 2,
+            'gold' => 3,
+            'platinum' => 4,
+        ];
+
+        return GameTrophyGroup::fromArray($data + $defaults, $usesPlayStation5Assets);
+    }
+
+    public function testGetIconPathUsesConsoleSpecificPlaceholder(): void
+    {
+        $ps5Group = $this->createGroup(['icon_url' => '.png'], true);
+        $ps4Group = $this->createGroup(['icon_url' => '.png'], false);
+
+        $this->assertSame('../missing-ps5-game-and-trophy.png', $ps5Group->getIconPath());
+        $this->assertSame('../missing-ps4-game.png', $ps4Group->getIconPath());
+    }
+
+    public function testIsDefaultGroupMatchesGroupId(): void
+    {
+        $defaultGroup = $this->createGroup(['group_id' => 'default']);
+        $dlcGroup = $this->createGroup(['group_id' => '100']);
+
+        $this->assertTrue($defaultGroup->isDefaultGroup());
+        $this->assertFalse($dlcGroup->isDefaultGroup());
+    }
+
+    public function testGettersExposeTrophyCounts(): void
+    {
+        $group = $this->createGroup([
+            'bronze' => '12',
+            'silver' => '5',
+            'gold' => '2',
+            'platinum' => '1',
+        ]);
+
+        $this->assertSame(12, $group->getBronzeCount());
+        $this->assertSame(5, $group->getSilverCount());
+        $this->assertSame(2, $group->getGoldCount());
+        $this->assertSame(1, $group->getPlatinumCount());
+    }
+}

--- a/wwwroot/classes/Game/GameTrophyGroup.php
+++ b/wwwroot/classes/Game/GameTrophyGroup.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+final class GameTrophyGroup
+{
+    private string $id;
+
+    private string $name;
+
+    private string $detail;
+
+    private string $iconUrl;
+
+    private int $bronzeCount;
+
+    private int $silverCount;
+
+    private int $goldCount;
+
+    private int $platinumCount;
+
+    private bool $usesPlayStation5Assets;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data, bool $usesPlayStation5Assets): self
+    {
+        return new self($data, $usesPlayStation5Assets);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function __construct(array $data, bool $usesPlayStation5Assets)
+    {
+        $this->id = (string) ($data['group_id'] ?? '');
+        $this->name = (string) ($data['name'] ?? '');
+        $this->detail = (string) ($data['detail'] ?? '');
+        $this->iconUrl = (string) ($data['icon_url'] ?? '');
+        $this->bronzeCount = isset($data['bronze']) ? (int) $data['bronze'] : 0;
+        $this->silverCount = isset($data['silver']) ? (int) $data['silver'] : 0;
+        $this->goldCount = isset($data['gold']) ? (int) $data['gold'] : 0;
+        $this->platinumCount = isset($data['platinum']) ? (int) $data['platinum'] : 0;
+        $this->usesPlayStation5Assets = $usesPlayStation5Assets;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDetail(): string
+    {
+        return $this->detail;
+    }
+
+    public function getIconPath(): string
+    {
+        if ($this->iconUrl === '.png') {
+            return $this->usesPlayStation5Assets
+                ? '../missing-ps5-game-and-trophy.png'
+                : '../missing-ps4-game.png';
+        }
+
+        return $this->iconUrl;
+    }
+
+    public function isDefaultGroup(): bool
+    {
+        return $this->id === 'default';
+    }
+
+    public function getBronzeCount(): int
+    {
+        return $this->bronzeCount;
+    }
+
+    public function getSilverCount(): int
+    {
+        return $this->silverCount;
+    }
+
+    public function getGoldCount(): int
+    {
+        return $this->goldCount;
+    }
+
+    public function getPlatinumCount(): int
+    {
+        return $this->platinumCount;
+    }
+}

--- a/wwwroot/classes/GamePage.php
+++ b/wwwroot/classes/GamePage.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
 require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/Game/GamePlayerProgress.php';
 require_once __DIR__ . '/Game/GameHeaderData.php';
+require_once __DIR__ . '/Game/GameTrophyGroup.php';
 require_once __DIR__ . '/Game/GameTrophyRow.php';
 require_once __DIR__ . '/PageMetaData.php';
 require_once __DIR__ . '/Utility.php';
@@ -32,7 +33,7 @@ class GamePage
     private ?GamePlayerProgress $gamePlayer;
 
     /**
-     * @var array<int, array<string, mixed>>
+     * @var GameTrophyGroup[]
      */
     private array $trophyGroups = [];
 
@@ -128,12 +129,16 @@ class GamePage
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return GameTrophyGroup[]
      */
     public function getTrophyGroups(): array
     {
         if ($this->trophyGroups === []) {
-            $this->trophyGroups = $this->gameService->getTrophyGroups($this->game->getNpCommunicationId());
+            $usesPlayStation5Assets = $this->usesPlayStation5Assets();
+            $this->trophyGroups = array_map(
+                static fn (array $group) => GameTrophyGroup::fromArray($group, $usesPlayStation5Assets),
+                $this->gameService->getTrophyGroups($this->game->getNpCommunicationId())
+            );
         }
 
         return $this->trophyGroups;

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -106,7 +106,7 @@ require_once("header.php");
                 <?php
                 $trophyGroups = $gamePage->getTrophyGroups();
                 foreach ($trophyGroups as $trophyGroup) {
-                    $trophyGroupId = (string) $trophyGroup["group_id"];
+                    $trophyGroupId = $trophyGroup->getId();
                     $trophyGroupPlayer = $gamePage->getTrophyGroupPlayer($trophyGroupId);
 
                     $previousTimeStamp = null;
@@ -116,30 +116,30 @@ require_once("header.php");
                     }
                     ?>
                     <div class="table-responsive-xxl">
-                        <table class="table" id="<?= $trophyGroup["group_id"]; ?>">
+                        <table class="table" id="<?= htmlspecialchars($trophyGroupId, ENT_QUOTES, 'UTF-8'); ?>">
                             <thead>
                                 <tr>
                                     <th scope="col" colspan="4" class="bg-dark-subtle">
                                         <div class="hstack gap-3">
                                             <div>
-                                                <img class="card-img object-fit-cover" style="height: 7rem;" src="/img/group/<?= ($trophyGroup["icon_url"] == ".png") ? ((str_contains($game->getPlatform(), "PS5") || str_contains($game->getPlatform(), "PSVR2")) ? "../missing-ps5-game-and-trophy.png" : "../missing-ps4-game.png") : $trophyGroup["icon_url"]; ?>" alt="<?= htmlentities($trophyGroup["name"]); ?>">
+                                                <img class="card-img object-fit-cover" style="height: 7rem;" src="/img/group/<?= htmlspecialchars($trophyGroup->getIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophyGroup->getName()); ?>">
                                             </div>
                                             
                                             <div>
-                                                <b><?= htmlentities($trophyGroup["name"]); ?></b><br>
-                                                <?= nl2br(htmlentities($trophyGroup["detail"], ENT_QUOTES, "UTF-8")); ?>
+                                                <b><?= htmlentities($trophyGroup->getName()); ?></b><br>
+                                                <?= nl2br(htmlentities($trophyGroup->getDetail(), ENT_QUOTES, 'UTF-8')); ?>
                                             </div>
 
                                             <div class="ms-auto">
                                                 <?php
                                                 if ($trophyGroupPlayer !== null) {
-                                                    if ($trophyGroup["group_id"] == "default") {
+                                                    if ($trophyGroup->isDefaultGroup()) {
                                                         ?>
-                                                        <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $trophyGroupPlayer["platinum"] ?? "0"; ?>/<?= $trophyGroup["platinum"]; ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $trophyGroupPlayer["gold"] ?? "0"; ?>/<?= $trophyGroup["gold"]; ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $trophyGroupPlayer["silver"] ?? "0"; ?>/<?= $trophyGroup["silver"]; ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $trophyGroupPlayer["bronze"] ?? "0"; ?>/<?= $trophyGroup["bronze"]; ?></span>
+                                                        <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $trophyGroupPlayer["platinum"] ?? "0"; ?>/<?= $trophyGroup->getPlatinumCount(); ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $trophyGroupPlayer["gold"] ?? "0"; ?>/<?= $trophyGroup->getGoldCount(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $trophyGroupPlayer["silver"] ?? "0"; ?>/<?= $trophyGroup->getSilverCount(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $trophyGroupPlayer["bronze"] ?? "0"; ?>/<?= $trophyGroup->getBronzeCount(); ?></span>
                                                         <?php
                                                     } else {
                                                         ?>
-                                                        <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $trophyGroupPlayer["gold"] ?? "0"; ?>/<?= $trophyGroup["gold"]; ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $trophyGroupPlayer["silver"] ?? "0"; ?>/<?= $trophyGroup["silver"]; ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $trophyGroupPlayer["bronze"] ?? "0"; ?>/<?= $trophyGroup["bronze"]; ?></span>
+                                                        <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $trophyGroupPlayer["gold"] ?? "0"; ?>/<?= $trophyGroup->getGoldCount(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $trophyGroupPlayer["silver"] ?? "0"; ?>/<?= $trophyGroup->getSilverCount(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $trophyGroupPlayer["bronze"] ?? "0"; ?>/<?= $trophyGroup->getBronzeCount(); ?></span>
                                                         <?php
                                                     }
                                                     ?>
@@ -150,13 +150,13 @@ require_once("header.php");
                                                     </div>
                                                     <?php
                                                 } else {
-                                                    if ($trophyGroup["group_id"] == "default") {
+                                                    if ($trophyGroup->isDefaultGroup()) {
                                                         ?>
-                                                        <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $trophyGroup["platinum"]; ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $trophyGroup["gold"]; ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $trophyGroup["silver"]; ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $trophyGroup["bronze"]; ?></span>
+                                                        <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $trophyGroup->getPlatinumCount(); ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $trophyGroup->getGoldCount(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $trophyGroup->getSilverCount(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $trophyGroup->getBronzeCount(); ?></span>
                                                         <?php
                                                     } else {
                                                         ?>
-                                                        <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $trophyGroup["gold"]; ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $trophyGroup["silver"]; ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $trophyGroup["bronze"]; ?></span>
+                                                        <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $trophyGroup->getGoldCount(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $trophyGroup->getSilverCount(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $trophyGroup->getBronzeCount(); ?></span>
                                                         <?php
                                                     }
                                                 }


### PR DESCRIPTION
## Summary
- add a dedicated `GameTrophyGroup` value object to represent trophy groups, including console-specific placeholder handling
- update `GamePage` and the game template to work with the new object accessors instead of raw arrays
- cover the new object with unit tests

## Testing
- php ../tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ec332d20832fa10fd918ea18aecb)