### PR TITLE
Add progress update when pausing for missing game deletion check

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1410,6 +1410,10 @@ class ThirtyMinuteCronJob implements CronJobInterface
                         if ($shouldDeleteMissingGames) {
                             if (!($missingGameDeletionCheck[$onlineId] ?? false)) {
                                 $missingGameDeletionCheck[$onlineId] = true;
+                                $this->setWaitingScanProgress(
+                                    (int) $worker['id'],
+                                    'Waiting 5 minutes before retrying because of game deletion check.'
+                                );
                                 sleep(300);
                                 $recheck = '';
 


### PR DESCRIPTION
## Summary
- add a scan progress update before the five-minute pause triggered by the missing game deletion check

## Testing
- php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d7061f048832fa75eb1df1e87e088)