### PR TITLE
Refactor player queue status for PHP 8.5

### DIFF
--- a/tests/PlayerQueueResponseTest.php
+++ b/tests/PlayerQueueResponseTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponse.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerQueueStatus.php';
 
 final class PlayerQueueResponseTest extends TestCase
 {
@@ -11,6 +12,7 @@ final class PlayerQueueResponseTest extends TestCase
         $response = PlayerQueueResponse::queued('Queued for processing');
 
         $this->assertSame('queued', $response->getStatus());
+        $this->assertSame(PlayerQueueStatus::QUEUED, $response->getStatusEnum());
         $this->assertSame('Queued for processing', $response->getMessage());
         $this->assertTrue($response->shouldPoll());
         $this->assertSame(
@@ -29,6 +31,7 @@ final class PlayerQueueResponseTest extends TestCase
         $response = PlayerQueueResponse::complete('Processing complete');
 
         $this->assertSame('complete', $response->getStatus());
+        $this->assertSame(PlayerQueueStatus::COMPLETE, $response->getStatusEnum());
         $this->assertSame('Processing complete', $response->getMessage());
         $this->assertFalse($response->shouldPoll());
         $this->assertSame(
@@ -47,6 +50,7 @@ final class PlayerQueueResponseTest extends TestCase
         $response = PlayerQueueResponse::error('An error occurred');
 
         $this->assertSame('error', $response->getStatus());
+        $this->assertSame(PlayerQueueStatus::ERROR, $response->getStatusEnum());
         $this->assertSame('An error occurred', $response->getMessage());
         $this->assertFalse($response->shouldPoll());
         $this->assertSame(

--- a/wwwroot/classes/PlayerQueueResponse.php
+++ b/wwwroot/classes/PlayerQueueResponse.php
@@ -2,35 +2,38 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerQueueStatus.php';
+
 readonly class PlayerQueueResponse implements \JsonSerializable
 {
-    private const STATUS_QUEUED = 'queued';
-    private const STATUS_COMPLETE = 'complete';
-    private const STATUS_ERROR = 'error';
-
     private function __construct(
-        private string $status,
+        private PlayerQueueStatus $status,
         private string $message,
     ) {}
 
     public static function queued(string $message): self
     {
-        return new self(self::STATUS_QUEUED, $message);
+        return new self(PlayerQueueStatus::QUEUED, $message);
     }
 
     public static function complete(string $message): self
     {
-        return new self(self::STATUS_COMPLETE, $message);
+        return new self(PlayerQueueStatus::COMPLETE, $message);
     }
 
     public static function error(string $message): self
     {
-        return new self(self::STATUS_ERROR, $message);
+        return new self(PlayerQueueStatus::ERROR, $message);
+    }
+
+    public function getStatusEnum(): PlayerQueueStatus
+    {
+        return $this->status;
     }
 
     public function getStatus(): string
     {
-        return $this->status;
+        return $this->status->value;
     }
 
     public function getMessage(): string
@@ -40,7 +43,7 @@ readonly class PlayerQueueResponse implements \JsonSerializable
 
     public function shouldPoll(): bool
     {
-        return $this->status === self::STATUS_QUEUED;
+        return $this->status === PlayerQueueStatus::QUEUED;
     }
 
     /**

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -9,9 +9,9 @@ require_once __DIR__ . '/PlayerScanProgress.php';
 
 final class PlayerQueueResponseFactory
 {
-    private const EMPTY_NAME_MESSAGE = "PSN name can't be empty.";
+    private const string EMPTY_NAME_MESSAGE = "PSN name can't be empty.";
 
-    private const INVALID_NAME_MESSAGE = "PSN name must contain between three and 16 characters, and can consist of letters, numbers, hyphens (-) and underscores (_).";
+    private const string INVALID_NAME_MESSAGE = "PSN name must contain between three and 16 characters, and can consist of letters, numbers, hyphens (-) and underscores (_).";
 
     private PlayerQueueService $service;
 

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -7,8 +7,8 @@ require_once __DIR__ . '/PlayerScanStatus.php';
 
 class PlayerQueueService
 {
-    public const MAX_QUEUE_SUBMISSIONS_PER_IP = 10;
-    public const CHEATER_STATUS = 1;
+    public const int MAX_QUEUE_SUBMISSIONS_PER_IP = 10;
+    public const int CHEATER_STATUS = 1;
 
     private PDO $database;
 

--- a/wwwroot/classes/PlayerQueueStatus.php
+++ b/wwwroot/classes/PlayerQueueStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerQueueStatus: string
+{
+    case QUEUED = 'queued';
+    case COMPLETE = 'complete';
+    case ERROR = 'error';
+}


### PR DESCRIPTION
## Summary
- introduce a PHP 8.5 enum to represent player queue statuses and expose a typed accessor on responses
- tighten player queue constants with typed class constants to align with modern PHP
- extend queue response tests to cover the new enum-backed status handling

## Testing
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939fe0b661c832fb6021d1954769501)