### PR TITLE
Recompute MERGE progress after automatic merges

### DIFF
--- a/wwwroot/classes/AutomaticTrophyTitleMergeService.php
+++ b/wwwroot/classes/AutomaticTrophyTitleMergeService.php
@@ -131,6 +131,8 @@ final class AutomaticTrophyTitleMergeService
                 $gameToClone['np_communication_id']
             );
         }
+
+        $this->trophyMergeService->recomputeMergeProgressByParent($cloneInfo['clone_np_communication_id']);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Ensure MERGE parent progress and player aggregations remain consistent after an automatic multi-title merge, even when an individual merge is skipped due to ambiguous name mapping.  
- Drive the final recomputation using the parent MERGE `np_communication_id` returned from `cloneGameWithInfo()` so the parent is authoritative for aggregation.

### Description
- Added `recomputeMergeProgressByParent(string $parentNpCommunicationId)` to `TrophyMergeService` which looks up children for a MERGE parent and runs the group/title player recomputation.  
- Factored `updateTrophyGroupPlayer` and `updateTrophyTitlePlayer` to reuse new helper methods (`updateTrophyGroupPlayerForMerge`, `updateTrophyTitlePlayerForMerge`) and added `getMergeChildrenByParent`.  
- Triggered the recomputation at the end of the automatic multi-title merge flow in `AutomaticTrophyTitleMergeService` using the `clone_np_communication_id` from `cloneGameWithInfo()`.  
- Added `testRecomputesMergeProgressWhenAmbiguousMappingIsSkipped()` to `tests/AutomaticTrophyTitleMergeServiceTest.php` and extended the test stub `RecordingTrophyMergeService` to record recompute calls for assertion.

### Testing
- Ran PHP syntax checks with `php -l` on `wwwroot/classes/AutomaticTrophyTitleMergeService.php`, `wwwroot/classes/TrophyMergeService.php`, and `tests/AutomaticTrophyTitleMergeServiceTest.php`, all of which reported no syntax errors.  
- Attempted to run the test suite with `phpunit`, but the command was not available in the environment so the PHPUnit tests were not executed.  
- The new unit test asserts that the recompute entry point is invoked when a single ambiguous mapping causes one merge to be skipped (the assertion is present but not executed due to missing `phpunit`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69769cadbf6c832fb812db41f0d03941)