### PR TITLE
Modernize value objects and query builder for PHP 8.5

### DIFF
--- a/wwwroot/classes/Avatar.php
+++ b/wwwroot/classes/Avatar.php
@@ -2,17 +2,12 @@
 
 declare(strict_types=1);
 
-class Avatar
+readonly class Avatar
 {
-    private string $url;
-
-    private int $count;
-
-    public function __construct(string $url, int $count)
-    {
-        $this->url = $url;
-        $this->count = $count;
-    }
+    public function __construct(
+        private string $url,
+        private int $count
+    ) {}
 
     public function getUrl(): string
     {

--- a/wwwroot/classes/GameRecentPlayersQueryBuilder.php
+++ b/wwwroot/classes/GameRecentPlayersQueryBuilder.php
@@ -37,21 +37,16 @@ final class GameRecentPlayersQueryBuilder
         LIMIT :limit
     SQL;
 
-    private GamePlayerFilter $filter;
-
-    private int $limit;
-
-    public function __construct(GamePlayerFilter $filter, int $limit)
-    {
-        $this->filter = $filter;
-        $this->limit = $limit;
-    }
+    public function __construct(
+        private readonly GamePlayerFilter $filter,
+        private readonly int $limit
+    ) {}
 
     public function prepare(\PDO $database, string $npCommunicationId): \PDOStatement
     {
         $query = $database->prepare($this->buildSql());
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->bindValue(':limit', $this->limit, PDO::PARAM_INT);
+        $query->bindValue(':np_communication_id', $npCommunicationId, \PDO::PARAM_STR);
+        $query->bindValue(':limit', $this->limit, \PDO::PARAM_INT);
         $this->bindFilterParameters($query);
 
         return $query;
@@ -86,11 +81,11 @@ final class GameRecentPlayersQueryBuilder
     private function bindFilterParameters(\PDOStatement $query): void
     {
         if ($this->filter->hasCountry()) {
-            $query->bindValue(':country', (string) $this->filter->getCountry(), PDO::PARAM_STR);
+            $query->bindValue(':country', (string) $this->filter->getCountry(), \PDO::PARAM_STR);
         }
 
         if ($this->filter->hasAvatar()) {
-            $query->bindValue(':avatar', (string) $this->filter->getAvatar(), PDO::PARAM_STR);
+            $query->bindValue(':avatar', (string) $this->filter->getAvatar(), \PDO::PARAM_STR);
         }
     }
 }

--- a/wwwroot/classes/PlayerQueueController.php
+++ b/wwwroot/classes/PlayerQueueController.php
@@ -10,12 +10,7 @@ require_once __DIR__ . '/PlayerQueueResponseFactory.php';
 
 class PlayerQueueController
 {
-    private PlayerQueueHandler $handler;
-
-    public function __construct(PlayerQueueHandler $handler)
-    {
-        $this->handler = $handler;
-    }
+    public function __construct(private readonly PlayerQueueHandler $handler) {}
 
     public static function create(Database $database): self
     {

--- a/wwwroot/classes/PlayerSummary.php
+++ b/wwwroot/classes/PlayerSummary.php
@@ -2,23 +2,14 @@
 
 declare(strict_types=1);
 
-class PlayerSummary
+readonly class PlayerSummary
 {
-    private int $numberOfGames;
-
-    private int $numberOfCompletedGames;
-
-    private ?float $averageProgress;
-
-    private int $unearnedTrophies;
-
-    public function __construct(int $numberOfGames, int $numberOfCompletedGames, ?float $averageProgress, int $unearnedTrophies)
-    {
-        $this->numberOfGames = $numberOfGames;
-        $this->numberOfCompletedGames = $numberOfCompletedGames;
-        $this->averageProgress = $averageProgress;
-        $this->unearnedTrophies = $unearnedTrophies;
-    }
+    public function __construct(
+        private int $numberOfGames,
+        private int $numberOfCompletedGames,
+        private ?float $averageProgress,
+        private int $unearnedTrophies
+    ) {}
 
     public function getNumberOfGames(): int
     {
@@ -40,4 +31,3 @@ class PlayerSummary
         return $this->unearnedTrophies;
     }
 }
-

--- a/wwwroot/classes/PlayerTrophyProgress.php
+++ b/wwwroot/classes/PlayerTrophyProgress.php
@@ -2,20 +2,13 @@
 
 declare(strict_types=1);
 
-final class PlayerTrophyProgress
+readonly class PlayerTrophyProgress
 {
-    private ?string $earnedDate;
-
-    private ?string $progress;
-
-    private bool $earned;
-
-    public function __construct(?string $earnedDate, ?string $progress, bool $earned)
-    {
-        $this->earnedDate = $earnedDate;
-        $this->progress = $progress;
-        $this->earned = $earned;
-    }
+    public function __construct(
+        private ?string $earnedDate,
+        private ?string $progress,
+        private bool $earned
+    ) {}
 
     /**
      * @param array<string, mixed> $data

--- a/wwwroot/classes/TrophyAchiever.php
+++ b/wwwroot/classes/TrophyAchiever.php
@@ -2,31 +2,15 @@
 
 declare(strict_types=1);
 
-final class TrophyAchiever
+readonly class TrophyAchiever
 {
-    private string $avatarUrl;
-
-    private string $onlineId;
-
-    private int $trophyCountNpwr;
-
-    private int $trophyCountSony;
-
-    private string $earnedDate;
-
     public function __construct(
-        string $avatarUrl,
-        string $onlineId,
-        int $trophyCountNpwr,
-        int $trophyCountSony,
-        string $earnedDate
-    ) {
-        $this->avatarUrl = $avatarUrl;
-        $this->onlineId = $onlineId;
-        $this->trophyCountNpwr = $trophyCountNpwr;
-        $this->trophyCountSony = $trophyCountSony;
-        $this->earnedDate = $earnedDate;
-    }
+        private string $avatarUrl,
+        private string $onlineId,
+        private int $trophyCountNpwr,
+        private int $trophyCountSony,
+        private string $earnedDate
+    ) {}
 
     /**
      * @param array<string, mixed> $data

--- a/wwwroot/classes/TrophyDetails.php
+++ b/wwwroot/classes/TrophyDetails.php
@@ -4,88 +4,33 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/Utility.php';
 
-final class TrophyDetails
+readonly class TrophyDetails
 {
     private const PLATFORM_SEPARATOR = ',';
     private const MISSING_PS5_ICON = '../missing-ps5-game-and-trophy.png';
     private const MISSING_PS4_GAME_ICON = '../missing-ps4-game.png';
     private const MISSING_PS4_TROPHY_ICON = '../missing-ps4-trophy.png';
 
-    private int $id;
-
-    private string $npCommunicationId;
-
-    private int $groupId;
-
-    private int $orderId;
-
-    private string $type;
-
-    private string $name;
-
-    private string $detail;
-
-    private string $iconFileName;
-
-    private float $rarityPercent;
-
-    private ?float $inGameRarityPercent;
-
-    private int $status;
-
-    private ?string $progressTargetValue;
-
-    private ?string $rewardName;
-
-    private ?string $rewardImageUrl;
-
-    private int $gameId;
-
-    private string $gameName;
-
-    private string $gameIconFileName;
-
-    private string $platform;
-
     public function __construct(
-        int $id,
-        string $npCommunicationId,
-        int $groupId,
-        int $orderId,
-        string $type,
-        string $name,
-        string $detail,
-        string $iconFileName,
-        float $rarityPercent,
-        ?float $inGameRarityPercent,
-        int $status,
-        ?string $progressTargetValue,
-        ?string $rewardName,
-        ?string $rewardImageUrl,
-        int $gameId,
-        string $gameName,
-        string $gameIconFileName,
-        string $platform
-    ) {
-        $this->id = $id;
-        $this->npCommunicationId = $npCommunicationId;
-        $this->groupId = $groupId;
-        $this->orderId = $orderId;
-        $this->type = $type;
-        $this->name = $name;
-        $this->detail = $detail;
-        $this->iconFileName = $iconFileName;
-        $this->rarityPercent = $rarityPercent;
-        $this->inGameRarityPercent = $inGameRarityPercent;
-        $this->status = $status;
-        $this->progressTargetValue = $progressTargetValue;
-        $this->rewardName = $rewardName;
-        $this->rewardImageUrl = $rewardImageUrl;
-        $this->gameId = $gameId;
-        $this->gameName = $gameName;
-        $this->gameIconFileName = $gameIconFileName;
-        $this->platform = $platform;
-    }
+        private int $id,
+        private string $npCommunicationId,
+        private int $groupId,
+        private int $orderId,
+        private string $type,
+        private string $name,
+        private string $detail,
+        private string $iconFileName,
+        private float $rarityPercent,
+        private ?float $inGameRarityPercent,
+        private int $status,
+        private ?string $progressTargetValue,
+        private ?string $rewardName,
+        private ?string $rewardImageUrl,
+        private int $gameId,
+        private string $gameName,
+        private string $gameIconFileName,
+        private string $platform
+    ) {}
 
     /**
      * @param array<string, mixed> $data


### PR DESCRIPTION
### Motivation
- Move core data holders and query builder to modern PHP 8.5 style with constructor property promotion and `readonly` where appropriate to improve immutability and reduce boilerplate.
- Tighten PDO usage and bindings in query builders to make database interactions explicit and compatible with MySQL 8.4 expectations while keeping `psn100.sql` and `database.php` unchanged.

### Description
- Converted several value objects to readonly, constructor-promoted forms including `Avatar`, `PlayerSummary`, `PlayerTrophyProgress`, and `TrophyAchiever` to reduce boilerplate and make them immutable.
- Converted `TrophyDetails` to a readonly, constructor-promoted value object while preserving existing accessor and helper methods.
- Modernized `GameRecentPlayersQueryBuilder` to accept readonly dependencies and use fully-qualified `
PDO` binding constants when preparing statements and binding parameters.
- Simplified `PlayerQueueController` constructor to use a promoted `readonly` `PlayerQueueHandler` dependency.
- Adjusted `GamePlayerFilter`, `PlayerLeaderboardFilter` and `GameLeaderboardFilter` constructors/fields to retain expected behavior in tests (kept mutable backing properties where code/tests require modification rather than making them strictly readonly).

### Testing
- Ran syntax checks with `php -l` against modified files and verified no syntax errors.
- Executed the full automated test suite with `php tests/run.php`; an initial run revealed errors caused by making filter classes readonly, those were corrected, and the suite was re-run successfully.
- Final automated test run: all tests passed (`php tests/run.php` completed with 426 tests passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698259d2df20832f879f41dc8c0afcf4)