### PR TITLE
Improve avatar pagination and add coverage

### DIFF
--- a/tests/AvatarPageTest.php
+++ b/tests/AvatarPageTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/AvatarPage.php';
+require_once __DIR__ . '/../wwwroot/classes/AvatarService.php';
+require_once __DIR__ . '/../wwwroot/classes/Avatar.php';
+
+final class AvatarPageTest extends TestCase
+{
+    private PDO $database;
+
+    private AvatarService $avatarService;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec('CREATE TABLE player (avatar_url TEXT, status INTEGER)');
+
+        $this->avatarService = new AvatarService($this->database);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->avatarService);
+        unset($this->database);
+    }
+
+    public function testGetAvatarsReturnsCountsForCurrentPage(): void
+    {
+        $this->insertPlayer('alpha.png');
+        $this->insertPlayer('alpha.png');
+        $this->insertPlayer('bravo.png');
+        $this->insertPlayer('charlie.png', 1); // Flagged player should be ignored.
+
+        $page = AvatarPage::fromQueryParameters($this->avatarService, ['page' => '1'], 2);
+        $avatars = $page->getAvatars();
+
+        $this->assertCount(2, $avatars);
+        $this->assertSame('alpha.png', $avatars[0]->getUrl());
+        $this->assertSame(2, $avatars[0]->getCount());
+        $this->assertSame('bravo.png', $avatars[1]->getUrl());
+        $this->assertSame(1, $avatars[1]->getCount());
+    }
+
+    public function testCurrentPageIsClampedWhenRequestedPageExceedsTotalPages(): void
+    {
+        $this->insertPlayer('alpha.png');
+        $this->insertPlayer('bravo.png');
+        $this->insertPlayer('charlie.png');
+
+        $page = AvatarPage::fromQueryParameters($this->avatarService, ['page' => '5'], 2);
+
+        $this->assertSame(2, $page->getCurrentPage());
+        $this->assertSame(2, $page->getLastPage());
+
+        $avatars = $page->getAvatars();
+        $this->assertCount(1, $avatars);
+        $this->assertSame('charlie.png', $avatars[0]->getUrl());
+    }
+
+    public function testCurrentPageDefaultsToOneWhenNoAvatarsExist(): void
+    {
+        $page = AvatarPage::fromQueryParameters($this->avatarService, ['page' => '10'], 5);
+
+        $this->assertSame(1, $page->getCurrentPage());
+        $this->assertSame(0, $page->getTotalPages());
+        $this->assertSame(1, $page->getLastPage());
+        $this->assertCount(0, $page->getAvatars());
+    }
+
+    private function insertPlayer(string $avatarUrl, int $status = 0): void
+    {
+        $statement = $this->database->prepare('INSERT INTO player (avatar_url, status) VALUES (:avatar_url, :status)');
+        $statement->bindValue(':avatar_url', $avatarUrl, PDO::PARAM_STR);
+        $statement->bindValue(':status', $status, PDO::PARAM_INT);
+        $statement->execute();
+    }
+}

--- a/wwwroot/classes/AvatarPage.php
+++ b/wwwroot/classes/AvatarPage.php
@@ -25,13 +25,13 @@ class AvatarPage
     {
         $this->avatarService = $avatarService;
         $this->limit = max($limit, 1);
-        $this->currentPage = max($currentPage, 1);
+
+        $requestedPage = max($currentPage, 1);
 
         $this->totalAvatarCount = $this->avatarService->getTotalUniqueAvatarCount();
-        $this->totalPages = $this->totalAvatarCount > 0
-            ? (int) ceil($this->totalAvatarCount / $this->limit)
-            : 0;
+        $this->totalPages = $this->calculateTotalPages();
 
+        $this->currentPage = $this->normalizePageNumber($requestedPage);
         $this->avatars = $this->avatarService->getAvatars($this->currentPage, $this->limit);
     }
 
@@ -160,5 +160,21 @@ class AvatarPage
     public function getLastPage(): int
     {
         return $this->totalPages > 0 ? $this->totalPages : 1;
+    }
+
+    private function calculateTotalPages(): int
+    {
+        if ($this->totalAvatarCount === 0) {
+            return 0;
+        }
+
+        return (int) ceil($this->totalAvatarCount / $this->limit);
+    }
+
+    private function normalizePageNumber(int $requestedPage): int
+    {
+        $maximumPage = $this->totalPages > 0 ? $this->totalPages : 1;
+
+        return min($requestedPage, $maximumPage);
     }
 }


### PR DESCRIPTION
## Summary
- clamp the avatar listing page to valid pagination bounds by normalizing the requested page before querying
- add regression tests that exercise the avatar page behavior, including pagination clamping and empty datasets

## Testing
- php -l wwwroot/classes/AvatarPage.php
- php -l tests/AvatarPageTest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919ad8910b8832f88a2e9578713274c)