### PR TITLE
Refactor constants to leverage PHP 8.5 typing

### DIFF
--- a/wwwroot/classes/AboutPagePlayer.php
+++ b/wwwroot/classes/AboutPagePlayer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 class AboutPagePlayer
 {
-    private const STATUS_LABELS = [
+    private const array STATUS_LABELS = [
         1 => 'Cheater',
         3 => 'Private',
         4 => 'Inactive',

--- a/wwwroot/classes/Admin/GameDetailPage.php
+++ b/wwwroot/classes/Admin/GameDetailPage.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../GameStatusService.php';
 
 class GameDetailPage
 {
-    private const STATUS_OPTIONS = [
+    private const array STATUS_OPTIONS = [
         0 => 'Normal',
         1 => 'Delisted',
         2 => 'Merged',
@@ -16,7 +16,7 @@ class GameDetailPage
         4 => 'Delisted & Obsolete',
     ];
 
-    private const PLATFORM_OPTIONS = [
+    private const array PLATFORM_OPTIONS = [
         'PS3',
         'PSVITA',
         'PS4',

--- a/wwwroot/classes/Cron/CronJobRunner.php
+++ b/wwwroot/classes/Cron/CronJobRunner.php
@@ -6,8 +6,8 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final class CronJobRunner
 {
-    private const MINIMUM_MEMORY_LIMIT = '512M';
-    private const MINIMUM_MEMORY_LIMIT_BYTES = 536870912; // 512 MiB
+    private const string MINIMUM_MEMORY_LIMIT = '512M';
+    private const int MINIMUM_MEMORY_LIMIT_BYTES = 536870912; // 512 MiB
 
     private bool $environmentConfigured = false;
 

--- a/wwwroot/classes/GameListItem.php
+++ b/wwwroot/classes/GameListItem.php
@@ -7,13 +7,13 @@ require_once __DIR__ . '/Utility.php';
 
 final class GameListItem
 {
-    private const STATUS_NORMAL = 0;
-    private const STATUS_DELISTED = 1;
-    private const STATUS_OBSOLETE = 3;
-    private const STATUS_DELISTED_AND_OBSOLETE = 4;
-    private const COMPLETION_PERCENTAGE = 100;
-    private const MISSING_PS5_ICON = '../missing-ps5-game-and-trophy.png';
-    private const MISSING_PS4_ICON = '../missing-ps4-game.png';
+    private const int STATUS_NORMAL = 0;
+    private const int STATUS_DELISTED = 1;
+    private const int STATUS_OBSOLETE = 3;
+    private const int STATUS_DELISTED_AND_OBSOLETE = 4;
+    private const int COMPLETION_PERCENTAGE = 100;
+    private const string MISSING_PS5_ICON = '../missing-ps5-game-and-trophy.png';
+    private const string MISSING_PS4_ICON = '../missing-ps4-game.png';
 
     private int $id;
 

--- a/wwwroot/classes/PlayerAdvisorPageContext.php
+++ b/wwwroot/classes/PlayerAdvisorPageContext.php
@@ -15,8 +15,8 @@ require_once __DIR__ . '/Utility.php';
 
 final class PlayerAdvisorPageContext
 {
-    private const STATUS_FLAGGED = 1;
-    private const STATUS_PRIVATE = 3;
+    private const int STATUS_FLAGGED = 1;
+    private const int STATUS_PRIVATE = 3;
 
     private PlayerAdvisorPage $playerAdvisorPage;
 

--- a/wwwroot/classes/PlayerGame.php
+++ b/wwwroot/classes/PlayerGame.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 class PlayerGame
 {
-    private const STATUS_DELISTED = 1;
-    private const STATUS_OBSOLETE = 3;
-    private const STATUS_DELISTED_AND_OBSOLETE = 4;
+    private const int STATUS_DELISTED = 1;
+    private const int STATUS_OBSOLETE = 3;
+    private const int STATUS_DELISTED_AND_OBSOLETE = 4;
 
     private int $id;
     private string $npCommunicationId;

--- a/wwwroot/classes/PlayerGamesPage.php
+++ b/wwwroot/classes/PlayerGamesPage.php
@@ -8,8 +8,8 @@ require_once __DIR__ . '/PlayerGamesService.php';
 
 class PlayerGamesPage
 {
-    private const STATUS_FLAGGED = 1;
-    private const STATUS_PRIVATE = 3;
+    private const int STATUS_FLAGGED = 1;
+    private const int STATUS_PRIVATE = 3;
 
     private PlayerGamesFilter $requestedFilter;
 

--- a/wwwroot/classes/PlayerGamesPageContext.php
+++ b/wwwroot/classes/PlayerGamesPageContext.php
@@ -14,8 +14,8 @@ require_once __DIR__ . '/PlayerSummaryService.php';
 
 final class PlayerGamesPageContext
 {
-    private const STATUS_FLAGGED = 1;
-    private const STATUS_PRIVATE = 3;
+    private const int STATUS_FLAGGED = 1;
+    private const int STATUS_PRIVATE = 3;
 
     private PlayerGamesPage $playerGamesPage;
 

--- a/wwwroot/classes/PlayerLogPage.php
+++ b/wwwroot/classes/PlayerLogPage.php
@@ -7,8 +7,8 @@ require_once __DIR__ . '/PlayerLogService.php';
 
 class PlayerLogPage
 {
-    private const STATUS_FLAGGED = 1;
-    private const STATUS_PRIVATE = 3;
+    private const int STATUS_FLAGGED = 1;
+    private const int STATUS_PRIVATE = 3;
 
     private PlayerLogFilter $requestedFilter;
 

--- a/wwwroot/classes/PlayerLogPageContext.php
+++ b/wwwroot/classes/PlayerLogPageContext.php
@@ -13,8 +13,8 @@ require_once __DIR__ . '/TrophyRarityFormatter.php';
 
 final class PlayerLogPageContext
 {
-    private const STATUS_FLAGGED = 1;
-    private const STATUS_PRIVATE = 3;
+    private const int STATUS_FLAGGED = 1;
+    private const int STATUS_PRIVATE = 3;
 
     private PlayerLogPage $playerLogPage;
 

--- a/wwwroot/classes/PlayerRandomGamesPage.php
+++ b/wwwroot/classes/PlayerRandomGamesPage.php
@@ -9,8 +9,8 @@ require_once __DIR__ . '/PlayerSummaryService.php';
 
 class PlayerRandomGamesPage
 {
-    private const STATUS_FLAGGED = 1;
-    private const STATUS_PRIVATE = 3;
+    private const int STATUS_FLAGGED = 1;
+    private const int STATUS_PRIVATE = 3;
 
     private PlayerRandomGamesFilter $filter;
 

--- a/wwwroot/classes/PlayerRandomGamesPageContext.php
+++ b/wwwroot/classes/PlayerRandomGamesPageContext.php
@@ -14,8 +14,8 @@ require_once __DIR__ . '/Utility.php';
 
 final class PlayerRandomGamesPageContext
 {
-    private const STATUS_FLAGGED = 1;
-    private const STATUS_PRIVATE = 3;
+    private const int STATUS_FLAGGED = 1;
+    private const int STATUS_PRIVATE = 3;
 
     private PlayerRandomGamesPage $playerRandomGamesPage;
 


### PR DESCRIPTION
## Summary
- update admin and player page classes to use typed status and option constants now that PHP 8.5 is targeted
- convert game list and model constants to typed ints/strings for clearer intent
- align cron runner memory limit constants with typed definitions

## Testing
- php ../tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bf77ac148832f918af16c5b6fe830)