### PR TITLE
Use PHP 8.5 helpers for memory limit parsing

### DIFF
--- a/tests/CronJobRunnerTest.php
+++ b/tests/CronJobRunnerTest.php
@@ -66,4 +66,20 @@ final class CronJobRunnerTest extends TestCase
 
         $this->assertSame('1024M', ini_get('memory_limit'));
     }
+
+    public function testConfigureEnvironmentHandlesWhitespaceAndUnlimitedValues(): void
+    {
+        ini_set('memory_limit', ' 256M ');
+
+        $runner = CronJobRunner::create();
+        $runner->configureEnvironment();
+
+        $this->assertSame('512M', ini_get('memory_limit'));
+
+        ini_set('memory_limit', '-1');
+
+        $runner->configureEnvironment();
+
+        $this->assertSame('-1', ini_get('memory_limit'));
+    }
 }


### PR DESCRIPTION
## Summary
- modernize CronJobRunner to use PHP 8.5 `ini_parse_quantity` for parsing memory limits and handle whitespace/unlimited settings
- keep minimum memory enforcement logic unchanged while simplifying unit parsing
- add regression coverage for whitespace and unlimited memory limit values

## Testing
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ca51181c832fa3f4e8e7222f5b65)