### PR TITLE
Add strict typing declarations to entry scripts

### DIFF
--- a/wwwroot/admin/rescan.php
+++ b/wwwroot/admin/rescan.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 require_once("../vendor/autoload.php");
 require_once("../init.php");
 ?>

--- a/wwwroot/avatars.php
+++ b/wwwroot/avatars.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 require_once 'classes/AvatarService.php';
 require_once 'classes/AvatarPage.php';
 

--- a/wwwroot/footer.php
+++ b/wwwroot/footer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 require_once __DIR__ . '/classes/FooterViewModel.php';
 require_once __DIR__ . '/classes/FooterRenderer.php';
 

--- a/wwwroot/header.php
+++ b/wwwroot/header.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 require_once __DIR__ . '/classes/PageMetaData.php';
 require_once __DIR__ . '/classes/PageMetaDataRenderer.php';
 

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 require_once 'classes/HomepageController.php';
 
 $homepageController = HomepageController::fromDatabase($database);

--- a/wwwroot/init.php
+++ b/wwwroot/init.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 require_once __DIR__ . '/classes/ApplicationBootstrapper.php';
 
 $applicationBootstrapper = ApplicationBootstrapper::bootstrap();

--- a/wwwroot/leaderboard_in_game_rarity.php
+++ b/wwwroot/leaderboard_in_game_rarity.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 require_once 'classes/Leaderboard/InGameRarityLeaderboardPageContext.php';
 
 $leaderboardPageContext = InGameRarityLeaderboardPageContext::fromGlobals($database, $utility, $_GET ?? []);

--- a/wwwroot/leaderboard_main.php
+++ b/wwwroot/leaderboard_main.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 require_once 'classes/Leaderboard/TrophyLeaderboardPageContext.php';
 
 $trophyLeaderboardPageContext = TrophyLeaderboardPageContext::fromGlobals($database, $utility, $_GET ?? []);

--- a/wwwroot/leaderboard_rarity.php
+++ b/wwwroot/leaderboard_rarity.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 require_once 'classes/Leaderboard/RarityLeaderboardPageContext.php';
 
 $rarityLeaderboardPageContext = RarityLeaderboardPageContext::fromGlobals($database, $utility, $_GET ?? []);

--- a/wwwroot/nav.php
+++ b/wwwroot/nav.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 require_once __DIR__ . '/classes/NavigationBarRenderer.php';
 
 $navigationState = NavigationState::fromGlobals($_SERVER ?? [], $_GET ?? []);

--- a/wwwroot/player_header.php
+++ b/wwwroot/player_header.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 require_once __DIR__ . '/classes/PlayerHeaderViewModel.php';
 
 $playerHeaderViewModel = new PlayerHeaderViewModel($player, $playerSummary, $utility);

--- a/wwwroot/trophy.php
+++ b/wwwroot/trophy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once 'classes/TrophyPage.php';
 require_once 'classes/TrophyRarityFormatter.php';
 


### PR DESCRIPTION
## Summary
- enable strict typing on shared layout components and page entry scripts to align with PHP 8.5 expectations

## Testing
- for f in wwwroot/admin/rescan.php wwwroot/avatars.php wwwroot/footer.php wwwroot/header.php wwwroot/home.php wwwroot/init.php wwwroot/leaderboard_in_game_rarity.php wwwroot/leaderboard_main.php wwwroot/leaderboard_rarity.php wwwroot/nav.php wwwroot/player_header.php wwwroot/trophy.php; do
  php -l "$f" || exit 1
done
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bdf147b3c832fb8d9b192a961660f)