### PR TITLE
Refactor DTOs for PHP 8.5 readiness

### DIFF
--- a/wwwroot/classes/AboutPageScanSummary.php
+++ b/wwwroot/classes/AboutPageScanSummary.php
@@ -2,15 +2,10 @@
 
 declare(strict_types=1);
 
-class AboutPageScanSummary
+readonly class AboutPageScanSummary
 {
-    private int $scannedPlayers;
-    private int $newPlayers;
-
-    public function __construct(int $scannedPlayers, int $newPlayers)
+    public function __construct(private int $scannedPlayers, private int $newPlayers)
     {
-        $this->scannedPlayers = $scannedPlayers;
-        $this->newPlayers = $newPlayers;
     }
 
     public function getScannedPlayers(): int

--- a/wwwroot/classes/PlayerReportResult.php
+++ b/wwwroot/classes/PlayerReportResult.php
@@ -2,19 +2,10 @@
 
 declare(strict_types=1);
 
-class PlayerReportResult
+readonly class PlayerReportResult
 {
-    private bool $hasMessage;
-
-    private bool $success;
-
-    private string $message;
-
-    private function __construct(bool $hasMessage, bool $success, string $message)
+    private function __construct(private bool $hasMessage, private bool $success, private string $message)
     {
-        $this->hasMessage = $hasMessage;
-        $this->success = $success;
-        $this->message = $message;
     }
 
     public static function success(string $message): self

--- a/wwwroot/classes/RouteResult.php
+++ b/wwwroot/classes/RouteResult.php
@@ -2,24 +2,18 @@
 
 declare(strict_types=1);
 
-class RouteResult
+readonly class RouteResult
 {
-    private ?string $include;
-    private ?string $redirect;
-    private bool $notFound;
     /**
-     * @var array<string, mixed>
+     * @param array<string, mixed> $variables
      */
-    private array $variables;
-    private ?int $statusCode;
-
-    private function __construct(?string $include, ?string $redirect, bool $notFound, array $variables = [], ?int $statusCode = null)
-    {
-        $this->include = $include;
-        $this->redirect = $redirect;
-        $this->notFound = $notFound;
-        $this->variables = $variables;
-        $this->statusCode = $statusCode;
+    private function __construct(
+        private ?string $include,
+        private ?string $redirect,
+        private bool $notFound,
+        private array $variables = [],
+        private ?int $statusCode = null,
+    ) {
     }
 
     public static function include(string $file, array $variables = []): self

--- a/wwwroot/composer.json
+++ b/wwwroot/composer.json
@@ -1,4 +1,7 @@
 {
+    "require": {
+        "php": "^8.5"
+    },
     "config": {
         "platform": {
             "php": "8.5.0"


### PR DESCRIPTION
## Summary
- refactor simple DTOs into readonly classes using constructor property promotion
- require PHP 8.5 in composer configuration to match the new language features

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a8e95de4832f9ab68fb544bf35ec)