### PR TITLE
Modernize queue position query and view models

### DIFF
--- a/wwwroot/classes/ChangelogEntryPresenter.php
+++ b/wwwroot/classes/ChangelogEntryPresenter.php
@@ -38,91 +38,75 @@ readonly class ChangelogEntryPresenter
 
         $extra = $this->escape($this->entry->getExtra());
 
-        switch ($this->entry->getChangeType()) {
-            case ChangelogEntryType::GAME_CLONE:
-                return sprintf(
-                    '%s was cloned: %s',
-                    $this->formatGameReference($param1Link, '', $param1PlatformBadges),
-                    $this->formatGameReference($param2Link, '', $param2PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_COPY:
-                return sprintf(
-                    'Copied trophy data from %s into %s.',
-                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges),
-                    $this->formatGameReference($param2Link, '', $param2PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_DELETE:
-                return sprintf(
-                    "The merged game entry for '%s' have been deleted.",
-                    $extra
-                );
-            case ChangelogEntryType::GAME_DELISTED:
-                return sprintf(
-                    '%s status was set to delisted.',
-                    $this->formatGameReference($param1Link, '', $param1PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_DELISTED_AND_OBSOLETE:
-                return sprintf(
-                    '%s status was set to delisted &amp; obsolete.',
-                    $this->formatGameReference($param1Link, '', $param1PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_HISTORY_SNAPSHOT:
-                return sprintf(
-                    'A new trophy history snapshot was recorded for %s.',
-                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_MERGE:
-                return sprintf(
-                    '%s was merged into %s',
-                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges),
-                    $this->formatGameReference($param2Link, '', $param2PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_NORMAL:
-                return sprintf(
-                    '%s status was set to normal.',
-                    $this->formatGameReference($param1Link, '', $param1PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_OBSOLETE:
-                return sprintf(
-                    '%s status was set to obsolete.',
-                    $this->formatGameReference($param1Link, '', $param1PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_OBTAINABLE:
-                return sprintf(
-                    'Trophies have been tagged as obtainable for %s.',
-                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_RESCAN:
-                return sprintf(
-                    'The game %s have been rescanned for updated/new trophy data and game details.',
-                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_RESET:
-                return sprintf(
-                    'Merged trophies have been reset for %s.',
-                    $this->formatGameReference($param1Link, '', $param1PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_UNOBTAINABLE:
-                return sprintf(
-                    'Trophies have been tagged as unobtainable for %s.',
-                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_UPDATE:
-                return sprintf(
-                    '%s was updated.',
-                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
-                );
-            case ChangelogEntryType::GAME_VERSION:
-                return sprintf(
-                    '%s has a new version.',
-                    $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
-                );
-            default:
-                return sprintf(
-                    'Unknown type: %s',
-                    $this->escape($this->entry->getChangeTypeValue())
-                );
-        }
+        return match ($this->entry->getChangeType()) {
+            ChangelogEntryType::GAME_CLONE => sprintf(
+                '%s was cloned: %s',
+                $this->formatGameReference($param1Link, '', $param1PlatformBadges),
+                $this->formatGameReference($param2Link, '', $param2PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_COPY => sprintf(
+                'Copied trophy data from %s into %s.',
+                $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges),
+                $this->formatGameReference($param2Link, '', $param2PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_DELETE => sprintf(
+                "The merged game entry for '%s' have been deleted.",
+                $extra
+            ),
+            ChangelogEntryType::GAME_DELISTED => sprintf(
+                '%s status was set to delisted.',
+                $this->formatGameReference($param1Link, '', $param1PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_DELISTED_AND_OBSOLETE => sprintf(
+                '%s status was set to delisted &amp; obsolete.',
+                $this->formatGameReference($param1Link, '', $param1PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_HISTORY_SNAPSHOT => sprintf(
+                'A new trophy history snapshot was recorded for %s.',
+                $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_MERGE => sprintf(
+                '%s was merged into %s',
+                $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges),
+                $this->formatGameReference($param2Link, '', $param2PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_NORMAL => sprintf(
+                '%s status was set to normal.',
+                $this->formatGameReference($param1Link, '', $param1PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_OBSOLETE => sprintf(
+                '%s status was set to obsolete.',
+                $this->formatGameReference($param1Link, '', $param1PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_OBTAINABLE => sprintf(
+                'Trophies have been tagged as obtainable for %s.',
+                $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_RESCAN => sprintf(
+                'The game %s have been rescanned for updated/new trophy data and game details.',
+                $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_RESET => sprintf(
+                'Merged trophies have been reset for %s.',
+                $this->formatGameReference($param1Link, '', $param1PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_UNOBTAINABLE => sprintf(
+                'Trophies have been tagged as unobtainable for %s.',
+                $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_UPDATE => sprintf(
+                '%s was updated.',
+                $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
+            ),
+            ChangelogEntryType::GAME_VERSION => sprintf(
+                '%s has a new version.',
+                $this->formatGameReference($param1Link, $param1RegionBadge, $param1PlatformBadges)
+            ),
+            default => sprintf(
+                'Unknown type: %s',
+                $this->escape($this->entry->getChangeTypeValue())
+            ),
+        };
     }
 
     /**

--- a/wwwroot/classes/PlayerHeaderViewModel.php
+++ b/wwwroot/classes/PlayerHeaderViewModel.php
@@ -8,26 +8,16 @@ require_once __DIR__ . '/PlayerLeaderboardRank.php';
 require_once __DIR__ . '/PlayerLeaderboardRankChange.php';
 require_once __DIR__ . '/PlayerStatusNotice.php';
 
-class PlayerHeaderViewModel
+final readonly class PlayerHeaderViewModel
 {
-    /**
-     * @var array<string, mixed>
-     */
-    private array $player;
-
-    private PlayerSummary $playerSummary;
-
-    private Utility $utility;
-
     /**
      * @param array<string, mixed> $player
      */
-    public function __construct(array $player, PlayerSummary $playerSummary, Utility $utility)
-    {
-        $this->player = $player;
-        $this->playerSummary = $playerSummary;
-        $this->utility = $utility;
-    }
+    public function __construct(
+        private array $player,
+        private PlayerSummary $playerSummary,
+        private Utility $utility
+    ) {}
 
     public function getAboutMe(): string
     {
@@ -85,30 +75,29 @@ class PlayerHeaderViewModel
      */
     public function getAlerts(): array
     {
-        $alerts = [];
         $status = $this->getStatus();
         $onlineId = $this->getOnlineId();
         $accountId = $this->getAccountId();
 
-        switch ($status) {
-            case 1:
-                $notice = PlayerStatusNotice::flagged($onlineId, (string) $accountId);
-                $alerts[] = $notice->getMessage();
-                break;
-            case 3:
-                $notice = PlayerStatusNotice::privateProfile();
-                $alerts[] = $notice->getMessage() . ' Make sure this player is no longer private, and then issue a new scan of the profile on the front page.';
-                break;
-            case 4:
-                $alerts[] = 'This player has not played a game in over a year and is considered inactive by this site. All data from this player will be excluded from site statistics and leaderboards.';
-                break;
-            case 5:
-                $alerts[] = 'This player seems to no longer be available from Sony, maybe removed for some reason. We will recheck after 24h and if this player is still not available it will be removed from here as well.';
-                break;
-            case 99:
-                $alerts[] = 'This is a new player currently being scanned for the first time. Rank and stats will be done once the scan is complete.';
-                break;
-        }
+        $alerts = match ($status) {
+            1 => [
+                PlayerStatusNotice::flagged($onlineId, (string) $accountId)->getMessage(),
+            ],
+            3 => [
+                PlayerStatusNotice::privateProfile()->getMessage()
+                . ' Make sure this player is no longer private, and then issue a new scan of the profile on the front page.',
+            ],
+            4 => [
+                'This player has not played a game in over a year and is considered inactive by this site. All data from this player will be excluded from site statistics and leaderboards.',
+            ],
+            5 => [
+                'This player seems to no longer be available from Sony, maybe removed for some reason. We will recheck after 24h and if this player is still not available it will be removed from here as well.',
+            ],
+            99 => [
+                'This is a new player currently being scanned for the first time. Rank and stats will be done once the scan is complete.',
+            ],
+            default => [],
+        };
 
         if ($status === 1 || $status === 3 || $status === 99) {
             return $alerts;
@@ -269,4 +258,3 @@ class PlayerHeaderViewModel
         return (int) ($this->player['status'] ?? 0) === 0;
     }
 }
-


### PR DESCRIPTION
### Motivation
- Adopt PHP 8.5 language features and MySQL 8.4 capabilities to simplify control flow and improve query performance.
- Replace legacy switch logic and verbose constructors with more expressive, type-safe constructs to improve readability and maintainability.
- Reduce database work for queue position lookups by leveraging window functions instead of multi-step queries.

### Description
- `wwwroot/classes/PlayerQueueService.php`: Rewrote `getQueuePosition()` to return early for empty names and compute the player's position using a MySQL `ROW_NUMBER()` window function over `player_queue` ordered by `request_time, online_id`.
- `wwwroot/classes/PlayerHeaderViewModel.php`: Converted the class to `final readonly`, applied constructor property promotion, and replaced a `switch`-based alerts builder with a `match` expression for clearer status-driven alert arrays.
- `wwwroot/classes/ChangelogEntryPresenter.php`: Replaced a large `switch` statement in `getMessage()` with a `match` expression to make the mapping from `ChangelogEntryType` to message clearer and more concise.
- No changes were made to `database/psn100.sql` or `wwwroot/database.php` as requested.

### Testing
- Ran syntax checks with `php -l` for modified files: `PlayerQueueService.php`, `PlayerHeaderViewModel.php`, and `ChangelogEntryPresenter.php`, and they reported no syntax errors.
- Executed the full test suite with `php tests/run.php`, and all automated tests passed (Total: 426 tests; status: all passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698259d2df20832f879f41dc8c0afcf4)