### PR TITLE
Recompute merge progress after automatic trophy title merges

### DIFF
--- a/tests/AutomaticTrophyTitleMergeServiceTest.php
+++ b/tests/AutomaticTrophyTitleMergeServiceTest.php
@@ -38,7 +38,7 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
             [1, 'Trophy B', 'Detail B'],
         ]);
 
-        $this->service->handleNewTitle('NP_NEW');
+        $parentsToRecompute = $this->service->handleNewTitle('NP_NEW');
 
         $this->assertSame([
             ['NP_NEW', 'MERGE_000001'],
@@ -67,7 +67,7 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
             [0, 'Hidden Trophy', 'Secret'],
         ]);
 
-        $this->service->handleNewTitle('NP_NEW');
+        $parentsToRecompute = $this->service->handleNewTitle('NP_NEW');
 
         $this->assertSame([], $this->mergeService->mergedGames);
     }
@@ -84,7 +84,7 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
             [0, 'Trophy A', 'Detail A'],
         ]);
 
-        $this->service->handleNewTitle('NP_NEW');
+        $parentsToRecompute = $this->service->handleNewTitle('NP_NEW');
 
         $this->assertSame([], $this->mergeService->copiedGames);
         $this->assertSame([
@@ -107,7 +107,7 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
             [1, 'Trophy B', 'Detail B'],
         ]);
 
-        $this->service->handleNewTitle('NP_NEW');
+        $parentsToRecompute = $this->service->handleNewTitle('NP_NEW');
 
         $this->assertSame([
             [1, 2, 'order'],
@@ -129,7 +129,7 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
             [1, 'Trophy B', 'Detail B'],
         ]);
 
-        $this->service->handleNewTitle('NP_NEW');
+        $parentsToRecompute = $this->service->handleNewTitle('NP_NEW');
 
         $this->assertSame([
             ['NP_NEW', 'MERGE_000001'],
@@ -160,7 +160,7 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
             'clone_np_communication_id' => 'MERGE_000099',
         ];
 
-        $this->service->handleNewTitle('NP_NEW');
+        $parentsToRecompute = $this->service->handleNewTitle('NP_NEW');
 
         $this->assertSame([1], $this->mergeService->clonedGames);
         $this->assertSame([
@@ -195,14 +195,14 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
             'clone_np_communication_id' => 'MERGE_000099',
         ];
 
-        $this->service->handleNewTitle('NP_NEW');
+        $parentsToRecompute = $this->service->handleNewTitle('NP_NEW');
 
         $this->assertSame([1], $this->mergeService->clonedGames);
         $this->assertSame([
             [1, 99, 'order'],
             [2, 99, 'order'],
         ], $this->mergeService->mergedGames);
-        $this->assertSame(['MERGE_000099'], $this->mergeService->recomputedParents);
+        $this->assertSame(['MERGE_000099'], $parentsToRecompute);
     }
 
     public function testMergeTitleRecalculationUsesAllChildrenAfterSecondMerge(): void

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1300,7 +1300,10 @@ class ThirtyMinuteCronJob implements CronJobInterface
                             }
 
                             if ($isNewTitle) {
-                                $this->automaticTrophyTitleMergeService->handleNewTitle($npid);
+                                $mergeParents = $this->automaticTrophyTitleMergeService->handleNewTitle($npid);
+                                foreach ($mergeParents as $mergeParent) {
+                                    $this->automaticTrophyTitleMergeService->recomputeMergeProgressByParent($mergeParent);
+                                }
                             }
 
                             if ($newTrophies) {


### PR DESCRIPTION
### Motivation
- Address a race/consistency issue where player progress can end up as 0 after an automatic title merge by ensuring merge-parent progress is recomputed when a new title triggers an auto-merge.

### Description
- Change `AutomaticTrophyTitleMergeService::handleNewTitle` to return a `list<string>` of merge-parent `np_communication_id` values instead of `void` so callers can act on merge targets.
- Add a small public helper `AutomaticTrophyTitleMergeService::recomputeMergeProgressByParent(string)` that delegates to `TrophyMergeService::recomputeMergeProgressByParent`.
- Update the 30-minute cron job (`ThirtyMinuteCronJob`) to call `handleNewTitle($npid)` and iterate returned parents to call `recomputeMergeProgressByParent(...)` for each returned merge parent.
- Update `AutomaticTrophyTitleMergeService` tests to capture and assert the returned recompute targets from `handleNewTitle`.

### Testing
- Ran PHP lint on modified files with `php -l wwwroot/classes/AutomaticTrophyTitleMergeService.php`, `php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php`, and `php -l tests/AutomaticTrophyTitleMergeServiceTest.php` and found no syntax errors.
- Executed the full test suite with `php tests/run.php` and confirmed all tests passed (425 tests passed, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a8d2f414c832fbde02042947be1a3)