### PR TITLE
Normalize spacing around colons in trophy titles

### DIFF
--- a/tests/TrophyTitleNamingTest.php
+++ b/tests/TrophyTitleNamingTest.php
@@ -80,6 +80,13 @@ final class TrophyTitleNamingTest extends TestCase
         $this->assertSame("Journey: Collector's Edition", $formatted);
     }
 
+    public function testExtraSpacingAroundColonsIsNormalized(): void
+    {
+        $formatted = $this->formatTitle('Bus Simulator : World Tour');
+
+        $this->assertSame('Bus Simulator: World Tour', $formatted);
+    }
+
     public function testApaTitleCaseLeavesSmallWordsLowercase(): void
     {
         $formatted = $this->formatTitle('return of the jedi and the sith');

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -2326,6 +2326,8 @@ class ThirtyMinuteCronJob implements CronJobInterface
         // Normalize en dash to hyphen-minus to keep downstream handling consistent.
         $name = str_replace('–', '-', $name);
 
+        $name = preg_replace('/\s*:\s*/', ': ', $name) ?? $name;
+
         if ($name === '') {
             return $name;
         }


### PR DESCRIPTION
### Motivation
- Ensure trophy title names are normalized when ingested so extra spacing around colons (e.g. `Bus Simulator : World Tour`) becomes the canonical `Bus Simulator: World Tour` for consistent storage and display.

### Description
- Add a normalization step in `sanitizeTrophyTitleName` to collapse whitespace around colons (`preg_replace('/\s*:\s*/', ': ', $name)`), and add a unit test `testExtraSpacingAroundColonsIsNormalized` to `tests/TrophyTitleNamingTest.php` to cover the change.

### Testing
- Ran syntax checks with `php -l` for the modified files and executed the full test suite with `php tests/run.php`, and all tests passed (426 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a916dd960832f9125ba1f240186ef)