### PR TITLE
Fix ImageHashCalculator tests to match RGBA hashing logic

### DIFF
--- a/tests/ImageHashCalculatorTest.php
+++ b/tests/ImageHashCalculatorTest.php
@@ -45,6 +45,7 @@ final class ImageHashCalculatorTest extends TestCase
                 $buffer .= chr($pixel['red']);
                 $buffer .= chr($pixel['green']);
                 $buffer .= chr($pixel['blue']);
+                $buffer .= chr(255);
             }
         }
 
@@ -68,7 +69,7 @@ final class ImageHashCalculatorTest extends TestCase
                 $buffer .= chr($pixel['green']);
                 $buffer .= chr($pixel['blue']);
 
-                $alpha = (int) round(($pixel['alpha'] ?? 0) * 255 / 127);
+                $alpha = (int) round((127 - ($pixel['alpha'] ?? 0)) * 255 / 127);
                 $alpha = max(0, min(255, $alpha));
                 $buffer .= chr($alpha);
             }
@@ -117,6 +118,22 @@ final class FakeImageProcessor implements ImageProcessorInterface
         }
 
         $this->imageHandle = imagecreatetruecolor(max(1, $this->width), max(1, $this->height));
+
+        if ($this->pixels !== []) {
+            imagealphablending($this->imageHandle, false);
+            imagesavealpha($this->imageHandle, true);
+
+            foreach ($this->pixels as $y => $row) {
+                foreach ($row as $x => $pixel) {
+                    $color = (($pixel['alpha'] ?? 0) << 24)
+                        | (($pixel['red'] ?? 0) << 16)
+                        | (($pixel['green'] ?? 0) << 8)
+                        | ($pixel['blue'] ?? 0);
+
+                    imagesetpixel($this->imageHandle, $x, $y, $color);
+                }
+            }
+        }
     }
 
     #[\Override]


### PR DESCRIPTION
### Motivation
- Two unit tests for `ImageHashCalculator` were failing because the test expectations did not match the runtime RGBA/alpha encoding used when hashing GD pixels.
- The test double did not populate the GD image with deterministic RGBA pixel values, causing `imagecolorat()` to return unexpected values.

### Description
- Updated `tests/ImageHashCalculatorTest.php` to include an explicit alpha byte (`255`) for opaque-pixel hash expectations so the test buffer matches the production RGBA format.
- Corrected the alpha conversion in the transparency test to use the same formula as production (`127 - gdAlpha` normalized to 0..255) so expected hash bytes align with actual output.
- Improved the `FakeImageProcessor` test double to write configured RGBA pixels into the GD image via `imagesetpixel()` and enabled `imagealphablending()`/`imagesavealpha()` so `imagecolorat()` returns deterministic RGBA values during tests.
- No production code was modified (did not change `ImageHashCalculator.php`).

### Testing
- Ran a PHP syntax check on the modified test file with `php -l tests/ImageHashCalculatorTest.php`, which succeeded.
- Ran the full test suite with `php tests/run.php`, after which all automated tests passed: 430/430 tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3daf8f6c832f83dbe66e99f488f1)