### PR TITLE
Fix merge progress recompute timing during scans

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1304,11 +1304,9 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 }
                             }
 
+                            $mergeParentsToRecompute = [];
                             if ($isNewTitle) {
-                                $mergeParents = $this->automaticTrophyTitleMergeService->handleNewTitle($npid);
-                                foreach ($mergeParents as $mergeParent) {
-                                    $this->automaticTrophyTitleMergeService->recomputeMergeProgressByParent($mergeParent);
-                                }
+                                $mergeParentsToRecompute = $this->automaticTrophyTitleMergeService->handleNewTitle($npid);
                             }
 
                             if ($newTrophies) {
@@ -1460,6 +1458,10 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                             while ($row = $query->fetch()) {
                                 $this->trophyCalculator->recalculateTrophyGroup($row["parent_np_communication_id"], $row["parent_group_id"], (int) $user->accountId());
                                 $this->trophyCalculator->recalculateTrophyTitle($row["parent_np_communication_id"], $trophyTitle->lastUpdatedDateTime(), false, (int) $user->accountId(), true);
+                            }
+
+                            foreach ($mergeParentsToRecompute as $mergeParent) {
+                                $this->automaticTrophyTitleMergeService->recomputeMergeProgressByParent($mergeParent);
                             }
                         }
 


### PR DESCRIPTION
## Summary
- delay automatic merge-parent recomputation in `ThirtyMinuteCronJob` until after the current player's trophy/group/title recalculations finish
- keep auto-merge detection for new titles unchanged, but store returned parent IDs and recompute them at the end of per-title processing

## Why
- previously, recompute ran immediately after detecting a new title merge, before the current player's earned data and title/group progress had been processed
- that ordering could leave merged leaderboard/title progress stale for one side of a just-merged player until a later scan

## Validation
- `php tests/run.php` (pass, all tests)
- `php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php` (pass)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993746d9974832fa52a61cbdf4e2d55)