### PR TITLE
Refactor PlayerLogEntry to readonly value object and simplify fetchAll handling

### DIFF
--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -88,10 +88,6 @@ class GameListService
 
         $games = $statement->fetchAll(PDO::FETCH_ASSOC);
 
-        if (!is_array($games)) {
-            return [];
-        }
-
         return array_map(
             static fn(array $row): GameListItem => GameListItem::fromArray($row),
             $games

--- a/wwwroot/classes/PlayerLogEntry.php
+++ b/wwwroot/classes/PlayerLogEntry.php
@@ -2,48 +2,29 @@
 
 declare(strict_types=1);
 
-final class PlayerLogEntry
+final readonly class PlayerLogEntry
 {
-    private int $trophyId;
-
-    private string $trophyType;
-
-    private string $trophyName;
-
-    private string $trophyDetail;
-
-    private string $trophyIcon;
-
-    private ?string $rarityPercent;
-
-    private ?string $inGameRarityPercent;
-
-    private int $trophyStatus;
-
-    private ?int $progressTargetValue;
-
-    private ?int $progress;
-
-    private bool $isEarned;
-
-    private ?string $rewardName;
-
-    private ?string $rewardImageUrl;
-
-    private int $gameId;
-
-    private string $gameName;
-
-    private int $gameStatus;
-
-    private string $gameIcon;
-
-    private string $platforms;
-
-    private string $earnedDate;
-
-    private function __construct()
-    {
+    public function __construct(
+        private int $trophyId,
+        private string $trophyType,
+        private string $trophyName,
+        private string $trophyDetail,
+        private string $trophyIcon,
+        private ?string $rarityPercent,
+        private ?string $inGameRarityPercent,
+        private int $trophyStatus,
+        private ?int $progressTargetValue,
+        private ?int $progress,
+        private bool $isEarned,
+        private ?string $rewardName,
+        private ?string $rewardImageUrl,
+        private int $gameId,
+        private string $gameName,
+        private int $gameStatus,
+        private string $gameIcon,
+        private string $platforms,
+        private string $earnedDate
+    ) {
     }
 
     /**
@@ -51,28 +32,27 @@ final class PlayerLogEntry
      */
     public static function fromArray(array $row): self
     {
-        $entry = new self();
-        $entry->trophyId = isset($row['trophy_id']) ? (int) $row['trophy_id'] : 0;
-        $entry->trophyType = (string) ($row['trophy_type'] ?? '');
-        $entry->trophyName = (string) ($row['trophy_name'] ?? '');
-        $entry->trophyDetail = (string) ($row['trophy_detail'] ?? '');
-        $entry->trophyIcon = (string) ($row['trophy_icon'] ?? '');
-        $entry->rarityPercent = self::toNullableString($row['rarity_percent'] ?? null);
-        $entry->inGameRarityPercent = self::toNullableString($row['in_game_rarity_percent'] ?? null);
-        $entry->trophyStatus = isset($row['trophy_status']) ? (int) $row['trophy_status'] : 0;
-        $entry->progressTargetValue = self::toNullableInt($row['progress_target_value'] ?? null);
-        $entry->progress = self::toNullableInt($row['progress'] ?? null);
-        $entry->isEarned = isset($row['earned']) ? ((int) $row['earned'] === 1) : false;
-        $entry->rewardName = self::toNullableString($row['reward_name'] ?? null);
-        $entry->rewardImageUrl = self::toNullableString($row['reward_image_url'] ?? null);
-        $entry->gameId = isset($row['game_id']) ? (int) $row['game_id'] : 0;
-        $entry->gameName = (string) ($row['game_name'] ?? '');
-        $entry->gameStatus = isset($row['game_status']) ? (int) $row['game_status'] : 0;
-        $entry->gameIcon = (string) ($row['game_icon'] ?? '');
-        $entry->platforms = (string) ($row['platform'] ?? '');
-        $entry->earnedDate = (string) ($row['earned_date'] ?? '');
-
-        return $entry;
+        return new self(
+            trophyId: isset($row['trophy_id']) ? (int) $row['trophy_id'] : 0,
+            trophyType: (string) ($row['trophy_type'] ?? ''),
+            trophyName: (string) ($row['trophy_name'] ?? ''),
+            trophyDetail: (string) ($row['trophy_detail'] ?? ''),
+            trophyIcon: (string) ($row['trophy_icon'] ?? ''),
+            rarityPercent: self::toNullableString($row['rarity_percent'] ?? null),
+            inGameRarityPercent: self::toNullableString($row['in_game_rarity_percent'] ?? null),
+            trophyStatus: isset($row['trophy_status']) ? (int) $row['trophy_status'] : 0,
+            progressTargetValue: self::toNullableInt($row['progress_target_value'] ?? null),
+            progress: self::toNullableInt($row['progress'] ?? null),
+            isEarned: isset($row['earned']) ? ((int) $row['earned'] === 1) : false,
+            rewardName: self::toNullableString($row['reward_name'] ?? null),
+            rewardImageUrl: self::toNullableString($row['reward_image_url'] ?? null),
+            gameId: isset($row['game_id']) ? (int) $row['game_id'] : 0,
+            gameName: (string) ($row['game_name'] ?? ''),
+            gameStatus: isset($row['game_status']) ? (int) $row['game_status'] : 0,
+            gameIcon: (string) ($row['game_icon'] ?? ''),
+            platforms: (string) ($row['platform'] ?? ''),
+            earnedDate: (string) ($row['earned_date'] ?? '')
+        );
     }
 
     public function getTrophyId(): int

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -92,8 +92,7 @@ class PlayerLogService
         $query->execute();
 
         $rows = $query->fetchAll(PDO::FETCH_ASSOC);
-
-        if (!is_array($rows) || $rows === []) {
+        if ($rows === []) {
             return [];
         }
 


### PR DESCRIPTION
### Motivation
- Modernize parts of the codebase to take advantage of PHP 8.5 features and simplify collection handling after `fetchAll()` while keeping existing behavior intact.

### Description
- Convert `PlayerLogEntry` into a `readonly` value object with a promoted constructor and a named-argument `fromArray()` factory to improve immutability and clarity.  
- Simplify `PlayerLogService::getTrophies()` to treat `fetchAll(PDO::FETCH_ASSOC)` as returning an array and only check for an empty result (`$rows === []`) before mapping.  
- Simplify `GameListService::getGames()` by removing an `is_array()` guard and directly mapping the `fetchAll()` result to `GameListItem::fromArray()`.  
- No changes were made to `psn100.sql` or `database.php` as requested.

### Testing
- Ran syntax checks with `php -l` on `wwwroot/classes/PlayerLogEntry.php`, `wwwroot/classes/PlayerLogService.php`, and `wwwroot/classes/GameListService.php` and they reported no syntax errors.  
- Executed the full test suite with `php tests/run.php` and all tests passed (426 tests, all `PASS`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989a4b23888832f8e1935397e10838c)