### PR TITLE
Improve scanner progress messaging

### DIFF
--- a/tests/PlayerQueueResponseFactoryTest.php
+++ b/tests/PlayerQueueResponseFactoryTest.php
@@ -187,4 +187,31 @@ final class PlayerQueueResponseFactoryTest extends TestCase
             $service->getEscapedValues()
         );
     }
+
+    public function testCreateQueuedForScanResponseUsesActionVerbsForProgressTitle(): void
+    {
+        $service = new RecordingPlayerQueueServiceStub();
+        $factory = new PlayerQueueResponseFactory($service);
+
+        $progress = PlayerScanProgress::fromArray([
+            'current' => null,
+            'total' => null,
+            'title' => 'Updating avatar for Ragowit.',
+        ]);
+        $this->assertTrue($progress instanceof PlayerScanProgress, 'Expected PlayerScanProgress instance.');
+
+        $response = $factory->createQueuedForScanResponse('Ragowit', $progress);
+
+        $this->assertSame('queued', $response->getStatus());
+        $this->assertTrue($response->shouldPoll());
+
+        $message = $response->getMessage();
+        $this->assertStringContainsString('is currently being scanned.', $message);
+        $this->assertStringContainsString('Currently updating avatar.', $message);
+
+        $this->assertSame(
+            ['Ragowit', '/player/Ragowit', 'updating avatar'],
+            $service->getEscapedValues()
+        );
+    }
 }

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -108,7 +108,11 @@ final class PlayerQueueResponseFactory
 
         $title = $progress->getTitle();
         if ($title !== null) {
-            $parts[] = 'Currently scanning <strong>' . $this->service->escapeHtml($title) . '</strong>';
+            $progressTitle = $this->formatProgressTitle($title);
+
+            if ($progressTitle !== '') {
+                $parts[] = $progressTitle;
+            }
         }
 
         $summary = $progress->getProgressSummary();
@@ -135,6 +139,24 @@ final class PlayerQueueResponseFactory
         }
 
         return $message;
+    }
+
+    private function formatProgressTitle(string $title): string
+    {
+        $normalizedTitle = preg_replace('/\s+for\s+[^.]+\.?$/i', '', trim($title)) ?? '';
+        $normalizedTitle = rtrim($normalizedTitle, " .\t\n\r\0\v");
+
+        if ($normalizedTitle === '') {
+            return '';
+        }
+
+        if (preg_match('/^(Updating|Fetching)\b/i', $normalizedTitle) === 1) {
+            $actionText = lcfirst($normalizedTitle);
+
+            return 'Currently ' . $this->service->escapeHtml($actionText);
+        }
+
+        return 'Currently scanning <strong>' . $this->service->escapeHtml($normalizedTitle) . '</strong>';
     }
 
     private function createCheaterMessage(string $playerName, ?string $accountId): string


### PR DESCRIPTION
## Summary
- normalize scan progress titles so updating/fetching steps drop the player name and read more naturally
- add formatting helper and tests to cover the new progress wording

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c3232170832fb1bb86c13aeff4cf)