### PR TITLE
Refactor player status handling with PHP 8.5 enums

### DIFF
--- a/tests/PlayerAdvisorPageContextTest.php
+++ b/tests/PlayerAdvisorPageContextTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/PlayerAdvisorPageContext.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerStatus.php';
 
 final class PlayerAdvisorPageContextTest extends TestCase
 {
@@ -18,7 +19,7 @@ final class PlayerAdvisorPageContextTest extends TestCase
             $filter,
             'ExampleUser',
             123,
-            0,
+            PlayerStatus::NORMAL,
             '456789'
         );
 
@@ -63,7 +64,7 @@ final class PlayerAdvisorPageContextTest extends TestCase
             $filter,
             'FlaggedUser',
             99,
-            1,
+            PlayerStatus::FLAGGED,
             '123456'
         );
 
@@ -83,7 +84,7 @@ final class PlayerAdvisorPageContextTest extends TestCase
             $filter,
             'PrivateUser',
             88,
-            3,
+            PlayerStatus::PRIVATE_PROFILE,
             null
         );
 

--- a/tests/PlayerGamesPageContextTest.php
+++ b/tests/PlayerGamesPageContextTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../wwwroot/classes/PlayerGamesPageContext.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerGamesFilter.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerSummary.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerStatus.php';
 
 final class PlayerGamesPageContextPageStub extends PlayerGamesPage
 {
@@ -41,15 +42,15 @@ final class PlayerGamesPageContextTest extends TestCase
 
     public function testContextReflectsPlayerStatus(): void
     {
-        $flagged = $this->createContext([], 1);
+        $flagged = $this->createContext([], PlayerStatus::FLAGGED);
         $this->assertTrue($flagged->isPlayerFlagged());
         $this->assertFalse($flagged->shouldDisplayGames());
 
-        $private = $this->createContext([], 3);
+        $private = $this->createContext([], PlayerStatus::PRIVATE_PROFILE);
         $this->assertTrue($private->isPlayerPrivate());
         $this->assertFalse($private->shouldDisplayGames());
 
-        $public = $this->createContext([], 0);
+        $public = $this->createContext([], PlayerStatus::NORMAL);
         $this->assertFalse($public->isPlayerFlagged());
         $this->assertFalse($public->isPlayerPrivate());
         $this->assertTrue($public->shouldDisplayGames());
@@ -58,7 +59,7 @@ final class PlayerGamesPageContextTest extends TestCase
     /**
      * @param array<string, mixed> $overrides
      */
-    private function createContext(array $overrides = [], int $status = 0): PlayerGamesPageContext
+    private function createContext(array $overrides = [], PlayerStatus $status = PlayerStatus::NORMAL): PlayerGamesPageContext
     {
         $playerData = array_merge(
             [

--- a/tests/PlayerLogPageContextTest.php
+++ b/tests/PlayerLogPageContextTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/PlayerLogPageContext.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerStatus.php';
 
 final class PlayerLogPageContextTest extends TestCase
 {
@@ -27,7 +28,7 @@ final class PlayerLogPageContextTest extends TestCase
             ]),
         ];
 
-        $playerLogPage = $this->createPlayerLogPage($filter, $entries, 0, 99);
+        $playerLogPage = $this->createPlayerLogPage($filter, $entries, PlayerStatus::NORMAL, 99);
         $playerSummary = new PlayerSummary(10, 4, 75.0, 12);
 
         $context = PlayerLogPageContext::fromComponents(
@@ -36,7 +37,7 @@ final class PlayerLogPageContextTest extends TestCase
             $filter,
             'ExampleUser',
             99,
-            0
+            PlayerStatus::NORMAL
         );
 
         $this->assertSame($playerLogPage, $context->getPlayerLogPage());
@@ -73,27 +74,27 @@ final class PlayerLogPageContextTest extends TestCase
         $filter = PlayerLogFilter::fromArray([]);
         $playerSummary = new PlayerSummary(0, 0, null, 0);
 
-        $flaggedPage = $this->createPlayerLogPage($filter, [], 1, 50);
+        $flaggedPage = $this->createPlayerLogPage($filter, [], PlayerStatus::FLAGGED, 50);
         $flaggedContext = PlayerLogPageContext::fromComponents(
             $flaggedPage,
             $playerSummary,
             $filter,
             'FlaggedUser',
             50,
-            1
+            PlayerStatus::FLAGGED
         );
 
         $this->assertTrue($flaggedContext->isPlayerFlagged());
         $this->assertFalse($flaggedContext->shouldDisplayLog());
 
-        $privatePage = $this->createPlayerLogPage($filter, [], 3, 75);
+        $privatePage = $this->createPlayerLogPage($filter, [], PlayerStatus::PRIVATE_PROFILE, 75);
         $privateContext = PlayerLogPageContext::fromComponents(
             $privatePage,
             $playerSummary,
             $filter,
             'PrivateUser',
             75,
-            3
+            PlayerStatus::PRIVATE_PROFILE
         );
 
         $this->assertTrue($privateContext->isPlayerPrivate());
@@ -106,7 +107,7 @@ final class PlayerLogPageContextTest extends TestCase
     private function createPlayerLogPage(
         PlayerLogFilter $filter,
         array $entries,
-        int $playerStatus,
+        PlayerStatus $playerStatus,
         int $accountId
     ): PlayerLogPage {
         $service = new class($entries) extends PlayerLogService {

--- a/tests/PlayerRandomGamesPageContextTest.php
+++ b/tests/PlayerRandomGamesPageContextTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/PlayerRandomGamesPageContext.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerStatus.php';
 
 final class PlayerRandomGamesPageContextTest extends TestCase
 {
@@ -31,7 +32,7 @@ final class PlayerRandomGamesPageContextTest extends TestCase
         $randomGames = [$randomGame];
 
         $playerSummary = new PlayerSummary(10, 4, 75.0, 12);
-        $page = $this->createPage($filter, $randomGames, $playerSummary, 0, 99);
+        $page = $this->createPage($filter, $randomGames, $playerSummary, PlayerStatus::NORMAL, 99);
 
         $context = PlayerRandomGamesPageContext::fromComponents(
             $page,
@@ -39,7 +40,7 @@ final class PlayerRandomGamesPageContextTest extends TestCase
             $page->getFilter(),
             'ExampleUser',
             99,
-            0
+            PlayerStatus::NORMAL
         );
 
         $this->assertSame("ExampleUser's Random Games ~ PSN 100%", $context->getTitle());
@@ -77,27 +78,27 @@ final class PlayerRandomGamesPageContextTest extends TestCase
         $playerSummary = new PlayerSummary(0, 0, null, 0);
         $randomGames = [];
 
-        $flaggedPage = $this->createPage($filter, $randomGames, $playerSummary, 1, 50);
+        $flaggedPage = $this->createPage($filter, $randomGames, $playerSummary, PlayerStatus::FLAGGED, 50);
         $flaggedContext = PlayerRandomGamesPageContext::fromComponents(
             $flaggedPage,
             $flaggedPage->getPlayerSummary(),
             $flaggedPage->getFilter(),
             'FlaggedUser',
             50,
-            1
+            PlayerStatus::FLAGGED
         );
 
         $this->assertTrue($flaggedContext->shouldShowFlaggedMessage());
         $this->assertFalse($flaggedContext->shouldShowRandomGames());
 
-        $privatePage = $this->createPage($filter, $randomGames, $playerSummary, 3, 75);
+        $privatePage = $this->createPage($filter, $randomGames, $playerSummary, PlayerStatus::PRIVATE_PROFILE, 75);
         $privateContext = PlayerRandomGamesPageContext::fromComponents(
             $privatePage,
             $privatePage->getPlayerSummary(),
             $privatePage->getFilter(),
             'PrivateUser',
             75,
-            3
+            PlayerStatus::PRIVATE_PROFILE
         );
 
         $this->assertTrue($privateContext->shouldShowPrivateMessage());
@@ -111,7 +112,7 @@ final class PlayerRandomGamesPageContextTest extends TestCase
         PlayerRandomGamesFilter $filter,
         array $randomGames,
         PlayerSummary $playerSummary,
-        int $playerStatus,
+        PlayerStatus $playerStatus,
         int $accountId
     ): PlayerRandomGamesPage {
         $randomGamesService = new class($randomGames) extends PlayerRandomGamesService {

--- a/wwwroot/classes/PlayerAdvisorPage.php
+++ b/wwwroot/classes/PlayerAdvisorPage.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerStatus.php';
+
 class PlayerAdvisorPage
 {
     private PlayerAdvisorService $playerAdvisorService;
@@ -12,7 +14,7 @@ class PlayerAdvisorPage
 
     private int $accountId;
 
-    private int $playerStatus;
+    private PlayerStatus $playerStatus;
 
     private ?PlayerSummary $playerSummary = null;
 
@@ -28,7 +30,7 @@ class PlayerAdvisorPage
         PlayerSummaryService $playerSummaryService,
         PlayerAdvisorFilter $filter,
         int $accountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ) {
         $this->playerAdvisorService = $playerAdvisorService;
         $this->playerSummaryService = $playerSummaryService;
@@ -68,7 +70,7 @@ class PlayerAdvisorPage
 
     public function shouldDisplayAdvisor(): bool
     {
-        return !in_array($this->playerStatus, [1, 3], true);
+        return !$this->playerStatus->isRestricted();
     }
 
     public function getTotalTrophies(): int

--- a/wwwroot/classes/PlayerAdvisorPageContext.php
+++ b/wwwroot/classes/PlayerAdvisorPageContext.php
@@ -12,12 +12,10 @@ require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/PlayerSummaryService.php';
 require_once __DIR__ . '/TrophyRarityFormatter.php';
 require_once __DIR__ . '/Utility.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
 final class PlayerAdvisorPageContext
 {
-    private const int STATUS_FLAGGED = 1;
-    private const int STATUS_PRIVATE = 3;
-
     private PlayerAdvisorPage $playerAdvisorPage;
 
     private PlayerSummary $playerSummary;
@@ -36,7 +34,7 @@ final class PlayerAdvisorPageContext
 
     private int $playerAccountId;
 
-    private int $playerStatus;
+    private PlayerStatus $playerStatus;
 
     private ?string $playerAccountIdValue;
 
@@ -84,7 +82,7 @@ final class PlayerAdvisorPageContext
         PlayerAdvisorFilter $filter,
         string $playerOnlineId,
         int $playerAccountId,
-        int $playerStatus,
+        PlayerStatus $playerStatus,
         ?string $playerAccountIdValue = null
     ): self {
         return new self(
@@ -104,7 +102,7 @@ final class PlayerAdvisorPageContext
         PlayerAdvisorFilter $filter,
         string $playerOnlineId,
         int $playerAccountId,
-        int $playerStatus,
+        PlayerStatus $playerStatus,
         ?string $playerAccountIdValue
     ) {
         $this->playerAdvisorPage = $playerAdvisorPage;
@@ -187,12 +185,12 @@ final class PlayerAdvisorPageContext
             return null;
         }
 
-        return match ($this->playerStatus) {
-            self::STATUS_FLAGGED => PlayerStatusNotice::flagged(
+        return match (true) {
+            $this->playerStatus->isFlagged() => PlayerStatusNotice::flagged(
                 $this->playerOnlineId,
                 $this->playerAccountIdValue
             ),
-            self::STATUS_PRIVATE => PlayerStatusNotice::privateProfile(),
+            $this->playerStatus->isPrivateProfile() => PlayerStatusNotice::privateProfile(),
             default => null,
         };
     }
@@ -208,9 +206,9 @@ final class PlayerAdvisorPageContext
     /**
      * @param array<string, mixed> $playerData
      */
-    private static function extractPlayerStatus(array $playerData): int
+    private static function extractPlayerStatus(array $playerData): PlayerStatus
     {
-        return (int) ($playerData['status'] ?? 0);
+        return PlayerStatus::fromValue((int) ($playerData['status'] ?? 0));
     }
 
     /**

--- a/wwwroot/classes/PlayerGamesPage.php
+++ b/wwwroot/classes/PlayerGamesPage.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 require_once __DIR__ . '/ChangelogPaginator.php';
 require_once __DIR__ . '/PlayerGamesFilter.php';
 require_once __DIR__ . '/PlayerGamesService.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
 class PlayerGamesPage
 {
-    private const int STATUS_FLAGGED = 1;
-    private const int STATUS_PRIVATE = 3;
-
     private PlayerGamesFilter $requestedFilter;
 
     private ChangelogPaginator $paginator;
@@ -24,7 +22,7 @@ class PlayerGamesPage
         PlayerGamesService $service,
         PlayerGamesFilter $filter,
         int $accountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ) {
         $this->requestedFilter = $filter;
 
@@ -174,9 +172,9 @@ class PlayerGamesPage
         return $this->requestedFilter->withPage($page);
     }
 
-    private function shouldLoadPlayerGames(int $playerStatus): bool
+    private function shouldLoadPlayerGames(PlayerStatus $playerStatus): bool
     {
-        return !in_array($playerStatus, [self::STATUS_FLAGGED, self::STATUS_PRIVATE], true);
+        return !$playerStatus->isRestricted();
     }
 
     private function createFilterForPage(int $page): PlayerGamesFilter

--- a/wwwroot/classes/PlayerLogPage.php
+++ b/wwwroot/classes/PlayerLogPage.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerLogFilter.php';
 require_once __DIR__ . '/PlayerLogService.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
 class PlayerLogPage
 {
-    private const int STATUS_FLAGGED = 1;
-    private const int STATUS_PRIVATE = 3;
-
     private PlayerLogFilter $requestedFilter;
 
     /**
@@ -23,7 +21,7 @@ class PlayerLogPage
         PlayerLogService $service,
         PlayerLogFilter $filter,
         int $accountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ) {
         $this->requestedFilter = $filter->withPageNumber(1);
 
@@ -160,8 +158,8 @@ class PlayerLogPage
         return $this->requestedFilter->getFilterParameters();
     }
 
-    private function shouldLoadPlayerLog(int $playerStatus): bool
+    private function shouldLoadPlayerLog(PlayerStatus $playerStatus): bool
     {
-        return !in_array($playerStatus, [self::STATUS_FLAGGED, self::STATUS_PRIVATE], true);
+        return !$playerStatus->isRestricted();
     }
 }

--- a/wwwroot/classes/PlayerLogPageContext.php
+++ b/wwwroot/classes/PlayerLogPageContext.php
@@ -10,11 +10,10 @@ require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/PlayerSummaryService.php';
 require_once __DIR__ . '/TrophyRarityFormatter.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
 final class PlayerLogPageContext
 {
-    private const int STATUS_FLAGGED = 1;
-    private const int STATUS_PRIVATE = 3;
 
     private PlayerLogPage $playerLogPage;
 
@@ -34,7 +33,7 @@ final class PlayerLogPageContext
 
     private int $playerAccountId;
 
-    private int $playerStatus;
+    private PlayerStatus $playerStatus;
 
     /**
      * @param array<string, mixed> $playerData
@@ -74,7 +73,7 @@ final class PlayerLogPageContext
         PlayerLogFilter $filter,
         string $playerOnlineId,
         int $playerAccountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ): self {
         return new self(
             $playerLogPage,
@@ -92,7 +91,7 @@ final class PlayerLogPageContext
         PlayerLogFilter $filter,
         string $playerOnlineId,
         int $playerAccountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ) {
         $this->playerLogPage = $playerLogPage;
         $this->playerSummary = $playerSummary;
@@ -155,12 +154,12 @@ final class PlayerLogPageContext
 
     public function isPlayerFlagged(): bool
     {
-        return $this->playerStatus === self::STATUS_FLAGGED;
+        return $this->playerStatus->isFlagged();
     }
 
     public function isPlayerPrivate(): bool
     {
-        return $this->playerStatus === self::STATUS_PRIVATE;
+        return $this->playerStatus->isPrivateProfile();
     }
 
     public function shouldDisplayLog(): bool
@@ -186,8 +185,8 @@ final class PlayerLogPageContext
         return (int) ($playerData['account_id'] ?? 0);
     }
 
-    private static function extractPlayerStatus(array $playerData): int
+    private static function extractPlayerStatus(array $playerData): PlayerStatus
     {
-        return (int) ($playerData['status'] ?? 0);
+        return PlayerStatus::fromValue((int) ($playerData['status'] ?? 0));
     }
 }

--- a/wwwroot/classes/PlayerRandomGamesPage.php
+++ b/wwwroot/classes/PlayerRandomGamesPage.php
@@ -6,12 +6,10 @@ require_once __DIR__ . '/PlayerRandomGamesService.php';
 require_once __DIR__ . '/PlayerRandomGamesFilter.php';
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/PlayerSummaryService.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
 class PlayerRandomGamesPage
 {
-    private const int STATUS_FLAGGED = 1;
-    private const int STATUS_PRIVATE = 3;
-
     private PlayerRandomGamesFilter $filter;
 
     private PlayerSummary $playerSummary;
@@ -21,14 +19,14 @@ class PlayerRandomGamesPage
      */
     private array $randomGames;
 
-    private int $playerStatus;
+    private PlayerStatus $playerStatus;
 
     public function __construct(
         PlayerRandomGamesService $randomGamesService,
         PlayerSummaryService $summaryService,
         PlayerRandomGamesFilter $filter,
         int $accountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ) {
         $this->filter = $filter;
         $this->playerSummary = $summaryService->getSummary($accountId);
@@ -61,12 +59,12 @@ class PlayerRandomGamesPage
 
     public function shouldShowFlaggedMessage(): bool
     {
-        return $this->playerStatus === self::STATUS_FLAGGED;
+        return $this->playerStatus->isFlagged();
     }
 
     public function shouldShowPrivateMessage(): bool
     {
-        return $this->playerStatus === self::STATUS_PRIVATE;
+        return $this->playerStatus->isPrivateProfile();
     }
 
     public function shouldShowRandomGames(): bool

--- a/wwwroot/classes/PlayerRandomGamesPageContext.php
+++ b/wwwroot/classes/PlayerRandomGamesPageContext.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/PlayerSummaryService.php';
 require_once __DIR__ . '/PlayerNavigation.php';
 require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
 require_once __DIR__ . '/Utility.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
 final class PlayerRandomGamesPageContext
 {
@@ -33,7 +34,7 @@ final class PlayerRandomGamesPageContext
 
     private int $playerAccountId;
 
-    private int $playerStatus;
+    private PlayerStatus $playerStatus;
 
     /**
      * @param array<string, mixed> $playerData
@@ -76,7 +77,7 @@ final class PlayerRandomGamesPageContext
         PlayerRandomGamesFilter $filter,
         string $playerOnlineId,
         int $playerAccountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ): self {
         return new self(
             $playerRandomGamesPage,
@@ -94,7 +95,7 @@ final class PlayerRandomGamesPageContext
         PlayerRandomGamesFilter $filter,
         string $playerOnlineId,
         int $playerAccountId,
-        int $playerStatus
+        PlayerStatus $playerStatus
     ) {
         $this->playerRandomGamesPage = $playerRandomGamesPage;
         $this->playerSummary = $playerSummary;
@@ -151,12 +152,12 @@ final class PlayerRandomGamesPageContext
 
     public function isPlayerFlagged(): bool
     {
-        return $this->playerStatus === self::STATUS_FLAGGED;
+        return $this->playerStatus->isFlagged();
     }
 
     public function isPlayerPrivate(): bool
     {
-        return $this->playerStatus === self::STATUS_PRIVATE;
+        return $this->playerStatus->isPrivateProfile();
     }
 
     public function shouldShowFlaggedMessage(): bool
@@ -193,8 +194,8 @@ final class PlayerRandomGamesPageContext
     /**
      * @param array<string, mixed> $playerData
      */
-    private static function extractPlayerStatus(array $playerData): int
+    private static function extractPlayerStatus(array $playerData): PlayerStatus
     {
-        return (int) ($playerData['status'] ?? 0);
+        return PlayerStatus::fromValue((int) ($playerData['status'] ?? 0));
     }
 }

--- a/wwwroot/classes/PlayerStatus.php
+++ b/wwwroot/classes/PlayerStatus.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerStatus: int
+{
+    case NORMAL = 0;
+    case FLAGGED = 1;
+    case PRIVATE_PROFILE = 3;
+    case INACTIVE = 4;
+    case UNAVAILABLE = 5;
+    case NEW_PLAYER = 99;
+
+    public static function fromValue(int $status): self
+    {
+        return self::tryFrom($status) ?? self::NORMAL;
+    }
+
+    public function isFlagged(): bool
+    {
+        return $this === self::FLAGGED;
+    }
+
+    public function isPrivateProfile(): bool
+    {
+        return $this === self::PRIVATE_PROFILE;
+    }
+
+    public function isRestricted(): bool
+    {
+        return $this->isFlagged() || $this->isPrivateProfile();
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `PlayerStatus` enum to modernize player status handling
- update player page and service classes to consume the enum instead of raw integers
- align related tests with the new typed status workflow

## Testing
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694479e58528832f88dabbf31e821827)