### PR TITLE
Refactor changelog models for PHP 8.5

### DIFF
--- a/wwwroot/classes/ChangelogDateGroup.php
+++ b/wwwroot/classes/ChangelogDateGroup.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/ChangelogEntryPresenter.php';
 
-class ChangelogDateGroup
+readonly class ChangelogDateGroup
 {
-    private string $dateLabel;
-
     /**
      * @var ChangelogEntryPresenter[]
      */
@@ -16,9 +14,10 @@ class ChangelogDateGroup
     /**
      * @param ChangelogEntryPresenter[] $entries
      */
-    public function __construct(string $dateLabel, array $entries)
-    {
-        $this->dateLabel = $dateLabel;
+    public function __construct(
+        private string $dateLabel,
+        array $entries
+    ) {
         $this->entries = array_values($entries);
     }
 

--- a/wwwroot/classes/ChangelogEntry.php
+++ b/wwwroot/classes/ChangelogEntry.php
@@ -22,57 +22,26 @@ enum ChangelogEntryType: string
     case UNKNOWN = 'UNKNOWN';
 }
 
-class ChangelogEntry
+readonly class ChangelogEntry
 {
-    private DateTimeImmutable $time;
-    private ChangelogEntryType $changeType;
-    private string $changeTypeValue;
-    private ?int $param1Id;
-    private ?string $param1Name;
-    /**
-     * @var array<int, string>
-     */
-    private array $param1Platforms;
-    private ?string $param1Region;
-    private ?int $param2Id;
-    private ?string $param2Name;
-    /**
-     * @var array<int, string>
-     */
-    private array $param2Platforms;
-    private ?string $param2Region;
-    private ?string $extra;
-
     /**
      * @param array<int, string> $param1Platforms
      * @param array<int, string> $param2Platforms
      */
     private function __construct(
-        DateTimeImmutable $time,
-        string $changeType,
-        ?int $param1Id,
-        ?string $param1Name,
-        array $param1Platforms,
-        ?string $param1Region,
-        ?int $param2Id,
-        ?string $param2Name,
-        array $param2Platforms,
-        ?string $param2Region,
-        ?string $extra
-    ) {
-        $this->time = $time;
-        $this->changeTypeValue = $changeType;
-        $this->changeType = self::normalizeChangeType($changeType);
-        $this->param1Id = $param1Id;
-        $this->param1Name = $param1Name;
-        $this->param1Platforms = $param1Platforms;
-        $this->param1Region = $param1Region;
-        $this->param2Id = $param2Id;
-        $this->param2Name = $param2Name;
-        $this->param2Platforms = $param2Platforms;
-        $this->param2Region = $param2Region;
-        $this->extra = $extra;
-    }
+        private DateTimeImmutable $time,
+        private string $changeTypeValue,
+        private ChangelogEntryType $changeType,
+        private ?int $param1Id,
+        private ?string $param1Name,
+        private array $param1Platforms,
+        private ?string $param1Region,
+        private ?int $param2Id,
+        private ?string $param2Name,
+        private array $param2Platforms,
+        private ?string $param2Region,
+        private ?string $extra
+    ) {}
 
     /**
      * @param array<string, mixed> $row
@@ -81,7 +50,8 @@ class ChangelogEntry
     {
         return new self(
             self::createDateTime(isset($row['time']) ? (string) $row['time'] : 'now'),
-            isset($row['change_type']) ? (string) $row['change_type'] : '',
+            $changeTypeValue = isset($row['change_type']) ? (string) $row['change_type'] : '',
+            self::normalizeChangeType($changeTypeValue),
             isset($row['param_1']) ? (int) $row['param_1'] : null,
             isset($row['param_1_name']) ? (string) $row['param_1_name'] : null,
             self::normalizePlatforms($row['param_1_platform'] ?? null),

--- a/wwwroot/classes/ChangelogEntryPresenter.php
+++ b/wwwroot/classes/ChangelogEntryPresenter.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 require_once __DIR__ . '/ChangelogEntry.php';
 require_once __DIR__ . '/Utility.php';
 
-class ChangelogEntryPresenter
+readonly class ChangelogEntryPresenter
 {
-    private ChangelogEntry $entry;
-    private Utility $utility;
-
-    public function __construct(ChangelogEntry $entry, Utility $utility)
-    {
-        $this->entry = $entry;
-        $this->utility = $utility;
-    }
+    public function __construct(
+        private ChangelogEntry $entry,
+        private Utility $utility
+    ) {}
 
     public function getDateLabel(): string
     {


### PR DESCRIPTION
## Summary
- modernize changelog entry and presenter models to use readonly classes and promoted properties suited for PHP 8.5
- streamline changelog entry construction by normalizing change types before instantiation
- keep changelog date grouping immutable while reindexing entry arrays

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bdf147b3c832fb8d9b192a961660f)