### PR TITLE
Show full progress for earned trophies

### DIFF
--- a/tests/GameTrophyRowTest.php
+++ b/tests/GameTrophyRowTest.php
@@ -73,6 +73,17 @@ final class GameTrophyRowTest extends TestCase
         $this->assertSame('15/15', $row->getProgressDisplay());
     }
 
+    public function testProgressDisplayUsesTargetWhenEarnedWithPartialProgress(): void
+    {
+        $row = $this->createRow([
+            'progress_target_value' => 10,
+            'progress' => 9,
+            'earned' => 1,
+        ]);
+
+        $this->assertSame('10/10', $row->getProgressDisplay());
+    }
+
     public function testInGameRarityPercentUsesStoredValue(): void
     {
         $row = $this->createRow([

--- a/wwwroot/classes/Game/GameTrophyRow.php
+++ b/wwwroot/classes/Game/GameTrophyRow.php
@@ -134,13 +134,9 @@ final class GameTrophyRow
             return null;
         }
 
-        $progress = $this->progress;
-
-        if ($progress === null && $this->isEarned) {
-            $progress = $this->progressTargetValue;
-        }
-
-        $progressValue = $progress ?? 0;
+        $progressValue = $this->isEarned
+            ? $this->progressTargetValue
+            : ($this->progress ?? 0);
 
         return $progressValue . '/' . $this->progressTargetValue;
     }


### PR DESCRIPTION
## Summary
- ensure earned trophies always display full progress even when stored progress is below target
- add regression test for earned trophies with partial progress

## Testing
- php tests/run.php
- php -l wwwroot/classes/Game/GameTrophyRow.php
- php -l tests/GameTrophyRowTest.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1e5e2470832face94665bd0d5a89)