### PR TITLE
Modernize service constructors for PHP 8.5

### DIFF
--- a/wwwroot/classes/AboutPageService.php
+++ b/wwwroot/classes/AboutPageService.php
@@ -10,13 +10,10 @@ class AboutPageService implements AboutPageDataProviderInterface
 {
     private const DEFAULT_SCAN_LOG_LIMIT = 10;
 
-    private PDO $database;
-    private Utility $utility;
-
-    public function __construct(PDO $database, Utility $utility)
-    {
-        $this->database = $database;
-        $this->utility = $utility;
+    public function __construct(
+        private readonly PDO $database,
+        private readonly Utility $utility
+    ) {
     }
 
     #[\Override]

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -11,14 +11,10 @@ require_once __DIR__ . '/PsnpPlusClient.php';
 
 class GameHeaderService
 {
-    private PDO $database;
-
-    private PsnpPlusClient $psnpPlusClient;
-
-    public function __construct(PDO $database, ?PsnpPlusClient $psnpPlusClient = null)
-    {
-        $this->database = $database;
-        $this->psnpPlusClient = $psnpPlusClient ?? new PsnpPlusClient();
+    public function __construct(
+        private readonly PDO $database,
+        private readonly PsnpPlusClient $psnpPlusClient = new PsnpPlusClient()
+    ) {
     }
 
     public function buildHeaderData(GameDetails $game): GameHeaderData

--- a/wwwroot/classes/GameHistoryService.php
+++ b/wwwroot/classes/GameHistoryService.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 final class GameHistoryService
 {
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     /**

--- a/wwwroot/classes/GameLeaderboardService.php
+++ b/wwwroot/classes/GameLeaderboardService.php
@@ -9,11 +9,8 @@ class GameLeaderboardService
 {
     public const PAGE_SIZE = 50;
 
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     public function getGame(int $gameId): ?GameDetails

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -9,14 +9,10 @@ class GameListService
 {
     private const PAGE_LIMIT = 40;
 
-    private PDO $database;
-
-    private SearchQueryHelper $searchQueryHelper;
-
-    public function __construct(PDO $database, SearchQueryHelper $searchQueryHelper)
-    {
-        $this->database = $database;
-        $this->searchQueryHelper = $searchQueryHelper;
+    public function __construct(
+        private readonly PDO $database,
+        private readonly SearchQueryHelper $searchQueryHelper
+    ) {
     }
 
     public function resolvePlayer(?string $onlineId): ?string

--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -11,11 +11,8 @@ class GameRecentPlayersService
 {
     public const RECENT_PLAYERS_LIMIT = 10;
 
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     public function getGame(int $gameId): ?GameDetails

--- a/wwwroot/classes/GameRepository.php
+++ b/wwwroot/classes/GameRepository.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 class GameRepository
 {
-    private \PDO $database;
-
-    public function __construct(\PDO $database)
+    public function __construct(private readonly \PDO $database)
     {
-        $this->database = $database;
     }
 
     public function findIdFromSegment(?string $segment): ?int

--- a/wwwroot/classes/GameStatusService.php
+++ b/wwwroot/classes/GameStatusService.php
@@ -6,11 +6,8 @@ require_once __DIR__ . '/GameAvailabilityStatus.php';
 
 class GameStatusService
 {
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     public function updateGameStatus(int $gameId, GameAvailabilityStatus $status): string

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -14,11 +14,8 @@ class HomepageContentService
     private const DEFAULT_NEW_DLCS_LIMIT = 8;
     private const DEFAULT_POPULAR_GAME_LIMIT = 10;
 
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     /**

--- a/wwwroot/classes/PlayerLeaderboardService.php
+++ b/wwwroot/classes/PlayerLeaderboardService.php
@@ -8,11 +8,8 @@ class PlayerLeaderboardService implements PlayerLeaderboardDataProvider
 {
     public const PAGE_SIZE = 50;
 
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     #[\Override]

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -18,11 +18,8 @@ class PlayerLogService
         'psvr2' => "tt.platform LIKE '%PSVR2%'",
     ];
 
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     public function countTrophies(int $accountId, PlayerLogFilter $filter): int

--- a/wwwroot/classes/PlayerRarityLeaderboardService.php
+++ b/wwwroot/classes/PlayerRarityLeaderboardService.php
@@ -8,11 +8,8 @@ class PlayerRarityLeaderboardService implements PlayerLeaderboardDataProvider
 {
     public const PAGE_SIZE = 50;
 
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     #[\Override]

--- a/wwwroot/classes/PlayerReportService.php
+++ b/wwwroot/classes/PlayerReportService.php
@@ -8,11 +8,8 @@ class PlayerReportService
 {
     private const MAX_PENDING_REPORTS_PER_IP = 10;
 
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     public function submitReport(int $accountId, string $ipAddress, string $explanation): PlayerReportResult

--- a/wwwroot/classes/Psn100Logger.php
+++ b/wwwroot/classes/Psn100Logger.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 final class Psn100Logger
 {
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     public function log(string $message): void

--- a/wwwroot/classes/TrophyListService.php
+++ b/wwwroot/classes/TrophyListService.php
@@ -8,11 +8,8 @@ class TrophyListService
 {
     public const PAGE_SIZE = 50;
 
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     public function countTrophies(): int
@@ -78,4 +75,3 @@ class TrophyListService
         );
     }
 }
-

--- a/wwwroot/classes/TrophyMetaRepository.php
+++ b/wwwroot/classes/TrophyMetaRepository.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 class TrophyMetaRepository
 {
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     public function ensureExists(string $npCommunicationId, string $groupId, int $orderId): void

--- a/wwwroot/classes/TrophyRepository.php
+++ b/wwwroot/classes/TrophyRepository.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 class TrophyRepository
 {
-    private \PDO $database;
-
-    public function __construct(\PDO $database)
+    public function __construct(private readonly \PDO $database)
     {
-        $this->database = $database;
     }
 
     public function findIdFromSegment(?string $segment): ?int

--- a/wwwroot/classes/TrophyService.php
+++ b/wwwroot/classes/TrophyService.php
@@ -8,11 +8,8 @@ require_once __DIR__ . '/TrophyAchiever.php';
 
 class TrophyService
 {
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     public function getTrophyById(int $trophyId): ?TrophyDetails


### PR DESCRIPTION
### Motivation
- Upgrade the codebase to use modern PHP 8.5 language features and patterns for clearer, more concise dependency wiring. 
- Reduce boilerplate and make intent explicit by using readonly promoted constructor properties for services that depend on PDO and helpers. 
- Simplify dependency injection for `GameHeaderService` by providing a default `PsnpPlusClient` while keeping behavior unchanged.

### Description
- Converted many services/repositories to use constructor property promotion with `private readonly` for PDO and helper dependencies (examples: `AboutPageService`, `GameListService`, `GameLeaderboardService`, `GameRecentPlayersService`, `GameRepository`, `GameStatusService`, `HomepageContentService`, `PlayerLeaderboardService`, `PlayerLogService`, `PlayerRarityLeaderboardService`, `PlayerReportService`, `Psn100Logger`, `TrophyListService`, `TrophyMetaRepository`, `TrophyRepository`, `TrophyService`, and others). 
- Updated `GameHeaderService` to accept a promoted `PsnpPlusClient` with a default `new PsnpPlusClient()` to simplify callers while preserving existing functionality. 
- No behavioral changes to SQL, database wiring, or legacy compatibility; `database/psn100.sql` and `wwwroot/database.php` were left untouched.

### Testing
- Ran syntax checks on modified files with `for file in $(git diff --name-only); do php -l "$file"; done` and all files reported no syntax errors. 
- Executed the full test suite with `php tests/run.php` and all tests passed (426 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a95b85424832fb071856efb6e62d4)