### PR TITLE
Display in-game rarity points in game header

### DIFF
--- a/tests/AutomaticTrophyTitleMergeServiceTest.php
+++ b/tests/AutomaticTrophyTitleMergeServiceTest.php
@@ -264,7 +264,8 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
             'CREATE TABLE trophy_title_meta (
                 np_communication_id TEXT PRIMARY KEY,
                 status INTEGER NOT NULL DEFAULT 0,
-                psnprofiles_id TEXT NULL
+                psnprofiles_id TEXT NULL,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0
             )'
         );
 

--- a/tests/ChangelogServiceTest.php
+++ b/tests/ChangelogServiceTest.php
@@ -39,6 +39,7 @@ final class ChangelogServiceTest extends TestCase
             'CREATE TABLE trophy_title_meta (' .
             'np_communication_id TEXT PRIMARY KEY, ' .
             'region TEXT NULL, ' .
+            'in_game_rarity_points INTEGER NOT NULL DEFAULT 0, ' .
             'obsolete_ids TEXT NULL, ' .
             'psnprofiles_id TEXT NULL)'
         );

--- a/tests/GameDetailServiceTest.php
+++ b/tests/GameDetailServiceTest.php
@@ -33,6 +33,7 @@ final class GameDetailServiceTest extends TestCase
             'message TEXT NOT NULL, ' .
             'region TEXT NULL, ' .
             'psnprofiles_id TEXT NULL, ' .
+            'in_game_rarity_points INTEGER NOT NULL DEFAULT 0, ' .
             'status INTEGER NOT NULL DEFAULT 0, ' .
             'obsolete_ids TEXT NULL)'
         );

--- a/tests/GameHeaderServiceTest.php
+++ b/tests/GameHeaderServiceTest.php
@@ -66,7 +66,8 @@ final class GameHeaderServiceTest extends TestCase
             'parent_np_communication_id TEXT NULL, ' .
             'region TEXT NULL, ' .
             'obsolete_ids TEXT NULL, ' .
-            'psnprofiles_id TEXT NULL)'
+            'psnprofiles_id TEXT NULL, ' .
+            'in_game_rarity_points INTEGER NOT NULL DEFAULT 0)'
         );
 
         $this->database->exec(

--- a/tests/GameRecentPlayersServiceTest.php
+++ b/tests/GameRecentPlayersServiceTest.php
@@ -282,6 +282,7 @@ final class GameRecentPlayersServiceTest extends TestCase
                 status INTEGER,
                 psnprofiles_id INTEGER,
                 rarity_points INTEGER,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
                 obsolete_ids TEXT
             )
             SQL

--- a/tests/GameResetServiceTest.php
+++ b/tests/GameResetServiceTest.php
@@ -200,6 +200,8 @@ final class GameResetServiceTest extends TestCase
             np_communication_id TEXT PRIMARY KEY,
             owners INTEGER DEFAULT 0,
             owners_completed INTEGER DEFAULT 0,
+            rarity_points INTEGER NOT NULL DEFAULT 0,
+            in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
             parent_np_communication_id TEXT,
             obsolete_ids TEXT NULL,
             psnprofiles_id TEXT NULL

--- a/tests/GameStatusServiceTest.php
+++ b/tests/GameStatusServiceTest.php
@@ -15,7 +15,7 @@ final class GameStatusServiceTest extends TestCase
         $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         $this->database->exec('CREATE TABLE trophy_title (id INTEGER PRIMARY KEY, np_communication_id TEXT NOT NULL)');
-        $this->database->exec('CREATE TABLE trophy_title_meta (np_communication_id TEXT PRIMARY KEY, status INTEGER NOT NULL, obsolete_ids TEXT NULL, psnprofiles_id TEXT NULL)');
+        $this->database->exec('CREATE TABLE trophy_title_meta (np_communication_id TEXT PRIMARY KEY, status INTEGER NOT NULL, obsolete_ids TEXT NULL, psnprofiles_id TEXT NULL, in_game_rarity_points INTEGER NOT NULL DEFAULT 0)');
         $this->database->exec('CREATE TABLE psn100_change (change_type TEXT NOT NULL, param_1 INTEGER NOT NULL)');
         $this->database->exec("INSERT INTO trophy_title (id, np_communication_id) VALUES (1, 'NPWR-1')");
         $this->database->exec("INSERT INTO trophy_title_meta (np_communication_id, status) VALUES ('NPWR-1', 0)");

--- a/tests/HomepageContentServiceTest.php
+++ b/tests/HomepageContentServiceTest.php
@@ -48,7 +48,8 @@ final class HomepageContentServiceTest extends TestCase
                 parent_np_communication_id TEXT DEFAULT NULL,
                 region TEXT DEFAULT NULL,
                 obsolete_ids TEXT DEFAULT NULL,
-                rarity_points INTEGER DEFAULT 0
+                rarity_points INTEGER DEFAULT 0,
+                in_game_rarity_points INTEGER DEFAULT 0
             )
             SQL
         );

--- a/tests/PlayerAdvisorServiceTest.php
+++ b/tests/PlayerAdvisorServiceTest.php
@@ -41,7 +41,8 @@ final class PlayerAdvisorServiceTest extends TestCase
                 parent_np_communication_id TEXT DEFAULT NULL,
                 region TEXT DEFAULT NULL,
                 obsolete_ids TEXT DEFAULT NULL,
-                rarity_points INTEGER DEFAULT 0
+                rarity_points INTEGER DEFAULT 0,
+                in_game_rarity_points INTEGER DEFAULT 0
             )'
         );
 

--- a/tests/PlayerSummaryServiceTest.php
+++ b/tests/PlayerSummaryServiceTest.php
@@ -30,7 +30,8 @@ final class PlayerSummaryServiceTest extends TestCase
                 np_communication_id TEXT PRIMARY KEY,
                 status INTEGER NOT NULL,
                 obsolete_ids TEXT NULL,
-                psnprofiles_id TEXT NULL
+                psnprofiles_id TEXT NULL,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0
             )'
         );
 

--- a/tests/TrophyMergeServiceMetaUsageTest.php
+++ b/tests/TrophyMergeServiceMetaUsageTest.php
@@ -87,7 +87,8 @@ final class TrophyMergeServiceMetaUsageTest extends TestCase
                 parent_np_communication_id TEXT NULL,
                 status INTEGER NOT NULL DEFAULT 0,
                 obsolete_ids TEXT NULL,
-                psnprofiles_id TEXT NULL
+                psnprofiles_id TEXT NULL,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0
             )'
         );
     }

--- a/wwwroot/classes/Game/GameDetails.php
+++ b/wwwroot/classes/Game/GameDetails.php
@@ -42,6 +42,8 @@ class GameDetails
 
     private int $rarityPoints;
 
+    private int $inGameRarityPoints;
+
     /**
      * @var int[]
      */
@@ -79,6 +81,7 @@ class GameDetails
         $game->difficulty = (string) ($row['difficulty'] ?? '0');
         $game->status = (int) ($row['status'] ?? 0);
         $game->rarityPoints = (int) ($row['rarity_points'] ?? 0);
+        $game->inGameRarityPoints = (int) ($row['in_game_rarity_points'] ?? 0);
         $game->obsoleteGameIds = self::parseObsoleteIds($row['obsolete_ids'] ?? null);
 
         return $game;
@@ -239,6 +242,11 @@ class GameDetails
     public function getRarityPoints(): int
     {
         return $this->rarityPoints;
+    }
+
+    public function getInGameRarityPoints(): int
+    {
+        return $this->inGameRarityPoints;
     }
 
     /**

--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -43,7 +43,8 @@ class GameRecentPlayersService
                 ttm.psnprofiles_id,
                 ttm.parent_np_communication_id,
                 ttm.region,
-                ttm.rarity_points
+                ttm.rarity_points,
+                ttm.in_game_rarity_points
             FROM
                 trophy_title tt
                 JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id

--- a/wwwroot/classes/GameService.php
+++ b/wwwroot/classes/GameService.php
@@ -41,6 +41,7 @@ class GameService
                 ttm.parent_np_communication_id,
                 ttm.region,
                 ttm.rarity_points,
+                ttm.in_game_rarity_points,
                 ttm.obsolete_ids
             FROM
                 trophy_title tt

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -218,19 +218,25 @@ require_once __DIR__ . '/classes/Game/GamePlayerProgress.php';
                 <div>
                     <?php
                     $status = $game->getStatus();
+                    $details = [];
+
                     if ($status === 0) {
-                        echo number_format($game->getRarityPoints()) . ' Rarity Points';
+                        $details[] = number_format($game->getRarityPoints()) . ' Rarity Points';
                     } elseif ($status === 1) {
-                        echo "<span class='badge rounded-pill text-bg-warning' title='This game is delisted, no trophies will be accounted for on any leaderboard.'>Delisted</span>";
+                        $details[] = "<span class='badge rounded-pill text-bg-warning' title='This game is delisted, no trophies will be accounted for on any leaderboard.'>Delisted</span>";
                     } elseif ($status === 3) {
-                        echo "<span class='badge rounded-pill text-bg-warning' title='This game is obsolete, no trophies will be accounted for on any leaderboard.'>Obsolete</span>";
+                        $details[] = "<span class='badge rounded-pill text-bg-warning' title='This game is obsolete, no trophies will be accounted for on any leaderboard.'>Obsolete</span>";
                     } elseif ($status === 4) {
-                        echo "<span class='badge rounded-pill text-bg-warning' title='This game is delisted &amp; obsolete, no trophies will be accounted for on any leaderboard.'>Delisted &amp; Obsolete</span>";
+                        $details[] = "<span class='badge rounded-pill text-bg-warning' title='This game is delisted &amp; obsolete, no trophies will be accounted for on any leaderboard.'>Delisted &amp; Obsolete</span>";
                     }
 
+                    $details[] = number_format($game->getInGameRarityPoints()) . ' Rarity (In-Game) Points';
+
                     if (isset($gamePlayer) && $gamePlayer instanceof GamePlayerProgress && $gamePlayer->isCompleted()) {
-                        echo " <span class='badge rounded-pill text-bg-success' title='Player has completed this game to 100%!'>Completed!</span>";
+                        $details[] = "<span class='badge rounded-pill text-bg-success' title='Player has completed this game to 100%!'>Completed!</span>";
                     }
+
+                    echo implode(' • ', $details);
                     ?>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- expose in-game rarity points on the game header alongside existing status info
- wire game detail models and queries to include in-game rarity totals
- align test schemas with the new trophy title meta column

## Testing
- php ../tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692338b79814832f9b48badd392dc31c)