### PR TITLE
Handle invalid PSN profile responses during cron

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -486,6 +486,26 @@ class ThirtyMinuteCronJob implements CronJobInterface
                     )
                 );
 
+                $query = $this->database->prepare("DELETE FROM player_queue
+                    WHERE  online_id = :online_id ");
+                $query->bindValue(":online_id", $player["online_id"], PDO::PARAM_STR);
+                $query->execute();
+
+                $query = $this->database->prepare("SELECT account_id
+                    FROM   player
+                    WHERE  online_id = :online_id ");
+                $query->bindValue(":online_id", $player["online_id"], PDO::PARAM_STR);
+                $query->execute();
+                $accountId = $query->fetchColumn();
+
+                if ($accountId) {
+                    $query = $this->database->prepare("UPDATE player
+                        SET `status` = 5, last_updated_date = NOW()
+                        WHERE  account_id = :account_id ");
+                    $query->bindValue(":account_id", $accountId, PDO::PARAM_INT);
+                    $query->execute();
+                }
+
                 $this->releaseWorkerFromCurrentScan((int) $worker['id']);
 
                 continue;


### PR DESCRIPTION
## Summary
- add a helper to release a worker's scanning slot when logins or scans fail
- log and skip a player when PSN profile lookups return invalid responses to prevent cron failures

## Testing
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692320e43284832f869903a274281b8b)