### PR TITLE
Refactor core services for PHP 8.5 and MySQL 8.4

### DIFF
--- a/wwwroot/classes/Admin/DeletePlayerService.php
+++ b/wwwroot/classes/Admin/DeletePlayerService.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 final class DeletePlayerService
 {
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     /**

--- a/wwwroot/classes/GameResetService.php
+++ b/wwwroot/classes/GameResetService.php
@@ -7,11 +7,8 @@ class GameResetService
     private const ACTION_RESET = 0;
     private const ACTION_DELETE = 1;
 
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     public function process(int $gameId, int $action): string
@@ -127,7 +124,10 @@ class GameResetService
             $callback();
             $this->database->commit();
         } catch (Throwable $exception) {
-            $this->database->rollBack();
+            if ($this->database->inTransaction()) {
+                $this->database->rollBack();
+            }
+
             throw $exception;
         }
     }


### PR DESCRIPTION
### Motivation
- Modernize core services to leverage PHP 8.5 language features and MySQL 8.4 semantics while removing legacy conversion helpers and making transaction handling more robust.
- Keep compatibility with the current schema by not modifying `database.php` or `psn100.sql`.

### Description
- Converted constructor boilerplate to PHP 8.5 readonly constructor property promotion for `PlayerSummaryService`, `GameResetService`, and `DeletePlayerService` by switching to `public function __construct(private readonly PDO $database)`.
- Updated `PlayerSummaryService::fetchSummaryRow` SQL to use MySQL 8 boolean aggregation (`SUM(ttp.progress = 100)`) and explicit `CAST(... AS UNSIGNED)` for numeric aggregates and removed legacy `toInt`/`toFloat` helpers in favor of direct typed casts in the returned array.
- Added a safety check `if ($this->database->inTransaction())` before calling `rollBack()` in `GameResetService::executeWithinTransaction` to avoid rollback errors when not in a transaction.
- Added a narrow docblock on the fetched row shape in `PlayerSummaryService` to clarify types coming from PDO.

### Testing
- Ran `php -v` to verify the running PHP version (PHP 8.5) which succeeded. 
- Ran PHP lint on modified files with `php -l` for `wwwroot/classes/PlayerSummaryService.php`, `wwwroot/classes/GameResetService.php`, and `wwwroot/classes/Admin/DeletePlayerService.php`, and all reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4f144c78832fae96e8304d994fb5)