### PR TITLE
Refine callback typing for PHP 8.5

### DIFF
--- a/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
+++ b/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
@@ -7,16 +7,16 @@ require_once __DIR__ . '/GameRescanProgressListener.php';
 final class CallableGameRescanProgressListener implements GameRescanProgressListener
 {
     /**
-     * @var callable(int, string):void
+     * @var \Closure(int, string):void
      */
-    private $callback;
+    private readonly \Closure $callback;
 
     /**
      * @param callable(int, string):void $callback
      */
     public function __construct(callable $callback)
     {
-        $this->callback = $callback;
+        $this->callback = \Closure::fromCallable($callback);
     }
 
     #[\Override]

--- a/wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
+++ b/wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
@@ -7,16 +7,16 @@ require_once __DIR__ . '/TrophyMergeProgressListener.php';
 final class CallableTrophyMergeProgressListener implements TrophyMergeProgressListener
 {
     /**
-     * @var callable(int, string):void
+     * @var \Closure(int, string):void
      */
-    private $callback;
+    private readonly \Closure $callback;
 
     /**
      * @param callable(int, string):void $callback
      */
     public function __construct(callable $callback)
     {
-        $this->callback = $callback;
+        $this->callback = \Closure::fromCallable($callback);
     }
 
     #[\Override]

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -30,9 +30,9 @@ class GameRescanService
     private ImageHashCalculator $imageHashCalculator;
 
     /**
-     * @var callable(string):void|null
+     * @var \Closure(string):void|null
      */
-    private $logListener = null;
+    private ?\Closure $logListener = null;
 
     public function __construct(
         PDO $database,
@@ -57,7 +57,9 @@ class GameRescanService
         ?callable $logListener = null
     ): GameRescanResult {
         $previousLogListener = $this->logListener;
-        $this->logListener = $logListener;
+        $this->logListener = $logListener !== null
+            ? \Closure::fromCallable($logListener)
+            : null;
 
         try {
             $differenceTracker = new GameRescanDifferenceTracker();

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -11,14 +11,14 @@ use Tustin\PlayStation\Client;
 final class PsnPlayerLookupService
 {
     /**
-     * @var callable(): iterable<Worker>
+     * @var \Closure(): iterable<Worker>
      */
-    private $workerFetcher;
+    private readonly \Closure $workerFetcher;
 
     /**
-     * @var callable(): object
+     * @var \Closure(): object
      */
-    private $clientFactory;
+    private readonly \Closure $clientFactory;
 
     /**
      * @param callable(): iterable<Worker> $workerFetcher
@@ -26,10 +26,12 @@ final class PsnPlayerLookupService
      */
     public function __construct(callable $workerFetcher, ?callable $clientFactory = null)
     {
-        $this->workerFetcher = $workerFetcher;
-        $this->clientFactory = $clientFactory ?? static function (): object {
-            return new Client();
-        };
+        $this->workerFetcher = \Closure::fromCallable($workerFetcher);
+        $this->clientFactory = \Closure::fromCallable(
+            $clientFactory ?? static function (): object {
+                return new Client();
+            }
+        );
     }
 
     public static function fromDatabase(PDO $database): self


### PR DESCRIPTION
## Summary
- replace loosely typed callback properties with Closure-typed properties in admin services
- normalize log listeners and PSN lookup factories using Closure::fromCallable for PHP 8.5 expectations

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944802c2428832f87db461ca3af774b)