### PR TITLE
Modernize random game model and trophy rarity

### DIFF
--- a/tests/PlayerRandomGameTest.php
+++ b/tests/PlayerRandomGameTest.php
@@ -15,9 +15,33 @@ final class PlayerRandomGameTest extends TestCase
         $this->utility = new Utility();
     }
 
+    public function testFromArrayNormalizesTypesAndDefaults(): void
+    {
+        $game = PlayerRandomGame::fromArray([
+            'id' => '7',
+            'name' => 'Example Game',
+            'owners' => '15',
+            'gold' => '2',
+            'progress' => 0,
+        ], $this->utility);
+
+        $this->assertSame(7, $game->getId());
+        $this->assertSame('Example Game', $game->getName());
+        $this->assertSame(15, $game->getOwners());
+        $this->assertSame(2, $game->getGold());
+        $this->assertSame('0', $game->getProgress());
+
+        $gameWithoutProgress = PlayerRandomGame::fromArray([
+            'id' => 9,
+            'name' => 'Another Game',
+        ], $this->utility);
+
+        $this->assertSame(null, $gameWithoutProgress->getProgress());
+    }
+
     public function testGetPlatformsSplitsAndTrimsPlatformList(): void
     {
-        $game = new PlayerRandomGame([
+        $game = PlayerRandomGame::fromArray([
             'id' => 42,
             'name' => 'Example Game',
             'platform' => 'PS4, PS5 , , PSVITA ,,PSVR2,',
@@ -31,7 +55,7 @@ final class PlayerRandomGameTest extends TestCase
 
     public function testGetPlatformsReturnsEmptyArrayWhenPlatformMissing(): void
     {
-        $game = new PlayerRandomGame([
+        $game = PlayerRandomGame::fromArray([
             'id' => 42,
             'name' => 'Example Game',
             'platform' => '',
@@ -39,7 +63,7 @@ final class PlayerRandomGameTest extends TestCase
 
         $this->assertSame([], $game->getPlatforms());
 
-        $gameWithoutPlatformKey = new PlayerRandomGame([
+        $gameWithoutPlatformKey = PlayerRandomGame::fromArray([
             'id' => 42,
             'name' => 'Example Game',
         ], $this->utility);
@@ -49,7 +73,7 @@ final class PlayerRandomGameTest extends TestCase
 
     public function testGetIconUrlReturnsPlaceholderWhenIconMissingForPlayStation5Families(): void
     {
-        $gamePs5 = new PlayerRandomGame([
+        $gamePs5 = PlayerRandomGame::fromArray([
             'id' => 1,
             'name' => 'Game',
             'icon_url' => '.png',
@@ -58,7 +82,7 @@ final class PlayerRandomGameTest extends TestCase
 
         $this->assertSame('../missing-ps5-game-and-trophy.png', $gamePs5->getIconUrl());
 
-        $gamePsvr2 = new PlayerRandomGame([
+        $gamePsvr2 = PlayerRandomGame::fromArray([
             'id' => 2,
             'name' => 'Game',
             'icon_url' => '.png',
@@ -67,7 +91,7 @@ final class PlayerRandomGameTest extends TestCase
 
         $this->assertSame('../missing-ps5-game-and-trophy.png', $gamePsvr2->getIconUrl());
 
-        $gamePs4 = new PlayerRandomGame([
+        $gamePs4 = PlayerRandomGame::fromArray([
             'id' => 3,
             'name' => 'Game',
             'icon_url' => '.png',
@@ -76,7 +100,7 @@ final class PlayerRandomGameTest extends TestCase
 
         $this->assertSame('../missing-ps4-game.png', $gamePs4->getIconUrl());
 
-        $gameWithIcon = new PlayerRandomGame([
+        $gameWithIcon = PlayerRandomGame::fromArray([
             'id' => 4,
             'name' => 'Game',
             'icon_url' => 'https://example.com/icon.png',
@@ -88,7 +112,7 @@ final class PlayerRandomGameTest extends TestCase
 
     public function testGetGameLinkIncludesSlugifiedNameAndUrlEncodedPlayerId(): void
     {
-        $game = new PlayerRandomGame([
+        $game = PlayerRandomGame::fromArray([
             'id' => 321,
             'name' => 'Ratchet & Clank: Rift Apart',
         ], $this->utility);

--- a/tests/PlayerRandomGamesPageContextTest.php
+++ b/tests/PlayerRandomGamesPageContextTest.php
@@ -11,24 +11,21 @@ final class PlayerRandomGamesPageContextTest extends TestCase
     {
         $filter = PlayerRandomGamesFilter::fromArray(['ps5' => 'true']);
         $utility = new Utility();
-        $randomGame = new PlayerRandomGame(
-            [
-                'id' => 123,
-                'np_communication_id' => 'NPWR12345_00',
-                'name' => 'Random Game',
-                'icon_url' => 'random.png',
-                'platform' => 'PS5',
-                'owners' => 1000,
-                'difficulty' => '12.5',
-                'platinum' => 1,
-                'gold' => 2,
-                'silver' => 3,
-                'bronze' => 4,
-                'rarity_points' => 500,
-                'progress' => '50',
-            ],
-            $utility
-        );
+        $randomGame = PlayerRandomGame::fromArray([
+            'id' => 123,
+            'np_communication_id' => 'NPWR12345_00',
+            'name' => 'Random Game',
+            'icon_url' => 'random.png',
+            'platform' => 'PS5',
+            'owners' => 1000,
+            'difficulty' => '12.5',
+            'platinum' => 1,
+            'gold' => 2,
+            'silver' => 3,
+            'bronze' => 4,
+            'rarity_points' => 500,
+            'progress' => '50',
+        ], $utility);
         $randomGames = [$randomGame];
 
         $playerSummary = new PlayerSummary(10, 4, 75.0, 12);

--- a/wwwroot/classes/PlayerRandomGame.php
+++ b/wwwroot/classes/PlayerRandomGame.php
@@ -4,53 +4,47 @@ declare(strict_types=1);
 
 final readonly class PlayerRandomGame
 {
-    private int $id;
+    private function __construct(
+        private int $id,
+        private string $npCommunicationId,
+        private string $name,
+        private string $iconUrl,
+        private string $platform,
+        private int $owners,
+        private string $difficulty,
+        private int $platinum,
+        private int $gold,
+        private int $silver,
+        private int $bronze,
+        private int $rarityPoints,
+        private int $inGameRarityPoints,
+        private ?string $progress,
+        private Utility $utility,
+    ) {
+    }
 
-    private string $npCommunicationId;
-
-    private string $name;
-
-    private string $iconUrl;
-
-    private string $platform;
-
-    private int $owners;
-
-    private string $difficulty;
-
-    private int $platinum;
-
-    private int $gold;
-
-    private int $silver;
-
-    private int $bronze;
-
-    private int $rarityPoints;
-
-    private int $inGameRarityPoints;
-
-    private ?string $progress;
-
-    private Utility $utility;
-
-    public function __construct(array $data, Utility $utility)
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data, Utility $utility): self
     {
-        $this->id = isset($data['id']) ? (int) $data['id'] : 0;
-        $this->npCommunicationId = (string) ($data['np_communication_id'] ?? '');
-        $this->name = (string) ($data['name'] ?? '');
-        $this->iconUrl = (string) ($data['icon_url'] ?? '');
-        $this->platform = (string) ($data['platform'] ?? '');
-        $this->owners = isset($data['owners']) ? (int) $data['owners'] : 0;
-        $this->difficulty = (string) ($data['difficulty'] ?? '0');
-        $this->platinum = isset($data['platinum']) ? (int) $data['platinum'] : 0;
-        $this->gold = isset($data['gold']) ? (int) $data['gold'] : 0;
-        $this->silver = isset($data['silver']) ? (int) $data['silver'] : 0;
-        $this->bronze = isset($data['bronze']) ? (int) $data['bronze'] : 0;
-        $this->rarityPoints = isset($data['rarity_points']) ? (int) $data['rarity_points'] : 0;
-        $this->inGameRarityPoints = isset($data['in_game_rarity_points']) ? (int) $data['in_game_rarity_points'] : 0;
-        $this->progress = array_key_exists('progress', $data) ? (string) $data['progress'] : null;
-        $this->utility = $utility;
+        return new self(
+            id: (int) ($data['id'] ?? 0),
+            npCommunicationId: (string) ($data['np_communication_id'] ?? ''),
+            name: (string) ($data['name'] ?? ''),
+            iconUrl: (string) ($data['icon_url'] ?? ''),
+            platform: (string) ($data['platform'] ?? ''),
+            owners: (int) ($data['owners'] ?? 0),
+            difficulty: (string) ($data['difficulty'] ?? '0'),
+            platinum: (int) ($data['platinum'] ?? 0),
+            gold: (int) ($data['gold'] ?? 0),
+            silver: (int) ($data['silver'] ?? 0),
+            bronze: (int) ($data['bronze'] ?? 0),
+            rarityPoints: (int) ($data['rarity_points'] ?? 0),
+            inGameRarityPoints: (int) ($data['in_game_rarity_points'] ?? 0),
+            progress: array_key_exists('progress', $data) ? (string) $data['progress'] : null,
+            utility: $utility,
+        );
     }
 
     public function getId(): int

--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -75,7 +75,7 @@ class PlayerRandomGamesService
                 }
 
                 $seenIds[$id] = true;
-                $games[] = new PlayerRandomGame($gameData, $this->utility);
+                $games[] = PlayerRandomGame::fromArray($gameData, $this->utility);
 
                 if (count($games) >= $limit) {
                     break;
@@ -93,7 +93,7 @@ class PlayerRandomGamesService
                 }
 
                 $seenIds[$id] = true;
-                $games[] = new PlayerRandomGame($gameData, $this->utility);
+                $games[] = PlayerRandomGame::fromArray($gameData, $this->utility);
 
                 if (count($games) >= $limit) {
                     break;

--- a/wwwroot/classes/TrophyRarity.php
+++ b/wwwroot/classes/TrophyRarity.php
@@ -2,22 +2,14 @@
 
 declare(strict_types=1);
 
-class TrophyRarity
+final readonly class TrophyRarity
 {
-    private ?string $percentage;
-
-    private string $label;
-
-    private ?string $cssClass;
-
-    private bool $unobtainable;
-
-    public function __construct(?string $percentage, string $label, ?string $cssClass, bool $unobtainable)
-    {
-        $this->percentage = $percentage;
-        $this->label = $label;
-        $this->cssClass = $cssClass;
-        $this->unobtainable = $unobtainable;
+    public function __construct(
+        private ?string $percentage,
+        private string $label,
+        private ?string $cssClass,
+        private bool $unobtainable,
+    ) {
     }
 
     public function getPercentage(): ?string


### PR DESCRIPTION
## Summary
- convert PlayerRandomGame to a promoted readonly value object with a factory for normalized construction
- update services and page context tests to consume the new factory and cover data normalization
- mark TrophyRarity as a final readonly class to align with PHP 8.5 patterns

## Testing
- php -l wwwroot/classes/PlayerRandomGame.php
- php -l wwwroot/classes/PlayerRandomGamesService.php
- php -l wwwroot/classes/TrophyRarity.php
- php -l tests/PlayerRandomGameTest.php
- php -l tests/PlayerRandomGamesPageContextTest.php
- php tests/run.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944852369ec832fb7c9e48e95f96a21)