### PR TITLE
Refactor metadata model for immutability

### DIFF
--- a/tests/PageMetaDataRendererTest.php
+++ b/tests/PageMetaDataRendererTest.php
@@ -24,10 +24,10 @@ final class PageMetaDataRendererTest extends TestCase
     public function testRenderProducesExpectedTagsWithEscapedValues(): void
     {
         $metaData = (new PageMetaData())
-            ->setTitle('Title "special" & more')
-            ->setDescription("Description with 'quote' & <tag>")
-            ->setImage('https://example.com/image.png?foo=1&bar=2')
-            ->setUrl('https://example.com/page?foo=bar&baz=<baz>');
+            ->withTitle('Title "special" & more')
+            ->withDescription("Description with 'quote' & <tag>")
+            ->withImage('https://example.com/image.png?foo=1&bar=2')
+            ->withUrl('https://example.com/page?foo=bar&baz=<baz>');
 
         $result = $this->renderer->render($metaData);
 

--- a/tests/PageMetaDataTest.php
+++ b/tests/PageMetaDataTest.php
@@ -16,21 +16,23 @@ final class PageMetaDataTest extends TestCase
         $this->assertSame('https://example.com/page', $pageMetaData->getUrl());
     }
 
-    public function testSettersNormalizeValuesAndAreChainable(): void
+    public function testWithersNormalizeValuesAndCreateNewInstances(): void
     {
         $pageMetaData = new PageMetaData();
 
         $result = $pageMetaData
-            ->setTitle('  Example Title  ')
-            ->setDescription("\nExample Description\n")
-            ->setImage('  https://example.com/image.png  ')
-            ->setUrl('  https://example.com  ');
+            ->withTitle('  Example Title  ')
+            ->withDescription("\nExample Description\n")
+            ->withImage('  https://example.com/image.png  ')
+            ->withUrl('  https://example.com  ');
 
-        $this->assertSame($pageMetaData, $result);
-        $this->assertSame('Example Title', $pageMetaData->getTitle());
-        $this->assertSame('Example Description', $pageMetaData->getDescription());
-        $this->assertSame('https://example.com/image.png', $pageMetaData->getImage());
-        $this->assertSame('https://example.com', $pageMetaData->getUrl());
+        $this->assertTrue($pageMetaData !== $result);
+        $this->assertTrue($pageMetaData->isEmpty());
+
+        $this->assertSame('Example Title', $result->getTitle());
+        $this->assertSame('Example Description', $result->getDescription());
+        $this->assertSame('https://example.com/image.png', $result->getImage());
+        $this->assertSame('https://example.com', $result->getUrl());
     }
 
     public function testIsEmptyIndicatesWhetherAnyMetadataIsPresent(): void
@@ -38,10 +40,10 @@ final class PageMetaDataTest extends TestCase
         $pageMetaData = new PageMetaData();
         $this->assertTrue($pageMetaData->isEmpty());
 
-        $pageMetaData->setDescription('Description');
-        $this->assertFalse($pageMetaData->isEmpty());
+        $pageMetaDataWithDescription = $pageMetaData->withDescription('Description');
+        $this->assertFalse($pageMetaDataWithDescription->isEmpty());
 
-        $pageMetaData->setDescription('   ');
-        $this->assertTrue($pageMetaData->isEmpty());
+        $pageMetaDataCleared = $pageMetaDataWithDescription->withDescription('   ');
+        $this->assertTrue($pageMetaDataCleared->isEmpty());
     }
 }

--- a/wwwroot/classes/GameHistoryPage.php
+++ b/wwwroot/classes/GameHistoryPage.php
@@ -396,10 +396,10 @@ final class GameHistoryPage
     public function createMetaData(): PageMetaData
     {
         return (new PageMetaData())
-            ->setTitle($this->game->getName() . ' Trophy Data History')
-            ->setDescription('Version history and trophy data changes for ' . $this->game->getName())
-            ->setImage('https://psn100.net/img/title/' . $this->game->getIconUrl())
-            ->setUrl('https://psn100.net/game-history/' . $this->game->getId() . '-' . $this->getGameSlug());
+            ->withTitle($this->game->getName() . ' Trophy Data History')
+            ->withDescription('Version history and trophy data changes for ' . $this->game->getName())
+            ->withImage('https://psn100.net/img/title/' . $this->game->getIconUrl())
+            ->withUrl('https://psn100.net/game-history/' . $this->game->getId() . '-' . $this->getGameSlug());
     }
 
     public function getPageTitle(): string

--- a/wwwroot/classes/GamePage.php
+++ b/wwwroot/classes/GamePage.php
@@ -199,15 +199,15 @@ class GamePage
     public function createMetaData(): PageMetaData
     {
         return (new PageMetaData())
-            ->setTitle($this->game->getName() . ' Trophies')
-            ->setDescription(
+            ->withTitle($this->game->getName() . ' Trophies')
+            ->withDescription(
                 $this->game->getBronze() . ' Bronze ~ '
                 . $this->game->getSilver() . ' Silver ~ '
                 . $this->game->getGold() . ' Gold ~ '
                 . $this->game->getPlatinum() . ' Platinum'
             )
-            ->setImage('https://psn100.net/img/title/' . $this->game->getIconUrl())
-            ->setUrl('https://psn100.net/game/' . $this->game->getId() . '-' . $this->getGameSlug());
+            ->withImage('https://psn100.net/img/title/' . $this->game->getIconUrl())
+            ->withUrl('https://psn100.net/game/' . $this->game->getId() . '-' . $this->getGameSlug());
     }
 
     public function getPageTitle(): string

--- a/wwwroot/classes/PageMetaData.php
+++ b/wwwroot/classes/PageMetaData.php
@@ -2,23 +2,28 @@
 
 declare(strict_types=1);
 
-class PageMetaData
+final readonly class PageMetaData
 {
+    private ?string $title;
+    private ?string $description;
+    private ?string $image;
+    private ?string $url;
+
     public function __construct(
-        private ?string $title = null,
-        private ?string $description = null,
-        private ?string $image = null,
-        private ?string $url = null,
+        ?string $title = null,
+        ?string $description = null,
+        ?string $image = null,
+        ?string $url = null,
     ) {
-        $this->title = $this->normalize($this->title);
-        $this->description = $this->normalize($this->description);
-        $this->image = $this->normalize($this->image);
-        $this->url = $this->normalize($this->url);
+        $this->title = self::normalize($title);
+        $this->description = self::normalize($description);
+        $this->image = self::normalize($image);
+        $this->url = self::normalize($url);
     }
 
-    public function setTitle(?string $title): self
+    public function withTitle(?string $title): self
     {
-        return $this->setNormalizedValue('title', $title);
+        return new self($title, $this->description, $this->image, $this->url);
     }
 
     public function getTitle(): ?string
@@ -26,9 +31,9 @@ class PageMetaData
         return $this->title;
     }
 
-    public function setDescription(?string $description): self
+    public function withDescription(?string $description): self
     {
-        return $this->setNormalizedValue('description', $description);
+        return new self($this->title, $description, $this->image, $this->url);
     }
 
     public function getDescription(): ?string
@@ -36,9 +41,9 @@ class PageMetaData
         return $this->description;
     }
 
-    public function setImage(?string $image): self
+    public function withImage(?string $image): self
     {
-        return $this->setNormalizedValue('image', $image);
+        return new self($this->title, $this->description, $image, $this->url);
     }
 
     public function getImage(): ?string
@@ -46,9 +51,9 @@ class PageMetaData
         return $this->image;
     }
 
-    public function setUrl(?string $url): self
+    public function withUrl(?string $url): self
     {
-        return $this->setNormalizedValue('url', $url);
+        return new self($this->title, $this->description, $this->image, $url);
     }
 
     public function getUrl(): ?string
@@ -64,14 +69,7 @@ class PageMetaData
             && $this->url === null;
     }
 
-    private function setNormalizedValue(string $property, ?string $value): self
-    {
-        $this->$property = $this->normalize($value);
-
-        return $this;
-    }
-
-    private function normalize(?string $value): ?string
+    private static function normalize(?string $value): ?string
     {
         if ($value === null) {
             return null;

--- a/wwwroot/classes/PlayerGamesPageContext.php
+++ b/wwwroot/classes/PlayerGamesPageContext.php
@@ -215,18 +215,18 @@ final class PlayerGamesPageContext
     private function buildMetaData(array $playerData, PlayerSummary $playerSummary): PageMetaData
     {
         $metaData = (new PageMetaData())
-            ->setTitle($this->buildTitle($playerData))
-            ->setImage('https://psn100.net/img/avatar/' . $this->extractString($playerData['avatar_url'] ?? ''))
-            ->setUrl('https://psn100.net/player/' . $this->extractString($playerData['online_id'] ?? ''));
+            ->withTitle($this->buildTitle($playerData))
+            ->withImage('https://psn100.net/img/avatar/' . $this->extractString($playerData['avatar_url'] ?? ''))
+            ->withUrl('https://psn100.net/player/' . $this->extractString($playerData['online_id'] ?? ''));
 
         $status = self::extractPlayerStatus($playerData);
 
         if ($status->isFlagged()) {
-            return $metaData->setDescription('The player is flagged as a cheater.');
+            return $metaData->withDescription('The player is flagged as a cheater.');
         }
 
         if ($status->isPrivateProfile()) {
-            return $metaData->setDescription('The player is private.');
+            return $metaData->withDescription('The player is private.');
         }
 
         $numberOfGames = $playerSummary->getNumberOfGames();
@@ -242,7 +242,7 @@ final class PlayerGamesPageContext
             $platinums
         );
 
-        return $metaData->setDescription($description);
+        return $metaData->withDescription($description);
     }
 
     /**

--- a/wwwroot/classes/TrophyPage.php
+++ b/wwwroot/classes/TrophyPage.php
@@ -82,10 +82,10 @@ class TrophyPage
 
         $trophyName = $trophy->getName();
         $metaData = (new PageMetaData())
-            ->setTitle($trophyName . ' Trophy')
-            ->setDescription(htmlentities($trophy->getDetail(), ENT_QUOTES, 'UTF-8'))
-            ->setImage('https://psn100.net/img/trophy/' . $trophy->getIconFileName())
-            ->setUrl('https://psn100.net/trophy/' . $trophy->getTrophySlug($utility));
+            ->withTitle($trophyName . ' Trophy')
+            ->withDescription(htmlentities($trophy->getDetail(), ENT_QUOTES, 'UTF-8'))
+            ->withImage('https://psn100.net/img/trophy/' . $trophy->getIconFileName())
+            ->withUrl('https://psn100.net/trophy/' . $trophy->getTrophySlug($utility));
 
         $pageTitle = $trophyName . ' Trophy ~ PSN 100%';
         $metaRarity = $rarityFormatter->formatMeta($trophy->getRarityPercent(), $trophy->getStatus());


### PR DESCRIPTION
## Summary
- Refactor PageMetaData into an immutable value object with with* helpers
- Update metadata consumers to use immutable withers across page contexts
- Refresh metadata unit tests to match immutable API

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ca51181c832fa3f4e8e7222f5b65)