### PR TITLE
Refactor trophy group player data into objects

### DIFF
--- a/tests/GameTrophyFilterTest.php
+++ b/tests/GameTrophyFilterTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/GameTrophyFilter.php';
+require_once __DIR__ . '/../wwwroot/classes/Game/GameTrophyGroupPlayer.php';
 
 final class GameTrophyFilterTest extends TestCase
 {
@@ -39,11 +40,11 @@ final class GameTrophyFilterTest extends TestCase
         $filter = GameTrophyFilter::fromQueryParameters(['unearned' => true], true);
 
         $this->assertTrue($filter->shouldDisplayGroup(null));
-        $this->assertTrue($filter->shouldDisplayGroup([]));
-        $this->assertTrue($filter->shouldDisplayGroup(['progress' => 50]));
-        $this->assertTrue($filter->shouldDisplayGroup(['progress' => '75']));
-        $this->assertFalse($filter->shouldDisplayGroup(['progress' => 100]));
-        $this->assertFalse($filter->shouldDisplayGroup(['progress' => '100']));
+        $this->assertTrue($filter->shouldDisplayGroup($this->createGroupPlayer()));
+        $this->assertTrue($filter->shouldDisplayGroup($this->createGroupPlayer(['progress' => 50])));
+        $this->assertTrue($filter->shouldDisplayGroup($this->createGroupPlayer(['progress' => '75'])));
+        $this->assertFalse($filter->shouldDisplayGroup($this->createGroupPlayer(['progress' => 100])));
+        $this->assertFalse($filter->shouldDisplayGroup($this->createGroupPlayer(['progress' => '100'])));
     }
 
     public function testShouldDisplayGroupAlwaysReturnsTrueWhenUnearnedFilterDisabled(): void
@@ -51,8 +52,8 @@ final class GameTrophyFilterTest extends TestCase
         $filter = GameTrophyFilter::fromQueryParameters([], false);
 
         $this->assertTrue($filter->shouldDisplayGroup(null));
-        $this->assertTrue($filter->shouldDisplayGroup(['progress' => 0]));
-        $this->assertTrue($filter->shouldDisplayGroup(['progress' => 100]));
+        $this->assertTrue($filter->shouldDisplayGroup($this->createGroupPlayer(['progress' => 0])));
+        $this->assertTrue($filter->shouldDisplayGroup($this->createGroupPlayer(['progress' => 100])));
     }
 
     public function testShouldDisplayTrophyRequiresUnearnedFlag(): void
@@ -120,5 +121,21 @@ final class GameTrophyFilterTest extends TestCase
         $filter = GameTrophyFilter::fromQueryParameters(['unearned' => ['unexpected']], true);
 
         $this->assertTrue($filter->shouldShowUnearnedOnly());
+    }
+
+    private function createGroupPlayer(array $overrides = []): GameTrophyGroupPlayer
+    {
+        $defaults = [
+            'np_communication_id' => 'NPWRTEST',
+            'group_id' => 'default',
+            'account_id' => 1,
+            'bronze' => 0,
+            'silver' => 0,
+            'gold' => 0,
+            'platinum' => 0,
+            'progress' => 0,
+        ];
+
+        return GameTrophyGroupPlayer::fromArray($overrides + $defaults);
     }
 }

--- a/tests/GameTrophyGroupPlayerTest.php
+++ b/tests/GameTrophyGroupPlayerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/Game/GameTrophyGroupPlayer.php';
+
+final class GameTrophyGroupPlayerTest extends TestCase
+{
+    public function testFromArrayCastsValuesAndProvidesAccessors(): void
+    {
+        $player = GameTrophyGroupPlayer::fromArray([
+            'np_communication_id' => 'NPWR12345',
+            'group_id' => 'default',
+            'account_id' => '42',
+            'bronze' => '10',
+            'silver' => '5',
+            'gold' => '2',
+            'platinum' => '1',
+            'progress' => '75',
+        ]);
+
+        $this->assertSame('NPWR12345', $player->getNpCommunicationId());
+        $this->assertSame('default', $player->getGroupId());
+        $this->assertSame(42, $player->getAccountId());
+        $this->assertSame(10, $player->getBronzeCount());
+        $this->assertSame(5, $player->getSilverCount());
+        $this->assertSame(2, $player->getGoldCount());
+        $this->assertSame(1, $player->getPlatinumCount());
+        $this->assertSame(75, $player->getProgress());
+        $this->assertFalse($player->isComplete());
+    }
+
+    public function testIsCompleteReturnsTrueAtOrAboveHundredPercent(): void
+    {
+        $completePlayer = GameTrophyGroupPlayer::fromArray([
+            'np_communication_id' => 'NPWR67890',
+            'group_id' => '100',
+            'account_id' => 7,
+            'progress' => 100,
+        ]);
+
+        $overflowPlayer = GameTrophyGroupPlayer::fromArray([
+            'np_communication_id' => 'NPWR67890',
+            'group_id' => '100',
+            'account_id' => 7,
+            'progress' => 150,
+        ]);
+
+        $this->assertTrue($completePlayer->isComplete());
+        $this->assertTrue($overflowPlayer->isComplete());
+    }
+}

--- a/wwwroot/classes/Game/GameTrophyGroupPlayer.php
+++ b/wwwroot/classes/Game/GameTrophyGroupPlayer.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+final class GameTrophyGroupPlayer
+{
+    private string $npCommunicationId;
+
+    private string $groupId;
+
+    private int $accountId;
+
+    private int $bronzeCount;
+
+    private int $silverCount;
+
+    private int $goldCount;
+
+    private int $platinumCount;
+
+    private int $progress;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self($data);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function __construct(array $data)
+    {
+        $this->npCommunicationId = (string) ($data['np_communication_id'] ?? '');
+        $this->groupId = (string) ($data['group_id'] ?? '');
+        $this->accountId = isset($data['account_id']) ? (int) $data['account_id'] : 0;
+        $this->bronzeCount = isset($data['bronze']) ? (int) $data['bronze'] : 0;
+        $this->silverCount = isset($data['silver']) ? (int) $data['silver'] : 0;
+        $this->goldCount = isset($data['gold']) ? (int) $data['gold'] : 0;
+        $this->platinumCount = isset($data['platinum']) ? (int) $data['platinum'] : 0;
+        $this->progress = isset($data['progress']) ? (int) $data['progress'] : 0;
+    }
+
+    public function getNpCommunicationId(): string
+    {
+        return $this->npCommunicationId;
+    }
+
+    public function getGroupId(): string
+    {
+        return $this->groupId;
+    }
+
+    public function getAccountId(): int
+    {
+        return $this->accountId;
+    }
+
+    public function getBronzeCount(): int
+    {
+        return $this->bronzeCount;
+    }
+
+    public function getSilverCount(): int
+    {
+        return $this->silverCount;
+    }
+
+    public function getGoldCount(): int
+    {
+        return $this->goldCount;
+    }
+
+    public function getPlatinumCount(): int
+    {
+        return $this->platinumCount;
+    }
+
+    public function getProgress(): int
+    {
+        return $this->progress;
+    }
+
+    public function isComplete(): bool
+    {
+        return $this->progress >= 100;
+    }
+}

--- a/wwwroot/classes/GamePage.php
+++ b/wwwroot/classes/GamePage.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/Game/GamePlayerProgress.php';
 require_once __DIR__ . '/Game/GameHeaderData.php';
 require_once __DIR__ . '/Game/GameTrophyGroup.php';
+require_once __DIR__ . '/Game/GameTrophyGroupPlayer.php';
 require_once __DIR__ . '/Game/GameTrophyRow.php';
 require_once __DIR__ . '/PageMetaData.php';
 require_once __DIR__ . '/Utility.php';
@@ -38,7 +39,7 @@ class GamePage
     private array $trophyGroups = [];
 
     /**
-     * @var array<string, array<string, mixed>|null>
+     * @var array<string, GameTrophyGroupPlayer|null>
      */
     private array $trophyGroupPlayers = [];
 
@@ -144,10 +145,7 @@ class GamePage
         return $this->trophyGroups;
     }
 
-    /**
-     * @return array<string, mixed>|null
-     */
-    public function getTrophyGroupPlayer(string $groupId): ?array
+    public function getTrophyGroupPlayer(string $groupId): ?GameTrophyGroupPlayer
     {
         if ($this->playerAccountId === null) {
             return null;

--- a/wwwroot/classes/GameService.php
+++ b/wwwroot/classes/GameService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/Game/GamePlayerProgress.php';
+require_once __DIR__ . '/Game/GameTrophyGroupPlayer.php';
 
 class GameService
 {
@@ -155,7 +156,7 @@ class GameService
         return is_array($groups) ? $groups : [];
     }
 
-    public function getTrophyGroupPlayer(string $npCommunicationId, string $groupId, int $accountId): ?array
+    public function getTrophyGroupPlayer(string $npCommunicationId, string $groupId, int $accountId): ?GameTrophyGroupPlayer
     {
         $query = $this->database->prepare(
             <<<'SQL'
@@ -176,7 +177,11 @@ class GameService
 
         $trophyGroupPlayer = $query->fetch(PDO::FETCH_ASSOC);
 
-        return is_array($trophyGroupPlayer) ? $trophyGroupPlayer : null;
+        if (!is_array($trophyGroupPlayer)) {
+            return null;
+        }
+
+        return GameTrophyGroupPlayer::fromArray($trophyGroupPlayer);
     }
 
     /**

--- a/wwwroot/classes/GameTrophyFilter.php
+++ b/wwwroot/classes/GameTrophyFilter.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Game/GameTrophyGroupPlayer.php';
 require_once __DIR__ . '/Game/GameTrophyRow.php';
 
 class GameTrophyFilter
@@ -32,18 +33,13 @@ class GameTrophyFilter
         return $this->unearnedOnly;
     }
 
-    /**
-     * @param array<string, mixed>|null $trophyGroupPlayer
-     */
-    public function shouldDisplayGroup(?array $trophyGroupPlayer): bool
+    public function shouldDisplayGroup(?GameTrophyGroupPlayer $trophyGroupPlayer): bool
     {
         if (!$this->unearnedOnly || $trophyGroupPlayer === null) {
             return true;
         }
 
-        $progress = isset($trophyGroupPlayer['progress']) ? (int) $trophyGroupPlayer['progress'] : 0;
-
-        return $progress < 100;
+        return !$trophyGroupPlayer->isComplete();
     }
 
     /**

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -133,19 +133,24 @@ require_once("header.php");
                                             <div class="ms-auto">
                                                 <?php
                                                 if ($trophyGroupPlayer !== null) {
+                                                    $bronzeEarned = $trophyGroupPlayer->getBronzeCount();
+                                                    $silverEarned = $trophyGroupPlayer->getSilverCount();
+                                                    $goldEarned = $trophyGroupPlayer->getGoldCount();
+                                                    $platinumEarned = $trophyGroupPlayer->getPlatinumCount();
+                                                    $progress = $trophyGroupPlayer->getProgress();
                                                     if ($trophyGroup->isDefaultGroup()) {
                                                         ?>
-                                                        <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $trophyGroupPlayer["platinum"] ?? "0"; ?>/<?= $trophyGroup->getPlatinumCount(); ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $trophyGroupPlayer["gold"] ?? "0"; ?>/<?= $trophyGroup->getGoldCount(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $trophyGroupPlayer["silver"] ?? "0"; ?>/<?= $trophyGroup->getSilverCount(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $trophyGroupPlayer["bronze"] ?? "0"; ?>/<?= $trophyGroup->getBronzeCount(); ?></span>
+                                                        <img src="/img/trophy-platinum.svg" alt="Platinum" height="18"> <span class="trophy-platinum"><?= $platinumEarned; ?>/<?= $trophyGroup->getPlatinumCount(); ?></span> &bull; <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $goldEarned; ?>/<?= $trophyGroup->getGoldCount(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $silverEarned; ?>/<?= $trophyGroup->getSilverCount(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $bronzeEarned; ?>/<?= $trophyGroup->getBronzeCount(); ?></span>
                                                         <?php
                                                     } else {
                                                         ?>
-                                                        <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $trophyGroupPlayer["gold"] ?? "0"; ?>/<?= $trophyGroup->getGoldCount(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $trophyGroupPlayer["silver"] ?? "0"; ?>/<?= $trophyGroup->getSilverCount(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $trophyGroupPlayer["bronze"] ?? "0"; ?>/<?= $trophyGroup->getBronzeCount(); ?></span>
+                                                        <img src="/img/trophy-gold.svg" alt="Gold" height="18"> <span class="trophy-gold"><?= $goldEarned; ?>/<?= $trophyGroup->getGoldCount(); ?></span> &bull; <img src="/img/trophy-silver.svg" alt="Silver" height="18"> <span class="trophy-silver"><?= $silverEarned; ?>/<?= $trophyGroup->getSilverCount(); ?></span> &bull; <img src="/img/trophy-bronze.svg" alt="Bronze" height="18"> <span class="trophy-bronze"><?= $bronzeEarned; ?>/<?= $trophyGroup->getBronzeCount(); ?></span>
                                                         <?php
                                                     }
                                                     ?>
                                                     <div>
-                                                        <div class="progress mt-1" role="progressbar" aria-label="Player trophy progress" aria-valuenow="<?= $trophyGroupPlayer["progress"] ?? "0"; ?>" aria-valuemin="0" aria-valuemax="100">
-                                                            <div class="progress-bar" style="width: <?= $trophyGroupPlayer["progress"] ?? "0"; ?>%"><?= $trophyGroupPlayer["progress"] ?? "0"; ?>%</div>
+                                                        <div class="progress mt-1" role="progressbar" aria-label="Player trophy progress" aria-valuenow="<?= $progress; ?>" aria-valuemin="0" aria-valuemax="100">
+                                                            <div class="progress-bar" style="width: <?= $progress; ?>%"><?= $progress; ?>%</div>
                                                         </div>
                                                     </div>
                                                     <?php


### PR DESCRIPTION
## Summary
- introduce a dedicated `GameTrophyGroupPlayer` view model and use it throughout the game page service, filter logic, and template so trophy group progress is handled in an object-oriented way
- update the trophy filter to operate on the new model and streamline the game page template rendering
- add comprehensive unit tests that cover the new model and its integration into the existing filter behavior

## Testing
- php tests/run.php
- php -l tests/GameTrophyFilterTest.php
- php -l wwwroot/classes/GamePage.php
- php -l wwwroot/classes/GameService.php
- php -l wwwroot/classes/GameTrophyFilter.php
- php -l wwwroot/game.php
- php -l tests/GameTrophyGroupPlayerTest.php
- php -l wwwroot/classes/Game/GameTrophyGroupPlayer.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f693c130832f9e27a2e799efa115)