### PR TITLE
Add override attributes for PHP 8.5

### DIFF
--- a/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
+++ b/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
@@ -19,6 +19,7 @@ final class CallableGameRescanProgressListener implements GameRescanProgressList
         $this->callback = $callback;
     }
 
+    #[\Override]
     public function onProgress(int $percent, string $message): void
     {
         ($this->callback)($percent, $message);

--- a/wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
+++ b/wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
@@ -19,6 +19,7 @@ final class CallableTrophyMergeProgressListener implements TrophyMergeProgressLi
         $this->callback = $callback;
     }
 
+    #[\Override]
     public function onProgress(int $percent, string $message): void
     {
         ($this->callback)($percent, $message);

--- a/wwwroot/classes/PlayerQueueResponse.php
+++ b/wwwroot/classes/PlayerQueueResponse.php
@@ -58,6 +58,7 @@ readonly class PlayerQueueResponse implements \JsonSerializable
         ];
     }
 
+    #[\Override]
     public function jsonSerialize(): mixed
     {
         return $this->toArray();


### PR DESCRIPTION
## Summary
- annotate interface implementations with #[\Override] to leverage PHP 8.5 language features
- ensure queue response and admin progress listeners clearly document interface conformance

## Testing
- php -l wwwroot/classes/PlayerQueueResponse.php
- php -l wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
- php -l wwwroot/classes/Admin/CallableGameRescanProgressListener.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694479e58528832f88dabbf31e821827)