### PR TITLE
Refactor player advisor page context

### DIFF
--- a/tests/PlayerAdvisorPageContextTest.php
+++ b/tests/PlayerAdvisorPageContextTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerAdvisorPageContext.php';
+
+final class PlayerAdvisorPageContextTest extends TestCase
+{
+    public function testContextAggregatesDependencies(): void
+    {
+        $filter = PlayerAdvisorFilter::fromArray(['ps5' => 'true']);
+        $playerSummary = new PlayerSummary(10, 3, 75.0, 25);
+        $trophies = [$this->createAdvisableTrophy()];
+        $page = $this->createPageStub($playerSummary, $filter, $trophies, true);
+
+        $context = PlayerAdvisorPageContext::fromComponents(
+            $page,
+            $filter,
+            'ExampleUser',
+            123,
+            0,
+            '456789'
+        );
+
+        $this->assertSame($page, $context->getPlayerAdvisorPage());
+        $this->assertSame($playerSummary, $context->getPlayerSummary());
+        $this->assertSame($filter, $context->getFilter());
+        $this->assertSame("ExampleUser's Trophy Advisor ~ PSN 100%", $context->getTitle());
+        $this->assertSame('ExampleUser', $context->getPlayerOnlineId());
+        $this->assertSame(123, $context->getPlayerAccountId());
+        $this->assertTrue($context->shouldDisplayAdvisor());
+        $this->assertTrue($context->getPlayerStatusNotice() === null);
+
+        $navigation = $context->getPlayerNavigation();
+        $links = $navigation->getLinks();
+        $this->assertSame('/player/ExampleUser/advisor', $links[2]->getUrl());
+        $this->assertTrue($links[2]->isActive());
+
+        $platformOptions = $context->getPlatformFilterOptions()->getOptions();
+        $ps5Option = null;
+
+        foreach ($platformOptions as $option) {
+            if ($option->getInputName() === 'ps5') {
+                $ps5Option = $option;
+                break;
+            }
+        }
+
+        $this->assertTrue($ps5Option instanceof PlayerPlatformFilterOption);
+        $this->assertTrue($ps5Option->isSelected());
+
+        $this->assertTrue($context->getTrophyRarityFormatter() instanceof TrophyRarityFormatter);
+    }
+
+    public function testContextCreatesStatusNoticeForFlaggedPlayers(): void
+    {
+        $filter = PlayerAdvisorFilter::fromArray([]);
+        $playerSummary = new PlayerSummary(0, 0, null, 0);
+        $page = $this->createPageStub($playerSummary, $filter, [], false);
+
+        $context = PlayerAdvisorPageContext::fromComponents(
+            $page,
+            $filter,
+            'FlaggedUser',
+            99,
+            1,
+            '123456'
+        );
+
+        $notice = $context->getPlayerStatusNotice();
+        $this->assertTrue($notice instanceof PlayerStatusNotice);
+        $this->assertTrue($notice->isFlagged());
+    }
+
+    public function testContextCreatesStatusNoticeForPrivatePlayers(): void
+    {
+        $filter = PlayerAdvisorFilter::fromArray([]);
+        $playerSummary = new PlayerSummary(0, 0, null, 0);
+        $page = $this->createPageStub($playerSummary, $filter, [], false);
+
+        $context = PlayerAdvisorPageContext::fromComponents(
+            $page,
+            $filter,
+            'PrivateUser',
+            88,
+            3,
+            null
+        );
+
+        $notice = $context->getPlayerStatusNotice();
+        $this->assertTrue($notice instanceof PlayerStatusNotice);
+        $this->assertTrue($notice->isPrivateProfile());
+    }
+
+    /**
+     * @param PlayerAdvisableTrophy[] $trophies
+     */
+    private function createPageStub(
+        PlayerSummary $summary,
+        PlayerAdvisorFilter $filter,
+        array $trophies,
+        bool $shouldDisplay
+    ): PlayerAdvisorPage {
+        return new class($summary, $filter, $trophies, $shouldDisplay) extends PlayerAdvisorPage {
+            private PlayerSummary $summary;
+
+            private PlayerAdvisorFilter $filter;
+
+            /** @var PlayerAdvisableTrophy[] */
+            private array $trophies;
+
+            private bool $shouldDisplay;
+
+            public function __construct(
+                PlayerSummary $summary,
+                PlayerAdvisorFilter $filter,
+                array $trophies,
+                bool $shouldDisplay
+            ) {
+                $this->summary = $summary;
+                $this->filter = $filter;
+                $this->trophies = $trophies;
+                $this->shouldDisplay = $shouldDisplay;
+            }
+
+            public function getPlayerSummary(): PlayerSummary
+            {
+                return $this->summary;
+            }
+
+            public function getFilter(): PlayerAdvisorFilter
+            {
+                return $this->filter;
+            }
+
+            public function getCurrentPage(): int
+            {
+                return 1;
+            }
+
+            public function getPageSize(): int
+            {
+                return 50;
+            }
+
+            public function getOffset(): int
+            {
+                return 0;
+            }
+
+            public function shouldDisplayAdvisor(): bool
+            {
+                return $this->shouldDisplay;
+            }
+
+            public function getTotalTrophies(): int
+            {
+                return count($this->trophies);
+            }
+
+            public function getAdvisableTrophies(): array
+            {
+                return $this->trophies;
+            }
+
+            public function getTotalPages(): int
+            {
+                return 1;
+            }
+
+            public function getFilterParameters(): array
+            {
+                return $this->filter->getFilterParameters();
+            }
+        };
+    }
+
+    private function createAdvisableTrophy(): PlayerAdvisableTrophy
+    {
+        $utility = new Utility();
+
+        return PlayerAdvisableTrophy::fromArray(
+            [
+                'trophy_id' => 42,
+                'trophy_type' => 'gold',
+                'trophy_name' => 'Advisable Trophy',
+                'trophy_detail' => 'Complete the refactor.',
+                'trophy_icon' => 'icon.png',
+                'rarity_percent' => 12.5,
+                'game_id' => 7,
+                'game_name' => 'Sample Game',
+                'game_icon' => 'game.png',
+                'platform' => 'PS5',
+            ],
+            $utility
+        );
+    }
+}

--- a/wwwroot/classes/PlayerAdvisorPageContext.php
+++ b/wwwroot/classes/PlayerAdvisorPageContext.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerAdvisorFilter.php';
+require_once __DIR__ . '/PlayerAdvisorPage.php';
+require_once __DIR__ . '/PlayerAdvisorService.php';
+require_once __DIR__ . '/PlayerNavigation.php';
+require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
+require_once __DIR__ . '/PlayerStatusNotice.php';
+require_once __DIR__ . '/PlayerSummary.php';
+require_once __DIR__ . '/PlayerSummaryService.php';
+require_once __DIR__ . '/TrophyRarityFormatter.php';
+require_once __DIR__ . '/Utility.php';
+
+final class PlayerAdvisorPageContext
+{
+    private const STATUS_FLAGGED = 1;
+    private const STATUS_PRIVATE = 3;
+
+    private PlayerAdvisorPage $playerAdvisorPage;
+
+    private PlayerSummary $playerSummary;
+
+    private PlayerAdvisorFilter $filter;
+
+    private PlayerNavigation $playerNavigation;
+
+    private PlayerPlatformFilterOptions $platformFilterOptions;
+
+    private TrophyRarityFormatter $trophyRarityFormatter;
+
+    private ?PlayerStatusNotice $playerStatusNotice;
+
+    private string $playerOnlineId;
+
+    private int $playerAccountId;
+
+    private int $playerStatus;
+
+    private ?string $playerAccountIdValue;
+
+    private string $title;
+
+    /**
+     * @param array<string, mixed> $playerData
+     * @param array<string, mixed> $queryParameters
+     */
+    public static function fromGlobals(
+        PDO $database,
+        Utility $utility,
+        array $playerData,
+        int $accountId,
+        array $queryParameters
+    ): self {
+        $filter = PlayerAdvisorFilter::fromArray($queryParameters);
+        $playerStatus = self::extractPlayerStatus($playerData);
+        $playerOnlineId = self::extractPlayerOnlineId($playerData);
+        $playerAccountIdValue = self::extractPlayerAccountId($playerData);
+
+        $playerAdvisorService = new PlayerAdvisorService($database, $utility);
+        $playerSummaryService = new PlayerSummaryService($database);
+
+        $playerAdvisorPage = new PlayerAdvisorPage(
+            $playerAdvisorService,
+            $playerSummaryService,
+            $filter,
+            $accountId,
+            $playerStatus
+        );
+
+        return self::fromComponents(
+            $playerAdvisorPage,
+            $filter,
+            $playerOnlineId,
+            $accountId,
+            $playerStatus,
+            $playerAccountIdValue
+        );
+    }
+
+    public static function fromComponents(
+        PlayerAdvisorPage $playerAdvisorPage,
+        PlayerAdvisorFilter $filter,
+        string $playerOnlineId,
+        int $playerAccountId,
+        int $playerStatus,
+        ?string $playerAccountIdValue = null
+    ): self {
+        return new self(
+            $playerAdvisorPage,
+            $playerAdvisorPage->getPlayerSummary(),
+            $filter,
+            $playerOnlineId,
+            $playerAccountId,
+            $playerStatus,
+            $playerAccountIdValue
+        );
+    }
+
+    private function __construct(
+        PlayerAdvisorPage $playerAdvisorPage,
+        PlayerSummary $playerSummary,
+        PlayerAdvisorFilter $filter,
+        string $playerOnlineId,
+        int $playerAccountId,
+        int $playerStatus,
+        ?string $playerAccountIdValue
+    ) {
+        $this->playerAdvisorPage = $playerAdvisorPage;
+        $this->playerSummary = $playerSummary;
+        $this->filter = $filter;
+        $this->playerOnlineId = $playerOnlineId;
+        $this->playerAccountId = $playerAccountId;
+        $this->playerStatus = $playerStatus;
+        $this->playerAccountIdValue = $playerAccountIdValue;
+        $this->playerNavigation = PlayerNavigation::forSection(
+            $playerOnlineId,
+            PlayerNavigation::SECTION_TROPHY_ADVISOR
+        );
+        $this->platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
+            fn (string $platform): bool => $this->filter->isPlatformSelected($platform)
+        );
+        $this->trophyRarityFormatter = new TrophyRarityFormatter();
+        $this->title = sprintf("%s's Trophy Advisor ~ PSN 100%%", $playerOnlineId);
+        $this->playerStatusNotice = $this->createPlayerStatusNotice();
+    }
+
+    public function getPlayerAdvisorPage(): PlayerAdvisorPage
+    {
+        return $this->playerAdvisorPage;
+    }
+
+    public function getPlayerSummary(): PlayerSummary
+    {
+        return $this->playerSummary;
+    }
+
+    public function getFilter(): PlayerAdvisorFilter
+    {
+        return $this->filter;
+    }
+
+    public function getPlayerNavigation(): PlayerNavigation
+    {
+        return $this->playerNavigation;
+    }
+
+    public function getPlatformFilterOptions(): PlayerPlatformFilterOptions
+    {
+        return $this->platformFilterOptions;
+    }
+
+    public function getTrophyRarityFormatter(): TrophyRarityFormatter
+    {
+        return $this->trophyRarityFormatter;
+    }
+
+    public function getPlayerStatusNotice(): ?PlayerStatusNotice
+    {
+        return $this->playerStatusNotice;
+    }
+
+    public function getPlayerOnlineId(): string
+    {
+        return $this->playerOnlineId;
+    }
+
+    public function getPlayerAccountId(): int
+    {
+        return $this->playerAccountId;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function shouldDisplayAdvisor(): bool
+    {
+        return $this->playerAdvisorPage->shouldDisplayAdvisor();
+    }
+
+    private function createPlayerStatusNotice(): ?PlayerStatusNotice
+    {
+        if ($this->playerAdvisorPage->shouldDisplayAdvisor()) {
+            return null;
+        }
+
+        return match ($this->playerStatus) {
+            self::STATUS_FLAGGED => PlayerStatusNotice::flagged(
+                $this->playerOnlineId,
+                $this->playerAccountIdValue
+            ),
+            self::STATUS_PRIVATE => PlayerStatusNotice::privateProfile(),
+            default => null,
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $playerData
+     */
+    private static function extractPlayerOnlineId(array $playerData): string
+    {
+        return (string) ($playerData['online_id'] ?? '');
+    }
+
+    /**
+     * @param array<string, mixed> $playerData
+     */
+    private static function extractPlayerStatus(array $playerData): int
+    {
+        return (int) ($playerData['status'] ?? 0);
+    }
+
+    /**
+     * @param array<string, mixed> $playerData
+     */
+    private static function extractPlayerAccountId(array $playerData): ?string
+    {
+        if (!array_key_exists('account_id', $playerData)) {
+            return null;
+        }
+
+        $value = $playerData['account_id'];
+
+        if ($value === null) {
+            return null;
+        }
+
+        return (string) $value;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `PlayerAdvisorPageContext` to centralize data gathering, platform filter construction, and status notices for the trophy advisor page
- update `player_advisor.php` to rely on the new context, simplifying the script and ensuring links use the resolved online ID
- add unit tests that exercise the new context, including platform filter selection and status notice behavior

## Testing
- php -l wwwroot/classes/PlayerAdvisorPageContext.php
- php -l wwwroot/player_advisor.php
- php -l tests/PlayerAdvisorPageContextTest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a324baed4832f9f0a777f602096da)