### PR TITLE
Refactor code for PHP 8.5 conveniences

### DIFF
--- a/wwwroot/classes/GameStatusBadge.php
+++ b/wwwroot/classes/GameStatusBadge.php
@@ -2,19 +2,13 @@
 
 declare(strict_types=1);
 
-final class GameStatusBadge
+final readonly class GameStatusBadge
 {
-    private string $label;
-
-    private string $tooltip;
-
-    private string $cssClass;
-
-    public function __construct(string $label, string $tooltip, string $cssClass = 'badge rounded-pill text-bg-warning')
-    {
-        $this->label = $label;
-        $this->tooltip = $tooltip;
-        $this->cssClass = $cssClass;
+    public function __construct(
+        private string $label,
+        private string $tooltip,
+        private string $cssClass = 'badge rounded-pill text-bg-warning'
+    ) {
     }
 
     public function getLabel(): string

--- a/wwwroot/classes/HttpRequest.php
+++ b/wwwroot/classes/HttpRequest.php
@@ -5,16 +5,10 @@ declare(strict_types=1);
 class HttpRequest
 {
     /**
-     * @var array<string, mixed>
-     */
-    private array $server;
-
-    /**
      * @param array<string, mixed> $server
      */
-    public function __construct(array $server)
+    public function __construct(private array $server = [])
     {
-        $this->server = $server;
     }
 
     public static function fromGlobals(): self

--- a/wwwroot/classes/NavigationState.php
+++ b/wwwroot/classes/NavigationState.php
@@ -143,27 +143,15 @@ final class NavigationState
 
     private static function resolveActiveSection(string $requestUri): NavigationSection
     {
-        if (str_starts_with($requestUri, '/leaderboard') || str_starts_with($requestUri, '/player')) {
-            return NavigationSection::Leaderboard;
-        }
-
-        if (str_starts_with($requestUri, '/game')) {
-            return NavigationSection::Game;
-        }
-
-        if (str_starts_with($requestUri, '/trophy')) {
-            return NavigationSection::Trophy;
-        }
-
-        if (str_starts_with($requestUri, '/avatar')) {
-            return NavigationSection::Avatar;
-        }
-
-        if (str_starts_with($requestUri, '/about')) {
-            return NavigationSection::About;
-        }
-
-        return NavigationSection::Home;
+        return match (true) {
+            str_starts_with($requestUri, '/leaderboard') || str_starts_with($requestUri, '/player')
+                => NavigationSection::Leaderboard,
+            str_starts_with($requestUri, '/game') => NavigationSection::Game,
+            str_starts_with($requestUri, '/trophy') => NavigationSection::Trophy,
+            str_starts_with($requestUri, '/avatar') => NavigationSection::Avatar,
+            str_starts_with($requestUri, '/about') => NavigationSection::About,
+            default => NavigationSection::Home,
+        };
     }
 
     private function getSectionState(NavigationSection $section): ?NavigationSectionState


### PR DESCRIPTION
## Summary
- convert GameStatusBadge into a promoted readonly value object
- simplify NavigationState active section detection with a match expression
- promote HttpRequest server data storage to use constructor defaults

## Testing
- php -l wwwroot/classes/HttpRequest.php
- php -l wwwroot/classes/NavigationState.php
- php -l wwwroot/classes/GameStatusBadge.php
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bed7889e0832fa7a030e966799aae)