### PR TITLE
Refactor core services for PHP 8.5

### DIFF
--- a/tests/ApplicationRunnerTest.php
+++ b/tests/ApplicationRunnerTest.php
@@ -9,12 +9,26 @@ require_once __DIR__ . '/../wwwroot/classes/Application.php';
 require_once __DIR__ . '/../wwwroot/classes/HttpRequest.php';
 require_once __DIR__ . '/../wwwroot/classes/MaintenanceMode.php';
 require_once __DIR__ . '/../wwwroot/classes/MaintenanceResponder.php';
+require_once __DIR__ . '/../wwwroot/classes/Utility.php';
+require_once __DIR__ . '/../wwwroot/classes/PaginationRenderer.php';
+
+final class ApplicationRunnerTestDatabase extends Database
+{
+    public function __construct()
+    {
+        // Intentionally bypass parent constructor to avoid connecting to the database.
+    }
+}
 
 final class ThrowingApplicationContainerStub extends ApplicationContainer
 {
     public function __construct()
     {
-        // Parent constructor intentionally not called; overrides provide behaviour.
+        parent::__construct(
+            new ApplicationRunnerTestDatabase(),
+            new Utility(),
+            new PaginationRenderer()
+        );
     }
 
     public function createRequestFromGlobals(): HttpRequest
@@ -53,6 +67,12 @@ final class ApplicationContainerSpy extends ApplicationContainer
 
     public function __construct(HttpRequest $request, ApplicationSpy $application)
     {
+        parent::__construct(
+            new ApplicationRunnerTestDatabase(),
+            new Utility(),
+            new PaginationRenderer()
+        );
+
         $this->request = $request;
         $this->application = $application;
     }

--- a/wwwroot/classes/ApplicationContainer.php
+++ b/wwwroot/classes/ApplicationContainer.php
@@ -10,11 +10,12 @@ require_once __DIR__ . '/Application.php';
 
 class ApplicationContainer
 {
-    private readonly Database $database;
-
-    private readonly Utility $utility;
-
-    private readonly PaginationRenderer $paginationRenderer;
+    public function __construct(
+        private readonly Database $database,
+        private readonly Utility $utility,
+        private readonly PaginationRenderer $paginationRenderer,
+    ) {
+    }
 
     private ?GameRepository $gameRepository = null;
 
@@ -26,19 +27,13 @@ class ApplicationContainer
 
     private ?TemplateRenderer $templateRenderer = null;
 
-    public function __construct(
-        ?Database $database = null,
-        ?Utility $utility = null,
-        ?PaginationRenderer $paginationRenderer = null
-    ) {
-        $this->database = $database ?? Database::fromEnvironment($_ENV ?? []);
-        $this->utility = $utility ?? new Utility();
-        $this->paginationRenderer = $paginationRenderer ?? new PaginationRenderer();
-    }
-
     public static function create(): self
     {
-        return new self();
+        return new self(
+            Database::fromEnvironment($_ENV ?? []),
+            new Utility(),
+            new PaginationRenderer()
+        );
     }
 
     public function getDatabase(): Database

--- a/wwwroot/classes/TemplateRenderer.php
+++ b/wwwroot/classes/TemplateRenderer.php
@@ -8,17 +8,11 @@ require_once __DIR__ . '/PaginationRenderer.php';
 
 class TemplateRenderer
 {
-    private Database $database;
-
-    private Utility $utility;
-
-    private PaginationRenderer $paginationRenderer;
-
-    public function __construct(Database $database, Utility $utility, PaginationRenderer $paginationRenderer)
-    {
-        $this->database = $database;
-        $this->utility = $utility;
-        $this->paginationRenderer = $paginationRenderer;
+    public function __construct(
+        private readonly Database $database,
+        private readonly Utility $utility,
+        private readonly PaginationRenderer $paginationRenderer,
+    ) {
     }
 
     /**


### PR DESCRIPTION
## Summary
- promote core dependencies in ApplicationContainer and TemplateRenderer using PHP 8.5-friendly property promotion and readonly typing
- initialize container defaults via the factory helper and update ApplicationRunner tests to construct with explicit dependencies

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944802c2428832f87db461ca3af774b)