### PR TITLE
Refactor admin log deletion handling

### DIFF
--- a/tests/LogDeletionRequestTest.php
+++ b/tests/LogDeletionRequestTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/LogDeletionRequest.php';
+
+final class LogDeletionRequestTest extends TestCase
+{
+    public function testFromPostDataParsesSingleDeletionId(): void
+    {
+        $request = LogDeletionRequest::fromPostData(['delete_id' => '42']);
+
+        $this->assertTrue($request->isSingleDeletion());
+        $this->assertSame(42, $request->getSingleDeletionId());
+        $this->assertFalse($request->hasError());
+    }
+
+    public function testFromPostDataReturnsErrorWhenSingleDeletionIdInvalid(): void
+    {
+        $request = LogDeletionRequest::fromPostData(['delete_id' => 'foo']);
+
+        $this->assertTrue($request->hasError());
+        $this->assertSame('Please provide a valid log entry ID to delete.', $request->getErrorMessage());
+        $this->assertFalse($request->isSingleDeletion());
+    }
+
+    public function testFromPostDataParsesBulkDeletionIds(): void
+    {
+        $request = LogDeletionRequest::fromPostData([
+            'delete_selected' => '1',
+            'delete_ids' => ['3', '2', '2', 'invalid', ' 5 '],
+        ]);
+
+        $this->assertTrue($request->isBulkDeletion());
+        $this->assertSame([2, 3, 5], $request->getBulkDeletionIds());
+        $this->assertFalse($request->hasError());
+    }
+
+    public function testFromPostDataReturnsErrorWhenBulkDeletionIdsMissing(): void
+    {
+        $request = LogDeletionRequest::fromPostData(['delete_selected' => '1', 'delete_ids' => []]);
+
+        $this->assertTrue($request->hasError());
+        $this->assertSame('Please select at least one log entry to delete.', $request->getErrorMessage());
+        $this->assertFalse($request->isBulkDeletion());
+    }
+}

--- a/wwwroot/classes/Admin/LogDeletionRequest.php
+++ b/wwwroot/classes/Admin/LogDeletionRequest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+final class LogDeletionRequest
+{
+    private const ACTION_SINGLE = 'single';
+    private const ACTION_BULK = 'bulk';
+
+    private ?string $action;
+
+    private ?int $singleDeletionId;
+
+    /**
+     * @var list<int>
+     */
+    private array $bulkDeletionIds;
+
+    private ?string $errorMessage;
+
+    /**
+     * @param list<int> $bulkDeletionIds
+     */
+    private function __construct(?string $action, ?int $singleDeletionId, array $bulkDeletionIds, ?string $errorMessage)
+    {
+        $this->action = $action;
+        $this->singleDeletionId = $singleDeletionId;
+        $this->bulkDeletionIds = $bulkDeletionIds;
+        $this->errorMessage = $errorMessage;
+    }
+
+    /**
+     * @param array<string, mixed> $postData
+     */
+    public static function fromPostData(array $postData): self
+    {
+        $action = null;
+        $singleDeletionId = null;
+        $bulkDeletionIds = [];
+        $errorMessage = null;
+
+        if (array_key_exists('delete_id', $postData)) {
+            $action = self::ACTION_SINGLE;
+            $singleDeletionId = self::parsePositiveInt($postData['delete_id'] ?? null);
+
+            if ($singleDeletionId === null) {
+                $errorMessage = 'Please provide a valid log entry ID to delete.';
+            }
+        } elseif (array_key_exists('delete_selected', $postData) || array_key_exists('delete_ids', $postData)) {
+            $action = self::ACTION_BULK;
+            $bulkDeletionIds = self::parsePositiveIntList($postData['delete_ids'] ?? []);
+
+            if ($bulkDeletionIds === []) {
+                $errorMessage = 'Please select at least one log entry to delete.';
+            }
+        }
+
+        return new self($action, $singleDeletionId, $bulkDeletionIds, $errorMessage);
+    }
+
+    public function hasError(): bool
+    {
+        return $this->errorMessage !== null;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+
+    public function hasDeletionRequest(): bool
+    {
+        return $this->action !== null;
+    }
+
+    public function isSingleDeletion(): bool
+    {
+        return $this->action === self::ACTION_SINGLE && !$this->hasError();
+    }
+
+    public function isBulkDeletion(): bool
+    {
+        return $this->action === self::ACTION_BULK && !$this->hasError();
+    }
+
+    public function getSingleDeletionId(): ?int
+    {
+        return $this->singleDeletionId;
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function getBulkDeletionIds(): array
+    {
+        return $this->bulkDeletionIds;
+    }
+
+    private static function parsePositiveInt(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value > 0 ? $value : null;
+        }
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '' || !ctype_digit($trimmed)) {
+            return null;
+        }
+
+        $intValue = (int) $trimmed;
+
+        return $intValue > 0 ? $intValue : null;
+    }
+
+    /**
+     * @param mixed $values
+     * @return list<int>
+     */
+    private static function parsePositiveIntList(mixed $values): array
+    {
+        if (!is_iterable($values)) {
+            return [];
+        }
+
+        $uniqueValues = [];
+
+        foreach ($values as $value) {
+            $parsed = self::parsePositiveInt($value);
+
+            if ($parsed === null) {
+                continue;
+            }
+
+            $uniqueValues[$parsed] = $parsed;
+        }
+
+        if ($uniqueValues !== []) {
+            ksort($uniqueValues);
+        }
+
+        return array_values($uniqueValues);
+    }
+}

--- a/wwwroot/classes/Admin/LogPage.php
+++ b/wwwroot/classes/Admin/LogPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/LogService.php';
 require_once __DIR__ . '/LogPageResult.php';
+require_once __DIR__ . '/LogDeletionRequest.php';
 
 final class LogPage
 {
@@ -27,12 +28,14 @@ final class LogPage
         $errorMessage = null;
 
         if (strtoupper($method) === 'POST') {
-            if (array_key_exists('delete_id', $postData)) {
-                $deleteId = $this->parsePositiveInt($postData['delete_id'] ?? null);
+            $deletionRequest = LogDeletionRequest::fromPostData($postData);
 
-                if ($deleteId === null) {
-                    $errorMessage = 'Please provide a valid log entry ID to delete.';
-                } else {
+            if ($deletionRequest->hasError()) {
+                $errorMessage = $deletionRequest->getErrorMessage();
+            } elseif ($deletionRequest->isSingleDeletion()) {
+                $deleteId = $deletionRequest->getSingleDeletionId();
+
+                if ($deleteId !== null) {
                     $deleted = $this->logService->deleteLogById($deleteId);
 
                     if ($deleted) {
@@ -41,33 +44,29 @@ final class LogPage
                         $errorMessage = sprintf('Log entry %d could not be found.', $deleteId);
                     }
                 }
-            } elseif (array_key_exists('delete_selected', $postData) || array_key_exists('delete_ids', $postData)) {
-                $deleteIds = $this->parsePositiveIntList($postData['delete_ids'] ?? []);
+            } elseif ($deletionRequest->isBulkDeletion()) {
+                $deleteIds = $deletionRequest->getBulkDeletionIds();
 
-                if ($deleteIds === []) {
-                    $errorMessage = 'Please select at least one log entry to delete.';
+                $deletedCount = $this->logService->deleteLogsByIds($deleteIds);
+
+                if ($deletedCount === 0) {
+                    $errorMessage = 'No matching log entries were found for the selected IDs.';
                 } else {
-                    $deletedCount = $this->logService->deleteLogsByIds($deleteIds);
+                    $entryLabel = $deletedCount === 1 ? 'log entry' : 'log entries';
 
-                    if ($deletedCount === 0) {
-                        $errorMessage = 'No matching log entries were found for the selected IDs.';
+                    if ($deletedCount === count($deleteIds)) {
+                        $successMessage = sprintf(
+                            'Deleted %d %s (IDs: %s).',
+                            $deletedCount,
+                            $entryLabel,
+                            implode(', ', $deleteIds)
+                        );
                     } else {
-                        $entryLabel = $deletedCount === 1 ? 'log entry' : 'log entries';
-
-                        if ($deletedCount === count($deleteIds)) {
-                            $successMessage = sprintf(
-                                'Deleted %d %s (IDs: %s).',
-                                $deletedCount,
-                                $entryLabel,
-                                implode(', ', $deleteIds)
-                            );
-                        } else {
-                            $successMessage = sprintf(
-                                'Deleted %d %s. Some selected entries may no longer exist.',
-                                $deletedCount,
-                                $entryLabel
-                            );
-                        }
+                        $successMessage = sprintf(
+                            'Deleted %d %s. Some selected entries may no longer exist.',
+                            $deletedCount,
+                            $entryLabel
+                        );
                     }
                 }
             }
@@ -111,30 +110,5 @@ final class LogPage
         $intValue = (int) $trimmed;
 
         return $intValue > 0 ? $intValue : null;
-    }
-
-    /**
-     * @param mixed $values
-     * @return list<int>
-     */
-    private function parsePositiveIntList(mixed $values): array
-    {
-        if (!is_iterable($values)) {
-            return [];
-        }
-
-        $uniqueValues = [];
-
-        foreach ($values as $value) {
-            $parsed = $this->parsePositiveInt($value);
-
-            if ($parsed === null) {
-                continue;
-            }
-
-            $uniqueValues[$parsed] = $parsed;
-        }
-
-        return array_values($uniqueValues);
     }
 }


### PR DESCRIPTION
## Summary
- extract admin log deletion parsing into a new `LogDeletionRequest` value object so POST handling logic is encapsulated in a reusable, object-oriented structure
- update `LogPage` to delegate deletion request parsing to the new class and keep the controller focused on orchestration
- add unit tests covering the new request parser to ensure both single and bulk deletions behave as expected

## Testing
- php -l wwwroot/classes/Admin/LogDeletionRequest.php
- php -l wwwroot/classes/Admin/LogPage.php
- php -l tests/LogDeletionRequestTest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f693c130832f9e27a2e799efa115)