### PR TITLE
Modernize cron job internals and JSON handling

### DIFF
--- a/wwwroot/classes/Admin/GameRescanDifferenceTracker.php
+++ b/wwwroot/classes/Admin/GameRescanDifferenceTracker.php
@@ -93,8 +93,10 @@ final class GameRescanDifferenceTracker
             return (string) $value;
         }
 
-        $encoded = json_encode($value, JSON_UNESCAPED_UNICODE);
-
-        return $encoded === false ? null : $encoded;
+        try {
+            return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
     }
 }

--- a/wwwroot/classes/PlayStationGraphqlPlayerSearch.php
+++ b/wwwroot/classes/PlayStationGraphqlPlayerSearch.php
@@ -246,13 +246,11 @@ final class PlayStationGraphqlPlayerSearch
 
     private function encodeJson(array $value): string
     {
-        $encoded = json_encode($value);
-
-        if (!is_string($encoded)) {
+        try {
+            return json_encode($value, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
             throw new RuntimeException('Failed to encode GraphQL payload.');
         }
-
-        return $encoded;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Bring code up-to-date with modern PHP features and type-safety (targeting PHP 8.5) and improve robustness around JSON handling. 
- Reduce fragile date and string handling in the cron job and centralize parsing/normalization logic to make behavior clearer and safer. 
- Harden JSON encoding/decoding paths to fail explicitly and avoid silent failures when encoding complex values.

### Description
- Refactored `wwwroot/classes/Cron/ThirtyMinuteCronJob.php` to be `final`, convert several dependencies to `readonly` constructor properties, accept optional injectable collaborators, centralize date parsing in a new `parseDateTime` method returning `?DateTimeImmutable`, replace `date_create` usage with the new parser, and switch to exception-safe JSON encoding for scan progress using `JSON_THROW_ON_ERROR` with a `try/catch` for `JsonException`; also replaced legacy string helpers with `str_ends_with`/`str_contains` and tightened `fetchColumn` handling and casts. 
- Hardened JSON serialization in `wwwroot/classes/Admin/GameRescanDifferenceTracker.php` by using `json_encode(..., JSON_THROW_ON_ERROR)` inside a `try/catch` and returning `null` on encoding failures. 
- Hardened GraphQL payload encoding in `wwwroot/classes/PlayStationGraphqlPlayerSearch.php` by using `json_encode(..., JSON_THROW_ON_ERROR)` and rethrowing a `RuntimeException` when encoding fails. 
- Kept functional behavior unchanged and did not modify database schema or configuration files (`psn100.sql` and `database.php` were left untouched).

### Testing
- Ran `php -l` on modified files: `wwwroot/classes/Cron/ThirtyMinuteCronJob.php`, `wwwroot/classes/Admin/GameRescanDifferenceTracker.php`, and `wwwroot/classes/PlayStationGraphqlPlayerSearch.php`, all with no syntax errors. 
- Executed the full test suite with `php tests/run.php`, and all tests passed: `426` tests passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989a4b23888832f8e1935397e10838c)