### PR TITLE
Refactor PlayerGamesService: modernize error handling and optimize completion ID collection

### DIFF
--- a/tests/PlayerGamesServiceTest.php
+++ b/tests/PlayerGamesServiceTest.php
@@ -185,6 +185,33 @@ final class PlayerGamesServiceTest extends TestCase
         $this->assertSame('Completed in 4 days, 1 hours', $game->getCompletionDurationLabel());
     }
 
+    public function testGetPlayerGamesIgnoresInvalidCompletionDates(): void
+    {
+        $this->insertGame(
+            id: 11,
+            npCommunicationId: 'NPWR778',
+            name: 'Epsilon Game',
+            platform: 'PS5',
+            status: 0,
+            accountId: 8,
+            progress: 100,
+            baseProgress: 100
+        );
+
+        $this->pdo->exec(
+            "INSERT INTO trophy_earned (account_id, np_communication_id, earned_date, earned) VALUES " .
+            " (8, 'NPWR778', 'not-a-date', 1)," .
+            " (8, 'NPWR778', 'still-not-a-date', 1)"
+        );
+
+        $filter = PlayerGamesFilter::fromArray([]);
+
+        $games = $this->service->getPlayerGames(8, $filter);
+
+        $this->assertCount(1, $games);
+        $this->assertSame(null, $games[0]->getCompletionDurationLabel());
+    }
+
     private function insertGame(
         int $id,
         string $npCommunicationId,


### PR DESCRIPTION
### Motivation
- Modernize `PlayerGamesService` for PHP 8.5-era code style and clearer intent when parsing completion dates.  
- Reduce unnecessary allocations and nested array operations when collecting completed NP communication IDs.  
- Simplify and clarify the SQL builders used for both count and list queries by removing an unused parameter.  

### Description
- Marked `PlayerGamesService` as `final` and removed the unused `buildWhereClause(..., $forCount)` parameter, reusing the same builder for count and list queries.  
- Extracted the NP communication ID collection into a new helper `collectCompletedNpCommunicationIds()` to deduplicate and collect IDs in a single pass.  
- Narrowed exception handling when parsing earned dates to catch `DateMalformedStringException` instead of a broad `Exception`, making malformed-date handling explicit.  
- Added a regression test `testGetPlayerGamesIgnoresInvalidCompletionDates` to ensure invalid `earned_date` values produce a `null` completion label and do not cause errors.  

### Testing
- Performed syntax checks with `php -l` on `wwwroot/classes/PlayerGamesService.php` and `tests/PlayerGamesServiceTest.php` which returned no syntax errors.  
- Ran the local test runner with `php tests/run.php` (and targeted test runs during development) and confirmed all tests passed: final run reported all 427 tests passed.  
- Also executed an isolated test run of `PlayerGamesServiceTest` to validate the new regression test, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4f144c78832fae96e8304d994fb5)