### PR TITLE
Exclude unobtainable trophies from player log

### DIFF
--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -30,7 +30,7 @@ class PlayerLogService
         $sql = <<<'SQL'
             SELECT COUNT(*)
             FROM trophy_earned te
-            LEFT JOIN trophy t USING (np_communication_id, order_id)
+            LEFT JOIN trophy t USING (np_communication_id, group_id, order_id)
             JOIN trophy_title tt USING (np_communication_id)
             LEFT JOIN trophy_meta tm ON tm.trophy_id = t.id
             JOIN trophy_title_meta ttm USING (np_communication_id)
@@ -74,7 +74,7 @@ class PlayerLogService
                 tt.icon_url AS game_icon,
                 tt.platform
             FROM trophy_earned te
-            LEFT JOIN trophy t USING (np_communication_id, order_id)
+            LEFT JOIN trophy t USING (np_communication_id, group_id, order_id)
             LEFT JOIN trophy_meta tm ON tm.trophy_id = t.id
             LEFT JOIN trophy_title tt USING (np_communication_id)
             LEFT JOIN trophy_title_meta ttm USING (np_communication_id)


### PR DESCRIPTION
## Summary
- prevent player log queries from including unobtainable trophies in counts and results

## Testing
- php -d detect_unicode=0 tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692354d5dda0832fa039d66757b3db0d)