### PR TITLE
Modernize JSON decoding paths and sanitize worker/lookup parsing

### DIFF
--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -214,14 +214,14 @@ final class PsnPlayerLookupService
         }
 
         if (is_object($profile)) {
-            $encoded = json_encode($profile);
-
-            if ($encoded !== false) {
-                $decoded = json_decode($encoded, true);
+            try {
+                $encoded = json_encode($profile, JSON_THROW_ON_ERROR);
+                $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
 
                 if (is_array($decoded)) {
                     return $decoded;
                 }
+            } catch (JsonException) {
             }
 
             return get_object_vars($profile);

--- a/wwwroot/classes/PsnpPlusClient.php
+++ b/wwwroot/classes/PsnpPlusClient.php
@@ -196,7 +196,11 @@ class PsnpPlusClient
      */
     private function decodeList(string $json): array
     {
-        $decoded = json_decode($json, true);
+        try {
+            $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException('Invalid PSNP+ data received.', 0, $exception);
+        }
         if (!is_array($decoded) || !isset($decoded['list']) || !is_array($decoded['list'])) {
             throw new RuntimeException('Invalid PSNP+ data received.');
         }


### PR DESCRIPTION
### Motivation

- Improve robustness of JSON handling by using exception-based decoding and tighter validation consistent with PHP 8.5.
- Harden parsing of worker scan progress and player lookup data to avoid silent failures and normalize inputs.

### Description

- `wwwroot/classes/Admin/WorkerScanProgress.php`: switched `fromJson` to `JSON_THROW_ON_ERROR`, added `sanitizeInt` and `sanitizeString` helpers, and simplified `fromArray` to use those sanitizers.
- `wwwroot/classes/PsnpPlusClient.php`: switched PSNP+ JSON decoding to use `JSON_THROW_ON_ERROR` and rethrow a `RuntimeException` that preserves the decoding exception as previous.
- `wwwroot/classes/Admin/PsnPlayerLookupService.php`: modernized `normalizeProfileResponse` to encode/decode objects with `JSON_THROW_ON_ERROR` and fall back to `get_object_vars` when encoding/decoding fails.
- Small defensive improvements to ensure invalid JSON payloads return `null` or surface a clear exception rather than producing unpredictable values.

### Testing

- Ran `php -l` on `wwwroot/classes/Admin/WorkerScanProgress.php`, `wwwroot/classes/PsnpPlusClient.php`, and `wwwroot/classes/Admin/PsnPlayerLookupService.php`, and all files passed syntax checks.
- Executed the full automated test suite with `php tests/run.php`, and all tests passed (426 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69897371425c832fbbad8c97c1fafa51)