### PR TITLE
Refactor history row mapping and normalize recent-players query limit

### DIFF
--- a/tests/GameRecentPlayersQueryBuilderTest.php
+++ b/tests/GameRecentPlayersQueryBuilderTest.php
@@ -32,6 +32,20 @@ final class GameRecentPlayersQueryBuilderTest extends TestCase
         $this->assertSame(['2024-01-03', '2024-01-02'], array_column($rows, 'last_known_date'));
     }
 
+
+    public function testPrepareNormalizesLimitToAtLeastOne(): void
+    {
+        $filter = new GamePlayerFilter(null, null);
+        $queryBuilder = new GameRecentPlayersQueryBuilder($filter, 0);
+        $statement = $queryBuilder->prepare($this->database, 'NPWR12345_001');
+        $statement->execute();
+
+        $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame([1], array_map('intval', array_column($rows, 'account_id')));
+    }
+
     public function testPrepareAppliesCountryFilter(): void
     {
         $filter = new GamePlayerFilter('US', null);

--- a/wwwroot/classes/GameRecentPlayersQueryBuilder.php
+++ b/wwwroot/classes/GameRecentPlayersQueryBuilder.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/GamePlayerFilter.php';
 
-final readonly class GameRecentPlayersQueryBuilder
+final class GameRecentPlayersQueryBuilder
 {
+    private readonly GamePlayerFilter $filter;
+
+    private readonly int $limit;
+
     private const BASE_QUERY = <<<'SQL'
         SELECT
             p.account_id,
@@ -37,10 +41,11 @@ final readonly class GameRecentPlayersQueryBuilder
         LIMIT :limit
     SQL;
 
-    public function __construct(
-        private readonly GamePlayerFilter $filter,
-        private readonly int $limit
-    ) {}
+    public function __construct(GamePlayerFilter $filter, int $limit)
+    {
+        $this->filter = $filter;
+        $this->limit = max(1, $limit);
+    }
 
     public function prepare(\PDO $database, string $npCommunicationId): \PDOStatement
     {


### PR DESCRIPTION
### Motivation

- Consolidate repetitive row-casting logic in `GameHistoryService` for clearer, safer data mapping under PHP 8.5 strict typing. 
- Prevent generation of a `LIMIT 0` clause from callers of the recent-players query builder by ensuring a sane minimum limit. 

### Description

- Introduced typed normalization helpers in `GameHistoryService` (`toInt`, `toNullableInt`, `toString`, `toNullableString`) and an internal `INVALID_HISTORY_ID` constant, and replaced ad-hoc `isset`/casts with these helpers and an `array_map` for id extraction. 
- Simplified title/group/trophy row mapping to use the new helpers and removed duplicated casting logic. 
- Updated `GameRecentPlayersQueryBuilder` to initialize explicit readonly properties and normalize the configured limit with `max(1, $limit)` to guarantee at least one row is requested. 
- Added `testPrepareNormalizesLimitToAtLeastOne` in `tests/GameRecentPlayersQueryBuilderTest.php` to cover the new limit-normalization behavior. 

### Testing

- Ran syntax checks: `php -l` on `wwwroot/classes/GameHistoryService.php`, `wwwroot/classes/GameRecentPlayersQueryBuilder.php`, and `tests/GameRecentPlayersQueryBuilderTest.php` (all passed). 
- Ran the full unit test suite with `php tests/run.php`; the suite completed but contains two pre-existing unrelated failures in `ImageHashCalculatorTest` (final result: 429 tests run, 2 failures, 0 errors). 
- Executed the new/updated tests locally (including `GameRecentPlayersQueryBuilderTest`) and confirmed the new test passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f2857988832fa51f66eb913bca86)