### PR TITLE
Show delisted warnings and combined delisted+obsolete message in game header

### DIFF
--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -47,6 +47,9 @@ require_once __DIR__ . '/classes/Game/GamePlayerProgress.php';
         <?php
     }
 
+    $status = $game->getStatus();
+
+    $replacementText = null;
     if ($gameHeaderData->hasObsoleteReplacements()) {
         $replacementLinks = [];
         foreach ($gameHeaderData->getObsoleteReplacements() as $replacement) {
@@ -70,6 +73,32 @@ require_once __DIR__ . '/classes/Game/GamePlayerProgress.php';
         } else {
             $replacementText = $replacementLinks[0];
         }
+    }
+
+    if ($status === 4) {
+        ?>
+        <div class="col-12">
+            <div class="alert alert-warning" role="alert">
+                This game is delisted &amp; obsolete, no trophies will be accounted for on any leaderboard.
+                <?php
+                if ($replacementText !== null) {
+                    ?>
+                    Please play <?= $replacementText; ?> instead.
+                    <?php
+                }
+                ?>
+            </div>
+        </div>
+        <?php
+    } elseif ($status === 1) {
+        ?>
+        <div class="col-12">
+            <div class="alert alert-warning" role="alert">
+                This game is delisted, no trophies will be accounted for on any leaderboard.
+            </div>
+        </div>
+        <?php
+    } elseif ($gameHeaderData->hasObsoleteReplacements()) {
         ?>
         <div class="col-12">
             <div class="alert alert-warning" role="alert">
@@ -227,7 +256,6 @@ require_once __DIR__ . '/classes/Game/GamePlayerProgress.php';
 
                 <div class="text-center">
                     <?php
-                    $status = $game->getStatus();
                     $details = [];
 
                     if ($status === 0) {


### PR DESCRIPTION
### Motivation
- Ensure the game header displays a clear delisted warning when a game is delisted and show a single combined message when a game is both delisted and obsolete, optionally including replacement guidance.

### Description
- Move status retrieval earlier and compute `replacementText` when obsolete replacements exist to reuse later in alerts.
- Replace the previous separate obsolete-only alert with status-driven logic that shows a combined "delisted & obsolete" alert when `status === 4` and includes replacement links if available.
- Add a dedicated delisted alert when `status === 1` and fall back to the obsolete-with-replacement alert only when appropriate.
- Update `wwwroot/game_header.php` to avoid showing duplicate warnings for the same game.

### Testing
- Ran syntax check with `php -l wwwroot/game_header.php` which reported no syntax errors.
- Ran the full test suite with `php tests/run.php` and observed all tests pass (`All 426 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698843dd2f48832fb2fbe67dd81914e4)