### PR TITLE
Update MySQL 8.4 upsert syntax for trophy merges

### DIFF
--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -477,14 +477,15 @@ class GameCopyService
         $upsert = $this->database->prepare(
             'INSERT INTO trophy_group (np_communication_id, group_id, name, detail, icon_url, bronze, silver, gold, platinum)
              VALUES (:np_communication_id, :group_id, :name, :detail, :icon_url, :bronze, :silver, :gold, :platinum)
+             AS new
              ON DUPLICATE KEY UPDATE
-                 name = VALUES(name),
-                 detail = VALUES(detail),
-                 icon_url = VALUES(icon_url),
-                 bronze = VALUES(bronze),
-                 silver = VALUES(silver),
-                 gold = VALUES(gold),
-                 platinum = VALUES(platinum)'
+                 name = new.name,
+                 detail = new.detail,
+                 icon_url = new.icon_url,
+                 bronze = new.bronze,
+                 silver = new.silver,
+                 gold = new.gold,
+                 platinum = new.platinum'
         );
 
         foreach ($conflictingGroupIds as $groupId) {
@@ -661,8 +662,9 @@ class GameCopyService
                 :trophy_id,
                 :status
             )
+            AS new
             ON DUPLICATE KEY UPDATE
-                status = VALUES(status)'
+                status = new.status'
         );
         $exists = $this->database->prepare(
             'SELECT 1
@@ -695,10 +697,11 @@ class GameCopyService
                 :parent_group_id,
                 :parent_order_id
             )
+            AS new
             ON DUPLICATE KEY UPDATE
-                parent_np_communication_id = VALUES(parent_np_communication_id),
-                parent_group_id = VALUES(parent_group_id),
-                parent_order_id = VALUES(parent_order_id)'
+                parent_np_communication_id = new.parent_np_communication_id,
+                parent_group_id = new.parent_group_id,
+                parent_order_id = new.parent_order_id'
         );
 
         foreach ($trophies as $trophy) {

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -509,11 +509,12 @@ SQL
             WHERE
                 child.np_communication_id = :child_np_communication_id
                 AND child.order_id = :child_order_id
+            AS new
             ON DUPLICATE KEY
             UPDATE
-                earned_date = VALUES(earned_date),
-                progress = VALUES(progress),
-                earned = VALUES(earned)
+                earned_date = new.earned_date,
+                progress = new.progress,
+                earned = new.earned
 SQL
         );
         $query->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);


### PR DESCRIPTION
### Motivation

- MySQL 8.4 deprecated the `VALUES()` function in `ON DUPLICATE KEY UPDATE` clauses, so existing upserts using `VALUES()` must be migrated to the new row-alias syntax. 

### Description

- Replaced `VALUES(...)` usage with a row alias and direct column references (e.g. `AS new` then `new.col`) in `wwwroot/classes/TrophyMergeService.php`. 
- Replaced `VALUES(...)` usage with a row alias and direct column references in `wwwroot/classes/Admin/GameCopyService.php` for `trophy_group`, `trophy_meta`, and `trophy_merge` upserts. 
- Kept logic and binding parameters unchanged; only the upsert syntax was updated for MySQL 8.4 compatibility. 

### Testing

- Ran syntax checks with `php -l wwwroot/classes/TrophyMergeService.php` and `php -l wwwroot/classes/Admin/GameCopyService.php`, both succeeded. 
- Executed the full test suite with `php tests/run.php`, and all tests passed (421 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976a0b8c3ac832f8d0f2c269c3066de)