### PR TITLE
Refactor queue scan progress handling

### DIFF
--- a/tests/PlayerQueueResponseFactoryTest.php
+++ b/tests/PlayerQueueResponseFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponseFactory.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponse.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueService.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerScanProgress.php';
 
 /**
  * @extends PlayerQueueService
@@ -163,11 +164,14 @@ final class PlayerQueueResponseFactoryTest extends TestCase
         $service = new RecordingPlayerQueueServiceStub();
         $factory = new PlayerQueueResponseFactory($service);
 
-        $response = $factory->createQueuedForScanResponse('Player <Name>', [
+        $progress = PlayerScanProgress::fromArray([
             'current' => 5,
             'total' => 34,
             'title' => 'Game <Title>',
         ]);
+        $this->assertTrue($progress instanceof PlayerScanProgress, 'Expected PlayerScanProgress instance.');
+
+        $response = $factory->createQueuedForScanResponse('Player <Name>', $progress);
 
         $this->assertSame('queued', $response->getStatus());
         $this->assertTrue($response->shouldPoll());

--- a/tests/PlayerQueueServiceTest.php
+++ b/tests/PlayerQueueServiceTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueService.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerScanProgress.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerScanStatus.php';
 
 final class PlayerQueueServiceTest extends TestCase
 {
@@ -156,16 +158,15 @@ final class PlayerQueueServiceTest extends TestCase
 
         $status = $this->service->getActiveScanStatus('ScanningPlayer');
 
-        $this->assertTrue(is_array($status));
-        $this->assertSame(
-            [
-                'current' => 5,
-                'total' => 34,
-                'title' => 'Example Game',
-                'npCommunicationId' => 'NPWR12345',
-            ],
-            $status['progress']
-        );
+        $this->assertTrue($status instanceof PlayerScanStatus, 'Scan status should be a PlayerScanStatus instance.');
+        $progress = $status->getProgress();
+        if (!$progress instanceof PlayerScanProgress) {
+            $this->fail('Expected a PlayerScanProgress instance.');
+        }
+        $this->assertSame(5, $progress->getCurrent());
+        $this->assertSame(34, $progress->getTotal());
+        $this->assertSame('Example Game', $progress->getTitle());
+        $this->assertSame('NPWR12345', $progress->getNpCommunicationId());
     }
 
     public function testGetActiveScanProgressReturnsNullWhenPayloadInvalid(): void

--- a/tests/PlayerScanProgressTest.php
+++ b/tests/PlayerScanProgressTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerScanProgress.php';
+
+final class PlayerScanProgressTest extends TestCase
+{
+    public function testFromArrayReturnsNullWhenNoDataProvided(): void
+    {
+        $this->assertSame(null, PlayerScanProgress::fromArray(null));
+        $this->assertSame(null, PlayerScanProgress::fromArray([]));
+    }
+
+    public function testFromArrayNormalizesValues(): void
+    {
+        $progress = PlayerScanProgress::fromArray([
+            'current' => '5',
+            'total' => 10,
+            'title' => ' Example ',
+            'npCommunicationId' => ' NPWR123 ',
+        ]);
+
+        $this->assertTrue($progress instanceof PlayerScanProgress, 'Expected PlayerScanProgress instance.');
+        if (!$progress instanceof PlayerScanProgress) {
+            return;
+        }
+        $this->assertSame(5, $progress->getCurrent());
+        $this->assertSame(10, $progress->getTotal());
+        $this->assertSame('Example', $progress->getTitle());
+        $this->assertSame('NPWR123', $progress->getNpCommunicationId());
+        $this->assertSame('(5/10)', $progress->getProgressSummary());
+        $this->assertSame(50, $progress->getPercentage());
+    }
+
+    public function testPercentageClampsValuesWithinRange(): void
+    {
+        $progress = PlayerScanProgress::fromArray([
+            'current' => 15,
+            'total' => 10,
+        ]);
+
+        $this->assertTrue($progress instanceof PlayerScanProgress, 'Expected PlayerScanProgress instance.');
+        if (!$progress instanceof PlayerScanProgress) {
+            return;
+        }
+        $this->assertSame('(10/10)', $progress->getProgressSummary());
+        $this->assertSame(100, $progress->getPercentage());
+    }
+}

--- a/wwwroot/classes/PlayerQueueHandler.php
+++ b/wwwroot/classes/PlayerQueueHandler.php
@@ -66,7 +66,7 @@ class PlayerQueueHandler
         if ($scanStatus !== null) {
             return $this->responseFactory->createQueuedForScanResponse(
                 $playerName,
-                $scanStatus['progress'] ?? null
+                $scanStatus->getProgress()
             );
         }
 

--- a/wwwroot/classes/PlayerScanProgress.php
+++ b/wwwroot/classes/PlayerScanProgress.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+final class PlayerScanProgress
+{
+    private ?int $current;
+
+    private ?int $total;
+
+    private ?string $title;
+
+    private ?string $npCommunicationId;
+
+    private function __construct(?int $current, ?int $total, ?string $title, ?string $npCommunicationId)
+    {
+        $this->current = $current;
+        $this->total = $total;
+        $this->title = $title;
+        $this->npCommunicationId = $npCommunicationId;
+    }
+
+    /**
+     * @param array<string, mixed>|null $data
+     */
+    public static function fromArray(?array $data): ?self
+    {
+        if ($data === null) {
+            return null;
+        }
+
+        $current = self::sanitizeInt($data['current'] ?? null);
+        $total = self::sanitizeInt($data['total'] ?? null);
+        $title = self::sanitizeString($data['title'] ?? null);
+        $npCommunicationId = self::sanitizeString($data['npCommunicationId'] ?? null);
+
+        if ($current === null && $total === null && $title === null && $npCommunicationId === null) {
+            return null;
+        }
+
+        return new self($current, $total, $title, $npCommunicationId);
+    }
+
+    public static function fromJson(?string $json): ?self
+    {
+        if ($json === null) {
+            return null;
+        }
+
+        $trimmedJson = trim($json);
+
+        if ($trimmedJson === '') {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($trimmedJson, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            return null;
+        }
+
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        return self::fromArray($decoded);
+    }
+
+    public function getCurrent(): ?int
+    {
+        return $this->current;
+    }
+
+    public function getTotal(): ?int
+    {
+        return $this->total;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function getNpCommunicationId(): ?string
+    {
+        return $this->npCommunicationId;
+    }
+
+    public function hasCounts(): bool
+    {
+        return $this->current !== null && $this->total !== null;
+    }
+
+    public function getProgressSummary(): ?string
+    {
+        if (!$this->hasCounts() || $this->total === null || $this->total === 0) {
+            return null;
+        }
+
+        $current = min($this->current ?? 0, $this->total);
+
+        return sprintf('(%d/%d)', $current, $this->total);
+    }
+
+    public function getPercentage(): ?int
+    {
+        if (!$this->hasCounts() || $this->total === null || $this->total === 0) {
+            return null;
+        }
+
+        $current = min($this->current ?? 0, $this->total);
+        $percentage = (int) round(($current / $this->total) * 100);
+
+        return max(0, min(100, $percentage));
+    }
+
+    private static function sanitizeInt(mixed $value): ?int
+    {
+        if (!is_numeric($value)) {
+            return null;
+        }
+
+        return max(0, (int) $value);
+    }
+
+    private static function sanitizeString(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+}

--- a/wwwroot/classes/PlayerScanStatus.php
+++ b/wwwroot/classes/PlayerScanStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+final class PlayerScanStatus
+{
+    private ?PlayerScanProgress $progress;
+
+    public function __construct(?PlayerScanProgress $progress)
+    {
+        $this->progress = $progress;
+    }
+
+    public static function withProgress(?PlayerScanProgress $progress): self
+    {
+        return new self($progress);
+    }
+
+    public function hasProgress(): bool
+    {
+        return $this->progress !== null;
+    }
+
+    public function getProgress(): ?PlayerScanProgress
+    {
+        return $this->progress;
+    }
+}


### PR DESCRIPTION
## Summary
- add PlayerScanProgress and PlayerScanStatus value objects plus dedicated unit tests
- update the player queue service, handler, and response factory to use the new objects for scan messaging

## Testing
- `php tests/run.php`
- `for file in wwwroot/classes/PlayerScanProgress.php wwwroot/classes/PlayerScanStatus.php wwwroot/classes/PlayerQueueService.php wwwroot/classes/PlayerQueueResponseFactory.php wwwroot/classes/PlayerQueueHandler.php tests/PlayerQueueServiceTest.php tests/PlayerQueueResponseFactoryTest.php tests/PlayerQueueHandlerTest.php tests/PlayerScanProgressTest.php; do
  php -l $file || exit 1
done`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a324baed4832f9f0a777f602096da)