### PR TITLE
Simplify runtime configuration for PHP 8.5

### DIFF
--- a/wwwroot/classes/Cron/CronJobRunner.php
+++ b/wwwroot/classes/Cron/CronJobRunner.php
@@ -37,34 +37,28 @@ final class CronJobRunner
         $this->applyIniSetting('max_execution_time', '0');
         $this->applyIniSetting('mysql.connect_timeout', '0');
 
-        if (function_exists('set_time_limit')) {
-            @set_time_limit(0);
-        }
+        @set_time_limit(0);
 
         $this->environmentConfigured = true;
     }
 
     private function applyIniSetting(string $option, string $value): void
     {
-        if (function_exists('ini_set')) {
-            @ini_set($option, $value);
-        }
+        @ini_set($option, $value);
     }
 
     private function increaseMemoryLimitIfNeeded(): void
     {
-        if (function_exists('ini_get')) {
-            $currentLimit = ini_get('memory_limit');
+        $currentLimit = ini_get('memory_limit');
 
-            if ($currentLimit === false || $currentLimit === '' || $currentLimit === '-1') {
-                return;
-            }
+        if ($currentLimit === false || $currentLimit === '' || $currentLimit === '-1') {
+            return;
+        }
 
-            $currentBytes = $this->parseIniSizeToBytes($currentLimit);
+        $currentBytes = $this->parseIniSizeToBytes($currentLimit);
 
-            if ($currentBytes !== null && $currentBytes >= self::MINIMUM_MEMORY_LIMIT_BYTES) {
-                return;
-            }
+        if ($currentBytes !== null && $currentBytes >= self::MINIMUM_MEMORY_LIMIT_BYTES) {
+            return;
         }
 
         $this->applyIniSetting('memory_limit', self::MINIMUM_MEMORY_LIMIT);

--- a/wwwroot/classes/ExecutionEnvironmentConfigurator.php
+++ b/wwwroot/classes/ExecutionEnvironmentConfigurator.php
@@ -54,10 +54,6 @@ final class ExecutionEnvironmentConfigurator
 
     private function applyIniSettings(): void
     {
-        if (!function_exists('ini_set')) {
-            return;
-        }
-
         foreach ($this->iniSettings as $option => $value) {
             @ini_set($option, $value);
         }
@@ -65,15 +61,11 @@ final class ExecutionEnvironmentConfigurator
 
     private function removeExecutionTimeLimit(): void
     {
-        if (function_exists('set_time_limit')) {
-            @set_time_limit(0);
-        }
+        @set_time_limit(0);
     }
 
     private function configureIgnoreUserAbort(): void
     {
-        if (function_exists('ignore_user_abort')) {
-            @ignore_user_abort(true);
-        }
+        @ignore_user_abort(true);
     }
 }

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -1153,11 +1153,7 @@ SQL
     {
         $name = trim($name);
 
-        if (function_exists('mb_strtolower')) {
-            return mb_strtolower($name, 'UTF-8');
-        }
-
-        return strtolower($name);
+        return mb_strtolower($name, 'UTF-8');
     }
 
     private function insertMappingsByName(int $childGameId, int $parentGameId): string


### PR DESCRIPTION
## Summary
- remove legacy function_exists guards now that PHP 8.5 features are assumed
- simplify cron environment configuration by invoking ini and timeout controls directly
- rely on mbstring for trophy name normalization instead of lowercasing fallbacks

## Testing
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944802c2428832f87db461ca3af774b)