### PR TITLE
Refactor leaderboard data providers into shared PHP 8.5 service base

### DIFF
--- a/wwwroot/classes/AbstractPlayerLeaderboardService.php
+++ b/wwwroot/classes/AbstractPlayerLeaderboardService.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerLeaderboardDataProvider.php';
+
+abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeaderboardDataProvider
+{
+    public const PAGE_SIZE = 50;
+
+    private const COUNT_SQL = <<<'SQL'
+        SELECT
+            COUNT(*)
+        FROM
+            player_ranking r
+        JOIN player p ON p.account_id = r.account_id
+        WHERE
+            p.status = 0
+    SQL;
+
+    public function __construct(protected \PDO $database)
+    {
+    }
+
+    #[\Override]
+    final public function countPlayers(PlayerLeaderboardFilter $filter): int
+    {
+        $query = $this->database->prepare(self::COUNT_SQL . $this->buildFilterSql($filter));
+        $this->bindFilterParameters($query, $filter);
+        $query->execute();
+
+        return (int) $query->fetchColumn();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    #[\Override]
+    final public function getPlayers(PlayerLeaderboardFilter $filter, int $limit = self::PAGE_SIZE): array
+    {
+        $sql = <<<SQL
+            SELECT
+                p.*,
+                {$this->getRankingProjection()}
+            FROM
+                player_ranking r
+            JOIN player p ON p.account_id = r.account_id
+            WHERE
+                p.status = 0
+        SQL;
+
+        $sql .= $this->buildFilterSql($filter);
+
+        $sql .= <<<SQL
+            ORDER BY
+                {$this->getOrderByExpression()}
+            LIMIT :limit OFFSET :offset
+        SQL;
+
+        $query = $this->database->prepare($sql);
+        $query->bindValue(':limit', $limit, \PDO::PARAM_INT);
+        $query->bindValue(':offset', $filter->getOffset($limit), \PDO::PARAM_INT);
+        $this->bindFilterParameters($query, $filter);
+        $query->execute();
+
+        return $query->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    #[\Override]
+    final public function getPageSize(): int
+    {
+        return self::PAGE_SIZE;
+    }
+
+    abstract protected function getRankingProjection(): string;
+
+    abstract protected function getOrderByExpression(): string;
+
+    final protected function buildFilterSql(PlayerLeaderboardFilter $filter): string
+    {
+        $clauses = [];
+
+        if ($filter->hasCountry()) {
+            $clauses[] = 'p.country = :country';
+        }
+
+        if ($filter->hasAvatar()) {
+            $clauses[] = 'p.avatar_url = :avatar';
+        }
+
+        if ($clauses === []) {
+            return '';
+        }
+
+        return ' AND ' . implode(' AND ', $clauses);
+    }
+
+    final protected function bindFilterParameters(\PDOStatement $query, PlayerLeaderboardFilter $filter): void
+    {
+        if ($filter->hasCountry()) {
+            $query->bindValue(':country', (string) $filter->getCountry(), \PDO::PARAM_STR);
+        }
+
+        if ($filter->hasAvatar()) {
+            $query->bindValue(':avatar', (string) $filter->getAvatar(), \PDO::PARAM_STR);
+        }
+    }
+}

--- a/wwwroot/classes/PlayerInGameRarityLeaderboardService.php
+++ b/wwwroot/classes/PlayerInGameRarityLeaderboardService.php
@@ -2,111 +2,19 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/PlayerLeaderboardDataProvider.php';
+require_once __DIR__ . '/AbstractPlayerLeaderboardService.php';
 
-class PlayerInGameRarityLeaderboardService implements PlayerLeaderboardDataProvider
+final readonly class PlayerInGameRarityLeaderboardService extends AbstractPlayerLeaderboardService
 {
-    public const PAGE_SIZE = 50;
-
-    private PDO $database;
-
-    public function __construct(PDO $database)
+    #[\Override]
+    protected function getRankingProjection(): string
     {
-        $this->database = $database;
+        return 'r.in_game_rarity_ranking AS ranking, r.in_game_rarity_ranking_country AS ranking_country';
     }
 
     #[\Override]
-    public function countPlayers(PlayerLeaderboardFilter $filter): int
+    protected function getOrderByExpression(): string
     {
-        $sql = <<<'SQL'
-            SELECT
-                COUNT(*)
-            FROM
-                player_ranking r
-            JOIN player p ON p.account_id = r.account_id
-            WHERE
-                p.status = 0
-        SQL;
-
-        $sql .= $this->buildFilterSql($filter);
-
-        $query = $this->database->prepare($sql);
-        $this->bindFilterParameters($query, $filter);
-        $query->execute();
-
-        return (int) $query->fetchColumn();
-    }
-
-    /**
-     * @return array<int, array<string, mixed>>
-     */
-    #[\Override]
-    public function getPlayers(PlayerLeaderboardFilter $filter, int $limit = self::PAGE_SIZE): array
-    {
-        $sql = <<<'SQL'
-            SELECT
-                p.*,
-                r.in_game_rarity_ranking AS ranking,
-                r.in_game_rarity_ranking_country AS ranking_country
-            FROM
-                player_ranking r
-            JOIN player p ON p.account_id = r.account_id
-            WHERE
-                p.status = 0
-        SQL;
-
-        $sql .= $this->buildFilterSql($filter);
-
-        $sql .= <<<'SQL'
-            ORDER BY
-                r.in_game_rarity_ranking
-            LIMIT :offset, :limit
-        SQL;
-
-        $query = $this->database->prepare($sql);
-        $query->bindValue(':offset', $filter->getOffset($limit), PDO::PARAM_INT);
-        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
-        $this->bindFilterParameters($query, $filter);
-        $query->execute();
-
-        $players = $query->fetchAll(PDO::FETCH_ASSOC);
-
-        if (!is_array($players)) {
-            return [];
-        }
-
-        return $players;
-    }
-
-    #[\Override]
-    public function getPageSize(): int
-    {
-        return self::PAGE_SIZE;
-    }
-
-    private function buildFilterSql(PlayerLeaderboardFilter $filter): string
-    {
-        $clauses = '';
-
-        if ($filter->hasCountry()) {
-            $clauses .= ' AND p.country = :country';
-        }
-
-        if ($filter->hasAvatar()) {
-            $clauses .= ' AND p.avatar_url = :avatar';
-        }
-
-        return $clauses;
-    }
-
-    private function bindFilterParameters(PDOStatement $query, PlayerLeaderboardFilter $filter): void
-    {
-        if ($filter->hasCountry()) {
-            $query->bindValue(':country', (string) $filter->getCountry(), PDO::PARAM_STR);
-        }
-
-        if ($filter->hasAvatar()) {
-            $query->bindValue(':avatar', (string) $filter->getAvatar(), PDO::PARAM_STR);
-        }
+        return 'r.in_game_rarity_ranking';
     }
 }

--- a/wwwroot/classes/PlayerLeaderboardService.php
+++ b/wwwroot/classes/PlayerLeaderboardService.php
@@ -2,108 +2,19 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/PlayerLeaderboardDataProvider.php';
+require_once __DIR__ . '/AbstractPlayerLeaderboardService.php';
 
-class PlayerLeaderboardService implements PlayerLeaderboardDataProvider
+final readonly class PlayerLeaderboardService extends AbstractPlayerLeaderboardService
 {
-    public const PAGE_SIZE = 50;
-
-    public function __construct(private readonly PDO $database)
+    #[\Override]
+    protected function getRankingProjection(): string
     {
+        return 'r.ranking, r.ranking_country';
     }
 
     #[\Override]
-    public function countPlayers(PlayerLeaderboardFilter $filter): int
+    protected function getOrderByExpression(): string
     {
-        $sql = <<<'SQL'
-            SELECT
-                COUNT(*)
-            FROM
-                player_ranking r
-            JOIN player p ON p.account_id = r.account_id
-            WHERE
-                p.status = 0
-        SQL;
-
-        $sql .= $this->buildFilterSql($filter);
-
-        $query = $this->database->prepare($sql);
-        $this->bindFilterParameters($query, $filter);
-        $query->execute();
-
-        return (int) $query->fetchColumn();
-    }
-
-    /**
-     * @return array<int, array<string, mixed>>
-     */
-    #[\Override]
-    public function getPlayers(PlayerLeaderboardFilter $filter, int $limit = self::PAGE_SIZE): array
-    {
-        $sql = <<<'SQL'
-            SELECT
-                p.*,
-                r.ranking,
-                r.ranking_country
-            FROM
-                player_ranking r
-            JOIN player p ON p.account_id = r.account_id
-            WHERE
-                p.status = 0
-        SQL;
-
-        $sql .= $this->buildFilterSql($filter);
-
-        $sql .= <<<'SQL'
-            ORDER BY
-                r.ranking
-            LIMIT :offset, :limit
-        SQL;
-
-        $query = $this->database->prepare($sql);
-        $query->bindValue(':offset', $filter->getOffset($limit), PDO::PARAM_INT);
-        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
-        $this->bindFilterParameters($query, $filter);
-        $query->execute();
-
-        $players = $query->fetchAll(PDO::FETCH_ASSOC);
-
-        if (!is_array($players)) {
-            return [];
-        }
-
-        return $players;
-    }
-
-    #[\Override]
-    public function getPageSize(): int
-    {
-        return self::PAGE_SIZE;
-    }
-
-    private function buildFilterSql(PlayerLeaderboardFilter $filter): string
-    {
-        $clauses = '';
-
-        if ($filter->hasCountry()) {
-            $clauses .= " AND p.country = :country";
-        }
-
-        if ($filter->hasAvatar()) {
-            $clauses .= " AND p.avatar_url = :avatar";
-        }
-
-        return $clauses;
-    }
-
-    private function bindFilterParameters(PDOStatement $query, PlayerLeaderboardFilter $filter): void
-    {
-        if ($filter->hasCountry()) {
-            $query->bindValue(':country', (string) $filter->getCountry(), PDO::PARAM_STR);
-        }
-
-        if ($filter->hasAvatar()) {
-            $query->bindValue(':avatar', (string) $filter->getAvatar(), PDO::PARAM_STR);
-        }
+        return 'r.ranking';
     }
 }

--- a/wwwroot/classes/PlayerRarityLeaderboardService.php
+++ b/wwwroot/classes/PlayerRarityLeaderboardService.php
@@ -2,108 +2,19 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/PlayerLeaderboardDataProvider.php';
+require_once __DIR__ . '/AbstractPlayerLeaderboardService.php';
 
-class PlayerRarityLeaderboardService implements PlayerLeaderboardDataProvider
+final readonly class PlayerRarityLeaderboardService extends AbstractPlayerLeaderboardService
 {
-    public const PAGE_SIZE = 50;
-
-    public function __construct(private readonly PDO $database)
+    #[\Override]
+    protected function getRankingProjection(): string
     {
+        return 'r.rarity_ranking AS ranking, r.rarity_ranking_country AS ranking_country';
     }
 
     #[\Override]
-    public function countPlayers(PlayerLeaderboardFilter $filter): int
+    protected function getOrderByExpression(): string
     {
-        $sql = <<<'SQL'
-            SELECT
-                COUNT(*)
-            FROM
-                player_ranking r
-            JOIN player p ON p.account_id = r.account_id
-            WHERE
-                p.status = 0
-        SQL;
-
-        $sql .= $this->buildFilterSql($filter);
-
-        $query = $this->database->prepare($sql);
-        $this->bindFilterParameters($query, $filter);
-        $query->execute();
-
-        return (int) $query->fetchColumn();
-    }
-
-    /**
-     * @return array<int, array<string, mixed>>
-     */
-    #[\Override]
-    public function getPlayers(PlayerLeaderboardFilter $filter, int $limit = self::PAGE_SIZE): array
-    {
-        $sql = <<<'SQL'
-            SELECT
-                p.*,
-                r.rarity_ranking AS ranking,
-                r.rarity_ranking_country AS ranking_country
-            FROM
-                player_ranking r
-            JOIN player p ON p.account_id = r.account_id
-            WHERE
-                p.status = 0
-        SQL;
-
-        $sql .= $this->buildFilterSql($filter);
-
-        $sql .= <<<'SQL'
-            ORDER BY
-                r.rarity_ranking
-            LIMIT :offset, :limit
-        SQL;
-
-        $query = $this->database->prepare($sql);
-        $query->bindValue(':offset', $filter->getOffset($limit), PDO::PARAM_INT);
-        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
-        $this->bindFilterParameters($query, $filter);
-        $query->execute();
-
-        $players = $query->fetchAll(PDO::FETCH_ASSOC);
-
-        if (!is_array($players)) {
-            return [];
-        }
-
-        return $players;
-    }
-
-    #[\Override]
-    public function getPageSize(): int
-    {
-        return self::PAGE_SIZE;
-    }
-
-    private function buildFilterSql(PlayerLeaderboardFilter $filter): string
-    {
-        $clauses = '';
-
-        if ($filter->hasCountry()) {
-            $clauses .= ' AND p.country = :country';
-        }
-
-        if ($filter->hasAvatar()) {
-            $clauses .= ' AND p.avatar_url = :avatar';
-        }
-
-        return $clauses;
-    }
-
-    private function bindFilterParameters(PDOStatement $query, PlayerLeaderboardFilter $filter): void
-    {
-        if ($filter->hasCountry()) {
-            $query->bindValue(':country', (string) $filter->getCountry(), PDO::PARAM_STR);
-        }
-
-        if ($filter->hasAvatar()) {
-            $query->bindValue(':avatar', (string) $filter->getAvatar(), PDO::PARAM_STR);
-        }
+        return 'r.rarity_ranking';
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce duplicated leaderboard query, filtering and pagination logic across multiple services and modernize code to PHP 8.5 idioms (use of `readonly` classes and typed properties). 
- Centralize SQL pagination to MySQL 8.4-friendly `LIMIT :limit OFFSET :offset` usage and simplify result handling.
- Keep database schema and connection files unchanged (`psn100.sql` and `database.php` were not modified). 

### Description
- Added `AbstractPlayerLeaderboardService.php` which implements shared counting, filtered query assembly, parameter binding and pagination flow for leaderboard providers. 
- Replaced the previous concrete implementations with small `final readonly` classes (`PlayerLeaderboardService`, `PlayerRarityLeaderboardService`, and `PlayerInGameRarityLeaderboardService`) that only provide the ranking projection and ordering expressions. 
- Switched pagination SQL to `LIMIT :limit OFFSET :offset` and removed redundant `is_array` checks around `fetchAll(PDO::FETCH_ASSOC)`, returning the typed array directly. 
- Updated files under `wwwroot/classes/` only and left `wwwroot/database.php` / SQL files untouched as requested. 

### Testing
- Ran syntax checks with `php -l` on the modified files, which reported no syntax errors for `AbstractPlayerLeaderboardService.php`, `PlayerLeaderboardService.php`, `PlayerRarityLeaderboardService.php`, and `PlayerInGameRarityLeaderboardService.php`. 
- Executed the full test suite with `php tests/run.php`, which ran 428 tests and produced 2 failures in `ImageHashCalculatorTest` (hash expectation mismatches in the current environment) while all leaderboard-related tests passed. 
- The failing tests appear unrelated to this refactor; the leaderboard changes did not introduce syntax errors and leaderboard provider tests exercised successfully during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e2dd2ad4832fae33fa631a548853)