### PR TITLE
Refactor date formatting to reusable class

### DIFF
--- a/wwwroot/game_leaderboard.php
+++ b/wwwroot/game_leaderboard.php
@@ -109,10 +109,10 @@ require_once("header.php");
                                     </td>
 
                                     <td class="align-middle text-center" style="white-space: nowrap; width: 5rem;">
-                                        <span id="date<?= $rank; ?>"></span>
-                                        <script>
-                                            document.getElementById("date<?= $rank; ?>").innerHTML = new Date(<?= json_encode($row->getLastKnownDate() . ' UTC'); ?>).toLocaleString('sv-SE').replace(' ', '<br>');
-                                        </script>
+                                        <span
+                                            class="js-leaderboard-date"
+                                            data-timestamp="<?= htmlspecialchars($row->getLastKnownDate(), ENT_QUOTES, 'UTF-8'); ?>"
+                                        ></span>
                                     </td>
 
                                     <td class="align-middle text-center" style="white-space: nowrap; width: 10rem;">
@@ -157,6 +157,13 @@ require_once("header.php");
         </div>
     </div>
 </main>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    const formatter = new LocalizedDateFormatter('.js-leaderboard-date');
+    formatter.initialize();
+});
+</script>
 
 <?php
 require_once("footer.php");

--- a/wwwroot/game_recent_players.php
+++ b/wwwroot/game_recent_players.php
@@ -134,42 +134,8 @@ require_once("header.php");
 </main>
 
 <script>
-class RecentPlayersDateFormatter {
-    constructor(selector, locale = 'sv-SE') {
-        this.selector = selector;
-        this.locale = locale;
-    }
-
-    initialize() {
-        const elements = document.querySelectorAll(this.selector);
-
-        elements.forEach((element) => {
-            const timestamp = element.getAttribute('data-timestamp');
-            const formattedValue = this.formatTimestamp(timestamp);
-
-            if (formattedValue !== null) {
-                element.innerHTML = formattedValue;
-            }
-        });
-    }
-
-    formatTimestamp(timestamp) {
-        if (!timestamp) {
-            return null;
-        }
-
-        const date = new Date(`${timestamp} UTC`);
-
-        if (Number.isNaN(date.getTime())) {
-            return null;
-        }
-
-        return date.toLocaleString(this.locale).replace(' ', '<br>');
-    }
-}
-
 document.addEventListener('DOMContentLoaded', () => {
-    const formatter = new RecentPlayersDateFormatter('.js-recent-player-date');
+    const formatter = new LocalizedDateFormatter('.js-recent-player-date');
     formatter.initialize();
 });
 </script>

--- a/wwwroot/header.php
+++ b/wwwroot/header.php
@@ -128,6 +128,8 @@ if (isset($metaData) && $metaData instanceof PageMetaData) {
             }
         </style>
 
+        <script src="/js/localized-date-formatter.js" defer></script>
+
         <title><?= $title; ?></title>
     </head>
     <body>

--- a/wwwroot/js/localized-date-formatter.js
+++ b/wwwroot/js/localized-date-formatter.js
@@ -1,0 +1,35 @@
+class LocalizedDateFormatter {
+    constructor(selector, locale = 'sv-SE') {
+        this.selector = selector;
+        this.locale = locale;
+    }
+
+    initialize() {
+        const elements = document.querySelectorAll(this.selector);
+
+        elements.forEach((element) => {
+            const timestamp = element.getAttribute('data-timestamp');
+            const formattedValue = this.formatTimestamp(timestamp);
+
+            if (formattedValue !== null) {
+                element.innerHTML = formattedValue;
+            }
+        });
+    }
+
+    formatTimestamp(timestamp) {
+        if (!timestamp) {
+            return null;
+        }
+
+        const date = new Date(`${timestamp} UTC`);
+
+        if (Number.isNaN(date.getTime())) {
+            return null;
+        }
+
+        return date.toLocaleString(this.locale).replace(' ', '<br>');
+    }
+}
+
+window.LocalizedDateFormatter = LocalizedDateFormatter;


### PR DESCRIPTION
## Summary
- add a reusable LocalizedDateFormatter JavaScript helper and load it through the shared header
- switch the game leaderboard page to use the formatter instead of inline scripts
- update the recent players page to rely on the shared formatter as well

## Testing
- php -l wwwroot/header.php
- php -l wwwroot/game_leaderboard.php
- php -l wwwroot/game_recent_players.php
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a324baed4832f9f0a777f602096da)