### PR TITLE
Add in-game rarity points tracking to trophy titles

### DIFF
--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -376,7 +376,8 @@ CREATE TABLE `trophy_title_meta` (
   `parent_np_communication_id` varchar(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `region` varchar(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `obsolete_ids` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `rarity_points` int UNSIGNED NOT NULL DEFAULT '0'
+  `rarity_points` int UNSIGNED NOT NULL DEFAULT '0',
+  `in_game_rarity_points` int UNSIGNED NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------

--- a/tests/PlayerGamesServiceTest.php
+++ b/tests/PlayerGamesServiceTest.php
@@ -35,6 +35,7 @@ final class PlayerGamesServiceTest extends TestCase
                 np_communication_id TEXT PRIMARY KEY,
                 status INTEGER,
                 rarity_points INTEGER,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
                 obsolete_ids TEXT,
                 psnprofiles_id TEXT NULL
             )
@@ -151,7 +152,9 @@ final class PlayerGamesServiceTest extends TestCase
             platinum: 1,
             lastUpdatedDate: '2024-03-10 12:34:56',
             rarityPoints: 321,
-            maxRarityPoints: 654
+            maxRarityPoints: 654,
+            inGameRarityPoints: 111,
+            maxInGameRarityPoints: 222
         );
 
         $this->pdo->exec(
@@ -176,7 +179,9 @@ final class PlayerGamesServiceTest extends TestCase
         $this->assertSame(100, $game->getProgress());
         $this->assertSame('2024-03-10 12:34:56', $game->getLastUpdatedDate());
         $this->assertSame(321, $game->getRarityPoints());
+        $this->assertSame(111, $game->getInGameRarityPoints());
         $this->assertSame(654, $game->getMaxRarityPoints());
+        $this->assertSame(222, $game->getMaxInGameRarityPoints());
         $this->assertSame('Completed in 4 days, 1 hours', $game->getCompletionDurationLabel());
     }
 
@@ -195,7 +200,9 @@ final class PlayerGamesServiceTest extends TestCase
         int $platinum = 0,
         string $lastUpdatedDate = '2024-01-01 00:00:00',
         int $rarityPoints = 0,
-        int $maxRarityPoints = 0
+        int $maxRarityPoints = 0,
+        int $inGameRarityPoints = 0,
+        int $maxInGameRarityPoints = 0
     ): void {
         $statement = $this->pdo->prepare(
             'INSERT INTO trophy_title (id, np_communication_id, name, icon_url, platform) '
@@ -210,18 +217,19 @@ final class PlayerGamesServiceTest extends TestCase
         ]);
 
         $statement = $this->pdo->prepare(
-            'INSERT INTO trophy_title_meta (np_communication_id, status, rarity_points) '
-            . 'VALUES (:np, :status, :rarity)'
+            'INSERT INTO trophy_title_meta (np_communication_id, status, rarity_points, in_game_rarity_points) '
+            . 'VALUES (:np, :status, :rarity, :in_game_rarity_points)'
         );
         $statement->execute([
             ':np' => $npCommunicationId,
             ':status' => $status,
             ':rarity' => $maxRarityPoints,
+            ':in_game_rarity_points' => $maxInGameRarityPoints,
         ]);
 
         $statement = $this->pdo->prepare(
-            'INSERT INTO trophy_title_player (account_id, np_communication_id, bronze, silver, gold, platinum, progress, last_updated_date, rarity_points) '
-            . 'VALUES (:account_id, :np, :bronze, :silver, :gold, :platinum, :progress, :last_updated_date, :rarity_points)'
+            'INSERT INTO trophy_title_player (account_id, np_communication_id, bronze, silver, gold, platinum, progress, last_updated_date, rarity_points, in_game_rarity_points) '
+            . 'VALUES (:account_id, :np, :bronze, :silver, :gold, :platinum, :progress, :last_updated_date, :rarity_points, :in_game_rarity_points)'
         );
         $statement->execute([
             ':account_id' => $accountId,
@@ -233,6 +241,7 @@ final class PlayerGamesServiceTest extends TestCase
             ':progress' => $progress,
             ':last_updated_date' => $lastUpdatedDate,
             ':rarity_points' => $rarityPoints,
+            ':in_game_rarity_points' => $inGameRarityPoints,
         ]);
 
         $statement = $this->pdo->prepare(

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -112,11 +112,12 @@ class DailyCronJob implements CronJobInterface
 
     private function updateTrophyTitleRarityPoints(): void
     {
-        $query = $this->database->prepare(
-            "WITH rarity AS (
-                SELECT
-                    t.np_communication_id,
-                    IFNULL(SUM(tm.rarity_point), 0) AS rarity_sum
+            $query = $this->database->prepare(
+                "WITH rarity AS (
+                    SELECT
+                        t.np_communication_id,
+                    IFNULL(SUM(tm.rarity_point), 0) AS rarity_sum,
+                    IFNULL(SUM(tm.in_game_rarity_point), 0) AS in_game_rarity_sum
                 FROM trophy t
                 JOIN trophy_meta tm ON tm.trophy_id = t.id
                 WHERE tm.status = 0
@@ -124,7 +125,9 @@ class DailyCronJob implements CronJobInterface
             )
             UPDATE trophy_title_meta ttm
             JOIN rarity r USING(np_communication_id)
-            SET ttm.rarity_points = r.rarity_sum"
+            SET
+                ttm.rarity_points = r.rarity_sum,
+                ttm.in_game_rarity_points = r.in_game_rarity_sum"
         );
 
         $query->execute();

--- a/wwwroot/classes/PlayerGame.php
+++ b/wwwroot/classes/PlayerGame.php
@@ -15,6 +15,7 @@ class PlayerGame
     private string $platform;
     private int $status;
     private int $maxRarityPoints;
+    private int $maxInGameRarityPoints;
     private int $bronze;
     private int $silver;
     private int $gold;
@@ -34,6 +35,7 @@ class PlayerGame
         $this->platform = '';
         $this->status = 0;
         $this->maxRarityPoints = 0;
+        $this->maxInGameRarityPoints = 0;
         $this->bronze = 0;
         $this->silver = 0;
         $this->gold = 0;
@@ -58,6 +60,7 @@ class PlayerGame
         $game->platform = (string) ($row['platform'] ?? '');
         $game->status = (int) ($row['status'] ?? 0);
         $game->maxRarityPoints = (int) ($row['max_rarity_points'] ?? 0);
+        $game->maxInGameRarityPoints = (int) ($row['max_in_game_rarity_points'] ?? 0);
         $game->bronze = (int) ($row['bronze'] ?? 0);
         $game->silver = (int) ($row['silver'] ?? 0);
         $game->gold = (int) ($row['gold'] ?? 0);
@@ -191,6 +194,11 @@ class PlayerGame
     public function getMaxRarityPoints(): int
     {
         return $this->maxRarityPoints;
+    }
+
+    public function getMaxInGameRarityPoints(): int
+    {
+        return $this->maxInGameRarityPoints;
     }
 
     public function getCompletionDurationLabel(): ?string

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -62,6 +62,7 @@ class PlayerGamesService
             'tt.platform',
             'ttm.status AS status',
             'ttm.rarity_points AS max_rarity_points',
+            'ttm.in_game_rarity_points AS max_in_game_rarity_points',
             'ttp.bronze',
             'ttp.silver',
             'ttp.gold',

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -203,8 +203,13 @@ require_once("header.php");
                                                 }
 
                                                 echo '<div class="text-body-secondary small">In-Game: '
-                                                    . number_format($playerGame->getInGameRarityPoints())
-                                                    . '</div>';
+                                                    . number_format($playerGame->getInGameRarityPoints());
+
+                                                if (!$playerGame->isCompleted()) {
+                                                    echo '/' . number_format($playerGame->getMaxInGameRarityPoints());
+                                                }
+
+                                                echo '</div>';
                                             } elseif ($playerGame->getStatus() == 1) {
                                                 echo "<span class=\"badge rounded-pill text-bg-warning\">Delisted</span>";
                                             } elseif ($playerGame->getStatus() == 3) {


### PR DESCRIPTION
## Summary
- add an `in_game_rarity_points` column to trophy title metadata and populate it during the daily cron rarity recalculation
- expose maximum in-game rarity totals for player games and show them on the player page
- update player game tests to cover the new in-game rarity values

## Testing
- php tests/run.php
- find wwwroot tests -name "*.php" -print0 | xargs -0 -n1 php -l

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922332a8a9c832f9ce80d04ae71d2f7)