### PR TITLE
Format PSNP+ notes with external links

### DIFF
--- a/tests/GameHeaderServiceTest.php
+++ b/tests/GameHeaderServiceTest.php
@@ -217,6 +217,24 @@ final class GameHeaderServiceTest extends TestCase
         $this->assertSame('Servers were shutdown.', $headerData->getPsnpPlusNote());
     }
 
+    public function testBuildHeaderDataConvertsPsnpPlusNoteMarkdownLinks(): void
+    {
+        $this->psnpPlusClient->withNotes([
+            555 => 'Server fix in progress. [More info](https://example.com/fix).',
+        ]);
+
+        $game = $this->createGameDetails([
+            'psnprofiles_id' => 555,
+        ]);
+
+        $headerData = $this->service->buildHeaderData($game);
+
+        $this->assertSame(
+            'Server fix in progress. <a href="https://example.com/fix" target="_blank" rel="noopener">More info</a>.',
+            $headerData->getPsnpPlusNote()
+        );
+    }
+
     public function testBuildHeaderDataFallsBackToParentPsnprofilesNote(): void
     {
         $this->insertTrophyTitle([

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -41,7 +41,7 @@ require_once __DIR__ . '/classes/Game/GamePlayerProgress.php';
         ?>
         <div class="col-12">
             <div class="alert alert-info" role="alert">
-                <strong>PSNP+ note:</strong> <?= htmlentities($gameHeaderData->getPsnpPlusNote(), ENT_QUOTES, 'UTF-8'); ?>
+                <strong>PSNP+ note:</strong> <?= $gameHeaderData->getPsnpPlusNote(); ?>
             </div>
         </div>
         <?php


### PR DESCRIPTION
## Summary
- format PSNP+ notes to convert markdown-style links into safe HTML anchors
- render PSNP+ notes without double escaping so formatted links are shown
- add coverage to verify PSNP+ notes convert external links correctly

## Testing
- php -l wwwroot/classes/GameHeaderService.php
- php -l wwwroot/game_header.php
- php -l tests/GameHeaderServiceTest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c586b8cc832fb89bcea7412d736b)