### PR TITLE
Tighten GD image typing for PHP 8.5

### DIFF
--- a/tests/ImageHashCalculatorTest.php
+++ b/tests/ImageHashCalculatorTest.php
@@ -92,7 +92,7 @@ final class FakeImageProcessor implements ImageProcessorInterface
 
     private bool $trueColor;
 
-    private object $imageHandle;
+    private \GdImage $imageHandle;
 
     public function __construct(
         bool $supported = true,
@@ -105,7 +105,6 @@ final class FakeImageProcessor implements ImageProcessorInterface
         $this->supported = $supported;
         $this->createSucceeds = $createSucceeds;
         $this->trueColor = $trueColor;
-        $this->imageHandle = new stdClass();
 
         if ($pixels !== []) {
             $this->pixels = $pixels;
@@ -116,6 +115,8 @@ final class FakeImageProcessor implements ImageProcessorInterface
             $this->width = $width;
             $this->height = $height;
         }
+
+        $this->imageHandle = imagecreatetruecolor(max(1, $this->width), max(1, $this->height));
     }
 
     #[\Override]
@@ -125,7 +126,7 @@ final class FakeImageProcessor implements ImageProcessorInterface
     }
 
     #[\Override]
-    public function createImageFromString(string $contents): mixed
+    public function createImageFromString(string $contents): ?\GdImage
     {
         if (!$this->createSucceeds) {
             return null;
@@ -135,43 +136,43 @@ final class FakeImageProcessor implements ImageProcessorInterface
     }
 
     #[\Override]
-    public function destroyImage(mixed $image): void
+    public function destroyImage(\GdImage $image): void
     {
-        // Nothing to clean up in the fake processor.
+        imagedestroy($image);
     }
 
     #[\Override]
-    public function getWidth(mixed $image): int
+    public function getWidth(\GdImage $image): int
     {
         return $this->width;
     }
 
     #[\Override]
-    public function getHeight(mixed $image): int
+    public function getHeight(\GdImage $image): int
     {
         return $this->height;
     }
 
     #[\Override]
-    public function isTrueColor(mixed $image): bool
+    public function isTrueColor(\GdImage $image): bool
     {
         return $this->trueColor;
     }
 
     #[\Override]
-    public function convertPaletteToTrueColor(mixed $image): void
+    public function convertPaletteToTrueColor(\GdImage $image): void
     {
         $this->trueColor = true;
     }
 
     #[\Override]
-    public function getColorAt(mixed $image, int $x, int $y): int
+    public function getColorAt(\GdImage $image, int $x, int $y): int
     {
         return $y * max(1, $this->width) + $x;
     }
 
     #[\Override]
-    public function getColorComponents(mixed $image, int $color): array
+    public function getColorComponents(\GdImage $image, int $color): array
     {
         if ($this->pixels === []) {
             return ['red' => 0, 'green' => 0, 'blue' => 0, 'alpha' => 0];

--- a/wwwroot/classes/ImageHashCalculator.php
+++ b/wwwroot/classes/ImageHashCalculator.php
@@ -54,7 +54,7 @@ final class ImageHashCalculator
         }
     }
 
-    private function hasTransparency(mixed $image, int $width, int $height): bool
+    private function hasTransparency(\GdImage $image, int $width, int $height): bool
     {
         for ($y = 0; $y < $height; $y++) {
             for ($x = 0; $x < $width; $x++) {
@@ -71,7 +71,7 @@ final class ImageHashCalculator
     }
 
     private function buildPixelBuffer(
-        mixed $image,
+        \GdImage $image,
         int $width,
         int $height,
         bool $hasTransparency

--- a/wwwroot/classes/ImageProcessor.php
+++ b/wwwroot/classes/ImageProcessor.php
@@ -6,27 +6,24 @@ interface ImageProcessorInterface
 {
     public function isSupported(): bool;
 
-    /**
-     * @return mixed|null
-     */
-    public function createImageFromString(string $contents);
+    public function createImageFromString(string $contents): ?\GdImage;
 
-    public function destroyImage(mixed $image): void;
+    public function destroyImage(\GdImage $image): void;
 
-    public function getWidth(mixed $image): int;
+    public function getWidth(\GdImage $image): int;
 
-    public function getHeight(mixed $image): int;
+    public function getHeight(\GdImage $image): int;
 
-    public function isTrueColor(mixed $image): bool;
+    public function isTrueColor(\GdImage $image): bool;
 
-    public function convertPaletteToTrueColor(mixed $image): void;
+    public function convertPaletteToTrueColor(\GdImage $image): void;
 
-    public function getColorAt(mixed $image, int $x, int $y): int;
+    public function getColorAt(\GdImage $image, int $x, int $y): int;
 
     /**
-     * @return array<string, int>
+     * @return array{red: int, green: int, blue: int, alpha: int}
      */
-    public function getColorComponents(mixed $image, int $color): array;
+    public function getColorComponents(\GdImage $image, int $color): array;
 }
 
 final class GdImageProcessor implements ImageProcessorInterface
@@ -38,7 +35,7 @@ final class GdImageProcessor implements ImageProcessorInterface
     }
 
     #[\Override]
-    public function createImageFromString(string $contents): mixed
+    public function createImageFromString(string $contents): ?\GdImage
     {
         try {
             $image = @imagecreatefromstring($contents);
@@ -54,45 +51,43 @@ final class GdImageProcessor implements ImageProcessorInterface
     }
 
     #[\Override]
-    public function destroyImage(mixed $image): void
+    public function destroyImage(\GdImage $image): void
     {
-        if (is_resource($image) || $image instanceof \GdImage) {
-            imagedestroy($image);
-        }
+        imagedestroy($image);
     }
 
     #[\Override]
-    public function getWidth(mixed $image): int
+    public function getWidth(\GdImage $image): int
     {
         return imagesx($image);
     }
 
     #[\Override]
-    public function getHeight(mixed $image): int
+    public function getHeight(\GdImage $image): int
     {
         return imagesy($image);
     }
 
     #[\Override]
-    public function isTrueColor(mixed $image): bool
+    public function isTrueColor(\GdImage $image): bool
     {
         return imageistruecolor($image);
     }
 
     #[\Override]
-    public function convertPaletteToTrueColor(mixed $image): void
+    public function convertPaletteToTrueColor(\GdImage $image): void
     {
         @imagepalettetotruecolor($image);
     }
 
     #[\Override]
-    public function getColorAt(mixed $image, int $x, int $y): int
+    public function getColorAt(\GdImage $image, int $x, int $y): int
     {
         return imagecolorat($image, $x, $y);
     }
 
     #[\Override]
-    public function getColorComponents(mixed $image, int $color): array
+    public function getColorComponents(\GdImage $image, int $color): array
     {
         return imagecolorsforindex($image, $color);
     }


### PR DESCRIPTION
## Summary
- add explicit GdImage typing to the image processor interface to embrace PHP 8.5's built-in GD objects
- update the hash calculator and supporting test doubles to operate on GdImage instances and clean up resources

## Testing
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bdf147b3c832fb8d9b192a961660f)