### PR TITLE
Fix timeline property declaration on PlayerTimelinePage

### DIFF
--- a/wwwroot/classes/PlayerTimelinePage.php
+++ b/wwwroot/classes/PlayerTimelinePage.php
@@ -11,10 +11,10 @@ class PlayerTimelinePage
 {
     private PlayerSummary $playerSummary;
 
-    // /**
-    //  * @var PlayerTimeline[]
-    //  */
-    // private array $timelines;
+    /**
+     * @var PlayerTimeline[]
+     */
+    private array $timelines = [];
 
     private PlayerStatus $playerStatus;
 


### PR DESCRIPTION
### Motivation
- Prevent PHP 8.5 deprecation warnings from creating the `timelines` dynamic property on `PlayerTimelinePage`.

### Description
- Declare a typed `private array $timelines = [];` property with an `@var PlayerTimeline[]` docblock in `wwwroot/classes/PlayerTimelinePage.php` and remove the old commented-out stub so the property is explicit.

### Testing
- Ran a syntax check with `php -l wwwroot/classes/PlayerTimelinePage.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976ac6e1328832f932fa8c8809919cc)