### PR TITLE
Refactor test harness for PHP 8.5 features

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/TestResult.php';
+require_once __DIR__ . '/TestStatus.php';
 
 abstract class TestCase
 {
@@ -19,19 +20,19 @@ abstract class TestCase
 
             try {
                 $this->$method();
-                $results[] = new TestResult($className, $method, 'passed');
+                $results[] = new TestResult($className, $method, TestStatus::PASSED);
             } catch (AssertionError $assertionError) {
                 $results[] = new TestResult(
                     $className,
                     $method,
-                    'failed',
+                    TestStatus::FAILED,
                     $assertionError->getMessage()
                 );
             } catch (Throwable $throwable) {
                 $results[] = new TestResult(
                     $className,
                     $method,
-                    'error',
+                    TestStatus::ERROR,
                     $throwable->getMessage()
                 );
             } finally {

--- a/tests/TestResult.php
+++ b/tests/TestResult.php
@@ -2,22 +2,16 @@
 
 declare(strict_types=1);
 
-final class TestResult
+require_once __DIR__ . '/TestStatus.php';
+
+final readonly class TestResult
 {
-    private string $className;
-
-    private string $methodName;
-
-    private string $status;
-
-    private ?string $message;
-
-    public function __construct(string $className, string $methodName, string $status, ?string $message = null)
-    {
-        $this->className = $className;
-        $this->methodName = $methodName;
-        $this->status = $status;
-        $this->message = $message;
+    public function __construct(
+        private string $className,
+        private string $methodName,
+        private TestStatus $status,
+        private ?string $message = null,
+    ) {
     }
 
     public function getClassName(): string
@@ -30,7 +24,7 @@ final class TestResult
         return $this->methodName;
     }
 
-    public function getStatus(): string
+    public function getStatus(): TestStatus
     {
         return $this->status;
     }
@@ -42,16 +36,16 @@ final class TestResult
 
     public function isPassed(): bool
     {
-        return $this->status === 'passed';
+        return $this->status === TestStatus::PASSED;
     }
 
     public function isFailed(): bool
     {
-        return $this->status === 'failed';
+        return $this->status === TestStatus::FAILED;
     }
 
     public function isError(): bool
     {
-        return $this->status === 'error';
+        return $this->status === TestStatus::ERROR;
     }
 }

--- a/tests/TestRunReporterTest.php
+++ b/tests/TestRunReporterTest.php
@@ -17,7 +17,7 @@ final class TestRunReporterTest extends TestCase
         });
 
         $result = new TestSuiteResult([
-            new TestResult('ExampleTest', 'testExample', 'passed'),
+            new TestResult('ExampleTest', 'testExample', TestStatus::PASSED),
         ]);
 
         $exitCode = $reporter->report($result);
@@ -38,8 +38,8 @@ final class TestRunReporterTest extends TestCase
         });
 
         $result = new TestSuiteResult([
-            new TestResult('ExampleTest', 'testSuccess', 'passed'),
-            new TestResult('ExampleTest', 'testFailure', 'failed', 'Something went wrong'),
+            new TestResult('ExampleTest', 'testSuccess', TestStatus::PASSED),
+            new TestResult('ExampleTest', 'testFailure', TestStatus::FAILED, 'Something went wrong'),
         ]);
 
         $exitCode = $reporter->report($result);

--- a/tests/TestRunner.php
+++ b/tests/TestRunner.php
@@ -6,18 +6,17 @@ require_once __DIR__ . '/TestSuiteInterface.php';
 require_once __DIR__ . '/TestSuite.php';
 require_once __DIR__ . '/TestRunReporter.php';
 
-final class TestRunner
+final readonly class TestRunner
 {
-    private TestSuiteInterface $suite;
-
     private TestRunReporter $reporter;
 
     /**
      * @param callable(string): void|null $outputWriter
      */
-    public function __construct(TestSuiteInterface $suite, ?callable $outputWriter = null)
-    {
-        $this->suite = $suite;
+    public function __construct(
+        private TestSuiteInterface $suite,
+        ?callable $outputWriter = null,
+    ) {
         $this->reporter = new TestRunReporter($outputWriter);
     }
 

--- a/tests/TestRunnerTest.php
+++ b/tests/TestRunnerTest.php
@@ -27,7 +27,7 @@ final class TestRunnerTest extends TestCase
     public function testRunOutputsSummaryForSuccessfulRun(): void
     {
         $suite = new TestSuiteStub(new TestSuiteResult([
-            new TestResult('ExampleTest', 'testExample', 'passed'),
+            new TestResult('ExampleTest', 'testExample', TestStatus::PASSED),
         ]));
 
         $output = [];
@@ -48,8 +48,8 @@ final class TestRunnerTest extends TestCase
     public function testRunOutputsSummaryForFailedRun(): void
     {
         $suite = new TestSuiteStub(new TestSuiteResult([
-            new TestResult('ExampleTest', 'testSuccess', 'passed'),
-            new TestResult('ExampleTest', 'testFailure', 'failed', 'Something went wrong'),
+            new TestResult('ExampleTest', 'testSuccess', TestStatus::PASSED),
+            new TestResult('ExampleTest', 'testFailure', TestStatus::FAILED, 'Something went wrong'),
         ]));
 
         $output = [];

--- a/tests/TestStatus.php
+++ b/tests/TestStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+enum TestStatus: string
+{
+    case PASSED = 'passed';
+    case FAILED = 'failed';
+    case ERROR = 'error';
+}

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -7,22 +7,15 @@ require_once __DIR__ . '/TestResult.php';
 require_once __DIR__ . '/TestSuiteResult.php';
 require_once __DIR__ . '/TestSuiteInterface.php';
 
-final class TestSuite implements TestSuiteInterface
+final readonly class TestSuite implements TestSuiteInterface
 {
-    private string $directory;
-
-    /**
-     * @var list<class-string<TestCase>>
-     */
-    private array $testClasses;
-
     /**
      * @param list<class-string<TestCase>> $testClasses
      */
-    private function __construct(string $directory, array $testClasses)
-    {
-        $this->directory = $directory;
-        $this->testClasses = $testClasses;
+    private function __construct(
+        private string $directory,
+        private array $testClasses,
+    ) {
     }
 
     public static function fromDirectory(string $directory): self

--- a/tests/TestSuiteResult.php
+++ b/tests/TestSuiteResult.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/TestResult.php';
 
-final class TestSuiteResult
+final readonly class TestSuiteResult
 {
     /**
      * @var list<TestResult>
@@ -34,12 +34,12 @@ final class TestSuiteResult
 
     public function getFailureCount(): int
     {
-        return $this->countByStatus('failed');
+        return $this->countByStatus(TestStatus::FAILED);
     }
 
     public function getErrorCount(): int
     {
-        return $this->countByStatus('error');
+        return $this->countByStatus(TestStatus::ERROR);
     }
 
     public function isSuccessful(): bool
@@ -47,7 +47,7 @@ final class TestSuiteResult
         return $this->getFailureCount() === 0 && $this->getErrorCount() === 0;
     }
 
-    private function countByStatus(string $status): int
+    private function countByStatus(TestStatus $status): int
     {
         $count = 0;
 


### PR DESCRIPTION
## Summary
- introduce a dedicated TestStatus enum and update test runner artifacts to use typed statuses
- modernize the custom test harness with readonly classes and constructor property promotion for PHP 8.5

## Testing
- php -d detect_unicode=0 tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bdf147b3c832fb8d9b192a961660f)