### PR TITLE
Refactor Player Timeline: structured service, CTE query, and layout helpers

### DIFF
--- a/wwwroot/classes/PlayerTimelineData.php
+++ b/wwwroot/classes/PlayerTimelineData.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+final readonly class PlayerTimelineData
+{
+    /**
+     * @param PlayerTimelineEntry[] $entries
+     */
+    public function __construct(
+        private DateTimeImmutable $startDate,
+        private DateTimeImmutable $endDate,
+        private array $entries,
+    ) {
+    }
+
+    public function getStartDate(): DateTimeImmutable
+    {
+        return $this->startDate;
+    }
+
+    public function getEndDate(): DateTimeImmutable
+    {
+        return $this->endDate;
+    }
+
+    /**
+     * @return PlayerTimelineEntry[]
+     */
+    public function getEntries(): array
+    {
+        return $this->entries;
+    }
+}

--- a/wwwroot/classes/PlayerTimelineEntry.php
+++ b/wwwroot/classes/PlayerTimelineEntry.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+final readonly class PlayerTimelineEntry
+{
+    private function __construct(
+        private int $gameId,
+        private string $name,
+        private int $progress,
+        private DateTimeImmutable $firstTrophyDate,
+        private DateTimeImmutable $lastTrophyDate,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromRow(array $row): self
+    {
+        return new self(
+            gameId: (int) ($row['game_id'] ?? 0),
+            name: (string) ($row['name'] ?? ''),
+            progress: (int) ($row['progress'] ?? 0),
+            firstTrophyDate: new DateTimeImmutable((string) $row['first_trophy']),
+            lastTrophyDate: new DateTimeImmutable((string) $row['last_trophy']),
+        );
+    }
+
+    public function getGameId(): int
+    {
+        return $this->gameId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getProgress(): int
+    {
+        return $this->progress;
+    }
+
+    public function getFirstTrophyDate(): DateTimeImmutable
+    {
+        return $this->firstTrophyDate;
+    }
+
+    public function getLastTrophyDate(): DateTimeImmutable
+    {
+        return $this->lastTrophyDate;
+    }
+
+    public function getStatusClass(DateTimeImmutable $today): string
+    {
+        if ($this->progress >= 100) {
+            return 'completed';
+        }
+
+        $daysSince = (int) $this->lastTrophyDate->diff($today)->format('%r%a');
+        if ($daysSince > 90) {
+            return 'stalled';
+        }
+
+        return 'playing';
+    }
+}

--- a/wwwroot/classes/PlayerTimelineLayout.php
+++ b/wwwroot/classes/PlayerTimelineLayout.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerTimelineEntry.php';
+require_once __DIR__ . '/PlayerTimelineLayoutItem.php';
+
+final class PlayerTimelineLayout
+{
+    /**
+     * @param PlayerTimelineEntry[] $entries
+     * @return list<list<PlayerTimelineLayoutItem>>
+     */
+    public static function buildRows(DateTimeImmutable $startDate, array $entries): array
+    {
+        if ($entries === []) {
+            return [];
+        }
+
+        $rows = [];
+        $rowEndDates = [];
+
+        foreach ($entries as $entry) {
+            $rowIndex = null;
+            foreach ($rowEndDates as $index => $rowEndDate) {
+                if ($entry->getFirstTrophyDate() > $rowEndDate) {
+                    $rowIndex = $index;
+                    break;
+                }
+            }
+
+            if ($rowIndex === null) {
+                $rowIndex = count($rows);
+                $rows[$rowIndex] = [];
+                $rowEndDates[$rowIndex] = $startDate->modify('-1 day');
+            }
+
+            $lastDate = $rowEndDates[$rowIndex];
+            $offsetDays = max(
+                0,
+                (int) $lastDate->diff($entry->getFirstTrophyDate())->format('%r%a') - 1
+            );
+            $durationDays = (int) $entry->getFirstTrophyDate()
+                ->diff($entry->getLastTrophyDate())
+                ->format('%r%a') + 1;
+
+            $rows[$rowIndex][] = new PlayerTimelineLayoutItem(
+                $entry,
+                $offsetDays,
+                max(1, $durationDays)
+            );
+            $rowEndDates[$rowIndex] = $entry->getLastTrophyDate();
+        }
+
+        return array_values($rows);
+    }
+}

--- a/wwwroot/classes/PlayerTimelineLayoutItem.php
+++ b/wwwroot/classes/PlayerTimelineLayoutItem.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+final readonly class PlayerTimelineLayoutItem
+{
+    public function __construct(
+        private PlayerTimelineEntry $entry,
+        private int $offsetDays,
+        private int $durationDays,
+    ) {
+    }
+
+    public function getEntry(): PlayerTimelineEntry
+    {
+        return $this->entry;
+    }
+
+    public function getOffsetDays(): int
+    {
+        return $this->offsetDays;
+    }
+
+    public function getDurationDays(): int
+    {
+        return $this->durationDays;
+    }
+}

--- a/wwwroot/classes/PlayerTimelinePage.php
+++ b/wwwroot/classes/PlayerTimelinePage.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerTimelineData.php';
 require_once __DIR__ . '/PlayerTimelineService.php';
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/PlayerSummaryService.php';
@@ -11,12 +12,9 @@ class PlayerTimelinePage
 {
     private PlayerSummary $playerSummary;
 
-    /**
-     * @var PlayerTimeline[]
-     */
-    private array $timelines = [];
-
     private PlayerStatus $playerStatus;
+
+    private ?PlayerTimelineData $timelineData = null;
 
     public function __construct(
         PlayerTimelineService $timelineService,
@@ -28,15 +26,18 @@ class PlayerTimelinePage
         $this->playerStatus = $playerStatus;
 
         if ($this->shouldLoadTimeline()) {
-            $this->timelines = $timelineService->getTimelines($accountId);
-        } else {
-            $this->timelines = [];
+            $this->timelineData = $timelineService->getTimelineData($accountId);
         }
     }
 
     public function getPlayerSummary(): PlayerSummary
     {
         return $this->playerSummary;
+    }
+
+    public function getTimelineData(): ?PlayerTimelineData
+    {
+        return $this->timelineData;
     }
 
     // /**
@@ -64,7 +65,6 @@ class PlayerTimelinePage
 
     private function shouldLoadTimeline(): bool
     {
-        return false;
-        //return $this->shouldShowTimeline();
+        return $this->shouldShowTimeline();
     }
 }

--- a/wwwroot/classes/PlayerTimelinePageContext.php
+++ b/wwwroot/classes/PlayerTimelinePageContext.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 //require_once __DIR__ . '/PlayerTimeline.php';
+require_once __DIR__ . '/PlayerTimelineData.php';
 require_once __DIR__ . '/PlayerTimelinePage.php';
 require_once __DIR__ . '/PlayerTimelineService.php';
 require_once __DIR__ . '/PlayerSummary.php';
@@ -14,9 +15,6 @@ require_once __DIR__ . '/PlayerStatus.php';
 
 final class PlayerTimelinePageContext
 {
-    private const int STATUS_FLAGGED = 1;
-    private const int STATUS_PRIVATE = 3;
-
     private PlayerTimelinePage $playerTimelinePage;
 
     private PlayerSummary $playerSummary;
@@ -44,7 +42,7 @@ final class PlayerTimelinePageContext
     ): self {
         $playerStatus = self::extractPlayerStatus($playerData);
 
-        $timelineService = new PlayerTimelineService($database, $utility);
+        $timelineService = new PlayerTimelineService($database);
         $summaryService = new PlayerSummaryService($database);
 
         $playerTimelinePage = new PlayerTimelinePage(
@@ -148,6 +146,11 @@ final class PlayerTimelinePageContext
     public function shouldShowTimeline(): bool
     {
         return $this->playerTimelinePage->shouldShowTimeline();
+    }
+
+    public function getTimelineData(): ?PlayerTimelineData
+    {
+        return $this->playerTimelinePage->getTimelineData();
     }
 
     // /**

--- a/wwwroot/classes/PlayerTimelineService.php
+++ b/wwwroot/classes/PlayerTimelineService.php
@@ -2,63 +2,67 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerTimelineData.php';
+require_once __DIR__ . '/PlayerTimelineEntry.php';
 class PlayerTimelineService
 {
     private readonly PDO $database;
 
-    private readonly Utility $utility;
-
-    public function __construct(PDO $database, Utility $utility)
+    public function __construct(PDO $database)
     {
         $this->database = $database;
-        $this->utility = $utility;
     }
 
-    // /**
-    //  * @return PlayerTimeline[]
-    //  */
-    public function getTimelines(int $accountId): array
+    public function getTimelineData(int $accountId): ?PlayerTimelineData
     {
-        return null;
+        $sql = <<<'SQL'
+            WITH timeline AS (
+                SELECT
+                    tt.id AS game_id,
+                    tt.name,
+                    ttp.progress,
+                    DATE(MIN(te.earned_date)) AS first_trophy,
+                    DATE(MAX(te.earned_date)) AS last_trophy
+                FROM trophy_title_player ttp
+                JOIN trophy_earned te
+                    ON te.np_communication_id = ttp.np_communication_id
+                    AND te.account_id = ttp.account_id
+                JOIN trophy_title tt ON tt.np_communication_id = ttp.np_communication_id
+                JOIN trophy_title_meta ttm ON ttm.np_communication_id = ttp.np_communication_id
+                WHERE ttp.account_id = :account_id
+                    AND ttm.status = 0
+                GROUP BY ttp.np_communication_id, tt.id, tt.name, ttp.progress
+            )
+            SELECT
+                game_id,
+                name,
+                progress,
+                first_trophy,
+                last_trophy,
+                MIN(first_trophy) OVER () AS timeline_start,
+                MAX(last_trophy) OVER () AS timeline_end
+            FROM timeline
+            ORDER BY first_trophy
+            SQL;
+
+        $statement = $this->database->prepare($sql);
+        $statement->execute([':account_id' => $accountId]);
+        $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+        if ($rows === []) {
+            return null;
+        }
+
+        $timelineStart = new DateTimeImmutable((string) $rows[0]['timeline_start']);
+        $timelineEnd = new DateTimeImmutable((string) $rows[0]['timeline_end']);
+        $startDate = $timelineStart->modify('first day of this month');
+        $endDate = $timelineEnd->modify('first day of next month');
+
+        $entries = array_map(
+            fn(array $row): PlayerTimelineEntry => PlayerTimelineEntry::fromRow($row),
+            $rows
+        );
+
+        return new PlayerTimelineData($startDate, $endDate, $entries);
     }
-
-    // private function buildSelectableQuery(PlayerRandomGamesFilter $filter): string
-    // {
-    //     return <<<'SQL'
-    //         SELECT
-    //             tt.id,
-    //             tt.np_communication_id,
-    //             tt.name,
-    //             tt.icon_url,
-    //             tt.platform,
-    //             ttm.owners,
-    //             ttm.difficulty,
-    //             tt.platinum,
-    //             tt.gold,
-    //             tt.silver,
-    //             tt.bronze,
-    //             ttm.rarity_points,
-    //             ttm.in_game_rarity_points,
-    //             ttp.progress
-    //         SQL
-    //         . $this->buildBaseQuery($filter);
-    // }
-
-    // private function buildBaseQuery(PlayerRandomGamesFilter $filter): string
-    // {
-    //     $sql = <<<'SQL'
-    //          FROM trophy_title tt
-    //         JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
-    //         LEFT JOIN trophy_title_player ttp ON
-    //             ttp.np_communication_id = tt.np_communication_id
-    //             AND ttp.account_id = :account_id
-    //         WHERE
-    //             ttm.status = 0
-    //             AND (ttp.progress IS NULL OR ttp.progress < 100)
-    //     SQL;
-
-    //     $sql .= $this->buildPlatformFilter($filter);
-
-    //     return $sql;
-    // }
 }


### PR DESCRIPTION
### Motivation
- Move timeline data access out of the template into a typed service and use modern SQL features to improve clarity and performance on MySQL 8.4.
- Represent timeline data with immutable value objects and compute layout rows in PHP to simplify rendering logic and make the codebase PHP 8.5-friendly.

### Description
- Add `PlayerTimelineData`, `PlayerTimelineEntry`, `PlayerTimelineLayout`, and `PlayerTimelineLayoutItem` to model timeline ranges, entries, and per-row layout items used for rendering. 
- Replace inline SQL in the template with `PlayerTimelineService::getTimelineData(int $accountId): ?PlayerTimelineData` which uses a CTE and window functions to compute per-game ranges and global timeline start/end. 
- Remove the `Utility` dependency from the service constructor and wire the new service in `PlayerTimelinePage` / `PlayerTimelinePageContext`, exposing `getTimelineData()` for the template. 
- Update `player_timeline.php` to render rows using `PlayerTimelineLayout::buildRows()` and the new typed objects, escaping output with `htmlspecialchars()` and using `DateTimeImmutable` and `DateInterval` APIs.

### Testing
- Ran PHP syntax checks with `php -l` for the modified files which reported no syntax errors. 
- Ran the full automated test suite with `php tests/run.php` (421 tests executed) which completed but reported `6` failing tests; a notable failure is `PlayerRandomGamesPageContextTest::testContextAggregatesDependencies` which expected `/player/ExampleUser/random` but received `/game?sort=completion&filter=true&player=ExampleUser`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976ad69e5b4832fa933784c8a013744)