### PR TITLE
Refactor admin helpers for PHP 8.5 immutability

### DIFF
--- a/wwwroot/classes/Admin/AdminRequest.php
+++ b/wwwroot/classes/Admin/AdminRequest.php
@@ -2,23 +2,19 @@
 
 declare(strict_types=1);
 
-final class AdminRequest
+final readonly class AdminRequest
 {
     private string $method;
 
     /**
-     * @var array<string, mixed>
-     */
-    private array $postData;
-
-    /**
      * @param array<string, mixed> $postData
      */
-    public function __construct(string $method, array $postData)
-    {
+    public function __construct(
+        string $method,
+        private array $postData,
+    ) {
         $normalizedMethod = strtoupper(trim($method));
         $this->method = $normalizedMethod === '' ? 'GET' : $normalizedMethod;
-        $this->postData = $postData;
     }
 
     /**

--- a/wwwroot/classes/Admin/CheaterRequestResult.php
+++ b/wwwroot/classes/Admin/CheaterRequestResult.php
@@ -2,16 +2,12 @@
 
 declare(strict_types=1);
 
-class CheaterRequestResult
+final readonly class CheaterRequestResult
 {
-    private ?string $successMessage;
-
-    private ?string $errorMessage;
-
-    private function __construct(?string $successMessage, ?string $errorMessage)
-    {
-        $this->successMessage = $successMessage;
-        $this->errorMessage = $errorMessage;
+    private function __construct(
+        private ?string $successMessage,
+        private ?string $errorMessage,
+    ) {
     }
 
     public static function success(string $message): self

--- a/wwwroot/classes/Admin/DeletePlayerConfirmation.php
+++ b/wwwroot/classes/Admin/DeletePlayerConfirmation.php
@@ -2,16 +2,10 @@
 
 declare(strict_types=1);
 
-final class DeletePlayerConfirmation
+final readonly class DeletePlayerConfirmation
 {
-    private string $accountId;
-
-    private ?string $onlineId;
-
-    public function __construct(string $accountId, ?string $onlineId)
+    public function __construct(private string $accountId, private ?string $onlineId)
     {
-        $this->accountId = $accountId;
-        $this->onlineId = $onlineId;
     }
 
     public function getAccountId(): string

--- a/wwwroot/classes/Admin/GameResetRequestResult.php
+++ b/wwwroot/classes/Admin/GameResetRequestResult.php
@@ -2,16 +2,12 @@
 
 declare(strict_types=1);
 
-class GameResetRequestResult
+final readonly class GameResetRequestResult
 {
-    private ?string $successMessage;
-
-    private ?string $errorMessage;
-
-    private function __construct(?string $successMessage, ?string $errorMessage)
-    {
-        $this->successMessage = $successMessage;
-        $this->errorMessage = $errorMessage;
+    private function __construct(
+        private ?string $successMessage,
+        private ?string $errorMessage,
+    ) {
     }
 
     public static function success(string $message): self

--- a/wwwroot/classes/Admin/WorkerScanProgress.php
+++ b/wwwroot/classes/Admin/WorkerScanProgress.php
@@ -2,26 +2,14 @@
 
 declare(strict_types=1);
 
-final class WorkerScanProgress
+final readonly class WorkerScanProgress
 {
-    private ?int $current;
-
-    private ?int $total;
-
-    private ?string $title;
-
-    private ?string $npCommunicationId;
-
     private function __construct(
-        ?int $current,
-        ?int $total,
-        ?string $title,
-        ?string $npCommunicationId
+        private ?int $current,
+        private ?int $total,
+        private ?string $title,
+        private ?string $npCommunicationId,
     ) {
-        $this->current = $current;
-        $this->total = $total;
-        $this->title = $title;
-        $this->npCommunicationId = $npCommunicationId;
     }
 
     public static function fromJson(?string $value): ?self


### PR DESCRIPTION
## Summary
- adopt readonly classes and promoted properties for admin request/result value objects to align with PHP 8.5 features
- modernize worker scan progress and delete player confirmation models with immutable constructors

## Testing
- php -l wwwroot/classes/Admin/AdminRequest.php wwwroot/classes/Admin/CheaterRequestResult.php wwwroot/classes/Admin/DeletePlayerConfirmation.php wwwroot/classes/Admin/GameResetRequestResult.php wwwroot/classes/Admin/WorkerScanProgress.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694479e58528832f88dabbf31e821827)