### PR TITLE
Adjust PDO test doubles for PHP 8.5 compatibility

### DIFF
--- a/tests/TrophyCalculatorTest.php
+++ b/tests/TrophyCalculatorTest.php
@@ -127,7 +127,6 @@ final class FakePDO extends PDO
     {
     }
 
-    #[\ReturnTypeWillChange]
     public function prepare(string $query, array $options = []): FakePDOStatement
     {
         return new FakePDOStatement($this, $query);
@@ -237,7 +236,7 @@ final class FakePDO extends PDO
     }
 }
 
-final class FakePDOStatement
+final class FakePDOStatement extends PDOStatement
 {
     private FakePDO $database;
 
@@ -255,9 +254,11 @@ final class FakePDOStatement
         $this->query = $query;
     }
 
-    public function bindValue(string $param, mixed $value, ?int $type = null): void
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
     {
         $this->parameters[$param] = $value;
+
+        return true;
     }
 
     /**
@@ -300,7 +301,7 @@ final class FakePDOStatement
     /**
      * @return array<mixed>
      */
-    public function fetchAll(int $mode = PDO::FETCH_DEFAULT): array
+    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args): array
     {
         if ($mode === PDO::FETCH_KEY_PAIR) {
             return $this->result;
@@ -309,7 +310,7 @@ final class FakePDOStatement
         return $this->result;
     }
 
-    public function fetch(int $mode = PDO::FETCH_DEFAULT): array|false
+    public function fetch(int $mode = PDO::FETCH_DEFAULT, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0): array|false
     {
         if ($this->result === []) {
             return false;

--- a/tests/TrophyMergeServiceCopyMergedTrophiesTest.php
+++ b/tests/TrophyMergeServiceCopyMergedTrophiesTest.php
@@ -72,8 +72,7 @@ final class RecordingPDO extends PDO
         $this->mergeRowCount = $mergeRowCount;
     }
 
-    #[\ReturnTypeWillChange]
-    public function prepare($statement, $options = []): object
+    public function prepare(string $statement, array $options = []): PDOStatement
     {
         $trimmed = trim((string) $statement);
         $normalized = preg_replace('/\s+/', ' ', $trimmed) ?? '';
@@ -109,7 +108,7 @@ final class RecordingPDO extends PDO
     }
 }
 
-final class RecordingCountStatement
+final class RecordingCountStatement extends PDOStatement
 {
     private int $count;
 
@@ -118,24 +117,25 @@ final class RecordingCountStatement
         $this->count = $count;
     }
 
-    public function bindValue($param, $value, $type = null): void
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
     {
         // No-op for testing purposes.
+
+        return true;
     }
 
-    public function execute(): bool
+    public function execute(?array $params = null): bool
     {
         return true;
     }
 
-    #[\ReturnTypeWillChange]
-    public function fetchColumn(): int
+    public function fetchColumn(int $column = 0): int
     {
         return $this->count;
     }
 }
 
-final class RecordingInsertStatement
+final class RecordingInsertStatement extends PDOStatement
 {
     private RecordingPDO $pdo;
     /** @var array<string, scalar|null> */
@@ -146,12 +146,14 @@ final class RecordingInsertStatement
         $this->pdo = $pdo;
     }
 
-    public function bindValue($param, $value, $type = null): void
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
     {
         $this->parameters[$param] = $value;
+
+        return true;
     }
 
-    public function execute(): bool
+    public function execute(?array $params = null): bool
     {
         $this->pdo->recordInsert($this->parameters);
 
@@ -159,7 +161,7 @@ final class RecordingInsertStatement
     }
 }
 
-final class RecordingUpdateStatement
+final class RecordingUpdateStatement extends PDOStatement
 {
     private RecordingPDO $pdo;
     /** @var array<string, scalar|null> */
@@ -170,12 +172,14 @@ final class RecordingUpdateStatement
         $this->pdo = $pdo;
     }
 
-    public function bindValue($param, $value, $type = null): void
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
     {
         $this->parameters[$param] = $value;
+
+        return true;
     }
 
-    public function execute(): bool
+    public function execute(?array $params = null): bool
     {
         $this->pdo->recordUpdate($this->parameters);
 


### PR DESCRIPTION
## Summary
- update PDO-based test doubles to use typed signatures compatible with PHP 8.5
- convert fake statement classes to extend PDOStatement and return proper boolean results
- remove ReturnTypeWillChange shims used for older PHP versions

## Testing
- php -l tests/TrophyCalculatorTest.php
- php -l tests/TrophyMergeServiceCopyMergedTrophiesTest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a07a5df8832f945d04dee21450e7)