### PR TITLE
Make Pagination readonly and simplify constructor normalization

### DIFF
--- a/wwwroot/classes/Pagination.php
+++ b/wwwroot/classes/Pagination.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PaginationItem.php';
 
-final class Pagination
+final readonly class Pagination
 {
     private int $currentPage;
 
@@ -13,8 +13,7 @@ final class Pagination
     public function __construct(int $currentPage, int $totalPages)
     {
         $this->totalPages = max(1, $totalPages);
-        $normalizedCurrentPage = max(1, $currentPage);
-        $this->currentPage = min($normalizedCurrentPage, $this->totalPages);
+        $this->currentPage = min(max(1, $currentPage), $this->totalPages);
     }
 
     public static function create(int $currentPage, int $totalPages): self
@@ -71,4 +70,3 @@ final class Pagination
         return $items;
     }
 }
-


### PR DESCRIPTION
### Motivation
- Align `Pagination` with PHP 8.5 modern patterns by making it an immutable `readonly` value object and simplify page normalization logic.

### Description
- Convert `Pagination` to a `readonly` class and replace the two-step current-page normalization with a single `min(max(1, $currentPage), $totalPages)` expression while preserving existing behavior.

### Testing
- Ran `php -l wwwroot/classes/Pagination.php` and the full test suite with `php tests/run.php`; lint passed and all 426 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4f144c78832fae96e8304d994fb5)