### PR TITLE
Modernize PHP 8.5 data objects and services

### DIFF
--- a/wwwroot/classes/Admin/AdminNavigation.php
+++ b/wwwroot/classes/Admin/AdminNavigation.php
@@ -2,16 +2,10 @@
 
 declare(strict_types=1);
 
-class AdminNavigationItem
+readonly class AdminNavigationItem
 {
-    private string $label;
-
-    private string $href;
-
-    public function __construct(string $label, string $href)
+    public function __construct(private string $label, private string $href)
     {
-        $this->label = $label;
-        $this->href = $href;
     }
 
     public function getLabel(): string

--- a/wwwroot/classes/Admin/PsnpPlusFixedGame.php
+++ b/wwwroot/classes/Admin/PsnpPlusFixedGame.php
@@ -2,19 +2,18 @@
 
 declare(strict_types=1);
 
-class PsnpPlusFixedGame
+readonly class PsnpPlusFixedGame
 {
-    private int $gameId;
-    private string $gameName;
     /**
      * @var int[]
      */
     private array $trophyIds;
 
-    public function __construct(int $gameId, string $gameName, array $trophyIds)
-    {
-        $this->gameId = $gameId;
-        $this->gameName = $gameName;
+    public function __construct(
+        private int $gameId,
+        private string $gameName,
+        array $trophyIds
+    ) {
         $this->trophyIds = array_map('intval', $trophyIds);
     }
 

--- a/wwwroot/classes/Admin/PsnpPlusGame.php
+++ b/wwwroot/classes/Admin/PsnpPlusGame.php
@@ -2,18 +2,13 @@
 
 declare(strict_types=1);
 
-class PsnpPlusGame
+readonly class PsnpPlusGame
 {
-    private int $id;
-    private string $npCommunicationId;
-    private string $name;
-
-    public function __construct(int $id, string $npCommunicationId, string $name)
-    {
-        $this->id = $id;
-        $this->npCommunicationId = $npCommunicationId;
-        $this->name = $name;
-    }
+    public function __construct(
+        private int $id,
+        private string $npCommunicationId,
+        private string $name
+    ) {}
 
     public static function fromArray(array $row): self
     {

--- a/wwwroot/classes/Admin/PsnpPlusMissingGame.php
+++ b/wwwroot/classes/Admin/PsnpPlusMissingGame.php
@@ -2,13 +2,10 @@
 
 declare(strict_types=1);
 
-class PsnpPlusMissingGame
+readonly class PsnpPlusMissingGame
 {
-    private int $psnprofilesId;
-
-    public function __construct(int $psnprofilesId)
+    public function __construct(private int $psnprofilesId)
     {
-        $this->psnprofilesId = $psnprofilesId;
     }
 
     public function getPsnprofilesId(): int

--- a/wwwroot/classes/Admin/ReportedPlayer.php
+++ b/wwwroot/classes/Admin/ReportedPlayer.php
@@ -2,20 +2,13 @@
 
 declare(strict_types=1);
 
-class ReportedPlayer
+readonly class ReportedPlayer
 {
-    private int $reportId;
-
-    private string $onlineId;
-
-    private string $explanation;
-
-    public function __construct(int $reportId, string $onlineId, string $explanation)
-    {
-        $this->reportId = $reportId;
-        $this->onlineId = $onlineId;
-        $this->explanation = $explanation;
-    }
+    public function __construct(
+        private int $reportId,
+        private string $onlineId,
+        private string $explanation
+    ) {}
 
     public function getReportId(): int
     {

--- a/wwwroot/classes/AvatarService.php
+++ b/wwwroot/classes/AvatarService.php
@@ -6,11 +6,8 @@ require_once __DIR__ . '/Avatar.php';
 
 class AvatarService
 {
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     public function getTotalUniqueAvatarCount(): int
@@ -63,13 +60,12 @@ class AvatarService
 
         $rows = $query->fetchAll(PDO::FETCH_ASSOC);
 
-        $avatars = [];
-        foreach ($rows as $row) {
-            $avatarUrl = isset($row['avatar_url']) ? (string) $row['avatar_url'] : '';
-            $count = isset($row['count']) ? (int) $row['count'] : 0;
-            $avatars[] = new Avatar($avatarUrl, $count);
-        }
-
-        return $avatars;
+        return array_map(
+            static fn (array $row): Avatar => new Avatar(
+                (string) ($row['avatar_url'] ?? ''),
+                (int) ($row['count'] ?? 0)
+            ),
+            $rows
+        );
     }
 }

--- a/wwwroot/classes/PlayerPlatformFilterOptions.php
+++ b/wwwroot/classes/PlayerPlatformFilterOptions.php
@@ -2,20 +2,13 @@
 
 declare(strict_types=1);
 
-final class PlayerPlatformFilterOption
+readonly final class PlayerPlatformFilterOption
 {
-    private string $key;
-
-    private string $label;
-
-    private bool $selected;
-
-    public function __construct(string $key, string $label, bool $selected)
-    {
-        $this->key = $key;
-        $this->label = $label;
-        $this->selected = $selected;
-    }
+    public function __construct(
+        private string $key,
+        private string $label,
+        private bool $selected
+    ) {}
 
     public function getInputName(): string
     {
@@ -38,12 +31,12 @@ final class PlayerPlatformFilterOption
     }
 }
 
-final class PlayerPlatformFilterOptions
+readonly final class PlayerPlatformFilterOptions
 {
     /**
      * @var array<string, string>
      */
-    private const PLATFORM_LABELS = [
+    private const array PLATFORM_LABELS = [
         'pc' => 'PC',
         'ps3' => 'PS3',
         'ps4' => 'PS4',
@@ -54,16 +47,10 @@ final class PlayerPlatformFilterOptions
     ];
 
     /**
-     * @var PlayerPlatformFilterOption[]
-     */
-    private array $options;
-
-    /**
      * @param PlayerPlatformFilterOption[] $options
      */
-    private function __construct(array $options)
+    private function __construct(private array $options)
     {
-        $this->options = $options;
     }
 
     /**
@@ -71,17 +58,16 @@ final class PlayerPlatformFilterOptions
      */
     public static function fromSelectionCallback(callable $selectionCallback): self
     {
-        $options = [];
-
-        foreach (self::PLATFORM_LABELS as $key => $label) {
-            $options[] = new PlayerPlatformFilterOption(
-                $key,
-                $label,
-                (bool) $selectionCallback($key)
-            );
-        }
-
-        return new self($options);
+        return new self(
+            array_map(
+                static fn (string $key): PlayerPlatformFilterOption => new PlayerPlatformFilterOption(
+                    $key,
+                    self::PLATFORM_LABELS[$key],
+                    (bool) $selectionCallback($key)
+                ),
+                array_keys(self::PLATFORM_LABELS)
+            )
+        );
     }
 
     /**
@@ -92,4 +78,3 @@ final class PlayerPlatformFilterOptions
         return $this->options;
     }
 }
-

--- a/wwwroot/classes/PlayerPlatformFilterRenderer.php
+++ b/wwwroot/classes/PlayerPlatformFilterRenderer.php
@@ -6,11 +6,8 @@ require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
 
 final class PlayerPlatformFilterRenderer
 {
-    private string $buttonLabel;
-
-    public function __construct(string $buttonLabel = 'Filter')
+    public function __construct(private readonly string $buttonLabel = 'Filter')
     {
-        $this->buttonLabel = $buttonLabel;
     }
 
     public static function createDefault(): self


### PR DESCRIPTION
### Motivation
- Bring small service and value-object classes up to modern PHP 8.5 idioms using constructor property promotion and `readonly` where appropriate to improve immutability and reduce boilerplate.
- Streamline minor data transformations to use functional mappings and stronger typing for clearer, more concise code.
- Maintain compatibility with the codebase's PHP 8.5 / MySQL 8.4 target and explicitly avoid changes to the database files `psn100.sql` and `database.php`.

### Description
- Converted several admin/data classes to `readonly` and used constructor property promotion for compact immutable objects (`AdminNavigationItem`, `ReportedPlayer`, `PsnpPlusGame`, `PsnpPlusFixedGame`, `PsnpPlusMissingGame`).
- Promoted service properties to `private readonly` and simplified constructors where applicable (e.g. `AvatarService`, `PlayerPlatformFilterRenderer`).
- Rewrote `AvatarService::getAvatars` to return an array built with `array_map` and strict casts for clearer mapping from DB rows to `Avatar` instances.
- Modernized `PlayerPlatformFilterOption(s)` by making option objects `readonly`, promoting properties, declaring platform labels as a typed `array`, and constructing options via `array_map`.

### Testing
- Ran syntax checks with `php -l` against modified files and all returned no syntax errors.  (files: `AvatarService.php`, `PlayerPlatformFilterRenderer.php`, `PlayerPlatformFilterOptions.php`, `Admin/ReportedPlayer.php`, `Admin/AdminNavigation.php`, `Admin/PsnpPlusGame.php`, `Admin/PsnpPlusFixedGame.php`, `Admin/PsnpPlusMissingGame.php`).
- Executed the full test suite with `php tests/run.php` and all tests passed (`All 426 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698988766d2c832f8e6d6f1af1ec4c63)