### PR TITLE
Refactor changelog types for PHP 8.5

### DIFF
--- a/wwwroot/classes/ChangelogEntry.php
+++ b/wwwroot/classes/ChangelogEntry.php
@@ -2,27 +2,31 @@
 
 declare(strict_types=1);
 
+enum ChangelogEntryType: string
+{
+    case GAME_CLONE = 'GAME_CLONE';
+    case GAME_COPY = 'GAME_COPY';
+    case GAME_DELETE = 'GAME_DELETE';
+    case GAME_DELISTED = 'GAME_DELISTED';
+    case GAME_DELISTED_AND_OBSOLETE = 'GAME_DELISTED_AND_OBSOLETE';
+    case GAME_HISTORY_SNAPSHOT = 'GAME_HISTORY_SNAPSHOT';
+    case GAME_MERGE = 'GAME_MERGE';
+    case GAME_NORMAL = 'GAME_NORMAL';
+    case GAME_OBSOLETE = 'GAME_OBSOLETE';
+    case GAME_OBTAINABLE = 'GAME_OBTAINABLE';
+    case GAME_RESCAN = 'GAME_RESCAN';
+    case GAME_RESET = 'GAME_RESET';
+    case GAME_UNOBTAINABLE = 'GAME_UNOBTAINABLE';
+    case GAME_UPDATE = 'GAME_UPDATE';
+    case GAME_VERSION = 'GAME_VERSION';
+    case UNKNOWN = 'UNKNOWN';
+}
 
 class ChangelogEntry
 {
-    public const TYPE_GAME_CLONE = 'GAME_CLONE';
-    public const TYPE_GAME_COPY = 'GAME_COPY';
-    public const TYPE_GAME_DELETE = 'GAME_DELETE';
-    public const TYPE_GAME_DELISTED = 'GAME_DELISTED';
-    public const TYPE_GAME_DELISTED_AND_OBSOLETE = 'GAME_DELISTED_AND_OBSOLETE';
-    public const TYPE_GAME_HISTORY_SNAPSHOT = 'GAME_HISTORY_SNAPSHOT';
-    public const TYPE_GAME_MERGE = 'GAME_MERGE';
-    public const TYPE_GAME_NORMAL = 'GAME_NORMAL';
-    public const TYPE_GAME_OBSOLETE = 'GAME_OBSOLETE';
-    public const TYPE_GAME_OBTAINABLE = 'GAME_OBTAINABLE';
-    public const TYPE_GAME_RESCAN = 'GAME_RESCAN';
-    public const TYPE_GAME_RESET = 'GAME_RESET';
-    public const TYPE_GAME_UNOBTAINABLE = 'GAME_UNOBTAINABLE';
-    public const TYPE_GAME_UPDATE = 'GAME_UPDATE';
-    public const TYPE_GAME_VERSION = 'GAME_VERSION';
-
     private DateTimeImmutable $time;
-    private string $changeType;
+    private ChangelogEntryType $changeType;
+    private string $changeTypeValue;
     private ?int $param1Id;
     private ?string $param1Name;
     /**
@@ -57,7 +61,8 @@ class ChangelogEntry
         ?string $extra
     ) {
         $this->time = $time;
-        $this->changeType = $changeType;
+        $this->changeTypeValue = $changeType;
+        $this->changeType = self::normalizeChangeType($changeType);
         $this->param1Id = $param1Id;
         $this->param1Name = $param1Name;
         $this->param1Platforms = $param1Platforms;
@@ -98,6 +103,11 @@ class ChangelogEntry
         }
     }
 
+    private static function normalizeChangeType(string $changeType): ChangelogEntryType
+    {
+        return ChangelogEntryType::tryFrom($changeType) ?? ChangelogEntryType::UNKNOWN;
+    }
+
     /**
      * @return array<int, string>
      */
@@ -121,9 +131,14 @@ class ChangelogEntry
         return $this->time;
     }
 
-    public function getChangeType(): string
+    public function getChangeType(): ChangelogEntryType
     {
         return $this->changeType;
+    }
+
+    public function getChangeTypeValue(): string
+    {
+        return $this->changeTypeValue;
     }
 
     public function getParam1Id(): ?int

--- a/wwwroot/classes/ChangelogEntryPresenter.php
+++ b/wwwroot/classes/ChangelogEntryPresenter.php
@@ -43,80 +43,80 @@ class ChangelogEntryPresenter
         $extra = $this->escape($this->entry->getExtra());
 
         switch ($this->entry->getChangeType()) {
-            case ChangelogEntry::TYPE_GAME_CLONE:
+            case ChangelogEntryType::GAME_CLONE:
                 return sprintf(
                     '%s was cloned: %s',
                     $this->formatGameReference($param1Link, '', $param1PlatformBadges),
                     $this->formatGameReference($param2Link, '', $param2PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_COPY:
+            case ChangelogEntryType::GAME_COPY:
                 return sprintf(
                     'Copied trophy data from %s into %s.',
                     $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges),
                     $this->formatGameReference($param2Link, '', $param2PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_DELETE:
+            case ChangelogEntryType::GAME_DELETE:
                 return sprintf(
                     "The merged game entry for '%s' have been deleted.",
                     $extra
                 );
-            case ChangelogEntry::TYPE_GAME_DELISTED:
+            case ChangelogEntryType::GAME_DELISTED:
                 return sprintf(
                     '%s status was set to delisted.',
                     $this->formatGameReference($param1Link, '', $param1PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_DELISTED_AND_OBSOLETE:
+            case ChangelogEntryType::GAME_DELISTED_AND_OBSOLETE:
                 return sprintf(
                     '%s status was set to delisted &amp; obsolete.',
                     $this->formatGameReference($param1Link, '', $param1PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_HISTORY_SNAPSHOT:
+            case ChangelogEntryType::GAME_HISTORY_SNAPSHOT:
                 return sprintf(
                     'A new trophy history snapshot was recorded for %s.',
                     $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_MERGE:
+            case ChangelogEntryType::GAME_MERGE:
                 return sprintf(
                     '%s was merged into %s',
                     $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges),
                     $this->formatGameReference($param2Link, '', $param2PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_NORMAL:
+            case ChangelogEntryType::GAME_NORMAL:
                 return sprintf(
                     '%s status was set to normal.',
                     $this->formatGameReference($param1Link, '', $param1PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_OBSOLETE:
+            case ChangelogEntryType::GAME_OBSOLETE:
                 return sprintf(
                     '%s status was set to obsolete.',
                     $this->formatGameReference($param1Link, '', $param1PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_OBTAINABLE:
+            case ChangelogEntryType::GAME_OBTAINABLE:
                 return sprintf(
                     'Trophies have been tagged as obtainable for %s.',
                     $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_RESCAN:
+            case ChangelogEntryType::GAME_RESCAN:
                 return sprintf(
                     'The game %s have been rescanned for updated/new trophy data and game details.',
                     $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_RESET:
+            case ChangelogEntryType::GAME_RESET:
                 return sprintf(
                     'Merged trophies have been reset for %s.',
                     $this->formatGameReference($param1Link, '', $param1PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_UNOBTAINABLE:
+            case ChangelogEntryType::GAME_UNOBTAINABLE:
                 return sprintf(
                     'Trophies have been tagged as unobtainable for %s.',
                     $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_UPDATE:
+            case ChangelogEntryType::GAME_UPDATE:
                 return sprintf(
                     '%s was updated.',
                     $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
                 );
-            case ChangelogEntry::TYPE_GAME_VERSION:
+            case ChangelogEntryType::GAME_VERSION:
                 return sprintf(
                     '%s has a new version.',
                     $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
@@ -124,7 +124,7 @@ class ChangelogEntryPresenter
             default:
                 return sprintf(
                     'Unknown type: %s',
-                    $this->escape($this->entry->getChangeType())
+                    $this->escape($this->entry->getChangeTypeValue())
                 );
         }
     }


### PR DESCRIPTION
## Summary
- migrate changelog change types to a PHP 8.5 enum while keeping the original value for unknown entries
- update changelog presenter to switch on the enum and preserve fallback messaging

## Testing
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930af0d62e8832f9f7c074e28b18f50)