### PR TITLE
Modernize cron jobs for PHP 8.5

### DIFF
--- a/wwwroot/classes/Cron/CronJobRunner.php
+++ b/wwwroot/classes/Cron/CronJobRunner.php
@@ -77,8 +77,7 @@ final class CronJobRunner
         }
 
         if (str_ends_with($trimmed, 'B') || str_ends_with($trimmed, 'b')) {
-            $trimmed = substr($trimmed, 0, -1);
-            $trimmed = trim($trimmed);
+            $trimmed = trim(substr($trimmed, 0, -1));
         }
 
         if ($trimmed === '') {
@@ -92,20 +91,17 @@ final class CronJobRunner
             return null;
         }
 
-        $number = (float) $numberPart;
+        $multiplier = match ($unit) {
+            'g' => 1024 ** 3,
+            'm' => 1024 ** 2,
+            'k' => 1024,
+            default => null,
+        };
 
-        switch ($unit) {
-            case 'g':
-                $number *= 1024;
-                // no break intentionally
-            case 'm':
-                $number *= 1024;
-                // no break intentionally
-            case 'k':
-                $number *= 1024;
-                return (int) round($number);
+        if ($multiplier === null) {
+            return null;
         }
 
-        return null;
+        return (int) round(((float) $numberPart) * $multiplier);
     }
 }

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/CronJobInterface.php';
 
-class DailyCronJob implements CronJobInterface
+use Throwable;
+
+final readonly class DailyCronJob implements CronJobInterface
 {
-    private PDO $database;
-
-    private int $retryDelaySeconds;
-
-    public function __construct(PDO $database, int $retryDelaySeconds = 3)
+    public function __construct(private PDO $database, private int $retryDelaySeconds = 3)
     {
-        $this->database = $database;
-        $this->retryDelaySeconds = $retryDelaySeconds;
     }
 
     #[\Override]
@@ -133,13 +129,13 @@ class DailyCronJob implements CronJobInterface
         $query->execute();
     }
 
-    private function executeWithRetry(callable $operation, ...$arguments): void
+    private function executeWithRetry(callable $operation, mixed ...$arguments): void
     {
         while (true) {
             try {
                 $operation(...$arguments);
                 return;
-            } catch (Exception $exception) {
+            } catch (Throwable $exception) {
                 sleep($this->retryDelaySeconds);
             }
         }

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/CronJobInterface.php';
 
-class HourlyCronJob implements CronJobInterface
+use Throwable;
+
+final readonly class HourlyCronJob implements CronJobInterface
 {
     private const BATCH_SIZE = 500;
 
@@ -32,14 +34,8 @@ class HourlyCronJob implements CronJobInterface
             ttm.difficulty = IF(g.owners = 0, 0, (g.owners_completed / g.owners) * 100)
         SQL;
 
-    private PDO $database;
-
-    private int $retryDelaySeconds;
-
-    public function __construct(PDO $database, int $retryDelaySeconds = 3)
+    public function __construct(private PDO $database, private int $retryDelaySeconds = 3)
     {
-        $this->database = $database;
-        $this->retryDelaySeconds = $retryDelaySeconds;
     }
 
     #[\Override]
@@ -116,7 +112,7 @@ class HourlyCronJob implements CronJobInterface
                 $operation();
 
                 return;
-            } catch (Exception $exception) {
+            } catch (Throwable $exception) {
                 sleep($this->retryDelaySeconds);
             }
         }

--- a/wwwroot/classes/Cron/PlayerRankingCronJob.php
+++ b/wwwroot/classes/Cron/PlayerRankingCronJob.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 require_once __DIR__ . '/CronJobInterface.php';
 require_once __DIR__ . '/PlayerRankingUpdater.php';
 
-final class PlayerRankingCronJob implements CronJobInterface
+final readonly class PlayerRankingCronJob implements CronJobInterface
 {
-    private PlayerRankingUpdater $playerRankingUpdater;
-
-    public function __construct(PlayerRankingUpdater $playerRankingUpdater)
+    public function __construct(private PlayerRankingUpdater $playerRankingUpdater)
     {
-        $this->playerRankingUpdater = $playerRankingUpdater;
     }
 
     #[\Override]

--- a/wwwroot/classes/Cron/WeeklyCronJob.php
+++ b/wwwroot/classes/Cron/WeeklyCronJob.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/CronJobInterface.php';
 
-class WeeklyCronJob implements CronJobInterface
+use Throwable;
+
+final readonly class WeeklyCronJob implements CronJobInterface
 {
     private const UPDATE_PLAYER_RANKINGS_QUERY = <<<'SQL'
         UPDATE player p
@@ -33,14 +35,8 @@ class WeeklyCronJob implements CronJobInterface
             p.status != 0
         SQL;
 
-    private PDO $database;
-
-    private int $retryDelaySeconds;
-
-    public function __construct(PDO $database, int $retryDelaySeconds = 3)
+    public function __construct(private PDO $database, private int $retryDelaySeconds = 3)
     {
-        $this->database = $database;
-        $this->retryDelaySeconds = $retryDelaySeconds;
     }
 
     #[\Override]
@@ -69,7 +65,7 @@ class WeeklyCronJob implements CronJobInterface
                 $operation();
 
                 return;
-            } catch (Exception $exception) {
+            } catch (Throwable $exception) {
                 sleep($this->retryDelaySeconds);
             }
         }


### PR DESCRIPTION
## Summary
- modernize cron job runner memory limit parsing using PHP 8.5 features
- update cron job classes to use constructor property promotion and readonly semantics
- standardize retry handling across cron jobs to catch throwables

## Testing
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944852369ec832fb7c9e48e95f96a21)