### PR TITLE
Refactor player status handling for PHP 8.5

### DIFF
--- a/tests/PlayerAdvisorPageContextTest.php
+++ b/tests/PlayerAdvisorPageContextTest.php
@@ -18,7 +18,7 @@ final class PlayerAdvisorPageContextTest extends TestCase
             $filter,
             'ExampleUser',
             123,
-            0,
+            PlayerStatus::NORMAL,
             '456789'
         );
 
@@ -63,7 +63,7 @@ final class PlayerAdvisorPageContextTest extends TestCase
             $filter,
             'FlaggedUser',
             99,
-            1,
+            PlayerStatus::FLAGGED,
             '123456'
         );
 
@@ -83,7 +83,7 @@ final class PlayerAdvisorPageContextTest extends TestCase
             $filter,
             'PrivateUser',
             88,
-            3,
+            PlayerStatus::PRIVATE,
             null
         );
 

--- a/tests/PlayerGamesPageContextTest.php
+++ b/tests/PlayerGamesPageContextTest.php
@@ -41,15 +41,15 @@ final class PlayerGamesPageContextTest extends TestCase
 
     public function testContextReflectsPlayerStatus(): void
     {
-        $flagged = $this->createContext([], 1);
+        $flagged = $this->createContext([], PlayerStatus::FLAGGED);
         $this->assertTrue($flagged->isPlayerFlagged());
         $this->assertFalse($flagged->shouldDisplayGames());
 
-        $private = $this->createContext([], 3);
+        $private = $this->createContext([], PlayerStatus::PRIVATE);
         $this->assertTrue($private->isPlayerPrivate());
         $this->assertFalse($private->shouldDisplayGames());
 
-        $public = $this->createContext([], 0);
+        $public = $this->createContext([], PlayerStatus::NORMAL);
         $this->assertFalse($public->isPlayerFlagged());
         $this->assertFalse($public->isPlayerPrivate());
         $this->assertTrue($public->shouldDisplayGames());
@@ -58,7 +58,7 @@ final class PlayerGamesPageContextTest extends TestCase
     /**
      * @param array<string, mixed> $overrides
      */
-    private function createContext(array $overrides = [], int $status = 0): PlayerGamesPageContext
+    private function createContext(array $overrides = [], PlayerStatus $status = PlayerStatus::NORMAL): PlayerGamesPageContext
     {
         $playerData = array_merge(
             [

--- a/tests/PlayerLogPageContextTest.php
+++ b/tests/PlayerLogPageContextTest.php
@@ -27,7 +27,7 @@ final class PlayerLogPageContextTest extends TestCase
             ]),
         ];
 
-        $playerLogPage = $this->createPlayerLogPage($filter, $entries, 0, 99);
+        $playerLogPage = $this->createPlayerLogPage($filter, $entries, PlayerStatus::NORMAL, 99);
         $playerSummary = new PlayerSummary(10, 4, 75.0, 12);
 
         $context = PlayerLogPageContext::fromComponents(
@@ -36,7 +36,7 @@ final class PlayerLogPageContextTest extends TestCase
             $filter,
             'ExampleUser',
             99,
-            0
+            PlayerStatus::NORMAL
         );
 
         $this->assertSame($playerLogPage, $context->getPlayerLogPage());
@@ -73,27 +73,27 @@ final class PlayerLogPageContextTest extends TestCase
         $filter = PlayerLogFilter::fromArray([]);
         $playerSummary = new PlayerSummary(0, 0, null, 0);
 
-        $flaggedPage = $this->createPlayerLogPage($filter, [], 1, 50);
+        $flaggedPage = $this->createPlayerLogPage($filter, [], PlayerStatus::FLAGGED, 50);
         $flaggedContext = PlayerLogPageContext::fromComponents(
             $flaggedPage,
             $playerSummary,
             $filter,
             'FlaggedUser',
             50,
-            1
+            PlayerStatus::FLAGGED
         );
 
         $this->assertTrue($flaggedContext->isPlayerFlagged());
         $this->assertFalse($flaggedContext->shouldDisplayLog());
 
-        $privatePage = $this->createPlayerLogPage($filter, [], 3, 75);
+        $privatePage = $this->createPlayerLogPage($filter, [], PlayerStatus::PRIVATE, 75);
         $privateContext = PlayerLogPageContext::fromComponents(
             $privatePage,
             $playerSummary,
             $filter,
             'PrivateUser',
             75,
-            3
+            PlayerStatus::PRIVATE
         );
 
         $this->assertTrue($privateContext->isPlayerPrivate());
@@ -106,7 +106,7 @@ final class PlayerLogPageContextTest extends TestCase
     private function createPlayerLogPage(
         PlayerLogFilter $filter,
         array $entries,
-        int $playerStatus,
+        PlayerStatus $playerStatus,
         int $accountId
     ): PlayerLogPage {
         $service = new class($entries) extends PlayerLogService {

--- a/tests/PlayerRandomGamesPageContextTest.php
+++ b/tests/PlayerRandomGamesPageContextTest.php
@@ -31,7 +31,7 @@ final class PlayerRandomGamesPageContextTest extends TestCase
         $randomGames = [$randomGame];
 
         $playerSummary = new PlayerSummary(10, 4, 75.0, 12);
-        $page = $this->createPage($filter, $randomGames, $playerSummary, 0, 99);
+        $page = $this->createPage($filter, $randomGames, $playerSummary, PlayerStatus::NORMAL, 99);
 
         $context = PlayerRandomGamesPageContext::fromComponents(
             $page,
@@ -39,7 +39,7 @@ final class PlayerRandomGamesPageContextTest extends TestCase
             $page->getFilter(),
             'ExampleUser',
             99,
-            0
+            PlayerStatus::NORMAL
         );
 
         $this->assertSame("ExampleUser's Random Games ~ PSN 100%", $context->getTitle());
@@ -77,27 +77,27 @@ final class PlayerRandomGamesPageContextTest extends TestCase
         $playerSummary = new PlayerSummary(0, 0, null, 0);
         $randomGames = [];
 
-        $flaggedPage = $this->createPage($filter, $randomGames, $playerSummary, 1, 50);
+        $flaggedPage = $this->createPage($filter, $randomGames, $playerSummary, PlayerStatus::FLAGGED, 50);
         $flaggedContext = PlayerRandomGamesPageContext::fromComponents(
             $flaggedPage,
             $flaggedPage->getPlayerSummary(),
             $flaggedPage->getFilter(),
             'FlaggedUser',
             50,
-            1
+            PlayerStatus::FLAGGED
         );
 
         $this->assertTrue($flaggedContext->shouldShowFlaggedMessage());
         $this->assertFalse($flaggedContext->shouldShowRandomGames());
 
-        $privatePage = $this->createPage($filter, $randomGames, $playerSummary, 3, 75);
+        $privatePage = $this->createPage($filter, $randomGames, $playerSummary, PlayerStatus::PRIVATE, 75);
         $privateContext = PlayerRandomGamesPageContext::fromComponents(
             $privatePage,
             $privatePage->getPlayerSummary(),
             $privatePage->getFilter(),
             'PrivateUser',
             75,
-            3
+            PlayerStatus::PRIVATE
         );
 
         $this->assertTrue($privateContext->shouldShowPrivateMessage());
@@ -111,7 +111,7 @@ final class PlayerRandomGamesPageContextTest extends TestCase
         PlayerRandomGamesFilter $filter,
         array $randomGames,
         PlayerSummary $playerSummary,
-        int $playerStatus,
+        PlayerStatus $playerStatus,
         int $accountId
     ): PlayerRandomGamesPage {
         $randomGamesService = new class($randomGames) extends PlayerRandomGamesService {

--- a/wwwroot/classes/PlayerAdvisorPageContext.php
+++ b/wwwroot/classes/PlayerAdvisorPageContext.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/PlayerAdvisorPage.php';
 require_once __DIR__ . '/PlayerAdvisorService.php';
 require_once __DIR__ . '/PlayerNavigation.php';
 require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
+require_once __DIR__ . '/PlayerStatus.php';
 require_once __DIR__ . '/PlayerStatusNotice.php';
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/PlayerSummaryService.php';
@@ -15,9 +16,6 @@ require_once __DIR__ . '/Utility.php';
 
 final class PlayerAdvisorPageContext
 {
-    private const STATUS_FLAGGED = 1;
-    private const STATUS_PRIVATE = 3;
-
     private PlayerAdvisorPage $playerAdvisorPage;
 
     private PlayerSummary $playerSummary;
@@ -36,7 +34,7 @@ final class PlayerAdvisorPageContext
 
     private int $playerAccountId;
 
-    private int $playerStatus;
+    private PlayerStatus $playerStatus;
 
     private ?string $playerAccountIdValue;
 
@@ -54,7 +52,7 @@ final class PlayerAdvisorPageContext
         array $queryParameters
     ): self {
         $filter = PlayerAdvisorFilter::fromArray($queryParameters);
-        $playerStatus = self::extractPlayerStatus($playerData);
+        $playerStatus = PlayerStatus::fromPlayerData($playerData);
         $playerOnlineId = self::extractPlayerOnlineId($playerData);
         $playerAccountIdValue = self::extractPlayerAccountId($playerData);
 
@@ -84,7 +82,7 @@ final class PlayerAdvisorPageContext
         PlayerAdvisorFilter $filter,
         string $playerOnlineId,
         int $playerAccountId,
-        int $playerStatus,
+        PlayerStatus $playerStatus,
         ?string $playerAccountIdValue = null
     ): self {
         return new self(
@@ -104,7 +102,7 @@ final class PlayerAdvisorPageContext
         PlayerAdvisorFilter $filter,
         string $playerOnlineId,
         int $playerAccountId,
-        int $playerStatus,
+        PlayerStatus $playerStatus,
         ?string $playerAccountIdValue
     ) {
         $this->playerAdvisorPage = $playerAdvisorPage;
@@ -188,11 +186,11 @@ final class PlayerAdvisorPageContext
         }
 
         return match ($this->playerStatus) {
-            self::STATUS_FLAGGED => PlayerStatusNotice::flagged(
+            PlayerStatus::FLAGGED => PlayerStatusNotice::flagged(
                 $this->playerOnlineId,
                 $this->playerAccountIdValue
             ),
-            self::STATUS_PRIVATE => PlayerStatusNotice::privateProfile(),
+            PlayerStatus::PRIVATE => PlayerStatusNotice::privateProfile(),
             default => null,
         };
     }
@@ -208,11 +206,6 @@ final class PlayerAdvisorPageContext
     /**
      * @param array<string, mixed> $playerData
      */
-    private static function extractPlayerStatus(array $playerData): int
-    {
-        return (int) ($playerData['status'] ?? 0);
-    }
-
     /**
      * @param array<string, mixed> $playerData
      */

--- a/wwwroot/classes/PlayerGamesPage.php
+++ b/wwwroot/classes/PlayerGamesPage.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 require_once __DIR__ . '/ChangelogPaginator.php';
 require_once __DIR__ . '/PlayerGamesFilter.php';
 require_once __DIR__ . '/PlayerGamesService.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
 class PlayerGamesPage
 {
-    private const STATUS_FLAGGED = 1;
-    private const STATUS_PRIVATE = 3;
-
     private PlayerGamesFilter $requestedFilter;
 
     private ChangelogPaginator $paginator;
@@ -24,7 +22,7 @@ class PlayerGamesPage
         PlayerGamesService $service,
         PlayerGamesFilter $filter,
         int $accountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ) {
         $this->requestedFilter = $filter;
 
@@ -174,9 +172,9 @@ class PlayerGamesPage
         return $this->requestedFilter->withPage($page);
     }
 
-    private function shouldLoadPlayerGames(int $playerStatus): bool
+    private function shouldLoadPlayerGames(PlayerStatus $playerStatus): bool
     {
-        return !in_array($playerStatus, [self::STATUS_FLAGGED, self::STATUS_PRIVATE], true);
+        return $playerStatus->isVisible();
     }
 
     private function createFilterForPage(int $page): PlayerGamesFilter

--- a/wwwroot/classes/PlayerLogPage.php
+++ b/wwwroot/classes/PlayerLogPage.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerLogFilter.php';
 require_once __DIR__ . '/PlayerLogService.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
 class PlayerLogPage
 {
-    private const STATUS_FLAGGED = 1;
-    private const STATUS_PRIVATE = 3;
-
     private PlayerLogFilter $requestedFilter;
 
     /**
@@ -23,7 +21,7 @@ class PlayerLogPage
         PlayerLogService $service,
         PlayerLogFilter $filter,
         int $accountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ) {
         $this->requestedFilter = $filter->withPageNumber(1);
 
@@ -160,8 +158,8 @@ class PlayerLogPage
         return $this->requestedFilter->getFilterParameters();
     }
 
-    private function shouldLoadPlayerLog(int $playerStatus): bool
+    private function shouldLoadPlayerLog(PlayerStatus $playerStatus): bool
     {
-        return !in_array($playerStatus, [self::STATUS_FLAGGED, self::STATUS_PRIVATE], true);
+        return $playerStatus->isVisible();
     }
 }

--- a/wwwroot/classes/PlayerRandomGamesPage.php
+++ b/wwwroot/classes/PlayerRandomGamesPage.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerRandomGamesService.php';
 require_once __DIR__ . '/PlayerRandomGamesFilter.php';
+require_once __DIR__ . '/PlayerStatus.php';
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/PlayerSummaryService.php';
 
 class PlayerRandomGamesPage
 {
-    private const STATUS_FLAGGED = 1;
-    private const STATUS_PRIVATE = 3;
-
     private PlayerRandomGamesFilter $filter;
 
     private PlayerSummary $playerSummary;
@@ -21,14 +19,14 @@ class PlayerRandomGamesPage
      */
     private array $randomGames;
 
-    private int $playerStatus;
+    private PlayerStatus $playerStatus;
 
     public function __construct(
         PlayerRandomGamesService $randomGamesService,
         PlayerSummaryService $summaryService,
         PlayerRandomGamesFilter $filter,
         int $accountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ) {
         $this->filter = $filter;
         $this->playerSummary = $summaryService->getSummary($accountId);
@@ -61,17 +59,17 @@ class PlayerRandomGamesPage
 
     public function shouldShowFlaggedMessage(): bool
     {
-        return $this->playerStatus === self::STATUS_FLAGGED;
+        return $this->playerStatus->isFlagged();
     }
 
     public function shouldShowPrivateMessage(): bool
     {
-        return $this->playerStatus === self::STATUS_PRIVATE;
+        return $this->playerStatus->isPrivate();
     }
 
     public function shouldShowRandomGames(): bool
     {
-        return !$this->shouldShowFlaggedMessage() && !$this->shouldShowPrivateMessage();
+        return $this->playerStatus->isVisible();
     }
 
     private function shouldLoadRandomGames(): bool

--- a/wwwroot/classes/PlayerRandomGamesPageContext.php
+++ b/wwwroot/classes/PlayerRandomGamesPageContext.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/PlayerRandomGame.php';
 require_once __DIR__ . '/PlayerRandomGamesFilter.php';
 require_once __DIR__ . '/PlayerRandomGamesPage.php';
 require_once __DIR__ . '/PlayerRandomGamesService.php';
+require_once __DIR__ . '/PlayerStatus.php';
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/PlayerSummaryService.php';
 require_once __DIR__ . '/PlayerNavigation.php';
@@ -14,9 +15,6 @@ require_once __DIR__ . '/Utility.php';
 
 final class PlayerRandomGamesPageContext
 {
-    private const STATUS_FLAGGED = 1;
-    private const STATUS_PRIVATE = 3;
-
     private PlayerRandomGamesPage $playerRandomGamesPage;
 
     private PlayerSummary $playerSummary;
@@ -33,7 +31,7 @@ final class PlayerRandomGamesPageContext
 
     private int $playerAccountId;
 
-    private int $playerStatus;
+    private PlayerStatus $playerStatus;
 
     /**
      * @param array<string, mixed> $playerData
@@ -47,7 +45,7 @@ final class PlayerRandomGamesPageContext
         array $queryParameters
     ): self {
         $filter = PlayerRandomGamesFilter::fromArray($queryParameters);
-        $playerStatus = self::extractPlayerStatus($playerData);
+        $playerStatus = PlayerStatus::fromPlayerData($playerData);
 
         $randomGamesService = new PlayerRandomGamesService($database, $utility);
         $summaryService = new PlayerSummaryService($database);
@@ -76,7 +74,7 @@ final class PlayerRandomGamesPageContext
         PlayerRandomGamesFilter $filter,
         string $playerOnlineId,
         int $playerAccountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ): self {
         return new self(
             $playerRandomGamesPage,
@@ -94,7 +92,7 @@ final class PlayerRandomGamesPageContext
         PlayerRandomGamesFilter $filter,
         string $playerOnlineId,
         int $playerAccountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ) {
         $this->playerRandomGamesPage = $playerRandomGamesPage;
         $this->playerSummary = $playerSummary;
@@ -151,12 +149,12 @@ final class PlayerRandomGamesPageContext
 
     public function isPlayerFlagged(): bool
     {
-        return $this->playerStatus === self::STATUS_FLAGGED;
+        return $this->playerStatus->isFlagged();
     }
 
     public function isPlayerPrivate(): bool
     {
-        return $this->playerStatus === self::STATUS_PRIVATE;
+        return $this->playerStatus->isPrivate();
     }
 
     public function shouldShowFlaggedMessage(): bool
@@ -193,8 +191,4 @@ final class PlayerRandomGamesPageContext
     /**
      * @param array<string, mixed> $playerData
      */
-    private static function extractPlayerStatus(array $playerData): int
-    {
-        return (int) ($playerData['status'] ?? 0);
-    }
 }

--- a/wwwroot/classes/PlayerStatus.php
+++ b/wwwroot/classes/PlayerStatus.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerStatus: int
+{
+    case NORMAL = 0;
+    case FLAGGED = 1;
+    case PRIVATE = 3;
+
+    public static function fromValue(int|string|null $status): self
+    {
+        $normalized = is_numeric($status) ? (int) $status : 0;
+
+        return match ($normalized) {
+            self::FLAGGED->value => self::FLAGGED,
+            self::PRIVATE->value => self::PRIVATE,
+            default => self::NORMAL,
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $playerData
+     */
+    public static function fromPlayerData(array $playerData): self
+    {
+        return self::fromValue($playerData['status'] ?? null);
+    }
+
+    public function isFlagged(): bool
+    {
+        return $this === self::FLAGGED;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this === self::PRIVATE;
+    }
+
+    public function isVisible(): bool
+    {
+        return !$this->isFlagged() && !$this->isPrivate();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a PlayerStatus enum to normalize player visibility checks for modern PHP
- update player page/context classes to consume the enum instead of raw integers
- adjust related tests to use the new status type

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bf77ac148832f918af16c5b6fe830)