### PR TITLE
Clamp in-game rarity percent in daily cron job

### DIFF
--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -49,7 +49,7 @@ class DailyCronJob implements CronJobInterface
                     (COUNT(p.account_id) / 10000.0) * 100 AS rarity_percent,
                     CASE
                         WHEN ttm.owners = 0 THEN 0
-                        ELSE (COUNT(p.account_id) / ttm.owners) * 100
+                        ELSE LEAST((COUNT(p.account_id) / ttm.owners) * 100, 100.0)
                     END AS in_game_rarity_percent
                 FROM trophy t
                 JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id


### PR DESCRIPTION
## Summary
- cap the daily cron rarity calculation so in-game rarity percent cannot exceed 100
- retain existing rarity updates for trophies and associated metadata

## Testing
- php -l wwwroot/classes/Cron/DailyCronJob.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921dfc41828832f88e41e04d6fada26)