### PR TITLE
Add in-game rarity sorting options

### DIFF
--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 class PlayerGamesFilter
 {
     public const SORT_DATE = 'date';
+    public const SORT_IN_GAME_MAX_RARITY = 'max-in-game-rarity';
+    public const SORT_IN_GAME_RARITY = 'in-game-rarity';
     public const SORT_MAX_RARITY = 'max-rarity';
     public const SORT_NAME = 'name';
     public const SORT_RARITY = 'rarity';
@@ -20,6 +22,8 @@ class PlayerGamesFilter
 
     private const ALLOWED_SORTS = [
         self::SORT_DATE,
+        self::SORT_IN_GAME_MAX_RARITY,
+        self::SORT_IN_GAME_RARITY,
         self::SORT_MAX_RARITY,
         self::SORT_NAME,
         self::SORT_RARITY,

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -164,6 +164,8 @@ class PlayerGamesService
     private function buildOrderByClause(PlayerGamesFilter $filter): string
     {
         return match ($filter->getSort()) {
+            PlayerGamesFilter::SORT_IN_GAME_MAX_RARITY => 'ORDER BY max_in_game_rarity_points DESC, `name`',
+            PlayerGamesFilter::SORT_IN_GAME_RARITY => 'ORDER BY in_game_rarity_points DESC, `name`',
             PlayerGamesFilter::SORT_MAX_RARITY => 'ORDER BY max_rarity_points DESC, `name`',
             PlayerGamesFilter::SORT_NAME => 'ORDER BY `name`',
             PlayerGamesFilter::SORT_RARITY => 'ORDER BY rarity_points DESC, `name`',

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -92,8 +92,10 @@ require_once("header.php");
                             <option disabled>Sort by...</option>
                             <option value="search"<?= ($sort == "search" ? " selected" : ""); ?>>Best Match</option>
                             <option value="date"<?= ($sort == "date" ? " selected" : ""); ?>>Date</option>
+                            <option value="max-in-game-rarity"<?= ($sort == "max-in-game-rarity" ? " selected" : ""); ?>>Max Rarity (In-Game)</option>
                             <option value="max-rarity"<?= ($sort == "max-rarity" ? " selected" : ""); ?>>Max Rarity</option>
                             <option value="name"<?= ($sort == "name" ? " selected" : ""); ?>>Name</option>
+                            <option value="in-game-rarity"<?= ($sort == "in-game-rarity" ? " selected" : ""); ?>>Rarity (In-Game)</option>
                             <option value="rarity"<?= ($sort == "rarity" ? " selected" : ""); ?>>Rarity</option>
                         </select>
                     </div>


### PR DESCRIPTION
## Summary
- add filter constants for in-game rarity and max in-game rarity sorts
- support ordering player games by in-game rarity values
- expose the new sort options in the player page dropdown

## Testing
- php -l wwwroot/classes/PlayerGamesFilter.php
- php -l wwwroot/classes/PlayerGamesService.php
- php -l wwwroot/player.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236dc868e4832fad42b7f2f21baa36)