### PR TITLE
Reset cloned trophy meta region and normalize status during game clone

### DIFF
--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -274,11 +274,11 @@ SQL
                     owners,
                     difficulty,
                     message,
-                    status,
+                    CASE WHEN status = 2 THEN 0 ELSE status END,
                     recent_players,
                     owners_completed,
                     NULL,
-                    region,
+                    '',
                     rarity_points
                 FROM trophy_title_meta
                 WHERE np_communication_id = :child_np_communication_id


### PR DESCRIPTION
### Motivation
- When cloning a game the metadata should not carry region data and merged meta status value `2` should be normalized to `0` for cloned entries.

### Description
- In `TrophyMergeService::cloneGameInternal` the `INSERT INTO trophy_title_meta SELECT ...` query now uses `CASE WHEN status = 2 THEN 0 ELSE status END` for `status` and sets `region` to an empty string when inserting cloned metadata.

### Testing
- Ran `php -l wwwroot/classes/TrophyMergeService.php` and executed the full test suite with `php tests/run.php`, and all tests passed (426 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885be1a920832fba953e1ea59ca561)