### PR TITLE
Modernize queue services for PHP 8.5

### DIFF
--- a/tests/PlayerQueueHandlerTest.php
+++ b/tests/PlayerQueueHandlerTest.php
@@ -172,6 +172,22 @@ final class PlayerQueueHandlerTest extends TestCase
         $this->assertSame("PSN name can't be empty.", $response->getMessage());
     }
 
+    public function testHandleAddToQueueRequestUsesDefaultResponseFactory(): void
+    {
+        $service = new ConfigurablePlayerQueueServiceStub();
+        $handler = new PlayerQueueHandler($service);
+        $request = PlayerQueueRequest::fromArrays(['q' => 'QueuedUser'], ['REMOTE_ADDR' => '203.0.113.5']);
+
+        $response = $handler->handleAddToQueueRequest($request);
+
+        $this->assertSame('queued', $response->getStatus());
+        $this->assertStringContainsString('QueuedUser', $response->getMessage());
+        $queuedPlayers = $service->getQueuedPlayers();
+        $this->assertCount(1, $queuedPlayers);
+        $this->assertSame('QueuedUser', $queuedPlayers[0]['playerName']);
+        $this->assertSame('203.0.113.5', $queuedPlayers[0]['ipAddress']);
+    }
+
     public function testHandleAddToQueueRequestReturnsCheaterResponseWhenCheaterAccountFound(): void
     {
         $service = new ConfigurablePlayerQueueServiceStub();

--- a/tests/PlayerQueueServiceTest.php
+++ b/tests/PlayerQueueServiceTest.php
@@ -49,6 +49,16 @@ final class PlayerQueueServiceTest extends TestCase
         $this->service = new PlayerQueueService($this->pdo);
     }
 
+    public function testThrowsMeaningfulExceptionWhenDatabaseNotConfigured(): void
+    {
+        try {
+            (new PlayerQueueService())->getIpSubmissionCount('127.0.0.1');
+            $this->fail('Expected an exception to be thrown.');
+        } catch (LogicException $exception) {
+            $this->assertStringContainsString('database connection', $exception->getMessage());
+        }
+    }
+
     public function testGetIpSubmissionCountReturnsZeroWhenIpEmpty(): void
     {
         $this->assertSame(0, $this->service->getIpSubmissionCount(''));

--- a/wwwroot/classes/Admin/GameCopyHandler.php
+++ b/wwwroot/classes/Admin/GameCopyHandler.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 class GameCopyHandler
 {
-    private GameCopyService $gameCopyService;
-
-    public function __construct(GameCopyService $gameCopyService)
+    public function __construct(private readonly GameCopyService $gameCopyService)
     {
-        $this->gameCopyService = $gameCopyService;
     }
 
     public function handle(array $postData): string

--- a/wwwroot/classes/PlayerQueueHandler.php
+++ b/wwwroot/classes/PlayerQueueHandler.php
@@ -8,13 +8,12 @@ require_once __DIR__ . '/PlayerQueueResponseFactory.php';
 
 class PlayerQueueHandler
 {
-    private PlayerQueueService $service;
+    private readonly PlayerQueueResponseFactory $responseFactory;
 
-    private PlayerQueueResponseFactory $responseFactory;
-
-    public function __construct(PlayerQueueService $service, ?PlayerQueueResponseFactory $responseFactory = null)
-    {
-        $this->service = $service;
+    public function __construct(
+        private readonly PlayerQueueService $service,
+        ?PlayerQueueResponseFactory $responseFactory = null,
+    ) {
         $this->responseFactory = $responseFactory ?? new PlayerQueueResponseFactory($service);
     }
 

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -13,11 +13,8 @@ final class PlayerQueueResponseFactory
 
     private const string INVALID_NAME_MESSAGE = "PSN name must contain between three and 16 characters, and can consist of letters, numbers, hyphens (-) and underscores (_).";
 
-    private PlayerQueueService $service;
-
-    public function __construct(PlayerQueueService $service)
+    public function __construct(private readonly PlayerQueueService $service)
     {
-        $this->service = $service;
     }
 
     public function createEmptyNameResponse(): PlayerQueueResponse

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -10,11 +10,17 @@ class PlayerQueueService
     public const int MAX_QUEUE_SUBMISSIONS_PER_IP = 10;
     public const int CHEATER_STATUS = 1;
 
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly ?PDO $database = null)
     {
-        $this->database = $database;
+    }
+
+    private function requireDatabase(): PDO
+    {
+        if ($this->database === null) {
+            throw new LogicException('PlayerQueueService requires a database connection.');
+        }
+
+        return $this->database;
     }
 
     public function getIpSubmissionCount(string $ipAddress): int
@@ -23,7 +29,7 @@ class PlayerQueueService
             return 0;
         }
 
-        $query = $this->database->prepare(
+        $query = $this->requireDatabase()->prepare(
             <<<'SQL'
             SELECT
                 COUNT(*)
@@ -50,7 +56,7 @@ class PlayerQueueService
             return null;
         }
 
-        $query = $this->database->prepare(
+        $query = $this->requireDatabase()->prepare(
             <<<'SQL'
             SELECT
                 account_id
@@ -72,7 +78,7 @@ class PlayerQueueService
 
     public function addPlayerToQueue(string $playerName, string $ipAddress): void
     {
-        $query = $this->database->prepare(
+        $query = $this->requireDatabase()->prepare(
             <<<'SQL'
             INSERT IGNORE INTO
                 player_queue (online_id, ip_address)
@@ -109,7 +115,7 @@ class PlayerQueueService
             return null;
         }
 
-        $query = $this->database->prepare(
+        $query = $this->requireDatabase()->prepare(
             <<<'SQL'
             SELECT
                 scan_progress
@@ -142,7 +148,7 @@ class PlayerQueueService
 
     public function getQueuePosition(string $playerName): ?int
     {
-        $requestTimeQuery = $this->database->prepare(
+        $requestTimeQuery = $this->requireDatabase()->prepare(
             <<<'SQL'
             SELECT
                 request_time
@@ -161,7 +167,7 @@ class PlayerQueueService
             return null;
         }
 
-        $positionQuery = $this->database->prepare(
+        $positionQuery = $this->requireDatabase()->prepare(
             <<<'SQL'
             SELECT
                 COUNT(*)
@@ -189,7 +195,7 @@ class PlayerQueueService
      */
     public function getPlayerStatusData(string $playerName): ?array
     {
-        $query = $this->database->prepare(
+        $query = $this->requireDatabase()->prepare(
             <<<'SQL'
             SELECT
                 account_id,


### PR DESCRIPTION
## Summary
- promote queue-related services and factories to use PHP 8.5 readonly property promotion and centralized database validation
- simplify admin game copy handler dependency handling with constructor property promotion
- add coverage for missing database configuration and default queue response factory wiring

## Testing
- php tests/run.php
- for f in wwwroot/classes/PlayerQueueService.php wwwroot/classes/PlayerQueueHandler.php wwwroot/classes/PlayerQueueResponseFactory.php wwwroot/classes/Admin/GameCopyHandler.php tests/PlayerQueueServiceTest.php tests/PlayerQueueHandlerTest.php; do php -l "$f"; done


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944852369ec832fb7c9e48e95f96a21)