### PR TITLE
Add in-game rarity stats per trophy title

### DIFF
--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -399,7 +399,13 @@ CREATE TABLE `trophy_title_player` (
   `uncommon` smallint UNSIGNED NOT NULL DEFAULT '0',
   `rare` smallint UNSIGNED NOT NULL DEFAULT '0',
   `epic` smallint UNSIGNED NOT NULL DEFAULT '0',
-  `legendary` smallint UNSIGNED NOT NULL DEFAULT '0'
+  `legendary` smallint UNSIGNED NOT NULL DEFAULT '0',
+  `in_game_rarity_points` int UNSIGNED NOT NULL DEFAULT '0',
+  `in_game_common` smallint UNSIGNED NOT NULL DEFAULT '0',
+  `in_game_uncommon` smallint UNSIGNED NOT NULL DEFAULT '0',
+  `in_game_rare` smallint UNSIGNED NOT NULL DEFAULT '0',
+  `in_game_epic` smallint UNSIGNED NOT NULL DEFAULT '0',
+  `in_game_legendary` smallint UNSIGNED NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --

--- a/tests/DeletePlayerRequestHandlerTest.php
+++ b/tests/DeletePlayerRequestHandlerTest.php
@@ -166,7 +166,15 @@ final class DeletePlayerRequestHandlerTest extends TestCase
         )');
         $this->database->exec('CREATE TABLE trophy_title_player (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            account_id TEXT NOT NULL
+            account_id TEXT NOT NULL,
+            np_communication_id TEXT,
+            rarity_points INTEGER NOT NULL DEFAULT 0,
+            in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
+            in_game_common INTEGER NOT NULL DEFAULT 0,
+            in_game_uncommon INTEGER NOT NULL DEFAULT 0,
+            in_game_rare INTEGER NOT NULL DEFAULT 0,
+            in_game_epic INTEGER NOT NULL DEFAULT 0,
+            in_game_legendary INTEGER NOT NULL DEFAULT 0
         )');
         $this->database->exec('CREATE TABLE player (
             account_id TEXT PRIMARY KEY,

--- a/tests/DeletePlayerServiceTest.php
+++ b/tests/DeletePlayerServiceTest.php
@@ -120,7 +120,15 @@ final class DeletePlayerServiceTest extends TestCase
         )');
         $this->database->exec('CREATE TABLE trophy_title_player (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            account_id TEXT NOT NULL
+            account_id TEXT NOT NULL,
+            np_communication_id TEXT,
+            rarity_points INTEGER NOT NULL DEFAULT 0,
+            in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
+            in_game_common INTEGER NOT NULL DEFAULT 0,
+            in_game_uncommon INTEGER NOT NULL DEFAULT 0,
+            in_game_rare INTEGER NOT NULL DEFAULT 0,
+            in_game_epic INTEGER NOT NULL DEFAULT 0,
+            in_game_legendary INTEGER NOT NULL DEFAULT 0
         )');
         $this->database->exec('CREATE TABLE player (
             account_id TEXT PRIMARY KEY,

--- a/tests/GameRecentPlayersQueryBuilderTest.php
+++ b/tests/GameRecentPlayersQueryBuilderTest.php
@@ -101,7 +101,14 @@ final class GameRecentPlayersQueryBuilderTest extends TestCase
                 progress REAL NOT NULL,
                 last_updated_date TEXT NOT NULL,
                 trophy_count_npwr INTEGER NOT NULL,
-                trophy_count_sony INTEGER NOT NULL
+                trophy_count_sony INTEGER NOT NULL,
+                rarity_points INTEGER NOT NULL DEFAULT 0,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
+                in_game_common INTEGER NOT NULL DEFAULT 0,
+                in_game_uncommon INTEGER NOT NULL DEFAULT 0,
+                in_game_rare INTEGER NOT NULL DEFAULT 0,
+                in_game_epic INTEGER NOT NULL DEFAULT 0,
+                in_game_legendary INTEGER NOT NULL DEFAULT 0
             )'
         );
     }

--- a/tests/GameRecentPlayersServiceTest.php
+++ b/tests/GameRecentPlayersServiceTest.php
@@ -320,7 +320,19 @@ final class GameRecentPlayersServiceTest extends TestCase
                 gold INTEGER,
                 platinum INTEGER,
                 progress INTEGER,
-                last_updated_date TEXT
+                last_updated_date TEXT,
+                rarity_points INTEGER NOT NULL DEFAULT 0,
+                common INTEGER NOT NULL DEFAULT 0,
+                uncommon INTEGER NOT NULL DEFAULT 0,
+                rare INTEGER NOT NULL DEFAULT 0,
+                epic INTEGER NOT NULL DEFAULT 0,
+                legendary INTEGER NOT NULL DEFAULT 0,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
+                in_game_common INTEGER NOT NULL DEFAULT 0,
+                in_game_uncommon INTEGER NOT NULL DEFAULT 0,
+                in_game_rare INTEGER NOT NULL DEFAULT 0,
+                in_game_epic INTEGER NOT NULL DEFAULT 0,
+                in_game_legendary INTEGER NOT NULL DEFAULT 0
             )
             SQL
         );

--- a/tests/GameResetServiceTest.php
+++ b/tests/GameResetServiceTest.php
@@ -207,7 +207,17 @@ final class GameResetServiceTest extends TestCase
         $this->database->exec('CREATE TABLE trophy_merge (parent_np_communication_id TEXT)');
         $this->database->exec('CREATE TABLE trophy_earned (np_communication_id TEXT)');
         $this->database->exec('CREATE TABLE trophy_group_player (np_communication_id TEXT)');
-        $this->database->exec('CREATE TABLE trophy_title_player (np_communication_id TEXT)');
+        $this->database->exec('CREATE TABLE trophy_title_player (
+            np_communication_id TEXT,
+            account_id INTEGER,
+            rarity_points INTEGER NOT NULL DEFAULT 0,
+            in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
+            in_game_common INTEGER NOT NULL DEFAULT 0,
+            in_game_uncommon INTEGER NOT NULL DEFAULT 0,
+            in_game_rare INTEGER NOT NULL DEFAULT 0,
+            in_game_epic INTEGER NOT NULL DEFAULT 0,
+            in_game_legendary INTEGER NOT NULL DEFAULT 0
+        )');
         $this->database->exec('CREATE TABLE trophy (np_communication_id TEXT)');
         $this->database->exec('CREATE TABLE trophy_group (np_communication_id TEXT)');
         $this->database->exec('CREATE TABLE psn100_change (change_type TEXT, param_1 INTEGER, extra TEXT)');

--- a/tests/PlayerAdvisorServiceTest.php
+++ b/tests/PlayerAdvisorServiceTest.php
@@ -75,7 +75,14 @@ final class PlayerAdvisorServiceTest extends TestCase
             'CREATE TABLE trophy_title_player (
                 np_communication_id TEXT NOT NULL,
                 account_id INTEGER NOT NULL,
-                last_updated_date TEXT NOT NULL
+                last_updated_date TEXT NOT NULL,
+                rarity_points INTEGER NOT NULL DEFAULT 0,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
+                in_game_common INTEGER NOT NULL DEFAULT 0,
+                in_game_uncommon INTEGER NOT NULL DEFAULT 0,
+                in_game_rare INTEGER NOT NULL DEFAULT 0,
+                in_game_epic INTEGER NOT NULL DEFAULT 0,
+                in_game_legendary INTEGER NOT NULL DEFAULT 0
             )'
         );
 

--- a/tests/PlayerGamesServiceTest.php
+++ b/tests/PlayerGamesServiceTest.php
@@ -52,7 +52,13 @@ final class PlayerGamesServiceTest extends TestCase
                 platinum INTEGER,
                 progress INTEGER,
                 last_updated_date TEXT,
-                rarity_points INTEGER
+                rarity_points INTEGER,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
+                in_game_common INTEGER NOT NULL DEFAULT 0,
+                in_game_uncommon INTEGER NOT NULL DEFAULT 0,
+                in_game_rare INTEGER NOT NULL DEFAULT 0,
+                in_game_epic INTEGER NOT NULL DEFAULT 0,
+                in_game_legendary INTEGER NOT NULL DEFAULT 0
             )
             SQL
         );

--- a/tests/PlayerSummaryServiceTest.php
+++ b/tests/PlayerSummaryServiceTest.php
@@ -42,7 +42,19 @@ final class PlayerSummaryServiceTest extends TestCase
                 bronze INTEGER NOT NULL,
                 silver INTEGER NOT NULL,
                 gold INTEGER NOT NULL,
-                platinum INTEGER NOT NULL
+                platinum INTEGER NOT NULL,
+                rarity_points INTEGER NOT NULL DEFAULT 0,
+                common INTEGER NOT NULL DEFAULT 0,
+                uncommon INTEGER NOT NULL DEFAULT 0,
+                rare INTEGER NOT NULL DEFAULT 0,
+                epic INTEGER NOT NULL DEFAULT 0,
+                legendary INTEGER NOT NULL DEFAULT 0,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
+                in_game_common INTEGER NOT NULL DEFAULT 0,
+                in_game_uncommon INTEGER NOT NULL DEFAULT 0,
+                in_game_rare INTEGER NOT NULL DEFAULT 0,
+                in_game_epic INTEGER NOT NULL DEFAULT 0,
+                in_game_legendary INTEGER NOT NULL DEFAULT 0
             )'
         );
 

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1551,11 +1551,17 @@ class ThirtyMinuteCronJob implements CronJobInterface
                                 SELECT
                                     trophy_earned.np_communication_id,
                                     SUM(tm.rarity_point) AS points,
+                                    SUM(tm.in_game_rarity_point) AS in_game_points,
                                     SUM(tm.rarity_name = 'COMMON') common,
                                     SUM(tm.rarity_name = 'UNCOMMON') uncommon,
                                     SUM(tm.rarity_name = 'RARE') rare,
                                     SUM(tm.rarity_name = 'EPIC') epic,
-                                    SUM(tm.rarity_name = 'LEGENDARY') legendary
+                                    SUM(tm.rarity_name = 'LEGENDARY') legendary,
+                                    SUM(tm.in_game_rarity_name = 'COMMON') in_game_common,
+                                    SUM(tm.in_game_rarity_name = 'UNCOMMON') in_game_uncommon,
+                                    SUM(tm.in_game_rarity_name = 'RARE') in_game_rare,
+                                    SUM(tm.in_game_rarity_name = 'EPIC') in_game_epic,
+                                    SUM(tm.in_game_rarity_name = 'LEGENDARY') in_game_legendary
                                 FROM
                                     trophy_earned
                                 JOIN trophy t ON t.np_communication_id = trophy_earned.np_communication_id
@@ -1572,11 +1578,17 @@ class ThirtyMinuteCronJob implements CronJobInterface
                                 rarity
                             SET
                                 ttp.rarity_points = rarity.points,
+                                ttp.in_game_rarity_points = rarity.in_game_points,
                                 ttp.common = rarity.common,
                                 ttp.uncommon = rarity.uncommon,
                                 ttp.rare = rarity.rare,
                                 ttp.epic = rarity.epic,
-                                ttp.legendary = rarity.legendary
+                                ttp.legendary = rarity.legendary,
+                                ttp.in_game_common = rarity.in_game_common,
+                                ttp.in_game_uncommon = rarity.in_game_uncommon,
+                                ttp.in_game_rare = rarity.in_game_rare,
+                                ttp.in_game_epic = rarity.in_game_epic,
+                                ttp.in_game_legendary = rarity.in_game_legendary
                             WHERE
                                 ttp.account_id = :account_id AND ttp.np_communication_id = rarity.np_communication_id");
                         $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);

--- a/wwwroot/classes/PlayerGame.php
+++ b/wwwroot/classes/PlayerGame.php
@@ -22,6 +22,7 @@ class PlayerGame
     private int $progress;
     private string $lastUpdatedDate;
     private int $rarityPoints;
+    private int $inGameRarityPoints;
     private ?string $completionDurationLabel;
 
     private function __construct()
@@ -40,6 +41,7 @@ class PlayerGame
         $this->progress = 0;
         $this->lastUpdatedDate = '';
         $this->rarityPoints = 0;
+        $this->inGameRarityPoints = 0;
         $this->completionDurationLabel = null;
     }
 
@@ -63,6 +65,7 @@ class PlayerGame
         $game->progress = (int) ($row['progress'] ?? 0);
         $game->lastUpdatedDate = (string) ($row['last_updated_date'] ?? '');
         $game->rarityPoints = (int) ($row['rarity_points'] ?? 0);
+        $game->inGameRarityPoints = (int) ($row['in_game_rarity_points'] ?? 0);
         $game->completionDurationLabel = $completionDurationLabel;
 
         return $game;
@@ -178,6 +181,11 @@ class PlayerGame
     public function getRarityPoints(): int
     {
         return $this->rarityPoints;
+    }
+
+    public function getInGameRarityPoints(): int
+    {
+        return $this->inGameRarityPoints;
     }
 
     public function getMaxRarityPoints(): int

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -69,6 +69,7 @@ class PlayerGamesService
             'ttp.progress',
             'ttp.last_updated_date',
             'ttp.rarity_points',
+            'ttp.in_game_rarity_points',
         ];
 
         $columns = $this->searchQueryHelper->addFulltextSelectColumns(

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -201,6 +201,10 @@ require_once("header.php");
                                                 if (!$playerGame->isCompleted()) {
                                                     echo '/'. number_format($playerGame->getMaxRarityPoints());
                                                 }
+
+                                                echo '<div class="text-body-secondary small">In-Game: '
+                                                    . number_format($playerGame->getInGameRarityPoints())
+                                                    . '</div>';
                                             } elseif ($playerGame->getStatus() == 1) {
                                                 echo "<span class=\"badge rounded-pill text-bg-warning\">Delisted</span>";
                                             } elseif ($playerGame->getStatus() == 3) {


### PR DESCRIPTION
## Summary
- add in-game rarity columns to the trophy_title_player schema and test fixtures
- update the thirty minute cron job to populate in-game rarity stats per title
- display per-game in-game rarity points on the player games page

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69222e3570c0832f84ff531c7fc2466f)