### PR TITLE
Add in-game rarity sorting to games list

### DIFF
--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -8,6 +8,7 @@ class GameListFilter
     public const SORT_COMPLETION = 'completion';
     public const SORT_OWNERS = 'owners';
     public const SORT_RARITY = 'rarity';
+    public const SORT_IN_GAME_RARITY = 'in-game-rarity';
     public const SORT_SEARCH = 'search';
 
     public const PLATFORM_PC = 'pc';
@@ -320,7 +321,8 @@ class GameListFilter
             self::SORT_ADDED,
             self::SORT_COMPLETION,
             self::SORT_OWNERS,
-            self::SORT_RARITY => $sort,
+            self::SORT_RARITY,
+            self::SORT_IN_GAME_RARITY => $sort,
             self::SORT_SEARCH => ($search !== '' || $sortSpecified) ? self::SORT_SEARCH : self::SORT_ADDED,
             default => $search !== '' ? self::SORT_SEARCH : self::SORT_ADDED,
         };

--- a/wwwroot/classes/GameListItem.php
+++ b/wwwroot/classes/GameListItem.php
@@ -29,6 +29,8 @@ final class GameListItem
 
     private int $rarityPoints;
 
+    private int $inGameRarityPoints;
+
     private string $difficulty;
 
     private int $platinum;
@@ -49,6 +51,7 @@ final class GameListItem
         string $platformValue,
         int $owners,
         int $rarityPoints,
+        int $inGameRarityPoints,
         string $difficulty,
         int $platinum,
         int $gold,
@@ -63,6 +66,7 @@ final class GameListItem
         $this->platformValue = $platformValue;
         $this->owners = $owners;
         $this->rarityPoints = $rarityPoints;
+        $this->inGameRarityPoints = $inGameRarityPoints;
         $this->difficulty = $difficulty;
         $this->platinum = $platinum;
         $this->gold = $gold;
@@ -84,6 +88,7 @@ final class GameListItem
             (string) ($row['platform'] ?? ''),
             isset($row['owners']) ? (int) $row['owners'] : 0,
             isset($row['rarity_points']) ? (int) $row['rarity_points'] : 0,
+            isset($row['in_game_rarity_points']) ? (int) $row['in_game_rarity_points'] : 0,
             (string) ($row['difficulty'] ?? '0'),
             isset($row['platinum']) ? (int) $row['platinum'] : 0,
             isset($row['gold']) ? (int) $row['gold'] : 0,
@@ -190,6 +195,11 @@ final class GameListItem
     public function getRarityPoints(): int
     {
         return $this->rarityPoints;
+    }
+
+    public function getInGameRarityPoints(): int
+    {
+        return $this->inGameRarityPoints;
     }
 
     public function getProgress(): int

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -155,6 +155,7 @@ class GameListService
             'tt.silver',
             'tt.bronze',
             'ttm.rarity_points AS rarity_points',
+            'ttm.in_game_rarity_points AS in_game_rarity_points',
             'ttp.progress',
         ];
 
@@ -203,6 +204,9 @@ class GameListService
             case GameListFilter::SORT_RARITY:
                 $conditions[] = 'ttm.status = 0';
                 break;
+            case GameListFilter::SORT_IN_GAME_RARITY:
+                $conditions[] = 'ttm.status = 0';
+                break;
             default:
                 $conditions[] = 'ttm.status != 2';
                 break;
@@ -233,6 +237,7 @@ class GameListService
             GameListFilter::SORT_COMPLETION => 'ORDER BY difficulty DESC, owners DESC, `name`',
             GameListFilter::SORT_OWNERS => 'ORDER BY owners DESC, `name`',
             GameListFilter::SORT_RARITY => 'ORDER BY rarity_points DESC, owners DESC, `name`',
+            GameListFilter::SORT_IN_GAME_RARITY => 'ORDER BY in_game_rarity_points DESC, owners DESC, `name`',
             GameListFilter::SORT_SEARCH => 'ORDER BY exact_match DESC, prefix_match DESC, score DESC, `name`, tt.id',
             default => 'ORDER BY id DESC',
         };

--- a/wwwroot/games.php
+++ b/wwwroot/games.php
@@ -123,6 +123,7 @@ require_once("header.php");
                         <option value="completion"<?= ($filter->isSort(GameListFilter::SORT_COMPLETION) ? ' selected' : ''); ?>>Completion Rate</option>
                         <option value="owners"<?= ($filter->isSort(GameListFilter::SORT_OWNERS) ? ' selected' : ''); ?>>Owners</option>
                         <option value="rarity"<?= ($filter->isSort(GameListFilter::SORT_RARITY) ? ' selected' : ''); ?>>Rarity Points</option>
+                        <option value="in-game-rarity"<?= ($filter->isSort(GameListFilter::SORT_IN_GAME_RARITY) ? ' selected' : ''); ?>>Rarity (In-Game) Points</option>
                     </select>
                 </div>
             </form>
@@ -139,6 +140,7 @@ require_once("header.php");
             $platforms = $game->getPlatforms();
             $owners = $game->getOwners();
             $rarityPoints = $game->getRarityPoints();
+            $inGameRarityPoints = $game->getInGameRarityPoints();
             $difficulty = $game->getDifficulty();
             $statusBadge = $game->getStatusBadge();
             ?>
@@ -187,8 +189,10 @@ require_once("header.php");
                         <!-- rarity points / status -->
                         <div>
                             <?php
-                            if ($game->shouldShowRarityPoints()) {
+                            if ($game->shouldShowRarityPoints() && $filter->isSort(GameListFilter::SORT_RARITY)) {
                                 echo number_format($rarityPoints) . ' Rarity Points';
+                            } elseif ($game->shouldShowRarityPoints() && $filter->isSort(GameListFilter::SORT_IN_GAME_RARITY)) {
+                                echo number_format($inGameRarityPoints) . ' Rarity (In-Game) Points';
                             } elseif ($statusBadge !== null) {
                                 ?>
                                 <span class="<?= $statusBadge->getCssClass(); ?>" title="<?= $statusBadge->getTooltip(); ?>"><?= $statusBadge->getLabel(); ?></span>


### PR DESCRIPTION
## Summary
- add an in-game rarity points sort option to the games list filter
- load in-game rarity point totals for list items and expose them for rendering
- only render rarity point totals when the corresponding sort is active

## Testing
- php -l wwwroot/classes/GameListFilter.php
- php -l wwwroot/classes/GameListService.php
- php -l wwwroot/classes/GameListItem.php
- php -l wwwroot/games.php
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237b42d3fc832f88ab14ccd796cd6c)