### PR TITLE
Display PSNP+ notes on game pages

### DIFF
--- a/tests/AutomaticTrophyTitleMergeServiceTest.php
+++ b/tests/AutomaticTrophyTitleMergeServiceTest.php
@@ -263,7 +263,8 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
         $this->database->exec(
             'CREATE TABLE trophy_title_meta (
                 np_communication_id TEXT PRIMARY KEY,
-                status INTEGER NOT NULL DEFAULT 0
+                status INTEGER NOT NULL DEFAULT 0,
+                psnprofiles_id TEXT NULL
             )'
         );
 

--- a/tests/ChangelogServiceTest.php
+++ b/tests/ChangelogServiceTest.php
@@ -39,7 +39,8 @@ final class ChangelogServiceTest extends TestCase
             'CREATE TABLE trophy_title_meta (' .
             'np_communication_id TEXT PRIMARY KEY, ' .
             'region TEXT NULL, ' .
-            'obsolete_ids TEXT NULL)'
+            'obsolete_ids TEXT NULL, ' .
+            'psnprofiles_id TEXT NULL)'
         );
 
         $this->service = new ChangelogService($this->database);

--- a/tests/GameHistoryPageTest.php
+++ b/tests/GameHistoryPageTest.php
@@ -93,7 +93,7 @@ final class GameHistoryPageTest extends TestCase
 
             public function buildHeaderData(GameDetails $game): GameHeaderData
             {
-                return new GameHeaderData(null, [], 0, []);
+                return new GameHeaderData(null, [], 0, [], null);
             }
         };
 

--- a/tests/GameResetServiceTest.php
+++ b/tests/GameResetServiceTest.php
@@ -201,7 +201,8 @@ final class GameResetServiceTest extends TestCase
             owners INTEGER DEFAULT 0,
             owners_completed INTEGER DEFAULT 0,
             parent_np_communication_id TEXT,
-            obsolete_ids TEXT NULL
+            obsolete_ids TEXT NULL,
+            psnprofiles_id TEXT NULL
         )');
         $this->database->exec('CREATE TABLE trophy_merge (parent_np_communication_id TEXT)');
         $this->database->exec('CREATE TABLE trophy_earned (np_communication_id TEXT)');

--- a/tests/GameStatusServiceTest.php
+++ b/tests/GameStatusServiceTest.php
@@ -15,7 +15,7 @@ final class GameStatusServiceTest extends TestCase
         $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         $this->database->exec('CREATE TABLE trophy_title (id INTEGER PRIMARY KEY, np_communication_id TEXT NOT NULL)');
-        $this->database->exec('CREATE TABLE trophy_title_meta (np_communication_id TEXT PRIMARY KEY, status INTEGER NOT NULL, obsolete_ids TEXT NULL)');
+        $this->database->exec('CREATE TABLE trophy_title_meta (np_communication_id TEXT PRIMARY KEY, status INTEGER NOT NULL, obsolete_ids TEXT NULL, psnprofiles_id TEXT NULL)');
         $this->database->exec('CREATE TABLE psn100_change (change_type TEXT NOT NULL, param_1 INTEGER NOT NULL)');
         $this->database->exec("INSERT INTO trophy_title (id, np_communication_id) VALUES (1, 'NPWR-1')");
         $this->database->exec("INSERT INTO trophy_title_meta (np_communication_id, status) VALUES ('NPWR-1', 0)");

--- a/tests/PlayerGamesServiceTest.php
+++ b/tests/PlayerGamesServiceTest.php
@@ -35,7 +35,8 @@ final class PlayerGamesServiceTest extends TestCase
                 np_communication_id TEXT PRIMARY KEY,
                 status INTEGER,
                 rarity_points INTEGER,
-                obsolete_ids TEXT
+                obsolete_ids TEXT,
+                psnprofiles_id TEXT NULL
             )
             SQL
         );

--- a/tests/PlayerSummaryServiceTest.php
+++ b/tests/PlayerSummaryServiceTest.php
@@ -29,7 +29,8 @@ final class PlayerSummaryServiceTest extends TestCase
             'CREATE TABLE trophy_title_meta (
                 np_communication_id TEXT PRIMARY KEY,
                 status INTEGER NOT NULL,
-                obsolete_ids TEXT NULL
+                obsolete_ids TEXT NULL,
+                psnprofiles_id TEXT NULL
             )'
         );
 

--- a/tests/TrophyMergeServiceMetaUsageTest.php
+++ b/tests/TrophyMergeServiceMetaUsageTest.php
@@ -86,7 +86,8 @@ final class TrophyMergeServiceMetaUsageTest extends TestCase
                 np_communication_id TEXT PRIMARY KEY,
                 parent_np_communication_id TEXT NULL,
                 status INTEGER NOT NULL DEFAULT 0,
-                obsolete_ids TEXT NULL
+                obsolete_ids TEXT NULL,
+                psnprofiles_id TEXT NULL
             )'
         );
     }

--- a/wwwroot/classes/Game/GameDetails.php
+++ b/wwwroot/classes/Game/GameDetails.php
@@ -12,6 +12,8 @@ class GameDetails
 
     private ?string $parentNpCommunicationId;
 
+    private ?int $psnprofilesId;
+
     private string $platform;
 
     private string $iconUrl;
@@ -62,6 +64,7 @@ class GameDetails
         $game->parentNpCommunicationId = isset($row['parent_np_communication_id'])
             ? self::toNullableString($row['parent_np_communication_id'])
             : null;
+        $game->psnprofilesId = self::toNullableInt($row['psnprofiles_id'] ?? null);
         $game->platform = (string) ($row['platform'] ?? '');
         $game->iconUrl = (string) ($row['icon_url'] ?? '');
         $game->setVersion = (string) ($row['set_version'] ?? '');
@@ -90,6 +93,21 @@ class GameDetails
         $stringValue = (string) $value;
 
         return $stringValue === '' ? null : $stringValue;
+    }
+
+    private static function toNullableInt(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        $stringValue = (string) $value;
+
+        return ctype_digit($stringValue) ? (int) $stringValue : null;
     }
 
     /**
@@ -136,6 +154,16 @@ class GameDetails
     public function getParentNpCommunicationId(): ?string
     {
         return $this->parentNpCommunicationId;
+    }
+
+    public function getPsnprofilesId(): ?int
+    {
+        return $this->psnprofilesId;
+    }
+
+    public function hasPsnprofilesId(): bool
+    {
+        return $this->psnprofilesId !== null;
     }
 
     public function getPlatform(): string

--- a/wwwroot/classes/Game/GameHeaderData.php
+++ b/wwwroot/classes/Game/GameHeaderData.php
@@ -18,6 +18,8 @@ class GameHeaderData
      */
     private array $obsoleteReplacements;
 
+    private ?string $psnpPlusNote;
+
     /**
      * @param GameHeaderStack[] $stacks
      * @param GameObsoleteReplacement[] $obsoleteReplacements
@@ -26,12 +28,14 @@ class GameHeaderData
         ?GameHeaderParent $parentGame,
         array $stacks,
         int $unobtainableTrophyCount,
-        array $obsoleteReplacements
+        array $obsoleteReplacements,
+        ?string $psnpPlusNote
     ) {
         $this->parentGame = $parentGame;
         $this->stacks = $stacks;
         $this->unobtainableTrophyCount = $unobtainableTrophyCount;
         $this->obsoleteReplacements = $obsoleteReplacements;
+        $this->psnpPlusNote = $psnpPlusNote;
     }
 
     public function hasMergedParent(): bool
@@ -78,5 +82,15 @@ class GameHeaderData
     public function hasObsoleteReplacements(): bool
     {
         return $this->obsoleteReplacements !== [];
+    }
+
+    public function getPsnpPlusNote(): ?string
+    {
+        return $this->psnpPlusNote;
+    }
+
+    public function hasPsnpPlusNote(): bool
+    {
+        return $this->psnpPlusNote !== null;
     }
 }

--- a/wwwroot/classes/PsnpPlusClient.php
+++ b/wwwroot/classes/PsnpPlusClient.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+class PsnpPlusClient
+{
+    private const DATA_URL = 'https://psnp-plus.huskycode.dev/list.json';
+
+    /**
+     * @var array<int, array<string, mixed>>|null
+     */
+    private static ?array $cachedList = null;
+
+    /**
+     * @return array<int, int[]>
+     */
+    public function getTrophiesByPsnprofilesId(): array
+    {
+        $list = $this->fetchList();
+
+        $trophiesById = [];
+        foreach ($list as $psnprofilesId => $entry) {
+            $trophies = $entry['trophies'] ?? [];
+            if (!is_array($trophies)) {
+                $trophies = [];
+            }
+
+            $trophiesById[$psnprofilesId] = array_map('intval', $trophies);
+        }
+
+        return $trophiesById;
+    }
+
+    public function getNote(int $psnprofilesId): ?string
+    {
+        $list = $this->fetchList();
+        if (!array_key_exists($psnprofilesId, $list)) {
+            return null;
+        }
+
+        $note = $list[$psnprofilesId]['note'] ?? null;
+        if (!is_string($note)) {
+            return null;
+        }
+
+        $trimmed = trim($note);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchList(): array
+    {
+        if (self::$cachedList !== null) {
+            return self::$cachedList;
+        }
+
+        $json = @file_get_contents(self::DATA_URL);
+
+        if ($json === false) {
+            throw new RuntimeException('Unable to download PSNP+ data.');
+        }
+
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded) || !isset($decoded['list']) || !is_array($decoded['list'])) {
+            throw new RuntimeException('Invalid PSNP+ data received.');
+        }
+
+        $normalized = [];
+        foreach ($decoded['list'] as $psnprofilesId => $entry) {
+            if (!is_array($entry)) {
+                $entry = [];
+            }
+
+            $normalized[(int) $psnprofilesId] = $entry;
+        }
+
+        self::$cachedList = $normalized;
+
+        return self::$cachedList;
+    }
+}

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -37,6 +37,16 @@ require_once __DIR__ . '/classes/Game/GamePlayerProgress.php';
         <?php
     }
 
+    if ($gameHeaderData->hasPsnpPlusNote()) {
+        ?>
+        <div class="col-12">
+            <div class="alert alert-info" role="alert">
+                <strong>PSNP+ note:</strong> <?= htmlentities($gameHeaderData->getPsnpPlusNote(), ENT_QUOTES, 'UTF-8'); ?>
+            </div>
+        </div>
+        <?php
+    }
+
     if ($gameHeaderData->hasObsoleteReplacements()) {
         $replacementLinks = [];
         foreach ($gameHeaderData->getObsoleteReplacements() as $replacement) {


### PR DESCRIPTION
## Summary
- add a PSNP+ client that consumes the latest list.json data
- surface PSNP+ notes on game headers with fallback to parent PSNProfiles IDs
- update models and tests to carry PSNProfiles IDs needed for note lookups

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920b8ba3080832f990bd331f2a467c9)