### PR TITLE
Refactor navigation and database classes for PHP 8.5

### DIFF
--- a/wwwroot/classes/NavigationSectionState.php
+++ b/wwwroot/classes/NavigationSectionState.php
@@ -2,16 +2,10 @@
 
 declare(strict_types=1);
 
-final class NavigationSectionState
+final readonly class NavigationSectionState
 {
-    private string $section;
-
-    private bool $active;
-
-    public function __construct(string $section, bool $active)
+    public function __construct(private string $section, private bool $active)
     {
-        $this->section = $section;
-        $this->active = $active;
     }
 
     public function getSection(): string

--- a/wwwroot/database.php
+++ b/wwwroot/database.php
@@ -2,22 +2,14 @@
 
 declare(strict_types=1);
 
-final class DatabaseConfig
+final readonly class DatabaseConfig
 {
-    private string $host;
-
-    private string $database;
-
-    private string $user;
-
-    private string $password;
-
-    public function __construct(string $host, string $database, string $user, string $password)
-    {
-        $this->host = $host;
-        $this->database = $database;
-        $this->user = $user;
-        $this->password = $password;
+    public function __construct(
+        private string $host,
+        private string $database,
+        private string $user,
+        private string $password,
+    ) {
     }
 
     public static function createDefault(): self
@@ -77,12 +69,12 @@ final class DatabaseConnectionException extends RuntimeException
 
 class Database extends PDO
 {
-    private DatabaseConfig $config;
+    private readonly DatabaseConfig $config;
 
     /**
      * @var array<int, mixed>
      */
-    private array $options;
+    private readonly array $options;
 
     public function __construct(?DatabaseConfig $config = null, array $options = [])
     {


### PR DESCRIPTION
## Summary
- modernize database configuration to use readonly, promoted properties for PHP 8.5
- refactor navigation state objects to immutable, promoted properties and static sanitization helpers

## Testing
- php -l wwwroot/database.php
- php -l wwwroot/classes/NavigationSectionState.php
- php -l wwwroot/classes/NavigationState.php
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a07a5df8832f945d04dee21450e7)