### PR TITLE
Add override attributes for PHP 8.5

### DIFF
--- a/tests/AboutPageContextTest.php
+++ b/tests/AboutPageContextTest.php
@@ -26,11 +26,13 @@ final class AboutPageDataProviderStub implements AboutPageDataProviderInterface
         $this->players = $players;
     }
 
+    #[\Override]
     public function getScanSummary(): AboutPageScanSummary
     {
         return $this->summary;
     }
 
+    #[\Override]
     public function getScanLogPlayers(int $limit): array
     {
         return array_slice($this->players, 0, $limit);

--- a/tests/AdminWorkerPageTest.php
+++ b/tests/AdminWorkerPageTest.php
@@ -108,6 +108,7 @@ final class FakeCommandExecutor implements CommandExecutorInterface
         $this->result = $result;
     }
 
+    #[\Override]
     public function run(array $command): CommandExecutionResult
     {
         return $this->result;

--- a/tests/AdminWorkerServiceTest.php
+++ b/tests/AdminWorkerServiceTest.php
@@ -108,6 +108,7 @@ SQL
                 $this->result = $result;
             }
 
+            #[\Override]
             public function run(array $command): CommandExecutionResult
             {
                 $this->commands[] = $command;
@@ -141,6 +142,7 @@ SQL
                 $this->result = $result;
             }
 
+            #[\Override]
             public function run(array $command): CommandExecutionResult
             {
                 $this->commands[] = $command;

--- a/tests/ImageHashCalculatorTest.php
+++ b/tests/ImageHashCalculatorTest.php
@@ -118,11 +118,13 @@ final class FakeImageProcessor implements ImageProcessorInterface
         }
     }
 
+    #[\Override]
     public function isSupported(): bool
     {
         return $this->supported;
     }
 
+    #[\Override]
     public function createImageFromString(string $contents): mixed
     {
         if (!$this->createSucceeds) {
@@ -132,36 +134,43 @@ final class FakeImageProcessor implements ImageProcessorInterface
         return $this->imageHandle;
     }
 
+    #[\Override]
     public function destroyImage(mixed $image): void
     {
         // Nothing to clean up in the fake processor.
     }
 
+    #[\Override]
     public function getWidth(mixed $image): int
     {
         return $this->width;
     }
 
+    #[\Override]
     public function getHeight(mixed $image): int
     {
         return $this->height;
     }
 
+    #[\Override]
     public function isTrueColor(mixed $image): bool
     {
         return $this->trueColor;
     }
 
+    #[\Override]
     public function convertPaletteToTrueColor(mixed $image): void
     {
         $this->trueColor = true;
     }
 
+    #[\Override]
     public function getColorAt(mixed $image, int $x, int $y): int
     {
         return $y * max(1, $this->width) + $x;
     }
 
+    #[\Override]
     public function getColorComponents(mixed $image, int $color): array
     {
         if ($this->pixels === []) {

--- a/tests/LeaderboardPageContextTest.php
+++ b/tests/LeaderboardPageContextTest.php
@@ -229,6 +229,7 @@ final class FakePlayerLeaderboardDataProvider implements PlayerLeaderboardDataPr
         $this->pageSize = $pageSize;
     }
 
+    #[\Override]
     public function countPlayers(PlayerLeaderboardFilter $filter): int
     {
         $this->countPlayersFilters[] = $filter;
@@ -236,6 +237,7 @@ final class FakePlayerLeaderboardDataProvider implements PlayerLeaderboardDataPr
         return $this->totalPlayers;
     }
 
+    #[\Override]
     public function getPlayers(PlayerLeaderboardFilter $filter, int $limit): array
     {
         $this->getPlayersCalls[] = [
@@ -246,6 +248,7 @@ final class FakePlayerLeaderboardDataProvider implements PlayerLeaderboardDataPr
         return $this->players;
     }
 
+    #[\Override]
     public function getPageSize(): int
     {
         return $this->pageSize;

--- a/tests/TestRunnerCommandTest.php
+++ b/tests/TestRunnerCommandTest.php
@@ -16,6 +16,7 @@ final class TestRunnerCommandSuiteStub implements TestSuiteInterface
         $this->result = $result;
     }
 
+    #[\Override]
     public function run(): TestSuiteResult
     {
         return $this->result;

--- a/tests/TestRunnerTest.php
+++ b/tests/TestRunnerTest.php
@@ -15,6 +15,7 @@ final class TestSuiteStub implements TestSuiteInterface
         $this->result = $result;
     }
 
+    #[\Override]
     public function run(): TestSuiteResult
     {
         return $this->result;

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -63,6 +63,7 @@ final class TestSuite implements TestSuiteInterface
         return new self($resolvedDirectory, $testClasses);
     }
 
+    #[\Override]
     public function run(): TestSuiteResult
     {
         $results = [];

--- a/wwwroot/classes/AboutPageService.php
+++ b/wwwroot/classes/AboutPageService.php
@@ -19,6 +19,7 @@ class AboutPageService implements AboutPageDataProviderInterface
         $this->utility = $utility;
     }
 
+    #[\Override]
     public function getScanSummary(): AboutPageScanSummary
     {
         $scannedQuery = $this->database->prepare(
@@ -40,6 +41,7 @@ class AboutPageService implements AboutPageDataProviderInterface
     /**
      * @return list<AboutPagePlayer>
      */
+    #[\Override]
     public function getScanLogPlayers(int $limit = self::DEFAULT_SCAN_LOG_LIMIT): array
     {
         $query = $this->database->prepare(

--- a/wwwroot/classes/Admin/SystemCommandExecutor.php
+++ b/wwwroot/classes/Admin/SystemCommandExecutor.php
@@ -7,6 +7,7 @@ final class SystemCommandExecutor implements CommandExecutorInterface
     /**
      * @param array<int, string> $command
      */
+    #[\Override]
     public function run(array $command): CommandExecutionResult
     {
         if ($command === []) {

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -16,6 +16,7 @@ class DailyCronJob implements CronJobInterface
         $this->retryDelaySeconds = $retryDelaySeconds;
     }
 
+    #[\Override]
     public function run(): void
     {
         $this->recalculateTrophyRarityForGames();

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -42,6 +42,7 @@ class HourlyCronJob implements CronJobInterface
         $this->retryDelaySeconds = $retryDelaySeconds;
     }
 
+    #[\Override]
     public function run(): void
     {
         $this->executeWithRetry([$this, 'updateTrophyTitleStatistics']);

--- a/wwwroot/classes/Cron/PlayerRankingCronJob.php
+++ b/wwwroot/classes/Cron/PlayerRankingCronJob.php
@@ -14,6 +14,7 @@ final class PlayerRankingCronJob implements CronJobInterface
         $this->playerRankingUpdater = $playerRankingUpdater;
     }
 
+    #[\Override]
     public function run(): void
     {
         $this->playerRankingUpdater->recalculate();

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -273,6 +273,7 @@ class ThirtyMinuteCronJob implements CronJobInterface
         return null;
     }
 
+    #[\Override]
     public function run(): void
     {
         $recheck = "";

--- a/wwwroot/classes/Cron/WeeklyCronJob.php
+++ b/wwwroot/classes/Cron/WeeklyCronJob.php
@@ -43,6 +43,7 @@ class WeeklyCronJob implements CronJobInterface
         $this->retryDelaySeconds = $retryDelaySeconds;
     }
 
+    #[\Override]
     public function run(): void
     {
         $this->executeWithRetry([$this, 'updateLeaderboardsForActivePlayers']);

--- a/wwwroot/classes/ImageProcessor.php
+++ b/wwwroot/classes/ImageProcessor.php
@@ -31,11 +31,13 @@ interface ImageProcessorInterface
 
 final class GdImageProcessor implements ImageProcessorInterface
 {
+    #[\Override]
     public function isSupported(): bool
     {
         return extension_loaded('gd');
     }
 
+    #[\Override]
     public function createImageFromString(string $contents): mixed
     {
         try {
@@ -51,6 +53,7 @@ final class GdImageProcessor implements ImageProcessorInterface
         return $image;
     }
 
+    #[\Override]
     public function destroyImage(mixed $image): void
     {
         if (is_resource($image) || $image instanceof \GdImage) {
@@ -58,31 +61,37 @@ final class GdImageProcessor implements ImageProcessorInterface
         }
     }
 
+    #[\Override]
     public function getWidth(mixed $image): int
     {
         return imagesx($image);
     }
 
+    #[\Override]
     public function getHeight(mixed $image): int
     {
         return imagesy($image);
     }
 
+    #[\Override]
     public function isTrueColor(mixed $image): bool
     {
         return imageistruecolor($image);
     }
 
+    #[\Override]
     public function convertPaletteToTrueColor(mixed $image): void
     {
         @imagepalettetotruecolor($image);
     }
 
+    #[\Override]
     public function getColorAt(mixed $image, int $x, int $y): int
     {
         return imagecolorat($image, $x, $y);
     }
 
+    #[\Override]
     public function getColorComponents(mixed $image, int $color): array
     {
         return imagecolorsforindex($image, $color);

--- a/wwwroot/classes/PlayerInGameRarityLeaderboardService.php
+++ b/wwwroot/classes/PlayerInGameRarityLeaderboardService.php
@@ -15,6 +15,7 @@ class PlayerInGameRarityLeaderboardService implements PlayerLeaderboardDataProvi
         $this->database = $database;
     }
 
+    #[\Override]
     public function countPlayers(PlayerLeaderboardFilter $filter): int
     {
         $sql = <<<'SQL'
@@ -39,6 +40,7 @@ class PlayerInGameRarityLeaderboardService implements PlayerLeaderboardDataProvi
     /**
      * @return array<int, array<string, mixed>>
      */
+    #[\Override]
     public function getPlayers(PlayerLeaderboardFilter $filter, int $limit = self::PAGE_SIZE): array
     {
         $sql = <<<'SQL'
@@ -76,6 +78,7 @@ class PlayerInGameRarityLeaderboardService implements PlayerLeaderboardDataProvi
         return $players;
     }
 
+    #[\Override]
     public function getPageSize(): int
     {
         return self::PAGE_SIZE;

--- a/wwwroot/classes/PlayerLeaderboardService.php
+++ b/wwwroot/classes/PlayerLeaderboardService.php
@@ -15,6 +15,7 @@ class PlayerLeaderboardService implements PlayerLeaderboardDataProvider
         $this->database = $database;
     }
 
+    #[\Override]
     public function countPlayers(PlayerLeaderboardFilter $filter): int
     {
         $sql = <<<'SQL'
@@ -39,6 +40,7 @@ class PlayerLeaderboardService implements PlayerLeaderboardDataProvider
     /**
      * @return array<int, array<string, mixed>>
      */
+    #[\Override]
     public function getPlayers(PlayerLeaderboardFilter $filter, int $limit = self::PAGE_SIZE): array
     {
         $sql = <<<'SQL'
@@ -76,6 +78,7 @@ class PlayerLeaderboardService implements PlayerLeaderboardDataProvider
         return $players;
     }
 
+    #[\Override]
     public function getPageSize(): int
     {
         return self::PAGE_SIZE;

--- a/wwwroot/classes/PlayerRarityLeaderboardService.php
+++ b/wwwroot/classes/PlayerRarityLeaderboardService.php
@@ -15,6 +15,7 @@ class PlayerRarityLeaderboardService implements PlayerLeaderboardDataProvider
         $this->database = $database;
     }
 
+    #[\Override]
     public function countPlayers(PlayerLeaderboardFilter $filter): int
     {
         $sql = <<<'SQL'
@@ -39,6 +40,7 @@ class PlayerRarityLeaderboardService implements PlayerLeaderboardDataProvider
     /**
      * @return array<int, array<string, mixed>>
      */
+    #[\Override]
     public function getPlayers(PlayerLeaderboardFilter $filter, int $limit = self::PAGE_SIZE): array
     {
         $sql = <<<'SQL'
@@ -76,6 +78,7 @@ class PlayerRarityLeaderboardService implements PlayerLeaderboardDataProvider
         return $players;
     }
 
+    #[\Override]
     public function getPageSize(): int
     {
         return self::PAGE_SIZE;

--- a/wwwroot/classes/Routing/GameRouteHandler.php
+++ b/wwwroot/classes/Routing/GameRouteHandler.php
@@ -30,6 +30,7 @@ class GameRouteHandler implements RouteHandlerInterface
     /**
      * @param list<string> $segments
      */
+    #[\Override]
     public function handle(array $segments): RouteResult
     {
         if (!isset($segments[0]) || $segments[0] === '') {

--- a/wwwroot/classes/Routing/HomeRouteHandler.php
+++ b/wwwroot/classes/Routing/HomeRouteHandler.php
@@ -16,6 +16,7 @@ class HomeRouteHandler implements RouteHandlerInterface
     /**
      * @param list<string> $segments
      */
+    #[\Override]
     public function handle(array $segments): RouteResult
     {
         return RouteResult::include($this->includeFile);

--- a/wwwroot/classes/Routing/LeaderboardRouteHandler.php
+++ b/wwwroot/classes/Routing/LeaderboardRouteHandler.php
@@ -11,6 +11,7 @@ class LeaderboardRouteHandler implements RouteHandlerInterface
     /**
      * @param list<string> $segments
      */
+    #[\Override]
     public function handle(array $segments): RouteResult
     {
         if (!isset($segments[0]) || $segments[0] === '') {

--- a/wwwroot/classes/Routing/PlayerRouteHandler.php
+++ b/wwwroot/classes/Routing/PlayerRouteHandler.php
@@ -17,6 +17,7 @@ class PlayerRouteHandler implements RouteHandlerInterface
     /**
      * @param list<string> $segments
      */
+    #[\Override]
     public function handle(array $segments): RouteResult
     {
         if (!isset($segments[0]) || $segments[0] === '') {

--- a/wwwroot/classes/Routing/SimpleRouteHandler.php
+++ b/wwwroot/classes/Routing/SimpleRouteHandler.php
@@ -19,6 +19,7 @@ class SimpleRouteHandler implements RouteHandlerInterface
     /**
      * @param list<string> $segments
      */
+    #[\Override]
     public function handle(array $segments): RouteResult
     {
         if ($this->hasAdditionalSegments($segments)) {

--- a/wwwroot/classes/Routing/TrophyRouteHandler.php
+++ b/wwwroot/classes/Routing/TrophyRouteHandler.php
@@ -17,6 +17,7 @@ class TrophyRouteHandler implements RouteHandlerInterface
     /**
      * @param list<string> $segments
      */
+    #[\Override]
     public function handle(array $segments): RouteResult
     {
         if (!isset($segments[0]) || $segments[0] === '') {


### PR DESCRIPTION
## Summary
- add PHP 8.5 #[\Override] attributes across interface implementations to enforce contract compliance
- update production services, cron jobs, route handlers, and test doubles to use the new override attribute

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939fe0b661c832fb6021d1954769501)