### PR TITLE
Add PlayerTimeline page and context tests

### DIFF
--- a/tests/PlayerTimelinePageContextTest.php
+++ b/tests/PlayerTimelinePageContextTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerTimelinePageContext.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerTimelineData.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerTimelineEntry.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerTimelineService.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerSummary.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerSummaryService.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerStatus.php';
+
+final class PlayerTimelinePageContextTest extends TestCase
+{
+    public function testContextAggregatesDependencies(): void
+    {
+        $summary = new PlayerSummary(8, 2, 55.5, 30);
+        $timelineData = $this->createTimelineData();
+        $page = $this->createPage($summary, $timelineData, PlayerStatus::NORMAL);
+
+        $context = PlayerTimelinePageContext::fromComponents(
+            $page,
+            $summary,
+            'ExampleUser',
+            123,
+            PlayerStatus::NORMAL
+        );
+
+        $this->assertSame($page, $context->getPlayerTimelinePage());
+        $this->assertSame($summary, $context->getPlayerSummary());
+        $this->assertSame("ExampleUser's Timeline ~ PSN 100%", $context->getTitle());
+        $this->assertSame('ExampleUser', $context->getPlayerOnlineId());
+        $this->assertSame(123, $context->getPlayerAccountId());
+        $this->assertTrue($context->shouldShowTimeline());
+        $this->assertFalse($context->isPlayerFlagged());
+        $this->assertFalse($context->isPlayerPrivate());
+        $this->assertSame($timelineData, $context->getTimelineData());
+
+        $links = $context->getPlayerNavigation()->getLinks();
+        $timelineLink = null;
+
+        foreach ($links as $link) {
+            if ($link->getLabel() === 'Timeline') {
+                $timelineLink = $link;
+                break;
+            }
+        }
+
+        $this->assertTrue($timelineLink instanceof PlayerNavigationLink);
+        $this->assertTrue($timelineLink->isActive());
+        $this->assertSame('/player/ExampleUser/timeline', $timelineLink->getUrl());
+    }
+
+    public function testContextReflectsPlayerStatuses(): void
+    {
+        $summary = new PlayerSummary(0, 0, null, 0);
+        $timelineData = $this->createTimelineData();
+
+        $flaggedPage = $this->createPage($summary, $timelineData, PlayerStatus::FLAGGED);
+        $flaggedContext = PlayerTimelinePageContext::fromComponents(
+            $flaggedPage,
+            $summary,
+            'FlaggedUser',
+            99,
+            PlayerStatus::FLAGGED
+        );
+
+        $this->assertTrue($flaggedContext->isPlayerFlagged());
+        $this->assertTrue($flaggedContext->shouldShowFlaggedMessage());
+        $this->assertFalse($flaggedContext->shouldShowTimeline());
+        $this->assertSame(null, $flaggedContext->getTimelineData());
+
+        $privatePage = $this->createPage($summary, $timelineData, PlayerStatus::PRIVATE_PROFILE);
+        $privateContext = PlayerTimelinePageContext::fromComponents(
+            $privatePage,
+            $summary,
+            'PrivateUser',
+            88,
+            PlayerStatus::PRIVATE_PROFILE
+        );
+
+        $this->assertTrue($privateContext->isPlayerPrivate());
+        $this->assertTrue($privateContext->shouldShowPrivateMessage());
+        $this->assertFalse($privateContext->shouldShowTimeline());
+        $this->assertSame(null, $privateContext->getTimelineData());
+    }
+
+    private function createTimelineData(): PlayerTimelineData
+    {
+        $entry = PlayerTimelineEntry::fromRow([
+            'game_id' => 12,
+            'name' => 'Timeline Game',
+            'progress' => 15,
+            'first_trophy' => '2024-02-01',
+            'last_trophy' => '2024-03-10',
+        ]);
+
+        return new PlayerTimelineData(
+            new DateTimeImmutable('2024-02-01'),
+            new DateTimeImmutable('2024-04-01'),
+            [$entry]
+        );
+    }
+
+    private function createPage(
+        PlayerSummary $summary,
+        ?PlayerTimelineData $timelineData,
+        PlayerStatus $status
+    ): PlayerTimelinePage {
+        $summaryService = new class($summary) extends PlayerSummaryService {
+            private PlayerSummary $summary;
+
+            public function __construct(PlayerSummary $summary)
+            {
+                $this->summary = $summary;
+            }
+
+            public function getSummary(int $accountId): PlayerSummary
+            {
+                return $this->summary;
+            }
+        };
+
+        $timelineService = new class($timelineData) extends PlayerTimelineService {
+            private ?PlayerTimelineData $timelineData;
+
+            public function __construct(?PlayerTimelineData $timelineData)
+            {
+                $this->timelineData = $timelineData;
+            }
+
+            public function getTimelineData(int $accountId): ?PlayerTimelineData
+            {
+                return $this->timelineData;
+            }
+        };
+
+        return new PlayerTimelinePage($timelineService, $summaryService, 42, $status);
+    }
+}

--- a/tests/PlayerTimelinePageTest.php
+++ b/tests/PlayerTimelinePageTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PlayerTimelinePage.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerTimelineData.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerTimelineEntry.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerTimelineService.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerSummary.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerSummaryService.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerStatus.php';
+
+final class PlayerTimelinePageTest extends TestCase
+{
+    public function testPageLoadsTimelineForPublicPlayers(): void
+    {
+        $summary = new PlayerSummary(12, 4, 66.6, 20);
+        $timelineData = $this->createTimelineData();
+        $summaryService = $this->createSummaryService($summary);
+        $timelineService = $this->createTimelineService($timelineData);
+
+        $page = new PlayerTimelinePage($timelineService, $summaryService, 321, PlayerStatus::NORMAL);
+
+        $this->assertSame($summary, $page->getPlayerSummary());
+        $this->assertSame($timelineData, $page->getTimelineData());
+        $this->assertTrue($page->shouldShowTimeline());
+        $this->assertFalse($page->shouldShowFlaggedMessage());
+        $this->assertFalse($page->shouldShowPrivateMessage());
+        $this->assertSame(1, $timelineService->getCallCount());
+    }
+
+    public function testPageSkipsTimelineForFlaggedAndPrivatePlayers(): void
+    {
+        $summary = new PlayerSummary(0, 0, null, 0);
+        $timelineData = $this->createTimelineData();
+
+        $flaggedService = $this->createTimelineService($timelineData);
+        $flaggedPage = new PlayerTimelinePage(
+            $flaggedService,
+            $this->createSummaryService($summary),
+            10,
+            PlayerStatus::FLAGGED
+        );
+
+        $this->assertTrue($flaggedPage->shouldShowFlaggedMessage());
+        $this->assertFalse($flaggedPage->shouldShowPrivateMessage());
+        $this->assertFalse($flaggedPage->shouldShowTimeline());
+        $this->assertSame(null, $flaggedPage->getTimelineData());
+        $this->assertSame(0, $flaggedService->getCallCount());
+
+        $privateService = $this->createTimelineService($timelineData);
+        $privatePage = new PlayerTimelinePage(
+            $privateService,
+            $this->createSummaryService($summary),
+            11,
+            PlayerStatus::PRIVATE_PROFILE
+        );
+
+        $this->assertFalse($privatePage->shouldShowFlaggedMessage());
+        $this->assertTrue($privatePage->shouldShowPrivateMessage());
+        $this->assertFalse($privatePage->shouldShowTimeline());
+        $this->assertSame(null, $privatePage->getTimelineData());
+        $this->assertSame(0, $privateService->getCallCount());
+    }
+
+    private function createTimelineData(): PlayerTimelineData
+    {
+        $entry = PlayerTimelineEntry::fromRow([
+            'game_id' => 50,
+            'name' => 'Example Game',
+            'progress' => 42,
+            'first_trophy' => '2024-01-01',
+            'last_trophy' => '2024-02-01',
+        ]);
+
+        return new PlayerTimelineData(
+            new DateTimeImmutable('2024-01-01'),
+            new DateTimeImmutable('2024-03-01'),
+            [$entry]
+        );
+    }
+
+    private function createSummaryService(PlayerSummary $summary): PlayerSummaryService
+    {
+        return new class($summary) extends PlayerSummaryService {
+            private PlayerSummary $summary;
+
+            public function __construct(PlayerSummary $summary)
+            {
+                $this->summary = $summary;
+            }
+
+            public function getSummary(int $accountId): PlayerSummary
+            {
+                return $this->summary;
+            }
+        };
+    }
+
+    private function createTimelineService(?PlayerTimelineData $timelineData): PlayerTimelineService
+    {
+        return new class($timelineData) extends PlayerTimelineService {
+            private ?PlayerTimelineData $timelineData;
+
+            private int $callCount = 0;
+
+            public function __construct(?PlayerTimelineData $timelineData)
+            {
+                $this->timelineData = $timelineData;
+            }
+
+            public function getTimelineData(int $accountId): ?PlayerTimelineData
+            {
+                $this->callCount++;
+
+                return $this->timelineData;
+            }
+
+            public function getCallCount(): int
+            {
+                return $this->callCount;
+            }
+        };
+    }
+}


### PR DESCRIPTION
### Motivation

- Add unit test coverage for the PlayerTimeline UI logic to ensure timeline loading, visibility rules and navigation behavior are correct.
- Verify status-based behavior (normal / flagged / private) so timeline data is only loaded and shown when appropriate.

### Description

- Add `tests/PlayerTimelinePageTest.php` which asserts `PlayerTimelinePage` loads timeline data for `PlayerStatus::NORMAL` and skips loading for `PlayerStatus::FLAGGED` and `PlayerStatus::PRIVATE_PROFILE`, using stubbed `PlayerTimelineService` and `PlayerSummaryService` to assert call counts and returned data.
- Add `tests/PlayerTimelinePageContextTest.php` which asserts `PlayerTimelinePageContext` aggregates dependencies, builds the expected title and navigation, and reflects player statuses (flagged/private) so the context exposes correct messaging and hides timeline data.
- Tests create minimal `PlayerTimelineData`/`PlayerTimelineEntry` fixtures and lightweight anonymous service subclasses to isolate behaviour under test.

### Testing

- Ran syntax checks with `php -l tests/PlayerTimelinePageTest.php` and `php -l tests/PlayerTimelinePageContextTest.php`, both reported no syntax errors. 
- Ran the full test suite with `php tests/run.php`, and the run completed successfully with all tests passing (425 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976b3fe8970832fa661293d0960b465)