### PR TITLE
Refactor to PHP 8.5 patterns

### DIFF
--- a/wwwroot/classes/Application.php
+++ b/wwwroot/classes/Application.php
@@ -9,21 +9,15 @@ require_once __DIR__ . '/RouteResultResponder.php';
 
 class Application
 {
-    private Router $router;
-
-    private HttpRequest $request;
-
     private RouteResultResponder $routeResultResponder;
 
     public function __construct(
-        Router $router,
-        HttpRequest $request,
+        private Router $router,
+        private HttpRequest $request,
         TemplateRenderer $templateRenderer,
         string $notFoundTemplate = '404.php',
         ?RouteResultResponder $routeResultResponder = null
     ) {
-        $this->router = $router;
-        $this->request = $request;
         $this->routeResultResponder = $routeResultResponder ?? new RouteResultResponder(
             $templateRenderer,
             $notFoundTemplate

--- a/wwwroot/classes/ApplicationContainer.php
+++ b/wwwroot/classes/ApplicationContainer.php
@@ -10,11 +10,11 @@ require_once __DIR__ . '/Application.php';
 
 class ApplicationContainer
 {
-    private Database $database;
+    private readonly Database $database;
 
-    private Utility $utility;
+    private readonly Utility $utility;
 
-    private PaginationRenderer $paginationRenderer;
+    private readonly PaginationRenderer $paginationRenderer;
 
     private ?GameRepository $gameRepository = null;
 

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -32,39 +32,22 @@ class GameListFilter
         self::PLATFORM_PSVR2,
     ];
 
-    private ?string $player;
-    private string $sort;
-    private bool $sortSpecified;
-    private string $search;
-    private int $page;
-    private bool $uncompletedOnly;
-    /**
-     * @var array<string, bool>
-     */
-    private array $platformFilters;
-    /**
-     * @var array<string, string>
-     */
-    private array $originalParameters;
-
     private function __construct(
-        ?string $player,
-        string $sort,
-        bool $sortSpecified,
-        string $search,
-        int $page,
-        bool $uncompletedOnly,
-        array $platformFilters,
-        array $originalParameters
+        private ?string $player,
+        private string $sort,
+        private bool $sortSpecified,
+        private string $search,
+        private int $page,
+        private bool $uncompletedOnly,
+        /**
+         * @var array<string, bool>
+         */
+        private array $platformFilters,
+        /**
+         * @var array<string, string>
+         */
+        private array $originalParameters
     ) {
-        $this->player = $player;
-        $this->sort = $sort;
-        $this->sortSpecified = $sortSpecified;
-        $this->search = $search;
-        $this->page = $page;
-        $this->uncompletedOnly = $uncompletedOnly;
-        $this->platformFilters = $platformFilters;
-        $this->originalParameters = $originalParameters;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adopt constructor property promotion in the application layer to align with PHP 8.5 conventions
- Make application container dependencies readonly while preserving lazy-loaded repositories

## Testing
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939fe0b661c832fb6021d1954769501)