### PR TITLE
Refactor request DTOs for PHP 8.5

### DIFF
--- a/wwwroot/classes/PlayerQueueRequest.php
+++ b/wwwroot/classes/PlayerQueueRequest.php
@@ -2,17 +2,12 @@
 
 declare(strict_types=1);
 
-class PlayerQueueRequest
+readonly class PlayerQueueRequest
 {
-    private string $playerName;
-
-    private string $ipAddress;
-
-    private function __construct(string $playerName, string $ipAddress)
-    {
-        $this->playerName = $playerName;
-        $this->ipAddress = $ipAddress;
-    }
+    private function __construct(
+        private string $playerName,
+        private string $ipAddress,
+    ) {}
 
     public static function fromArrays(array $requestData, array $serverData): self
     {

--- a/wwwroot/classes/PlayerReportRequest.php
+++ b/wwwroot/classes/PlayerReportRequest.php
@@ -2,20 +2,13 @@
 
 declare(strict_types=1);
 
-final class PlayerReportRequest
+final readonly class PlayerReportRequest
 {
-    private string $explanation;
-
-    private bool $explanationSubmitted;
-
-    private string $ipAddress;
-
-    private function __construct(string $explanation, bool $explanationSubmitted, string $ipAddress)
-    {
-        $this->explanation = $explanation;
-        $this->explanationSubmitted = $explanationSubmitted;
-        $this->ipAddress = $ipAddress;
-    }
+    private function __construct(
+        private string $explanation,
+        private bool $explanationSubmitted,
+        private string $ipAddress,
+    ) {}
 
     /**
      * @param array<string, mixed> $queryParameters


### PR DESCRIPTION
## Summary
- promote PlayerQueueRequest and PlayerReportRequest to readonly classes using constructor property promotion
- leverage PHP 8.5 immutability improvements while retaining existing factory methods and behavior

## Testing
- php -l wwwroot/classes/PlayerQueueRequest.php
- php -l wwwroot/classes/PlayerReportRequest.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930af0d62e8832f9f7c074e28b18f50)