### PR TITLE
Refactor value objects for PHP 8.5

### DIFF
--- a/wwwroot/classes/PlayerQueueResponse.php
+++ b/wwwroot/classes/PlayerQueueResponse.php
@@ -2,21 +2,16 @@
 
 declare(strict_types=1);
 
-class PlayerQueueResponse implements \JsonSerializable
+readonly class PlayerQueueResponse implements \JsonSerializable
 {
     private const STATUS_QUEUED = 'queued';
     private const STATUS_COMPLETE = 'complete';
     private const STATUS_ERROR = 'error';
 
-    private string $status;
-
-    private string $message;
-
-    private function __construct(string $status, string $message)
-    {
-        $this->status = $status;
-        $this->message = $message;
-    }
+    private function __construct(
+        private string $status,
+        private string $message,
+    ) {}
 
     public static function queued(string $message): self
     {

--- a/wwwroot/classes/PlayerScanProgress.php
+++ b/wwwroot/classes/PlayerScanProgress.php
@@ -2,23 +2,14 @@
 
 declare(strict_types=1);
 
-final class PlayerScanProgress
+final readonly class PlayerScanProgress
 {
-    private ?int $current;
-
-    private ?int $total;
-
-    private ?string $title;
-
-    private ?string $npCommunicationId;
-
-    private function __construct(?int $current, ?int $total, ?string $title, ?string $npCommunicationId)
-    {
-        $this->current = $current;
-        $this->total = $total;
-        $this->title = $title;
-        $this->npCommunicationId = $npCommunicationId;
-    }
+    private function __construct(
+        private ?int $current,
+        private ?int $total,
+        private ?string $title,
+        private ?string $npCommunicationId,
+    ) {}
 
     /**
      * @param array<string, mixed>|null $data


### PR DESCRIPTION
## Summary
- convert PlayerQueueResponse into a readonly value object using constructor property promotion
- make PlayerScanProgress immutable with promoted readonly properties to better align with PHP 8.5 features

## Testing
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69309dd0b904832fa7572480bc00e0aa)