### PR TITLE
Refactor navigation state to typed sections

### DIFF
--- a/tests/NavigationSectionStateTest.php
+++ b/tests/NavigationSectionStateTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../wwwroot/classes/NavigationSection.php';
 require_once __DIR__ . '/../wwwroot/classes/NavigationSectionState.php';
 require_once __DIR__ . '/TestCase.php';
 
@@ -9,16 +10,16 @@ final class NavigationSectionStateTest extends TestCase
 {
     public function testActiveSectionReportsCssClassAndState(): void
     {
-        $state = new NavigationSectionState('leaderboard', true);
+        $state = new NavigationSectionState(NavigationSection::Leaderboard, true);
 
-        $this->assertSame('leaderboard', $state->getSection());
+        $this->assertSame(NavigationSection::Leaderboard, $state->getSection());
         $this->assertTrue($state->isActive());
         $this->assertSame(' active', $state->getCssClass());
     }
 
     public function testInactiveSectionHasEmptyCssClass(): void
     {
-        $state = new NavigationSectionState('home', false);
+        $state = new NavigationSectionState(NavigationSection::Home, false);
 
         $this->assertFalse($state->isActive());
         $this->assertSame('', $state->getCssClass());

--- a/wwwroot/classes/NavigationMenu.php
+++ b/wwwroot/classes/NavigationMenu.php
@@ -2,32 +2,27 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/NavigationSection.php';
 require_once __DIR__ . '/NavigationState.php';
 
 final class NavigationMenu
 {
     /**
-     * @var NavigationMenuItem[]
-     */
-    private array $items;
-
-    /**
      * @param NavigationMenuItem[] $items
      */
-    private function __construct(array $items)
+    private function __construct(private readonly array $items)
     {
-        $this->items = $items;
     }
 
     public static function createDefault(NavigationState $state): self
     {
         $items = [
-            new NavigationMenuItem('Home', '/', $state->isSectionActive('home')),
-            new NavigationMenuItem('Leaderboards', '/leaderboard/trophy', $state->isSectionActive('leaderboard')),
-            new NavigationMenuItem('Games', '/game', $state->isSectionActive('game')),
-            new NavigationMenuItem('Trophies', '/trophy', $state->isSectionActive('trophy')),
-            new NavigationMenuItem('Avatars', '/avatar', $state->isSectionActive('avatar')),
-            new NavigationMenuItem('About', '/about', $state->isSectionActive('about')),
+            new NavigationMenuItem('Home', '/', $state->isSectionActive(NavigationSection::Home)),
+            new NavigationMenuItem('Leaderboards', '/leaderboard/trophy', $state->isSectionActive(NavigationSection::Leaderboard)),
+            new NavigationMenuItem('Games', '/game', $state->isSectionActive(NavigationSection::Game)),
+            new NavigationMenuItem('Trophies', '/trophy', $state->isSectionActive(NavigationSection::Trophy)),
+            new NavigationMenuItem('Avatars', '/avatar', $state->isSectionActive(NavigationSection::Avatar)),
+            new NavigationMenuItem('About', '/about', $state->isSectionActive(NavigationSection::About)),
         ];
 
         return new self($items);
@@ -42,19 +37,10 @@ final class NavigationMenu
     }
 }
 
-final class NavigationMenuItem
+final readonly class NavigationMenuItem
 {
-    private string $label;
-
-    private string $href;
-
-    private bool $active;
-
-    public function __construct(string $label, string $href, bool $active)
+    public function __construct(private string $label, private string $href, private bool $active)
     {
-        $this->label = $label;
-        $this->href = $href;
-        $this->active = $active;
     }
 
     public function getLabel(): string

--- a/wwwroot/classes/NavigationSection.php
+++ b/wwwroot/classes/NavigationSection.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+enum NavigationSection: string
+{
+    case Home = 'home';
+    case Leaderboard = 'leaderboard';
+    case Game = 'game';
+    case Trophy = 'trophy';
+    case Avatar = 'avatar';
+    case About = 'about';
+
+    public static function fromName(string $section): ?self
+    {
+        return self::tryFrom(strtolower($section));
+    }
+}

--- a/wwwroot/classes/NavigationSectionState.php
+++ b/wwwroot/classes/NavigationSectionState.php
@@ -2,13 +2,15 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/NavigationSection.php';
+
 final readonly class NavigationSectionState
 {
-    public function __construct(private string $section, private bool $active)
+    public function __construct(private NavigationSection $section, private bool $active)
     {
     }
 
-    public function getSection(): string
+    public function getSection(): NavigationSection
     {
         return $this->section;
     }


### PR DESCRIPTION
## Summary
- introduce a `NavigationSection` enum to represent navigation entries
- refactor navigation state and menu classes to use typed, readonly properties and enum values
- update navigation tests to cover the enum-based sections

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930af0d62e8832f9f7c074e28b18f50)