### PR TITLE
Add in-game rarity sorting and display to player log

### DIFF
--- a/wwwroot/classes/PlayerLogEntry.php
+++ b/wwwroot/classes/PlayerLogEntry.php
@@ -16,6 +16,8 @@ final class PlayerLogEntry
 
     private ?string $rarityPercent;
 
+    private ?string $inGameRarityPercent;
+
     private int $trophyStatus;
 
     private ?int $progressTargetValue;
@@ -54,6 +56,7 @@ final class PlayerLogEntry
         $entry->trophyDetail = (string) ($row['trophy_detail'] ?? '');
         $entry->trophyIcon = (string) ($row['trophy_icon'] ?? '');
         $entry->rarityPercent = self::toNullableString($row['rarity_percent'] ?? null);
+        $entry->inGameRarityPercent = self::toNullableString($row['in_game_rarity_percent'] ?? null);
         $entry->trophyStatus = isset($row['trophy_status']) ? (int) $row['trophy_status'] : 0;
         $entry->progressTargetValue = self::toNullableInt($row['progress_target_value'] ?? null);
         $entry->progress = self::toNullableInt($row['progress'] ?? null);
@@ -108,6 +111,11 @@ final class PlayerLogEntry
     public function getRarityPercent(): ?string
     {
         return $this->rarityPercent;
+    }
+
+    public function getInGameRarityPercent(): ?string
+    {
+        return $this->inGameRarityPercent;
     }
 
     public function getTrophyStatus(): int

--- a/wwwroot/classes/PlayerLogFilter.php
+++ b/wwwroot/classes/PlayerLogFilter.php
@@ -6,6 +6,7 @@ class PlayerLogFilter
 {
     public const SORT_DATE = 'date';
     public const SORT_RARITY = 'rarity';
+    public const SORT_IN_GAME_RARITY = 'in-game-rarity';
 
     /** @var array<int, string> */
     private const ALLOWED_PLATFORMS = [
@@ -133,6 +134,10 @@ class PlayerLogFilter
     {
         if ($sort === self::SORT_RARITY) {
             return self::SORT_RARITY;
+        }
+
+        if ($sort === self::SORT_IN_GAME_RARITY) {
+            return self::SORT_IN_GAME_RARITY;
         }
 
         return self::SORT_DATE;

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -60,6 +60,7 @@ class PlayerLogService
                 t.detail AS trophy_detail,
                 t.icon_url AS trophy_icon,
                 tm.rarity_percent,
+                tm.in_game_rarity_percent,
                 tm.status AS trophy_status,
                 t.progress_target_value,
                 t.reward_name,
@@ -126,6 +127,10 @@ class PlayerLogService
     {
         if ($filter->isSort(PlayerLogFilter::SORT_RARITY)) {
             return PHP_EOL . '            ORDER BY tm.rarity_percent, te.earned_date';
+        }
+
+        if ($filter->isSort(PlayerLogFilter::SORT_IN_GAME_RARITY)) {
+            return PHP_EOL . '            ORDER BY tm.in_game_rarity_percent, te.earned_date';
         }
 
         return PHP_EOL . '            ORDER BY te.earned_date DESC';

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -63,6 +63,7 @@ require_once("header.php");
                             <option disabled>Sort by...</option>
                             <option value="date"<?= $playerLogFilter->isSort(PlayerLogFilter::SORT_DATE) ? ' selected' : ''; ?>>Date</option>
                             <option value="rarity"<?= $playerLogFilter->isSort(PlayerLogFilter::SORT_RARITY) ? ' selected' : ''; ?>>Rarity</option>
+                            <option value="in-game-rarity"<?= $playerLogFilter->isSort(PlayerLogFilter::SORT_IN_GAME_RARITY) ? ' selected' : ''; ?>>In-Game Rarity</option>
                         </select>
                     </div>
                 </form>
@@ -160,13 +161,30 @@ require_once("header.php");
                                         <td class="text-center align-middle">
                                         <?php
                                         $trophyRarity = $trophyRarityFormatter->format($trophy->getRarityPercent(), $trophy->getTrophyStatus());
-
-                                        if ($trophyRarity->isUnobtainable()) {
-                                            echo "<span class='badge rounded-pill text-bg-warning p-2'>" . $trophyRarity->getLabel() . '</span>';
-                                        } else {
-                                            echo $trophyRarity->renderSpan();
-                                        }
+                                        $inGameRarity = $trophyRarityFormatter->formatInGame($trophy->getInGameRarityPercent(), $trophy->getTrophyStatus());
                                         ?>
+                                        <div class="vstack gap-2">
+                                            <div class="small text-uppercase text-secondary">Rarity (Meta)</div>
+                                            <div>
+                                                <?php
+                                                if ($trophyRarity->isUnobtainable()) {
+                                                    echo "<span class='badge rounded-pill text-bg-warning p-2'>" . $trophyRarity->getLabel() . '</span>';
+                                                } else {
+                                                    echo $trophyRarity->renderSpan();
+                                                }
+                                                ?>
+                                            </div>
+                                            <div class="small text-uppercase text-secondary">Rarity (In-Game)</div>
+                                            <div>
+                                                <?php
+                                                if ($inGameRarity->isUnobtainable()) {
+                                                    echo "<span class='badge rounded-pill text-bg-warning p-2'>" . $inGameRarity->getLabel() . '</span>';
+                                                } else {
+                                                    echo $inGameRarity->renderSpan();
+                                                }
+                                                ?>
+                                            </div>
+                                        </div>
                                         </td>
                                         <td class="text-center align-middle">
                                             <img src="/img/trophy-<?= htmlspecialchars($trophy->getTrophyType(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= htmlentities(ucfirst($trophy->getTrophyType()), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities(ucfirst($trophy->getTrophyType()), ENT_QUOTES, 'UTF-8'); ?>" height="50" />


### PR DESCRIPTION
## Summary
- add in-game rarity as a selectable sort option for the player log
- load in-game rarity data for log entries and show both meta and in-game rarity values
- support ordering log results by in-game rarity

## Testing
- php tests/run.php
- php -l wwwroot/classes/PlayerLogEntry.php
- php -l wwwroot/classes/PlayerLogFilter.php
- php -l wwwroot/classes/PlayerLogService.php
- php -l wwwroot/player_log.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692351bc4d14832faff3f9abad0081c6)