### PR TITLE
Remove redundant Throwable import from HourlyCronJob

### DIFF
--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/CronJobInterface.php';
 
-use Throwable;
-
 final readonly class HourlyCronJob implements CronJobInterface
 {
     private const BATCH_SIZE = 500;


### PR DESCRIPTION
### Motivation
- Remove a no-op `use Throwable` statement that emitted a PHP warning and is unnecessary under current code.

### Description
- Deleted the `use Throwable;` line from `wwwroot/classes/Cron/HourlyCronJob.php` to avoid the warning and clean up the file.

### Testing
- Ran `php -l wwwroot/classes/Cron/HourlyCronJob.php` (no syntax errors) and `php tests/run.php`, and the test suite completed successfully with all 417 tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69740dafb31c832f8db7b038d74e908e)