### PR TITLE
Modernize routing for PHP 8.5

### DIFF
--- a/wwwroot/classes/Application.php
+++ b/wwwroot/classes/Application.php
@@ -9,18 +9,18 @@ require_once __DIR__ . '/RouteResultResponder.php';
 
 class Application
 {
-    private RouteResultResponder $routeResultResponder;
+    private readonly RouteResultResponder $routeResultResponder;
 
     public function __construct(
-        private Router $router,
-        private HttpRequest $request,
-        TemplateRenderer $templateRenderer,
-        string $notFoundTemplate = '404.php',
-        ?RouteResultResponder $routeResultResponder = null
+        private readonly Router $router,
+        private readonly HttpRequest $request,
+        private readonly TemplateRenderer $templateRenderer,
+        private readonly string $notFoundTemplate = '404.php',
+        ?RouteResultResponder $routeResultResponder = null,
     ) {
         $this->routeResultResponder = $routeResultResponder ?? new RouteResultResponder(
-            $templateRenderer,
-            $notFoundTemplate
+            $this->templateRenderer,
+            $this->notFoundTemplate
         );
     }
 

--- a/wwwroot/classes/Router.php
+++ b/wwwroot/classes/Router.php
@@ -16,12 +16,12 @@ require_once __DIR__ . '/Routing/TrophyRouteHandler.php';
 
 class Router
 {
-    private RouteHandlerInterface $defaultHandler;
+    private readonly RouteHandlerInterface $defaultHandler;
 
     /**
      * @var array<string, RouteHandlerInterface>
      */
-    private array $routeHandlers;
+    private readonly array $routeHandlers;
 
     public function __construct(
         GameRepository $gameRepository,

--- a/wwwroot/classes/Routing/GameRouteHandler.php
+++ b/wwwroot/classes/Routing/GameRouteHandler.php
@@ -5,26 +5,14 @@ declare(strict_types=1);
 require_once __DIR__ . '/../GameRepository.php';
 require_once __DIR__ . '/RouteHandlerInterface.php';
 
-class GameRouteHandler implements RouteHandlerInterface
+final readonly class GameRouteHandler implements RouteHandlerInterface
 {
-    private GameRepository $gameRepository;
-
-    private string $includeFile;
-
-    private string $redirectPath;
-
-    private ?string $missingSegmentInclude;
-
     public function __construct(
-        GameRepository $gameRepository,
-        string $includeFile,
-        string $redirectPath,
-        ?string $missingSegmentInclude = null
+        private GameRepository $gameRepository,
+        private string $includeFile,
+        private string $redirectPath,
+        private ?string $missingSegmentInclude = null,
     ) {
-        $this->gameRepository = $gameRepository;
-        $this->includeFile = $includeFile;
-        $this->redirectPath = $redirectPath;
-        $this->missingSegmentInclude = $missingSegmentInclude;
     }
 
     /**

--- a/wwwroot/classes/Routing/HomeRouteHandler.php
+++ b/wwwroot/classes/Routing/HomeRouteHandler.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/RouteHandlerInterface.php';
 
-class HomeRouteHandler implements RouteHandlerInterface
+final readonly class HomeRouteHandler implements RouteHandlerInterface
 {
-    private string $includeFile;
-
-    public function __construct(string $includeFile = 'home.php')
+    public function __construct(private string $includeFile = 'home.php')
     {
-        $this->includeFile = $includeFile;
     }
 
     /**

--- a/wwwroot/classes/Routing/LeaderboardRouteHandler.php
+++ b/wwwroot/classes/Routing/LeaderboardRouteHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/RouteHandlerInterface.php';
 
-class LeaderboardRouteHandler implements RouteHandlerInterface
+final readonly class LeaderboardRouteHandler implements RouteHandlerInterface
 {
     private const DEFAULT_REDIRECT = '/leaderboard/trophy';
 

--- a/wwwroot/classes/Routing/PlayerRouteHandler.php
+++ b/wwwroot/classes/Routing/PlayerRouteHandler.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 require_once __DIR__ . '/../PlayerRepository.php';
 require_once __DIR__ . '/RouteHandlerInterface.php';
 
-class PlayerRouteHandler implements RouteHandlerInterface
+final readonly class PlayerRouteHandler implements RouteHandlerInterface
 {
-    private PlayerRepository $playerRepository;
-
-    public function __construct(PlayerRepository $playerRepository)
+    public function __construct(private PlayerRepository $playerRepository)
     {
-        $this->playerRepository = $playerRepository;
     }
 
     /**

--- a/wwwroot/classes/Routing/SimpleRouteHandler.php
+++ b/wwwroot/classes/Routing/SimpleRouteHandler.php
@@ -4,16 +4,10 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/RouteHandlerInterface.php';
 
-class SimpleRouteHandler implements RouteHandlerInterface
+final readonly class SimpleRouteHandler implements RouteHandlerInterface
 {
-    private string $includeFile;
-
-    private string $redirectPath;
-
-    public function __construct(string $includeFile, string $redirectPath)
+    public function __construct(private string $includeFile, private string $redirectPath)
     {
-        $this->includeFile = $includeFile;
-        $this->redirectPath = $redirectPath;
     }
 
     /**

--- a/wwwroot/classes/Routing/TrophyRouteHandler.php
+++ b/wwwroot/classes/Routing/TrophyRouteHandler.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 require_once __DIR__ . '/../TrophyRepository.php';
 require_once __DIR__ . '/RouteHandlerInterface.php';
 
-class TrophyRouteHandler implements RouteHandlerInterface
+final readonly class TrophyRouteHandler implements RouteHandlerInterface
 {
-    private TrophyRepository $trophyRepository;
-
-    public function __construct(TrophyRepository $trophyRepository)
+    public function __construct(private TrophyRepository $trophyRepository)
     {
-        $this->trophyRepository = $trophyRepository;
     }
 
     /**


### PR DESCRIPTION
## Summary
- adopt readonly dependency injection in the application bootstrap to align with PHP 8.5 immutability features
- upgrade routing handlers to readonly classes with constructor property promotion

## Testing
- php -l wwwroot/classes/Application.php wwwroot/classes/Router.php wwwroot/classes/Routing/GameRouteHandler.php wwwroot/classes/Routing/HomeRouteHandler.php wwwroot/classes/Routing/LeaderboardRouteHandler.php wwwroot/classes/Routing/PlayerRouteHandler.php wwwroot/classes/Routing/SimpleRouteHandler.php wwwroot/classes/Routing/TrophyRouteHandler.php
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bed7889e0832fa7a030e966799aae)