### PR TITLE
Refactor filters for PHP 8.5 immutability

### DIFF
--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-class GameLeaderboardFilter extends GamePlayerFilter
+readonly class GameLeaderboardFilter extends GamePlayerFilter
 {
     private int $page;
 

--- a/wwwroot/classes/GamePlayerFilter.php
+++ b/wwwroot/classes/GamePlayerFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-class GamePlayerFilter
+readonly class GamePlayerFilter
 {
     private ?string $country;
 

--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-class PlayerLeaderboardFilter
+readonly class PlayerLeaderboardFilter
 {
     private ?string $country;
     private ?string $avatar;


### PR DESCRIPTION
## Summary
- declare the leaderboard filter value objects as readonly classes to leverage PHP 8.5 immutability

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bed7889e0832fa7a030e966799aae)