### PR TITLE
Prevent header warnings during trophy merge stream

### DIFF
--- a/wwwroot/classes/Admin/TrophyMergeProcessor.php
+++ b/wwwroot/classes/Admin/TrophyMergeProcessor.php
@@ -53,6 +53,7 @@ class TrophyMergeProcessor
             return;
         }
 
+        http_response_code(200);
         $this->prepareStreamResponse();
 
         $this->sendEvent([
@@ -86,8 +87,6 @@ class TrophyMergeProcessor
                 'message' => $resultMessage,
             ]);
         } catch (\InvalidArgumentException | \RuntimeException $exception) {
-            http_response_code(200);
-
             $this->sendEvent([
                 'type' => 'error',
                 'success' => false,
@@ -95,7 +94,6 @@ class TrophyMergeProcessor
                 'error' => $exception->getMessage(),
             ]);
         } catch (\Throwable $exception) {
-            http_response_code(200);
             error_log($exception->getMessage());
 
             $this->sendEvent([


### PR DESCRIPTION
## Summary
- set the HTTP status code before beginning the streaming trophy merge response
- remove redundant status updates in the exception handlers to avoid header warnings once output has started

## Testing
- php -l wwwroot/classes/Admin/TrophyMergeProcessor.php
- composer validate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ace95d040832f98bf8396f1f13520)