### PR TITLE
Show trophy type icon behind earned dates

### DIFF
--- a/wwwroot/classes/Game/GameTrophyRow.php
+++ b/wwwroot/classes/Game/GameTrophyRow.php
@@ -13,6 +13,13 @@ final class GameTrophyRow
         'platinum' => '#667fb2',
     ];
 
+    private const TROPHY_TYPE_ICONS = [
+        'bronze' => '/img/trophy-bronze.svg',
+        'silver' => '/img/trophy-silver.svg',
+        'gold' => '/img/trophy-gold.svg',
+        'platinum' => '/img/trophy-platinum.svg',
+    ];
+
     private const UNOBTAINABLE_STATUS = 1;
     private const UNOBTAINABLE_TITLE = 'This trophy is unobtainable and not accounted for on any leaderboard.';
 
@@ -93,6 +100,11 @@ final class GameTrophyRow
     public function getType(): string
     {
         return $this->type;
+    }
+
+    public function getTypeIconPath(): string
+    {
+        return self::TROPHY_TYPE_ICONS[$this->type] ?? self::TROPHY_TYPE_ICONS['bronze'];
     }
 
     public function getName(): string

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -198,8 +198,19 @@ require_once("header.php");
                                     }
 
                                     $rowAttributes = $trophyRow->getRowAttributes($accountId);
-                                    $trophyColor = $trophyRow->getTypeColor();
                                     $trophyLink = $trophyRow->getTrophyLink(isset($player) ? (string) $player : null);
+                                    $trophyTypeIcon = $trophyRow->getTypeIconPath();
+
+                                    $earnedCellStyles = [];
+
+                                    if ($accountId !== null && $trophyRow->isEarned()) {
+                                        $earnedCellStyles[] = "background-image: url('" . $trophyTypeIcon . "')";
+                                        $earnedCellStyles[] = 'background-repeat: no-repeat';
+                                        $earnedCellStyles[] = 'background-position: center';
+                                        $earnedCellStyles[] = 'background-size: 3rem';
+                                    }
+
+                                    $earnedCellStyle = implode('; ', $earnedCellStyles);
                                     ?>
                                     <tr scope="row"<?= $rowAttributes; ?>>
                                         <td style="width: 5rem;">
@@ -241,7 +252,7 @@ require_once("header.php");
                                             </div>
                                         </td>
 
-                                        <td class="w-auto text-end align-middle">
+                                        <td class="w-auto text-end align-middle"<?= $earnedCellStyle !== '' ? ' style="' . htmlspecialchars($earnedCellStyle, ENT_QUOTES, 'UTF-8') . '"' : ''; ?>>
                                             <?php
                                             if ($accountId !== null && $trophyRow->isEarned()) {
                                                 $earnedElementId = $trophyRow->getEarnedElementId();
@@ -309,7 +320,7 @@ require_once("header.php");
                                             </div>
                                         </td>
 
-                                        <td style="width: 5rem; background: linear-gradient(to top right, var(--bs-table-bg), var(--bs-table-bg), var(--bs-table-bg), <?= $trophyColor; ?>);" class="text-center align-middle">
+                                        <td style="width: 5rem;" class="text-center align-middle">
                                             <?php
                                             $inGameRarity = $trophyRarityFormatter->formatInGame(
                                                 $trophyRow->getInGameRarityPercent(),


### PR DESCRIPTION
## Summary
- add a helper to expose trophy type icon paths for trophies
- display the earned-date cell over a trophy icon background and remove the rarity gradient background

## Testing
- php -l wwwroot/game.php
- php -l wwwroot/classes/Game/GameTrophyRow.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69238ffc1430832fa94b1d1c6eef4906)