### PR TITLE
Modernize homepage models for PHP 8.5

### DIFF
--- a/wwwroot/classes/Homepage/HomepageDlc.php
+++ b/wwwroot/classes/Homepage/HomepageDlc.php
@@ -2,35 +2,20 @@
 
 declare(strict_types=1);
 
-class HomepageDlc extends HomepageTitle
+readonly class HomepageDlc extends HomepageTitle
 {
-    private string $groupId;
-
-    private string $groupName;
-
-    private int $gold;
-
-    private int $silver;
-
-    private int $bronze;
-
     private function __construct(
         int $id,
         string $gameName,
-        string $groupId,
-        string $groupName,
+        private string $groupId,
+        private string $groupName,
         string $iconUrl,
         string $platform,
-        int $gold,
-        int $silver,
-        int $bronze
+        private int $gold,
+        private int $silver,
+        private int $bronze,
     ) {
         parent::__construct($id, $gameName, $iconUrl, $platform, 'group');
-        $this->groupId = $groupId;
-        $this->groupName = $groupName;
-        $this->gold = $gold;
-        $this->silver = $silver;
-        $this->bronze = $bronze;
     }
 
     /**

--- a/wwwroot/classes/Homepage/HomepageItem.php
+++ b/wwwroot/classes/Homepage/HomepageItem.php
@@ -2,21 +2,18 @@
 
 declare(strict_types=1);
 
-abstract class HomepageItem
+abstract readonly class HomepageItem
 {
     private const MISSING_PS5_ICON = '/img/missing-ps5-game-and-trophy.png';
     private const MISSING_PS4_ICON = '/img/missing-ps4-game.png';
 
-    private string $iconUrl;
-
-    private string $platform;
-
     private string $iconDirectory;
 
-    protected function __construct(string $iconUrl, string $platform, string $iconDirectory)
-    {
-        $this->iconUrl = $iconUrl;
-        $this->platform = $platform;
+    protected function __construct(
+        private string $iconUrl,
+        private string $platform,
+        string $iconDirectory,
+    ) {
         $this->iconDirectory = trim($iconDirectory, '/');
     }
 

--- a/wwwroot/classes/Homepage/HomepageNewGame.php
+++ b/wwwroot/classes/Homepage/HomepageNewGame.php
@@ -2,31 +2,19 @@
 
 declare(strict_types=1);
 
-class HomepageNewGame extends HomepageTitle
+readonly class HomepageNewGame extends HomepageTitle
 {
-    private int $platinum;
-
-    private int $gold;
-
-    private int $silver;
-
-    private int $bronze;
-
     private function __construct(
         int $id,
         string $name,
         string $iconUrl,
         string $platform,
-        int $platinum,
-        int $gold,
-        int $silver,
-        int $bronze
+        private int $platinum,
+        private int $gold,
+        private int $silver,
+        private int $bronze,
     ) {
         parent::__construct($id, $name, $iconUrl, $platform, 'title');
-        $this->platinum = $platinum;
-        $this->gold = $gold;
-        $this->silver = $silver;
-        $this->bronze = $bronze;
     }
 
     /**

--- a/wwwroot/classes/Homepage/HomepagePopularGame.php
+++ b/wwwroot/classes/Homepage/HomepagePopularGame.php
@@ -2,14 +2,16 @@
 
 declare(strict_types=1);
 
-class HomepagePopularGame extends HomepageTitle
+readonly class HomepagePopularGame extends HomepageTitle
 {
-    private int $recentPlayers;
-
-    private function __construct(int $id, string $name, string $iconUrl, string $platform, int $recentPlayers)
-    {
+    private function __construct(
+        int $id,
+        string $name,
+        string $iconUrl,
+        string $platform,
+        private int $recentPlayers,
+    ) {
         parent::__construct($id, $name, $iconUrl, $platform, 'title');
-        $this->recentPlayers = $recentPlayers;
     }
 
     /**

--- a/wwwroot/classes/Homepage/HomepageTitle.php
+++ b/wwwroot/classes/Homepage/HomepageTitle.php
@@ -2,17 +2,16 @@
 
 declare(strict_types=1);
 
-class HomepageTitle extends HomepageItem
+readonly class HomepageTitle extends HomepageItem
 {
-    private int $id;
-
-    private string $name;
-
-    protected function __construct(int $id, string $name, string $iconUrl, string $platform, string $iconDirectory)
-    {
+    protected function __construct(
+        private int $id,
+        private string $name,
+        string $iconUrl,
+        string $platform,
+        string $iconDirectory,
+    ) {
         parent::__construct($iconUrl, $platform, $iconDirectory);
-        $this->id = $id;
-        $this->name = $name;
     }
 
     public function getId(): int


### PR DESCRIPTION
## Summary
- refactor homepage item classes to readonly variants compatible with PHP 8.5 features
- simplify constructors with promoted properties while keeping existing platform and icon handling

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939fe0b661c832fb6021d1954769501)