### PR TITLE
Refactor admin value objects for PHP 8.5 immutability

### DIFF
--- a/wwwroot/classes/Admin/CommandExecutionResult.php
+++ b/wwwroot/classes/Admin/CommandExecutionResult.php
@@ -2,16 +2,12 @@
 
 declare(strict_types=1);
 
-final class CommandExecutionResult
+final readonly class CommandExecutionResult
 {
-    private int $exitCode;
-
-    private string $output;
-
-    public function __construct(int $exitCode, string $output)
-    {
-        $this->exitCode = $exitCode;
-        $this->output = $output;
+    public function __construct(
+        private int $exitCode,
+        private string $output
+    ) {
     }
 
     public function isSuccessful(): bool

--- a/wwwroot/classes/Admin/DeletePlayerRequestResult.php
+++ b/wwwroot/classes/Admin/DeletePlayerRequestResult.php
@@ -4,19 +4,13 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/DeletePlayerConfirmation.php';
 
-final class DeletePlayerRequestResult
+final readonly class DeletePlayerRequestResult
 {
-    private ?string $successMessage;
-
-    private ?string $errorMessage;
-
-    private ?DeletePlayerConfirmation $confirmation;
-
-    private function __construct(?string $successMessage, ?string $errorMessage, ?DeletePlayerConfirmation $confirmation)
-    {
-        $this->successMessage = $successMessage;
-        $this->errorMessage = $errorMessage;
-        $this->confirmation = $confirmation;
+    private function __construct(
+        private ?string $successMessage,
+        private ?string $errorMessage,
+        private ?DeletePlayerConfirmation $confirmation
+    ) {
     }
 
     public static function empty(): self

--- a/wwwroot/classes/Admin/GameRescanResult.php
+++ b/wwwroot/classes/Admin/GameRescanResult.php
@@ -2,10 +2,8 @@
 
 declare(strict_types=1);
 
-final class GameRescanResult
+final readonly class GameRescanResult
 {
-    private string $message;
-
     /**
      * @var array<int, array<string, mixed>>
      */
@@ -14,9 +12,10 @@ final class GameRescanResult
     /**
      * @param array<int, array<string, mixed>> $differences
      */
-    public function __construct(string $message, array $differences)
-    {
-        $this->message = $message;
+    public function __construct(
+        private string $message,
+        array $differences
+    ) {
         $this->differences = array_values($differences);
     }
 

--- a/wwwroot/classes/Admin/LogDeletionRequest.php
+++ b/wwwroot/classes/Admin/LogDeletionRequest.php
@@ -2,31 +2,21 @@
 
 declare(strict_types=1);
 
-final class LogDeletionRequest
+final readonly class LogDeletionRequest
 {
     private const ACTION_SINGLE = 'single';
     private const ACTION_BULK = 'bulk';
 
-    private ?string $action;
-
-    private ?int $singleDeletionId;
-
-    /**
-     * @var list<int>
-     */
-    private array $bulkDeletionIds;
-
-    private ?string $errorMessage;
-
     /**
      * @param list<int> $bulkDeletionIds
      */
-    private function __construct(?string $action, ?int $singleDeletionId, array $bulkDeletionIds, ?string $errorMessage)
-    {
-        $this->action = $action;
-        $this->singleDeletionId = $singleDeletionId;
-        $this->bulkDeletionIds = $bulkDeletionIds;
-        $this->errorMessage = $errorMessage;
+    private function __construct(
+        private ?string $action,
+        private ?int $singleDeletionId,
+        /** @var list<int> */
+        private array $bulkDeletionIds,
+        private ?string $errorMessage
+    ) {
     }
 
     /**

--- a/wwwroot/classes/Admin/LogPageResult.php
+++ b/wwwroot/classes/Admin/LogPageResult.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/LogEntry.php';
 
-final class LogPageResult
+final readonly class LogPageResult
 {
     /**
      * @var list<LogEntry>

--- a/wwwroot/classes/Admin/PsnPlayerLookupRequestResult.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupRequestResult.php
@@ -2,36 +2,18 @@
 
 declare(strict_types=1);
 
-final class PsnPlayerLookupRequestResult
+final readonly class PsnPlayerLookupRequestResult
 {
-    private string $normalizedOnlineId;
-
-    /**
-     * @var array<string, mixed>|null
-     */
-    private ?array $result;
-
-    private ?string $errorMessage;
-
-    private ?string $decodedNpId;
-
-    private ?string $npCountry;
-
     /**
      * @param array<string, mixed>|null $result
      */
     public function __construct(
-        string $normalizedOnlineId,
-        ?array $result,
-        ?string $errorMessage,
-        ?string $decodedNpId,
-        ?string $npCountry
+        private string $normalizedOnlineId,
+        private ?array $result,
+        private ?string $errorMessage,
+        private ?string $decodedNpId,
+        private ?string $npCountry
     ) {
-        $this->normalizedOnlineId = $normalizedOnlineId;
-        $this->result = $result;
-        $this->errorMessage = $errorMessage;
-        $this->decodedNpId = $decodedNpId;
-        $this->npCountry = $npCountry;
     }
 
     public function getNormalizedOnlineId(): string

--- a/wwwroot/classes/Admin/WorkerPageResult.php
+++ b/wwwroot/classes/Admin/WorkerPageResult.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/Worker.php';
 require_once __DIR__ . '/WorkerPageSortLink.php';
 
-final class WorkerPageResult
+final readonly class WorkerPageResult
 {
     /**
      * @var list<Worker>

--- a/wwwroot/classes/RouteResultResponder.php
+++ b/wwwroot/classes/RouteResultResponder.php
@@ -12,16 +12,12 @@ require_once __DIR__ . '/TemplateRenderer.php';
  * unit test and reuse response emitting logic while keeping the
  * {@see Application} class focused on routing concerns.
  */
-final class RouteResultResponder
+final readonly class RouteResultResponder
 {
-    private TemplateRenderer $templateRenderer;
-
-    private string $notFoundTemplate;
-
-    public function __construct(TemplateRenderer $templateRenderer, string $notFoundTemplate = '404.php')
-    {
-        $this->templateRenderer = $templateRenderer;
-        $this->notFoundTemplate = $notFoundTemplate;
+    public function __construct(
+        private TemplateRenderer $templateRenderer,
+        private string $notFoundTemplate = '404.php'
+    ) {
     }
 
     public function respond(RouteResult $routeResult): void


### PR DESCRIPTION
## Summary
- convert admin request/response value objects to readonly classes using constructor promotion for PHP 8.5 immutability
- update route responder dependencies to use promoted readonly properties

## Testing
- php -l wwwroot/classes/Admin/CommandExecutionResult.php wwwroot/classes/Admin/DeletePlayerRequestResult.php wwwroot/classes/Admin/GameRescanResult.php wwwroot/classes/Admin/LogDeletionRequest.php wwwroot/classes/Admin/LogPageResult.php wwwroot/classes/Admin/PsnPlayerLookupRequestResult.php wwwroot/classes/Admin/WorkerPageResult.php wwwroot/classes/RouteResultResponder.php
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a07a5df8832f945d04dee21450e7)