### PR TITLE
Extract Psn100Logger into dedicated class

### DIFF
--- a/tests/TrophyHistorySnapshotTest.php
+++ b/tests/TrophyHistorySnapshotTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/Psn100Logger.php';
-require_once __DIR__ . '/../wwwroot/classes/TrophyCalculator.php';
 require_once __DIR__ . '/../wwwroot/classes/TrophyHistoryRecorder.php';
 
 final class TrophyHistorySnapshotTest extends TestCase

--- a/wwwroot/classes/Admin/GameRescanProcessor.php
+++ b/wwwroot/classes/Admin/GameRescanProcessor.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../TrophyCalculator.php';
+require_once __DIR__ . '/../Psn100Logger.php';
 require_once __DIR__ . '/GameRescanService.php';
 require_once __DIR__ . '/GameRescanRequestHandler.php';
 

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/CronJobInterface.php';
 require_once __DIR__ . '/../AutomaticTrophyTitleMergeService.php';
 require_once __DIR__ . '/../ImageHashCalculator.php';
+require_once __DIR__ . '/../Psn100Logger.php';
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../TrophyMergeService.php';
 require_once __DIR__ . '/../TrophyMetaRepository.php';

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/CronJobEntryPoint.php';
 require_once __DIR__ . '/CronJobCliArguments.php';
 require_once __DIR__ . '/../TrophyCalculator.php';
+require_once __DIR__ . '/../Psn100Logger.php';
 require_once __DIR__ . '/ThirtyMinuteCronJob.php';
 
 final class ThirtyMinuteCronJobApplication

--- a/wwwroot/classes/Psn100Logger.php
+++ b/wwwroot/classes/Psn100Logger.php
@@ -2,4 +2,21 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/TrophyCalculator.php';
+final class Psn100Logger
+{
+    private PDO $database;
+
+    public function __construct(PDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function log(string $message): void
+    {
+        $statement = $this->database->prepare(
+            'INSERT INTO log (message) VALUES (:message)'
+        );
+        $statement->bindValue(':message', $message, PDO::PARAM_STR);
+        $statement->execute();
+    }
+}

--- a/wwwroot/classes/TrophyCalculator.php
+++ b/wwwroot/classes/TrophyCalculator.php
@@ -340,22 +340,3 @@ class TrophyCalculator
         $query->execute();
     }
 }
-
-class Psn100Logger
-{
-    private PDO $database;
-
-    public function __construct(PDO $database)
-    {
-        $this->database = $database;
-    }
-
-    public function log(string $message): void
-    {
-        $query = $this->database->prepare(
-            "INSERT INTO log (message) VALUES (:message)"
-        );
-        $query->bindValue(":message", $message, PDO::PARAM_STR);
-        $query->execute();
-    }
-}

--- a/wwwroot/classes/TrophyHistoryRecorder.php
+++ b/wwwroot/classes/TrophyHistoryRecorder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/TrophyCalculator.php';
+require_once __DIR__ . '/Psn100Logger.php';
 
 class TrophyHistoryRecorder
 {


### PR DESCRIPTION
## Summary
- extract the Psn100Logger implementation into its own class file so it can be reused without including the heavy TrophyCalculator dependency
- update the cron, rescan, and trophy history components to include the logger explicitly and keep their dependencies clear
- drop the unnecessary TrophyCalculator require from TrophyHistorySnapshotTest now that the logger is standalone

## Testing
- `for file in wwwroot/classes/Psn100Logger.php wwwroot/classes/TrophyCalculator.php wwwroot/classes/TrophyHistoryRecorder.php wwwroot/classes/Admin/GameRescanProcessor.php wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php wwwroot/classes/Cron/ThirtyMinuteCronJob.php tests/TrophyHistorySnapshotTest.php; do php -l "$file"; done`
- `php tests/run.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919ad8910b8832f88a2e9578713274c)