### PR TITLE
Add in-game rarity sorting to player advisor

### DIFF
--- a/tests/PlayerAdvisorFilterTest.php
+++ b/tests/PlayerAdvisorFilterTest.php
@@ -38,6 +38,20 @@ final class PlayerAdvisorFilterTest extends TestCase
         $this->assertFalse($filter->isPlatformSelected('unknown'));
     }
 
+    public function testFromArrayParsesSortWhenValid(): void
+    {
+        $filter = PlayerAdvisorFilter::fromArray(['sort' => PlayerAdvisorFilter::SORT_IN_GAME_RARITY]);
+
+        $this->assertSame(PlayerAdvisorFilter::SORT_IN_GAME_RARITY, $filter->getSort());
+    }
+
+    public function testFromArrayFallsBackToDefaultSortWhenUnknown(): void
+    {
+        $filter = PlayerAdvisorFilter::fromArray(['sort' => 'unknown']);
+
+        $this->assertSame(PlayerAdvisorFilter::SORT_RARITY, $filter->getSort());
+    }
+
     public function testPageIsNeverBelowOne(): void
     {
         $filter = PlayerAdvisorFilter::fromArray(['page' => '0']);
@@ -57,12 +71,13 @@ final class PlayerAdvisorFilterTest extends TestCase
         $filter = PlayerAdvisorFilter::fromArray([
             'psvr' => '1',
             'psvita' => 'yes',
+            'sort' => PlayerAdvisorFilter::SORT_IN_GAME_RARITY,
         ]);
 
         $this->assertSame([
             'psvita' => 'true',
             'psvr' => 'true',
-            'sort' => PlayerAdvisorFilter::SORT_RARITY,
+            'sort' => PlayerAdvisorFilter::SORT_IN_GAME_RARITY,
         ], $filter->getFilterParameters());
     }
 }

--- a/tests/PlayerPlatformFilterRendererTest.php
+++ b/tests/PlayerPlatformFilterRendererTest.php
@@ -77,4 +77,14 @@ final class PlayerPlatformFilterRendererTest extends TestCase
             );
         }
     }
+
+    public function testRenderIncludesHiddenInputsWhenProvided(): void
+    {
+        $options = PlayerPlatformFilterOptions::fromSelectionCallback(static fn (): bool => false);
+        $renderer = PlayerPlatformFilterRenderer::createDefault();
+
+        $html = $renderer->render($options, ['sort' => 'rarity']);
+
+        $this->assertStringContainsString('type="hidden" name="sort" value="rarity"', $html);
+    }
 }

--- a/wwwroot/classes/PlayerAdvisableTrophy.php
+++ b/wwwroot/classes/PlayerAdvisableTrophy.php
@@ -16,6 +16,8 @@ class PlayerAdvisableTrophy
 
     private float $rarityPercent;
 
+    private float $inGameRarityPercent;
+
     private ?int $progressTargetValue;
 
     private ?string $rewardName;
@@ -44,6 +46,7 @@ class PlayerAdvisableTrophy
         string $trophyDetail,
         string $trophyIcon,
         float $rarityPercent,
+        float $inGameRarityPercent,
         ?int $progressTargetValue,
         ?string $rewardName,
         ?string $rewardImageUrl,
@@ -60,6 +63,7 @@ class PlayerAdvisableTrophy
         $this->trophyDetail = $trophyDetail;
         $this->trophyIcon = $trophyIcon;
         $this->rarityPercent = $rarityPercent;
+        $this->inGameRarityPercent = $inGameRarityPercent;
         $this->progressTargetValue = $progressTargetValue;
         $this->rewardName = $rewardName;
         $this->rewardImageUrl = $rewardImageUrl;
@@ -80,6 +84,7 @@ class PlayerAdvisableTrophy
             (string) ($data['trophy_detail'] ?? ''),
             (string) ($data['trophy_icon'] ?? ''),
             isset($data['rarity_percent']) ? (float) $data['rarity_percent'] : 0.0,
+            isset($data['in_game_rarity_percent']) ? (float) $data['in_game_rarity_percent'] : 0.0,
             isset($data['progress_target_value']) ? (int) $data['progress_target_value'] : null,
             array_key_exists('reward_name', $data) ? ($data['reward_name'] !== null ? (string) $data['reward_name'] : null) : null,
             array_key_exists('reward_image_url', $data) ? ($data['reward_image_url'] !== null ? (string) $data['reward_image_url'] : null) : null,
@@ -128,6 +133,11 @@ class PlayerAdvisableTrophy
     public function getRarityPercent(): float
     {
         return $this->rarityPercent;
+    }
+
+    public function getInGameRarityPercent(): float
+    {
+        return $this->inGameRarityPercent;
     }
 
     public function hasProgressTarget(): bool

--- a/wwwroot/classes/PlayerAdvisorFilter.php
+++ b/wwwroot/classes/PlayerAdvisorFilter.php
@@ -5,6 +5,15 @@ declare(strict_types=1);
 class PlayerAdvisorFilter
 {
     public const SORT_RARITY = 'rarity';
+    public const SORT_IN_GAME_RARITY = 'in_game_rarity';
+
+    /**
+     * @var array<int, string>
+     */
+    private const ALLOWED_SORTS = [
+        self::SORT_RARITY,
+        self::SORT_IN_GAME_RARITY,
+    ];
 
     private const SUPPORTED_PLATFORMS = [
         'pc',
@@ -43,6 +52,9 @@ class PlayerAdvisorFilter
         }
 
         $sort = self::SORT_RARITY;
+        if (isset($parameters['sort']) && in_array($parameters['sort'], self::ALLOWED_SORTS, true)) {
+            $sort = (string) $parameters['sort'];
+        }
 
         $platforms = [];
         foreach (self::SUPPORTED_PLATFORMS as $platform) {

--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -72,6 +72,7 @@ class PlayerAdvisorService
                 t.detail AS trophy_detail,
                 t.icon_url AS trophy_icon,
                 tm.rarity_percent,
+                tm.in_game_rarity_percent,
                 t.progress_target_value,
                 t.reward_name,
                 t.reward_image_url,
@@ -148,6 +149,10 @@ class PlayerAdvisorService
 
     private function buildOrderByClause(PlayerAdvisorFilter $filter): string
     {
+        if ($filter->getSort() === PlayerAdvisorFilter::SORT_IN_GAME_RARITY) {
+            return ' ORDER BY tm.in_game_rarity_percent DESC, ttp.last_updated_date DESC';
+        }
+
         return ' ORDER BY tm.rarity_percent DESC, ttp.last_updated_date DESC';
     }
 }

--- a/wwwroot/classes/PlayerPlatformFilterRenderer.php
+++ b/wwwroot/classes/PlayerPlatformFilterRenderer.php
@@ -18,12 +18,17 @@ final class PlayerPlatformFilterRenderer
         return new self('Filter');
     }
 
-    public function render(PlayerPlatformFilterOptions $options): string
+    /**
+     * @param array<string, string> $hiddenInputs
+     */
+    public function render(PlayerPlatformFilterOptions $options, array $hiddenInputs = []): string
     {
         $dropdownControls = $this->renderDropdownControls($options);
+        $hiddenInputsHtml = $this->renderHiddenInputs($hiddenInputs);
 
         return <<<HTML
-<form>
+<form method="get">
+    {$hiddenInputsHtml}
     <div class="input-group d-flex justify-content-end">
         {$dropdownControls}
     </div>
@@ -80,5 +85,23 @@ HTML;
                 </div>
             </li>
 HTML;
+    }
+
+    /**
+     * @param array<string, string> $hiddenInputs
+     */
+    private function renderHiddenInputs(array $hiddenInputs): string
+    {
+        $inputs = [];
+
+        foreach ($hiddenInputs as $name => $value) {
+            $inputs[] = sprintf(
+                '<input type="hidden" name="%s" value="%s">',
+                htmlspecialchars($name, ENT_QUOTES, 'UTF-8'),
+                htmlspecialchars($value, ENT_QUOTES, 'UTF-8')
+            );
+        }
+
+        return implode(PHP_EOL, $inputs);
     }
 }

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -32,6 +32,12 @@ $platformFilterOptions = $playerAdvisorPageContext->getPlatformFilterOptions();
 $platformFilterRenderer = PlayerPlatformFilterRenderer::createDefault();
 $playerStatusNotice = $playerAdvisorPageContext->getPlayerStatusNotice();
 $playerOnlineId = $playerAdvisorPageContext->getPlayerOnlineId();
+$platformFilterHiddenInputs = ['sort' => $playerAdvisorFilter->getSort()];
+$selectedPlatformParameters = $playerAdvisorFilter->getFilterParameters();
+unset($selectedPlatformParameters['sort']);
+$rarityColumnLabel = $playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_IN_GAME_RARITY
+    ? 'Rarity (In-Game)'
+    : 'Rarity (Meta)';
 
 $title = $playerAdvisorPageContext->getTitle();
 require_once("header.php");
@@ -53,7 +59,20 @@ require_once("header.php");
             </div>
 
             <div class="col-12 col-lg-3 mb-3">
-                <?= $platformFilterRenderer->render($platformFilterOptions); ?>
+                <div class="d-flex flex-column gap-2 align-items-lg-end">
+                    <form method="get" class="w-100 w-lg-auto">
+                        <?php foreach ($selectedPlatformParameters as $name => $value) { ?>
+                            <input type="hidden" name="<?= htmlspecialchars($name, ENT_QUOTES, 'UTF-8'); ?>" value="<?= htmlspecialchars($value, ENT_QUOTES, 'UTF-8'); ?>">
+                        <?php } ?>
+                        <label for="advisor-sort" class="form-label mb-1">Sort by</label>
+                        <select id="advisor-sort" name="sort" class="form-select" onChange="this.form.submit()">
+                            <option value="<?= PlayerAdvisorFilter::SORT_RARITY; ?>" <?php if ($playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_RARITY) { echo 'selected'; } ?>>Rarity (Meta)</option>
+                            <option value="<?= PlayerAdvisorFilter::SORT_IN_GAME_RARITY; ?>" <?php if ($playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_IN_GAME_RARITY) { echo 'selected'; } ?>>Rarity (In-Game)</option>
+                        </select>
+                    </form>
+
+                    <?= $platformFilterRenderer->render($platformFilterOptions, $platformFilterHiddenInputs); ?>
+                </div>
             </div>
         </div>
     </div>
@@ -68,7 +87,7 @@ require_once("header.php");
                                 <th scope="col" class="text-center">Game</th>
                                 <th scope="col">Trophy</th>
                                 <th scope="col" class="text-center">Platform</th>
-                                <th scope="col" class="text-center">Rarity</th>
+                                <th scope="col" class="text-center"><?= htmlspecialchars($rarityColumnLabel, ENT_QUOTES, 'UTF-8'); ?></th>
                                 <th scope="col" class="text-center">Type</th>
                             </tr>
                         </thead>
@@ -137,7 +156,10 @@ require_once("header.php");
                                         </td>
                                         <td class="text-center align-middle">
                                         <?php
-                                        $trophyRarity = $trophyRarityFormatter->format($trophy->getRarityPercent());
+                                        $rarityPercent = $playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_IN_GAME_RARITY
+                                            ? $trophy->getInGameRarityPercent()
+                                            : $trophy->getRarityPercent();
+                                        $trophyRarity = $trophyRarityFormatter->format($rarityPercent);
                                         echo $trophyRarity->renderSpan();
                                         ?>
                                         </td>


### PR DESCRIPTION
## Summary
- allow the Player Trophy Advisor to choose between meta and in-game rarity sorting and display the selected rarity in the table
- include in-game rarity values in advisor results and respect the chosen sort when querying
- preserve sort selection when toggling platform filters and add coverage for the new options

## Testing
- php tests/run.php
- php -l wwwroot/classes/PlayerAdvisorFilter.php
- php -l wwwroot/classes/PlayerAdvisorService.php
- php -l wwwroot/classes/PlayerAdvisableTrophy.php
- php -l wwwroot/classes/PlayerPlatformFilterRenderer.php
- php -l wwwroot/player_advisor.php
- php -l tests/PlayerAdvisorFilterTest.php
- php -l tests/PlayerAdvisorServiceTest.php
- php -l tests/PlayerPlatformFilterRendererTest.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923739222c4832f9cc76baf9b3dcff6)