### PR TITLE
Update player navigation tests for timeline link

### DIFF
--- a/tests/PlayerAdvisorPageContextTest.php
+++ b/tests/PlayerAdvisorPageContextTest.php
@@ -34,8 +34,8 @@ final class PlayerAdvisorPageContextTest extends TestCase
 
         $navigation = $context->getPlayerNavigation();
         $links = $navigation->getLinks();
-        $this->assertSame('/player/ExampleUser/advisor', $links[2]->getUrl());
-        $this->assertTrue($links[2]->isActive());
+        $this->assertSame('/player/ExampleUser/advisor', $links[3]->getUrl());
+        $this->assertTrue($links[3]->isActive());
 
         $platformOptions = $context->getPlatformFilterOptions()->getOptions();
         $ps5Option = null;

--- a/tests/PlayerLogPageContextTest.php
+++ b/tests/PlayerLogPageContextTest.php
@@ -52,8 +52,8 @@ final class PlayerLogPageContextTest extends TestCase
 
         $navigation = $context->getPlayerNavigation();
         $links = $navigation->getLinks();
-        $this->assertSame('/player/ExampleUser/log', $links[1]->getUrl());
-        $this->assertTrue($links[1]->isActive());
+        $this->assertSame('/player/ExampleUser/log', $links[2]->getUrl());
+        $this->assertTrue($links[2]->isActive());
 
         $platformOptions = $context->getPlatformFilterOptions()->getOptions();
         $ps5Option = null;

--- a/tests/PlayerNavigationRendererTest.php
+++ b/tests/PlayerNavigationRendererTest.php
@@ -16,7 +16,7 @@ final class PlayerNavigationRendererTest extends TestCase
         $trimmedHtml = trim($html);
 
         $this->assertTrue(str_starts_with($trimmedHtml, '<div class="btn-group d-flex align-items-stretch">'));
-        $this->assertSame(5, substr_count($html, '<a class="'));
+        $this->assertSame(6, substr_count($html, '<a class="'));
         $this->assertStringContainsString('href="/player/Example%20User/log"', $html);
         $this->assertStringContainsString(
             'class="btn btn-primary active d-flex align-items-center justify-content-center"',

--- a/tests/PlayerNavigationTest.php
+++ b/tests/PlayerNavigationTest.php
@@ -12,10 +12,11 @@ final class PlayerNavigationTest extends TestCase
 
         $links = $navigation->getLinks();
 
-        $this->assertCount(5, $links);
+        $this->assertCount(6, $links);
 
         $expected = [
             ['label' => 'Games', 'url' => '/player/Test%20User'],
+            ['label' => 'Timeline', 'url' => '/player/Test%20User/timeline'],
             ['label' => 'Log', 'url' => '/player/Test%20User/log'],
             ['label' => 'Trophy Advisor', 'url' => '/player/Test%20User/advisor'],
             ['label' => 'Game Advisor', 'url' => '/game?sort=completion&filter=true&player=Test%20User'],
@@ -37,7 +38,7 @@ final class PlayerNavigationTest extends TestCase
 
         $links = $navigation->getLinks();
 
-        $this->assertCount(5, $links);
+        $this->assertCount(6, $links);
 
         foreach ($links as $link) {
             if ($link->getLabel() === 'Game Advisor') {

--- a/tests/PlayerRandomGamesPageContextTest.php
+++ b/tests/PlayerRandomGamesPageContextTest.php
@@ -53,8 +53,8 @@ final class PlayerRandomGamesPageContextTest extends TestCase
 
         $navigation = $context->getPlayerNavigation();
         $links = $navigation->getLinks();
-        $this->assertSame('/player/ExampleUser/random', $links[4]->getUrl());
-        $this->assertTrue($links[4]->isActive());
+        $this->assertSame('/player/ExampleUser/random', $links[5]->getUrl());
+        $this->assertTrue($links[5]->isActive());
 
         $platformOptions = $context->getPlatformFilterOptions()->getOptions();
         $ps5Option = null;


### PR DESCRIPTION
### Motivation
- The player navigation now includes a Timeline link, changing the ordering and total number of navigation buttons, so tests needed to be updated to reflect the new link set and indices.

### Description
- Updated `tests/PlayerNavigationTest.php` to expect 6 links and added the Timeline entry to the expected list.
- Adjusted indices in `tests/PlayerAdvisorPageContextTest.php`, `tests/PlayerLogPageContextTest.php`, and `tests/PlayerRandomGamesPageContextTest.php` so they assert the correct navigation link positions after the Timeline addition.
- Updated `tests/PlayerNavigationRendererTest.php` to expect 6 anchor elements when rendering the navigation.

### Testing
- Ran the full test suite with `php tests/run.php`, which completed with all tests passing (421 tests, 0 failures). 
- Ran syntax checks with `php -l` on the modified test files, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976b2edc638832fa260f003697fc1ad)