### PR TITLE
Refactor filtering and ordering queries for modern PHP/MySQL

### DIFF
--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -109,13 +109,11 @@ class PlayerLogService
             return '';
         }
 
-        $clauses = [];
-
-        foreach ($filter->getPlatforms() as $platform) {
-            if (isset(self::PLATFORM_FILTERS[$platform])) {
-                $clauses[] = self::PLATFORM_FILTERS[$platform];
-            }
-        }
+        $platforms = array_intersect($filter->getPlatforms(), array_keys(self::PLATFORM_FILTERS));
+        $clauses = array_map(
+            static fn(string $platform): string => self::PLATFORM_FILTERS[$platform],
+            $platforms
+        );
 
         if ($clauses === []) {
             return '';
@@ -126,14 +124,10 @@ class PlayerLogService
 
     private function buildOrderByClause(PlayerLogFilter $filter): string
     {
-        if ($filter->isSort(PlayerLogFilter::SORT_RARITY)) {
-            return PHP_EOL . '            ORDER BY tm.rarity_percent, te.earned_date';
-        }
-
-        if ($filter->isSort(PlayerLogFilter::SORT_IN_GAME_RARITY)) {
-            return PHP_EOL . '            ORDER BY tm.in_game_rarity_percent, te.earned_date';
-        }
-
-        return PHP_EOL . '            ORDER BY te.earned_date DESC';
+        return match ($filter->getSort()) {
+            PlayerLogFilter::SORT_RARITY => PHP_EOL . '            ORDER BY tm.rarity_percent, te.earned_date',
+            PlayerLogFilter::SORT_IN_GAME_RARITY => PHP_EOL . '            ORDER BY tm.in_game_rarity_percent, te.earned_date',
+            default => PHP_EOL . '            ORDER BY te.earned_date DESC',
+        };
     }
 }


### PR DESCRIPTION
### Motivation
- Modernize query-building and sorting code to leverage PHP 8.5 features and MySQL 8.4 capabilities while keeping existing DB schema and `psn100.sql`/`database.php` unchanged.
- Reduce duplicated logic and improve readability/performance of platform and ordering clauses in list and log services.

### Description
- Rewrote `GameListService::buildConditions` to use a `match` expression for initial status conditions and kept downstream condition composition unchanged.
- Replaced manual PSVR `LIKE` branching with a `REGEXP_LIKE` expression and converted per-platform clause generation to `array_map` in `GameListService::buildPlatformCondition` for clearer SQL generation.
- Streamlined `PlayerLogService::buildPlatformClause` to compute platform clauses via `array_intersect` + `array_map` and replaced conditional ordering with a `match` in `PlayerLogService::buildOrderByClause`.
- Only application class files were modified (`wwwroot/classes/GameListService.php` and `wwwroot/classes/PlayerLogService.php`) and no changes were made to `database/psn100.sql` or `database.php`.

### Testing
- Ran syntax checks with `php -l wwwroot/classes/PlayerLogService.php` and `php -l wwwroot/classes/GameListService.php` which reported no syntax errors. 
- Executed the full test suite with `php tests/run.php` and all tests passed (`All 426 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698988766d2c832f8e6d6f1af1ec4c63)