### PR TITLE
Clarify missing trophy icon log message

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -240,14 +240,16 @@ class ThirtyMinuteCronJob implements CronJobInterface
 
         for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
             $iconUrl = trim((string) $trophyTitle->iconUrl());
+            $titleName = trim((string) $trophyTitle->name());
+            $titleNameForLog = $titleName === '' ? $npCommunicationId : $titleName;
 
             if ($iconUrl !== '') {
                 return $trophyTitle;
             }
 
             $this->logger->log(sprintf(
-                'Trophy title "%s" (%s) missing icon for %s (attempt %d/%d).',
-                $trophyTitle->name(),
+                'Trophy title "%s" (%s) is missing an icon while processing user %s (attempt %d/%d).',
+                $titleNameForLog,
                 $npCommunicationId,
                 $onlineId,
                 $attempt,


### PR DESCRIPTION
## Summary
- add fallback trophy title name when logging missing icons
- clarify log message wording to specify it occurs while processing a user

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693abe3051f4832fb13cb2c750f73057)