### PR TITLE
Refactor status value objects for PHP 8.5

### DIFF
--- a/wwwroot/classes/PlayerScanStatus.php
+++ b/wwwroot/classes/PlayerScanStatus.php
@@ -2,13 +2,10 @@
 
 declare(strict_types=1);
 
-final class PlayerScanStatus
+readonly class PlayerScanStatus
 {
-    private ?PlayerScanProgress $progress;
-
-    public function __construct(?PlayerScanProgress $progress)
+    public function __construct(private ?PlayerScanProgress $progress)
     {
-        $this->progress = $progress;
     }
 
     public static function withProgress(?PlayerScanProgress $progress): self

--- a/wwwroot/classes/PlayerStatusNotice.php
+++ b/wwwroot/classes/PlayerStatusNotice.php
@@ -2,22 +2,17 @@
 
 declare(strict_types=1);
 
-final class PlayerStatusNotice
+readonly class PlayerStatusNotice
 {
     private const TYPE_FLAGGED = 'flagged';
     private const TYPE_PRIVATE = 'private';
     private const DISPUTE_BASE_URL = 'https://github.com/Ragowit/psn100/issues';
     private const PRIVATE_PROFILE_URL = 'https://www.playstation.com/en-us/support/account/privacy-settings-psn/';
 
-    private string $type;
-
-    private string $message;
-
-    private function __construct(string $type, string $message)
-    {
-        $this->type = $type;
-        $this->message = $message;
-    }
+    private function __construct(
+        private string $type,
+        private string $message,
+    ) {}
 
     public static function flagged(string $onlineId, ?string $accountId): self
     {


### PR DESCRIPTION
## Summary
- refactor PlayerStatusNotice to a readonly value object using constructor promotion
- mark PlayerScanStatus as readonly to embrace PHP 8.5 immutability defaults

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a5988988832fa2464be027f0cda0)