### PR TITLE
Modernize admin value objects for PHP 8.5

### DIFF
--- a/wwwroot/classes/Admin/LogEntry.php
+++ b/wwwroot/classes/Admin/LogEntry.php
@@ -2,19 +2,13 @@
 
 declare(strict_types=1);
 
-final class LogEntry
+final readonly class LogEntry
 {
-    private int $id;
-
-    private DateTimeImmutable $time;
-
-    private string $formattedMessage;
-
-    public function __construct(int $id, DateTimeImmutable $time, string $formattedMessage)
-    {
-        $this->id = $id;
-        $this->time = $time;
-        $this->formattedMessage = $formattedMessage;
+    public function __construct(
+        private int $id,
+        private DateTimeImmutable $time,
+        private string $formattedMessage,
+    ) {
     }
 
     public function getId(): int

--- a/wwwroot/classes/Admin/LogService.php
+++ b/wwwroot/classes/Admin/LogService.php
@@ -7,16 +7,12 @@ require_once __DIR__ . '/LogEntryFormatter.php';
 
 final class LogService
 {
-    private PDO $database;
-
-    private LogEntryFormatter $formatter;
-
     private ?string $logTable = null;
 
-    public function __construct(PDO $database, LogEntryFormatter $formatter)
-    {
-        $this->database = $database;
-        $this->formatter = $formatter;
+    public function __construct(
+        private readonly PDO $database,
+        private readonly LogEntryFormatter $formatter,
+    ) {
     }
 
     /**
@@ -172,11 +168,7 @@ final class LogService
 
     private function getLogTable(): string
     {
-        if ($this->logTable === null) {
-            $this->logTable = 'log';
-        }
-
-        return $this->logTable;
+        return $this->logTable ??= 'log';
     }
 
     private function quoteIdentifier(string $identifier): string

--- a/wwwroot/classes/Admin/Worker.php
+++ b/wwwroot/classes/Admin/Worker.php
@@ -4,30 +4,15 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/WorkerScanProgress.php';
 
-final class Worker
+final readonly class Worker
 {
-    private int $id;
-
-    private string $npsso;
-
-    private string $scanning;
-
-    private DateTimeImmutable $scanStart;
-
-    private ?WorkerScanProgress $scanProgress;
-
     public function __construct(
-        int $id,
-        string $npsso,
-        string $scanning,
-        DateTimeImmutable $scanStart,
-        ?WorkerScanProgress $scanProgress
+        private int $id,
+        private string $npsso,
+        private string $scanning,
+        private DateTimeImmutable $scanStart,
+        private ?WorkerScanProgress $scanProgress,
     ) {
-        $this->id = $id;
-        $this->npsso = $npsso;
-        $this->scanning = $scanning;
-        $this->scanStart = $scanStart;
-        $this->scanProgress = $scanProgress;
     }
 
     public function getId(): int

--- a/wwwroot/classes/Admin/WorkerPageResult.php
+++ b/wwwroot/classes/Admin/WorkerPageResult.php
@@ -10,20 +10,20 @@ final readonly class WorkerPageResult
     /**
      * @var list<Worker>
      */
-    private array $workers;
+    private readonly array $workers;
 
-    private ?string $successMessage;
+    private readonly ?string $successMessage;
 
-    private ?string $errorMessage;
+    private readonly ?string $errorMessage;
 
     /**
      * @var array<string, WorkerPageSortLink>
      */
-    private array $sortLinks;
+    private readonly array $sortLinks;
 
-    private string $sortField;
+    private readonly string $sortField;
 
-    private string $sortDirection;
+    private readonly string $sortDirection;
 
     /**
      * @param list<Worker> $workers

--- a/wwwroot/classes/Admin/WorkerPageSortLink.php
+++ b/wwwroot/classes/Admin/WorkerPageSortLink.php
@@ -2,19 +2,13 @@
 
 declare(strict_types=1);
 
-final class WorkerPageSortLink
+final readonly class WorkerPageSortLink
 {
-    private string $field;
-
-    private string $url;
-
-    private string $indicator;
-
-    public function __construct(string $field, string $url, string $indicator)
-    {
-        $this->field = $field;
-        $this->url = $url;
-        $this->indicator = $indicator;
+    public function __construct(
+        private string $field,
+        private string $url,
+        private string $indicator,
+    ) {
     }
 
     public function getField(): string

--- a/wwwroot/classes/Admin/WorkerService.php
+++ b/wwwroot/classes/Admin/WorkerService.php
@@ -9,17 +9,16 @@ require_once __DIR__ . '/SystemCommandExecutor.php';
 
 final class WorkerService
 {
-    private PDO $database;
+    private readonly CommandExecutorInterface $commandExecutor;
 
-    private CommandExecutorInterface $commandExecutor;
+    private const string WORKER_USERNAME = 'psn100';
 
-    private const WORKER_USERNAME = 'psn100';
+    private const string WORKER_SCRIPT = '30th_minute.php';
 
-    private const WORKER_SCRIPT = '30th_minute.php';
-
-    public function __construct(PDO $database, ?CommandExecutorInterface $commandExecutor = null)
-    {
-        $this->database = $database;
+    public function __construct(
+        private readonly PDO $database,
+        ?CommandExecutorInterface $commandExecutor = null,
+    ) {
         $this->commandExecutor = $commandExecutor ?? new SystemCommandExecutor();
     }
 


### PR DESCRIPTION
## Summary
- promote admin log and worker value objects to readonly constructors with promoted properties
- enforce typed constants and readonly dependencies in worker services and streamline log table resolution
- retain sorted worker page metadata through readonly properties

## Testing
- php -l wwwroot/classes/Admin/LogEntry.php wwwroot/classes/Admin/Worker.php wwwroot/classes/Admin/WorkerPageSortLink.php wwwroot/classes/Admin/WorkerPageResult.php wwwroot/classes/Admin/LogService.php wwwroot/classes/Admin/WorkerService.php
- php tests/run.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ca51181c832fa3f4e8e7222f5b65)