### PR TITLE
Load obsolete IDs so delisted/obsolete messages appear on leaderboard and recent players

### DIFF
--- a/wwwroot/classes/GameLeaderboardService.php
+++ b/wwwroot/classes/GameLeaderboardService.php
@@ -38,7 +38,9 @@ class GameLeaderboardService
                 ttm.psnprofiles_id,
                 ttm.parent_np_communication_id,
                 ttm.region,
-                ttm.rarity_points
+                ttm.rarity_points,
+                ttm.in_game_rarity_points,
+                ttm.obsolete_ids
             FROM
                 trophy_title tt
                 JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id

--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -41,7 +41,8 @@ class GameRecentPlayersService
                 ttm.parent_np_communication_id,
                 ttm.region,
                 ttm.rarity_points,
-                ttm.in_game_rarity_points
+                ttm.in_game_rarity_points,
+                ttm.obsolete_ids
             FROM
                 trophy_title tt
                 JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id


### PR DESCRIPTION
### Motivation
- Ensure the same game header warnings and messages (including delisted & obsolete and custom game messages) are available on the `game-leaderboard` and `game-recent-players` pages by providing the data the header needs when those pages load.

### Description
- Include `ttm.in_game_rarity_points` and `ttm.obsolete_ids` in the SELECT used by `GameLeaderboardService::getGame` so leaderboard pages have parity with the main game page.
- Include `ttm.obsolete_ids` in the SELECT used by `GameRecentPlayersService::getGame` so recent-players pages can render the same header warnings.
- Files modified: `wwwroot/classes/GameLeaderboardService.php` and `wwwroot/classes/GameRecentPlayersService.php`.

### Testing
- Ran syntax checks with `php -l wwwroot/classes/GameLeaderboardService.php` and `php -l wwwroot/classes/GameRecentPlayersService.php`, both succeeded. 
- Ran the full test suite with `php tests/run.php`, all tests passed (426 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698859a1e09c832fa480a55f421d7fd8)