### PR TITLE
Refactor maintenance handling for PHP 8.5

### DIFF
--- a/wwwroot/classes/MaintenanceMode.php
+++ b/wwwroot/classes/MaintenanceMode.php
@@ -2,16 +2,10 @@
 
 declare(strict_types=1);
 
-final class MaintenanceMode
+final readonly class MaintenanceMode
 {
-    private bool $enabled;
-
-    private string $templatePath;
-
-    private function __construct(bool $enabled, string $templatePath)
+    private function __construct(private bool $enabled, private string $templatePath)
     {
-        $this->enabled = $enabled;
-        $this->templatePath = $templatePath;
     }
 
     public static function disabled(string $templatePath): self


### PR DESCRIPTION
## Summary
- promote maintenance mode configuration to a readonly design using modern PHP 8.5 property promotion
- type the maintenance responder callables as closures with a shared conversion helper for cleaner defaults

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bf77ac148832f918af16c5b6fe830)