### PR TITLE
Ensure trophy rarity percentages show two decimals

### DIFF
--- a/tests/TrophyRarityFormatterTest.php
+++ b/tests/TrophyRarityFormatterTest.php
@@ -13,7 +13,7 @@ final class TrophyRarityFormatterTest extends TestCase
 
         $rarity = $formatter->format(42, 1);
 
-        $this->assertSame('42', $rarity->getPercentage());
+        $this->assertSame('42.00', $rarity->getPercentage());
         $this->assertSame('Unobtainable', $rarity->getLabel());
         $this->assertSame(null, $rarity->getCssClass());
         $this->assertTrue($rarity->isUnobtainable());
@@ -25,7 +25,7 @@ final class TrophyRarityFormatterTest extends TestCase
 
         $rarity = $formatter->format(' 0.015 ');
 
-        $this->assertSame('0.015', $rarity->getPercentage());
+        $this->assertSame('0.02', $rarity->getPercentage());
         $this->assertSame('Legendary', $rarity->getLabel());
         $this->assertSame('trophy-legendary', $rarity->getCssClass());
         $this->assertFalse($rarity->isUnobtainable());
@@ -37,7 +37,7 @@ final class TrophyRarityFormatterTest extends TestCase
 
         $rarity = $formatter->format(0.5);
 
-        $this->assertSame('0.5', $rarity->getPercentage());
+        $this->assertSame('0.50', $rarity->getPercentage());
         $this->assertSame('Rare', $rarity->getLabel());
         $this->assertSame('trophy-rare', $rarity->getCssClass());
         $this->assertFalse($rarity->isUnobtainable());
@@ -52,6 +52,18 @@ final class TrophyRarityFormatterTest extends TestCase
         $this->assertSame('N/A', $rarity->getPercentage());
         $this->assertSame('Common', $rarity->getLabel());
         $this->assertSame('trophy-common', $rarity->getCssClass());
+        $this->assertFalse($rarity->isUnobtainable());
+    }
+
+    public function testFormatAddsTrailingZeroesForNumericStrings(): void
+    {
+        $formatter = new TrophyRarityFormatter();
+
+        $rarity = $formatter->format('1.1');
+
+        $this->assertSame('1.10', $rarity->getPercentage());
+        $this->assertSame('Rare', $rarity->getLabel());
+        $this->assertSame('trophy-rare', $rarity->getCssClass());
         $this->assertFalse($rarity->isUnobtainable());
     }
 }

--- a/wwwroot/classes/TrophyRarityFormatter.php
+++ b/wwwroot/classes/TrophyRarityFormatter.php
@@ -11,13 +11,12 @@ class TrophyRarityFormatter
      */
     public function format($rarityPercent, int $status = 0): TrophyRarity
     {
-        $percentageString = $this->normalizePercentage($rarityPercent);
+        $value = $this->toFloat($rarityPercent);
+        $percentageString = $this->normalizePercentage($rarityPercent, $value);
 
         if ($status === 1) {
             return new TrophyRarity($percentageString, 'Unobtainable', null, true);
         }
-
-        $value = $this->toFloat($rarityPercent);
 
         if ($value !== null) {
             if ($value <= 0.02) {
@@ -43,18 +42,28 @@ class TrophyRarityFormatter
     /**
      * @param float|int|string|null $rarityPercent
      */
-    private function normalizePercentage($rarityPercent): ?string
+    private function normalizePercentage($rarityPercent, ?float $normalizedValue): ?string
     {
         if ($rarityPercent === null) {
             return null;
         }
 
+        if ($normalizedValue !== null) {
+            return number_format($normalizedValue, 2, '.', '');
+        }
+
         if (is_string($rarityPercent)) {
-            return trim($rarityPercent);
+            $rarityPercent = trim($rarityPercent);
+
+            if ($rarityPercent === '') {
+                return null;
+            }
+
+            return $rarityPercent;
         }
 
         if (is_int($rarityPercent) || is_float($rarityPercent)) {
-            return (string) $rarityPercent;
+            return number_format((float) $rarityPercent, 2, '.', '');
         }
 
         return null;


### PR DESCRIPTION
## Summary
- format trophy rarity percentages with two decimal places when numeric
- treat blank string percentages as null while preserving non-numeric strings
- update TrophyRarityFormatter tests to cover the new formatting behavior

## Testing
- php -l wwwroot/classes/TrophyRarityFormatter.php
- php -l tests/TrophyRarityFormatterTest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8b34dc78832f9bb95c4624c036c5)