### PR TITLE
Refactor pagination item for PHP 8.5 immutability

### DIFF
--- a/wwwroot/classes/PaginationItem.php
+++ b/wwwroot/classes/PaginationItem.php
@@ -2,22 +2,15 @@
 
 declare(strict_types=1);
 
-final class PaginationItem
+final readonly class PaginationItem
 {
-    private ?int $page;
-
-    private string $label;
-
-    private bool $active = false;
-
-    private bool $disabled = false;
-
-    private ?string $ariaLabel = null;
-
-    private function __construct(?int $page, string $label)
-    {
-        $this->page = $page;
-        $this->label = $label;
+    private function __construct(
+        private ?int $page,
+        private string $label,
+        private bool $active = false,
+        private bool $disabled = false,
+        private ?string $ariaLabel = null,
+    ) {
     }
 
     public static function forPage(int $page, string $label): self
@@ -27,28 +20,40 @@ final class PaginationItem
 
     public static function ellipsis(): self
     {
-        return (new self(null, '...'))->markAsDisabled();
+        return new self(null, '...', disabled: true);
     }
 
     public function markAsActive(): self
     {
-        $this->active = true;
-
-        return $this;
+        return new self(
+            page: $this->page,
+            label: $this->label,
+            active: true,
+            disabled: $this->disabled,
+            ariaLabel: $this->ariaLabel,
+        );
     }
 
     public function markAsDisabled(): self
     {
-        $this->disabled = true;
-
-        return $this;
+        return new self(
+            page: $this->page,
+            label: $this->label,
+            active: $this->active,
+            disabled: true,
+            ariaLabel: $this->ariaLabel,
+        );
     }
 
     public function setAriaLabel(?string $ariaLabel): self
     {
-        $this->ariaLabel = $ariaLabel;
-
-        return $this;
+        return new self(
+            page: $this->page,
+            label: $this->label,
+            active: $this->active,
+            disabled: $this->disabled,
+            ariaLabel: $ariaLabel,
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- refactor PaginationItem into a readonly value object using promoted constructor arguments
- return new instances from builder methods to preserve immutability while preserving the public API

## Testing
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930af0d62e8832f9f7c074e28b18f50)