### PR TITLE
Refactor player navigation to enum sections

### DIFF
--- a/tests/PlayerNavigationRendererTest.php
+++ b/tests/PlayerNavigationRendererTest.php
@@ -9,7 +9,7 @@ final class PlayerNavigationRendererTest extends TestCase
 {
     public function testRenderOutputsAllNavigationLinks(): void
     {
-        $navigation = PlayerNavigation::forSection('Example User', PlayerNavigation::SECTION_LOG);
+        $navigation = PlayerNavigation::forSection('Example User', PlayerNavigationSection::LOG);
         $renderer = new PlayerNavigationRenderer();
 
         $html = $renderer->render($navigation);
@@ -24,7 +24,7 @@ final class PlayerNavigationRendererTest extends TestCase
 
     public function testRenderEscapesAttributes(): void
     {
-        $navigation = PlayerNavigation::forSection('user & user', PlayerNavigation::SECTION_RANDOM);
+        $navigation = PlayerNavigation::forSection('user & user', PlayerNavigationSection::RANDOM);
         $renderer = new PlayerNavigationRenderer();
 
         $html = $renderer->render($navigation);

--- a/tests/PlayerNavigationTest.php
+++ b/tests/PlayerNavigationTest.php
@@ -33,7 +33,7 @@ final class PlayerNavigationTest extends TestCase
 
     public function testActiveSectionProducesActiveLinkStylingAndAriaAttributes(): void
     {
-        $navigation = PlayerNavigation::forSection('player+one', PlayerNavigation::SECTION_GAME_ADVISOR);
+        $navigation = PlayerNavigation::forSection('player+one', PlayerNavigationSection::GAME_ADVISOR);
 
         $links = $navigation->getLinks();
 

--- a/wwwroot/classes/PlayerAdvisorPageContext.php
+++ b/wwwroot/classes/PlayerAdvisorPageContext.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/PlayerAdvisorFilter.php';
 require_once __DIR__ . '/PlayerAdvisorPage.php';
 require_once __DIR__ . '/PlayerAdvisorService.php';
 require_once __DIR__ . '/PlayerNavigation.php';
+require_once __DIR__ . '/PlayerNavigationSection.php';
 require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
 require_once __DIR__ . '/PlayerStatusNotice.php';
 require_once __DIR__ . '/PlayerSummary.php';
@@ -114,7 +115,7 @@ final class PlayerAdvisorPageContext
         $this->playerAccountIdValue = $playerAccountIdValue;
         $this->playerNavigation = PlayerNavigation::forSection(
             $playerOnlineId,
-            PlayerNavigation::SECTION_TROPHY_ADVISOR
+            PlayerNavigationSection::TROPHY_ADVISOR
         );
         $this->platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
             fn (string $platform): bool => $this->filter->isPlatformSelected($platform)

--- a/wwwroot/classes/PlayerGamesPageContext.php
+++ b/wwwroot/classes/PlayerGamesPageContext.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/PlayerGamesFilter.php';
 require_once __DIR__ . '/PlayerGamesPage.php';
 require_once __DIR__ . '/PlayerGamesService.php';
 require_once __DIR__ . '/PlayerNavigation.php';
+require_once __DIR__ . '/PlayerNavigationSection.php';
 require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
 require_once __DIR__ . '/SearchQueryHelper.php';
 require_once __DIR__ . '/PlayerSummary.php';
@@ -62,7 +63,7 @@ final class PlayerGamesPageContext
         $this->playerOnlineId = $this->extractString($playerData['online_id'] ?? '');
         $this->playerNavigation = PlayerNavigation::forSection(
             $this->playerOnlineId,
-            PlayerNavigation::SECTION_GAMES
+            PlayerNavigationSection::GAMES
         );
         $this->platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
             fn (string $platform): bool => $this->filter->isPlatformSelected($platform)

--- a/wwwroot/classes/PlayerLogPageContext.php
+++ b/wwwroot/classes/PlayerLogPageContext.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/PlayerLogFilter.php';
 require_once __DIR__ . '/PlayerLogPage.php';
 require_once __DIR__ . '/PlayerLogService.php';
 require_once __DIR__ . '/PlayerNavigation.php';
+require_once __DIR__ . '/PlayerNavigationSection.php';
 require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/PlayerSummaryService.php';
@@ -58,17 +59,17 @@ final class PlayerLogPageContext
         $playerSummary = $playerSummaryService->getSummary($accountId);
 
         return new self(
-            $playerLogPage,
-            $playerSummary,
-            $filter,
-            self::extractOnlineId($playerData),
-            self::extractPlayerAccountId($playerData),
-            self::extractPlayerStatus($playerData)
-        );
-    }
+        $playerLogPage,
+        $playerSummary,
+        $filter,
+        self::extractOnlineId($playerData),
+        self::extractPlayerAccountId($playerData),
+        self::extractPlayerStatus($playerData)
+    );
+}
 
-    public static function fromComponents(
-        PlayerLogPage $playerLogPage,
+public static function fromComponents(
+    PlayerLogPage $playerLogPage,
         PlayerSummary $playerSummary,
         PlayerLogFilter $filter,
         string $playerOnlineId,
@@ -99,7 +100,7 @@ final class PlayerLogPageContext
         $this->playerOnlineId = $playerOnlineId;
         $this->playerAccountId = $playerAccountId;
         $this->playerStatus = $playerStatus;
-        $this->playerNavigation = PlayerNavigation::forSection($playerOnlineId, PlayerNavigation::SECTION_LOG);
+        $this->playerNavigation = PlayerNavigation::forSection($playerOnlineId, PlayerNavigationSection::LOG);
         $this->platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
             fn (string $platform): bool => $this->filter->isPlatformSelected($platform)
         );

--- a/wwwroot/classes/PlayerNavigation.php
+++ b/wwwroot/classes/PlayerNavigation.php
@@ -2,25 +2,17 @@
 
 declare(strict_types=1);
 
-final class PlayerNavigation
+require_once __DIR__ . '/PlayerNavigationSection.php';
+
+final readonly class PlayerNavigation
 {
-    public const SECTION_GAMES = 'games';
-    public const SECTION_LOG = 'log';
-    public const SECTION_TROPHY_ADVISOR = 'trophy-advisor';
-    public const SECTION_GAME_ADVISOR = 'game-advisor';
-    public const SECTION_RANDOM = 'random';
-
-    private string $onlineId;
-
-    private ?string $activeSection;
-
-    private function __construct(string $onlineId, ?string $activeSection)
-    {
-        $this->onlineId = $onlineId;
-        $this->activeSection = $activeSection;
+    private function __construct(
+        private string $onlineId,
+        private ?PlayerNavigationSection $activeSection,
+    ) {
     }
 
-    public static function forSection(string $onlineId, ?string $activeSection = null): self
+    public static function forSection(string $onlineId, ?PlayerNavigationSection $activeSection = null): self
     {
         return new self($onlineId, $activeSection);
     }
@@ -36,50 +28,44 @@ final class PlayerNavigation
             new PlayerNavigationLink(
                 'Games',
                 '/player/' . $encodedOnlineId,
-                $this->isActive(self::SECTION_GAMES)
+                $this->isActive(PlayerNavigationSection::GAMES)
             ),
             new PlayerNavigationLink(
                 'Log',
                 '/player/' . $encodedOnlineId . '/log',
-                $this->isActive(self::SECTION_LOG)
+                $this->isActive(PlayerNavigationSection::LOG)
             ),
             new PlayerNavigationLink(
                 'Trophy Advisor',
                 '/player/' . $encodedOnlineId . '/advisor',
-                $this->isActive(self::SECTION_TROPHY_ADVISOR)
+                $this->isActive(PlayerNavigationSection::TROPHY_ADVISOR)
             ),
             new PlayerNavigationLink(
                 'Game Advisor',
                 '/game?sort=completion&filter=true&player=' . $encodedOnlineId,
-                $this->isActive(self::SECTION_GAME_ADVISOR)
+                $this->isActive(PlayerNavigationSection::GAME_ADVISOR)
             ),
             new PlayerNavigationLink(
                 'Random Games',
                 '/player/' . $encodedOnlineId . '/random',
-                $this->isActive(self::SECTION_RANDOM)
+                $this->isActive(PlayerNavigationSection::RANDOM)
             ),
         ];
     }
 
-    private function isActive(string $section): bool
+    private function isActive(PlayerNavigationSection $section): bool
     {
         return $this->activeSection === $section;
     }
 }
 
-final class PlayerNavigationLink
+final readonly class PlayerNavigationLink
 {
-    private string $label;
-
-    private string $url;
-
-    private bool $active;
-
-    public function __construct(string $label, string $url, bool $active)
-    {
-        $this->label = $label;
-        $this->url = $url;
-        $this->active = $active;
+    public function __construct(
+        private string $label,
+        private string $url,
+        private bool $active,
+    ) {
     }
 
     public function getLabel(): string

--- a/wwwroot/classes/PlayerNavigationSection.php
+++ b/wwwroot/classes/PlayerNavigationSection.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerNavigationSection: string
+{
+    case GAMES = 'games';
+    case LOG = 'log';
+    case TROPHY_ADVISOR = 'trophy-advisor';
+    case GAME_ADVISOR = 'game-advisor';
+    case RANDOM = 'random';
+}

--- a/wwwroot/classes/PlayerRandomGamesPageContext.php
+++ b/wwwroot/classes/PlayerRandomGamesPageContext.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/PlayerRandomGamesService.php';
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/PlayerSummaryService.php';
 require_once __DIR__ . '/PlayerNavigation.php';
+require_once __DIR__ . '/PlayerNavigationSection.php';
 require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
 require_once __DIR__ . '/Utility.php';
 require_once __DIR__ . '/PlayerStatus.php';
@@ -103,7 +104,7 @@ final class PlayerRandomGamesPageContext
         $this->playerOnlineId = $playerOnlineId;
         $this->playerAccountId = $playerAccountId;
         $this->playerStatus = $playerStatus;
-        $this->playerNavigation = PlayerNavigation::forSection($playerOnlineId, PlayerNavigation::SECTION_RANDOM);
+        $this->playerNavigation = PlayerNavigation::forSection($playerOnlineId, PlayerNavigationSection::RANDOM);
         $this->platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
             fn (string $platform): bool => $this->filter->isPlatformSelected($platform)
         );


### PR DESCRIPTION
## Summary
- add PlayerNavigationSection enum to represent navigation sections explicitly
- update navigation contexts and renderer tests to use enum-based sections and readonly properties
- keep navigation link styling and aria support consistent while modernizing construction

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ca51181c832fa3f4e8e7222f5b65)