### PR TITLE
Refactor random game models for PHP 8.5

### DIFF
--- a/wwwroot/classes/PlayerRandomGame.php
+++ b/wwwroot/classes/PlayerRandomGame.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-class PlayerRandomGame
+final readonly class PlayerRandomGame
 {
     private int $id;
 
@@ -108,6 +108,9 @@ class PlayerRandomGame
         return $this->progress;
     }
 
+    /**
+     * @return list<string>
+     */
     public function getPlatforms(): array
     {
         if ($this->platform === '') {

--- a/wwwroot/classes/PlayerRandomGamesFilter.php
+++ b/wwwroot/classes/PlayerRandomGamesFilter.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-class PlayerRandomGamesFilter
+final readonly class PlayerRandomGamesFilter
 {
-    public const PLATFORM_PC = 'pc';
-    public const PLATFORM_PS3 = 'ps3';
-    public const PLATFORM_PS4 = 'ps4';
-    public const PLATFORM_PS5 = 'ps5';
-    public const PLATFORM_PSVITA = 'psvita';
-    public const PLATFORM_PSVR = 'psvr';
-    public const PLATFORM_PSVR2 = 'psvr2';
+    public const string PLATFORM_PC = 'pc';
+    public const string PLATFORM_PS3 = 'ps3';
+    public const string PLATFORM_PS4 = 'ps4';
+    public const string PLATFORM_PS5 = 'ps5';
+    public const string PLATFORM_PSVITA = 'psvita';
+    public const string PLATFORM_PSVR = 'psvr';
+    public const string PLATFORM_PSVR2 = 'psvr2';
 
     /**
      * @var array<string, bool>


### PR DESCRIPTION
## Summary
- mark the random game model and filter as readonly to leverage modern PHP semantics
- add typed platform constants to the filter for stricter typing on PHP 8.5
- document the platform list return type on the random game model

## Testing
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a8e95de4832f9ab68fb544bf35ec)