### PR TITLE
Remove redundant Throwable imports from cron jobs

### DIFF
--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/CronJobInterface.php';
 
-use Throwable;
-
 final readonly class DailyCronJob implements CronJobInterface
 {
     public function __construct(private PDO $database, private int $retryDelaySeconds = 3)

--- a/wwwroot/classes/Cron/WeeklyCronJob.php
+++ b/wwwroot/classes/Cron/WeeklyCronJob.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/CronJobInterface.php';
 
-use Throwable;
-
 final readonly class WeeklyCronJob implements CronJobInterface
 {
     private const UPDATE_PLAYER_RANKINGS_QUERY = <<<'SQL'


### PR DESCRIPTION
### Motivation
- Silence PHP warnings caused by the redundant `use Throwable;` statements in cron job classes.

### Description
- Remove `use Throwable;` from `wwwroot/classes/Cron/DailyCronJob.php` and `wwwroot/classes/Cron/WeeklyCronJob.php` to avoid the non-compound name warning.

### Testing
- Ran `php -l wwwroot/classes/Cron/WeeklyCronJob.php` and `php -l wwwroot/classes/Cron/DailyCronJob.php`, both returned no syntax errors.
- Ran the full test suite with `php tests/run.php`, which executed but completed with 6 failing tests out of 421 (failures appear unrelated to this import removal).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976b2610ab4832f8d77cebb2eb23a40)