### PR TITLE
Fix merge progress for all-unobtainable trophy titles

### DIFF
--- a/tests/TrophyMergeServiceGroupPlayerMergeTest.php
+++ b/tests/TrophyMergeServiceGroupPlayerMergeTest.php
@@ -39,6 +39,14 @@ final class TrophyMergeServiceGroupPlayerMergeTest extends TestCase
             str_contains($pdo->zeroProgressSql ?? '', 'IN (:child_np_0, :child_np_1)'),
             'Expected zero-progress insert to use all child placeholders.'
         );
+        $this->assertTrue(
+            str_contains($pdo->groupPlayerMergeSql ?? '', 'tg.max_score = 0'),
+            'Expected merge progress SQL to branch when a group has no obtainable points.'
+        );
+        $this->assertTrue(
+            str_contains($pdo->groupPlayerMergeSql ?? '', '100,'),
+            'Expected merge progress SQL to set 100% when a group has no obtainable points.'
+        );
     }
 }
 
@@ -51,6 +59,7 @@ final class RecordingGroupPlayerPDO extends PDO
     /** @var array<string, scalar|null> */
     public array $zeroProgressParameters = [];
     public ?string $zeroProgressSql = null;
+    public ?string $groupPlayerMergeSql = null;
 
     public function __construct(
         private string $childNpCommunicationId,
@@ -82,6 +91,8 @@ final class RecordingGroupPlayerPDO extends PDO
         }
 
         if (str_starts_with($normalized, 'INSERT INTO trophy_group_player')) {
+            $this->groupPlayerMergeSql = $trimmed;
+
             return new RecordingExecuteStatement();
         }
 

--- a/tests/TrophyMergeServiceTitlePlayerMergeTest.php
+++ b/tests/TrophyMergeServiceTitlePlayerMergeTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/TrophyMergeService.php';
+
+final class TrophyMergeServiceTitlePlayerMergeTest extends TestCase
+{
+    public function testUpdateTrophyTitlePlayerSetsFullProgressWhenMaxScoreIsZero(): void
+    {
+        $pdo = new RecordingTitlePlayerPDO(
+            'NP_CHILD_2',
+            'MERGE_000010',
+            ['NP_CHILD_1', 'NP_CHILD_2'],
+            ['platinum' => 0, 'max_score' => 0]
+        );
+        $service = new TrophyMergeService($pdo);
+
+        $reflection = new ReflectionMethod(TrophyMergeService::class, 'updateTrophyTitlePlayer');
+        $reflection->setAccessible(true);
+        $reflection->invoke($service, 42);
+
+        $this->assertTrue(
+            str_contains($pdo->titlePlayerMergeSql ?? '', 'WHEN :max_score = 0 THEN 100'),
+            'Expected title progress SQL to set 100% when a title has no obtainable points.'
+        );
+    }
+}
+
+final class RecordingTitlePlayerPDO extends PDO
+{
+    public ?string $titlePlayerMergeSql = null;
+
+    public function __construct(
+        private string $childNpCommunicationId,
+        private string $parentNpCommunicationId,
+        private array $childNpCommunicationIds,
+        private array $trophyTitle
+    ) {
+    }
+
+    public function prepare(string $statement, array $options = []): PDOStatement
+    {
+        $trimmed = trim((string) $statement);
+        $normalized = preg_replace('/\s+/', ' ', $trimmed) ?? '';
+
+        if (str_starts_with($normalized, 'SELECT np_communication_id FROM trophy_title')) {
+            return new RecordingTitlePlayerScalarStatement($this->childNpCommunicationId);
+        }
+
+        if (str_starts_with($normalized, 'SELECT DISTINCT parent_np_communication_id FROM trophy_merge')) {
+            return new RecordingTitlePlayerAssocStatement(['parent_np_communication_id' => $this->parentNpCommunicationId]);
+        }
+
+        if (str_starts_with($normalized, 'SELECT DISTINCT child_np_communication_id FROM trophy_merge')) {
+            return new RecordingTitlePlayerColumnStatement($this->childNpCommunicationIds);
+        }
+
+        if (str_starts_with($normalized, 'SELECT platinum, bronze * 15 + silver * 30 + gold * 90 AS max_score FROM trophy_title')) {
+            return new RecordingTitlePlayerAssocStatement($this->trophyTitle);
+        }
+
+        if (str_starts_with($normalized, 'INSERT INTO trophy_title_player')) {
+            $this->titlePlayerMergeSql = $trimmed;
+
+            return new RecordingTitlePlayerExecuteStatement();
+        }
+
+        if (str_starts_with($normalized, 'INSERT IGNORE INTO trophy_title_player')) {
+            return new RecordingTitlePlayerExecuteStatement();
+        }
+
+        throw new RuntimeException('Unexpected SQL statement: ' . $trimmed);
+    }
+}
+
+final class RecordingTitlePlayerScalarStatement extends PDOStatement
+{
+    public function __construct(private string $value)
+    {
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchColumn(int $column = 0): string
+    {
+        return $this->value;
+    }
+}
+
+final class RecordingTitlePlayerAssocStatement extends PDOStatement
+{
+    public function __construct(private array $row)
+    {
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetch(int $mode = PDO::FETCH_DEFAULT, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0): array|false
+    {
+        $row = $this->row;
+        $this->row = [];
+
+        return $row === [] ? false : $row;
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args): array
+    {
+        $row = $this->row;
+        $this->row = [];
+
+        if ($row === []) {
+            return [];
+        }
+
+        if ($mode === PDO::FETCH_COLUMN) {
+            return array_values($row);
+        }
+
+        return [$row];
+    }
+}
+
+final class RecordingTitlePlayerColumnStatement extends PDOStatement
+{
+    /** @var list<string> */
+    private array $rows;
+
+    /** @param list<string> $rows */
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args): array
+    {
+        return $this->rows;
+    }
+}
+
+final class RecordingTitlePlayerExecuteStatement extends PDOStatement
+{
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+}

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -625,20 +625,24 @@ SQL
                         player.gold,
                         player.platinum,
                         IF(
-                            player.score = 0,
-                            0,
-                            IFNULL(
-                                GREATEST(
-                                    FLOOR(
-                                        IF(
-                                            (player.score / NULLIF(tg.max_score, 0)) * 100 = 100 AND tg.platinum = 1 AND player.platinum = 0,
-                                            99,
-                                            (player.score / NULLIF(tg.max_score, 0)) * 100
-                                        )
+                            tg.max_score = 0,
+                            100,
+                            IF(
+                                player.score = 0,
+                                0,
+                                IFNULL(
+                                    GREATEST(
+                                        FLOOR(
+                                            IF(
+                                                (player.score / tg.max_score) * 100 = 100 AND tg.platinum = 1 AND player.platinum = 0,
+                                                99,
+                                                (player.score / tg.max_score) * 100
+                                            )
+                                        ),
+                                        1
                                     ),
-                                    1
-                                ),
-                                0
+                                    0
+                                )
                             )
                         ) AS progress
                     FROM
@@ -807,7 +811,7 @@ SQL
                     player.gold,
                     player.platinum,
                     CASE
-                        WHEN :max_score = 0 THEN 0
+                        WHEN :max_score = 0 THEN 100
                         WHEN player.score = 0 THEN 0
                         ELSE IFNULL(
                             GREATEST(


### PR DESCRIPTION
### Motivation
- When a game or group has all trophies marked unobtainable the merged progress calculation produced 0% for players who had earned trophies, which is incorrect for titles/groups with no obtainable-point trophies.
- The merge code needs to treat a zero `max_score` (no obtainable-score trophies) as a special case and set progress to `100` to reflect there is nothing left to earn.
- Tests asserting the SQL used for merge recalculation should cover the zero-`max_score` branch so regressions are detectable.

### Description
- Updated the merged group progress SQL in `wwwroot/classes/TrophyMergeService.php` so `tg.max_score = 0` yields `100` instead of `0` and removed `NULLIF`/division-by-zero approach in the merged-group path.
- Updated the merged title progress SQL in `wwwroot/classes/TrophyMergeService.php` so `:max_score = 0` yields `100` instead of `0` for `trophy_title_player` inserts/updates.
- Extended `tests/TrophyMergeServiceGroupPlayerMergeTest.php` to assert the generated merge SQL includes the zero-`max_score` branch and that it sets `100` for that branch.
- Added `tests/TrophyMergeServiceTitlePlayerMergeTest.php` to validate the title-player merge SQL contains `WHEN :max_score = 0 THEN 100` for the title merge flow.

### Testing
- Ran PHP linting on modified files with `php -l wwwroot/classes/TrophyMergeService.php` and `php -l tests/TrophyMergeService*.php`, which reported no syntax errors.
- Ran the full test suite with `php tests/run.php`; the suite completed but reported 2 pre-existing unrelated failures in `ImageHashCalculatorTest` that are not affected by these changes.
- Executed targeted test checks for the changed tests and they passed using the built-in runner: `php -r 'require "tests/TestCase.php"; require "tests/TrophyMergeServiceGroupPlayerMergeTest.php"; ...'` and `php -r 'require "tests/TestCase.php"; require "tests/TrophyMergeServiceTitlePlayerMergeTest.php"; ...'`.
- Confirmed the change by inspecting the generated SQL fragments in tests and by ensuring the new `100`-for-zero-`max_score` branches are present and exercised by the new/modified tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998d11f8538832f918422f416871fd5)