### PR TITLE
Refactor classes for PHP 8.5 readonly features

### DIFF
--- a/wwwroot/classes/ApplicationBootstrapper.php
+++ b/wwwroot/classes/ApplicationBootstrapper.php
@@ -6,13 +6,10 @@ require_once __DIR__ . '/ApplicationContainer.php';
 require_once __DIR__ . '/ApplicationRunner.php';
 require_once __DIR__ . '/MaintenanceResponder.php';
 
-final class ApplicationBootstrapper
+final readonly class ApplicationBootstrapper
 {
-    private ApplicationContainer $applicationContainer;
-
-    private function __construct(ApplicationContainer $applicationContainer)
+    private function __construct(private ApplicationContainer $applicationContainer)
     {
-        $this->applicationContainer = $applicationContainer;
     }
 
     public static function bootstrap(?ApplicationContainer $applicationContainer = null): self

--- a/wwwroot/classes/ApplicationRunner.php
+++ b/wwwroot/classes/ApplicationRunner.php
@@ -6,21 +6,15 @@ require_once __DIR__ . '/ApplicationContainer.php';
 require_once __DIR__ . '/MaintenanceMode.php';
 require_once __DIR__ . '/MaintenanceResponder.php';
 
-final class ApplicationRunner
+final readonly class ApplicationRunner
 {
-    private ApplicationContainer $applicationContainer;
-
-    private MaintenanceMode $maintenanceMode;
-
     private MaintenanceResponder $maintenanceResponder;
 
     public function __construct(
-        ApplicationContainer $applicationContainer,
-        MaintenanceMode $maintenanceMode,
+        private ApplicationContainer $applicationContainer,
+        private MaintenanceMode $maintenanceMode,
         ?MaintenanceResponder $maintenanceResponder = null
     ) {
-        $this->applicationContainer = $applicationContainer;
-        $this->maintenanceMode = $maintenanceMode;
         $this->maintenanceResponder = $maintenanceResponder ?? new MaintenanceResponder();
     }
 

--- a/wwwroot/classes/FooterViewModel.php
+++ b/wwwroot/classes/FooterViewModel.php
@@ -2,46 +2,19 @@
 
 declare(strict_types=1);
 
-final class FooterViewModel
+final readonly class FooterViewModel
 {
-    private int $startYear;
-
-    private int $currentYear;
-
-    private string $versionLabel;
-
-    private string $releaseUrl;
-
-    private string $changelogUrl;
-
-    private string $issuesUrl;
-
-    private string $creatorName;
-
-    private string $creatorProfileUrl;
-
-    private string $contributorsUrl;
-
     public function __construct(
-        int $startYear,
-        int $currentYear,
-        string $versionLabel,
-        string $releaseUrl,
-        string $changelogUrl,
-        string $issuesUrl,
-        string $creatorName,
-        string $creatorProfileUrl,
-        string $contributorsUrl
+        private int $startYear,
+        private int $currentYear,
+        private string $versionLabel,
+        private string $releaseUrl,
+        private string $changelogUrl,
+        private string $issuesUrl,
+        private string $creatorName,
+        private string $creatorProfileUrl,
+        private string $contributorsUrl
     ) {
-        $this->startYear = $startYear;
-        $this->currentYear = $currentYear;
-        $this->versionLabel = $versionLabel;
-        $this->releaseUrl = $releaseUrl;
-        $this->changelogUrl = $changelogUrl;
-        $this->issuesUrl = $issuesUrl;
-        $this->creatorName = $creatorName;
-        $this->creatorProfileUrl = $creatorProfileUrl;
-        $this->contributorsUrl = $contributorsUrl;
     }
 
     public static function createDefault(): self

--- a/wwwroot/classes/GameLeaderboardRow.php
+++ b/wwwroot/classes/GameLeaderboardRow.php
@@ -5,58 +5,22 @@ declare(strict_types=1);
 require_once __DIR__ . '/GamePlayerFilter.php';
 require_once __DIR__ . '/Utility.php';
 
-class GameLeaderboardRow
+readonly class GameLeaderboardRow
 {
-    private string $accountId;
-
-    private string $avatarUrl;
-
-    private string $countryCode;
-
-    private string $onlineId;
-
-    private int $trophyCountNpwr;
-
-    private int $trophyCountSony;
-
-    private int $bronzeCount;
-
-    private int $silverCount;
-
-    private int $goldCount;
-
-    private int $platinumCount;
-
-    private int $progress;
-
-    private string $lastKnownDate;
-
     private function __construct(
-        string $accountId,
-        string $avatarUrl,
-        string $countryCode,
-        string $onlineId,
-        int $trophyCountNpwr,
-        int $trophyCountSony,
-        int $bronzeCount,
-        int $silverCount,
-        int $goldCount,
-        int $platinumCount,
-        int $progress,
-        string $lastKnownDate
+        private string $accountId,
+        private string $avatarUrl,
+        private string $countryCode,
+        private string $onlineId,
+        private int $trophyCountNpwr,
+        private int $trophyCountSony,
+        private int $bronzeCount,
+        private int $silverCount,
+        private int $goldCount,
+        private int $platinumCount,
+        private int $progress,
+        private string $lastKnownDate
     ) {
-        $this->accountId = $accountId;
-        $this->avatarUrl = $avatarUrl;
-        $this->countryCode = $countryCode;
-        $this->onlineId = $onlineId;
-        $this->trophyCountNpwr = $trophyCountNpwr;
-        $this->trophyCountSony = $trophyCountSony;
-        $this->bronzeCount = $bronzeCount;
-        $this->silverCount = $silverCount;
-        $this->goldCount = $goldCount;
-        $this->platinumCount = $platinumCount;
-        $this->progress = $progress;
-        $this->lastKnownDate = $lastKnownDate;
     }
 
     /**


### PR DESCRIPTION
## Summary
- refactor key immutable classes to use readonly typing and constructor property promotion for PHP 8.5
- preserve existing APIs while reducing boilerplate across bootstrapper, runner, view model, and leaderboard row

## Testing
- php -l wwwroot/classes/FooterViewModel.php
- php -l wwwroot/classes/ApplicationBootstrapper.php
- php -l wwwroot/classes/ApplicationRunner.php
- php -l wwwroot/classes/GameLeaderboardRow.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a5988988832fa2464be027f0cda0)