### PR TITLE
Optimize SearchQueryHelper internals for PHP 8.5

### DIFF
--- a/wwwroot/classes/SearchQueryHelper.php
+++ b/wwwroot/classes/SearchQueryHelper.php
@@ -30,6 +30,11 @@ final class SearchQueryHelper
         'V' => 5,
         'I' => 1,
     ];
+
+    /**
+     * @var array<string, list<string>>
+     */
+    private array $searchVariantsCache = [];
     /**
      * @param array<int, string> $columns
      * @return array<int, string>
@@ -165,12 +170,17 @@ final class SearchQueryHelper
 
     private function buildSearchLikeParameter(string $search): string
     {
-        return '%' . addcslashes($search, "\\%_") . '%';
+        return '%' . $this->escapeLikeSpecialCharacters($search) . '%';
     }
 
     private function buildSearchPrefixParameter(string $search): string
     {
-        return addcslashes($search, "\\%_") . '%';
+        return $this->escapeLikeSpecialCharacters($search) . '%';
+    }
+
+    private function escapeLikeSpecialCharacters(string $value): string
+    {
+        return addcslashes($value, "\\%_");
     }
 
     /**
@@ -193,6 +203,10 @@ final class SearchQueryHelper
      */
     private function getSearchVariants(string $searchTerm): array
     {
+        if (isset($this->searchVariantsCache[$searchTerm])) {
+            return $this->searchVariantsCache[$searchTerm];
+        }
+
         $variants = [$searchTerm];
 
         $romanVariant = $this->replaceDigitsWithRomans($searchTerm);
@@ -204,6 +218,8 @@ final class SearchQueryHelper
         if ($numericVariant !== $searchTerm && !in_array($numericVariant, $variants, true)) {
             $variants[] = $numericVariant;
         }
+
+        $this->searchVariantsCache[$searchTerm] = $variants;
 
         return $variants;
     }


### PR DESCRIPTION
### Motivation
- Reduce redundant string processing when the same search term is handled multiple times during a request to improve performance on modern PHP (8.5) runtimes. 
- Centralize LIKE escaping and avoid behaviour changes to SQL so compatibility with MySQL 8.4 is preserved and `psn100.sql` / `database.php` remain untouched.

### Description
- Added a per-term in-memory cache property (`$searchVariantsCache`) to `SearchQueryHelper` so Roman/numeric variant generation is computed once per term per instance. 
- Extracted LIKE escaping into a single helper method `escapeLikeSpecialCharacters()` and updated `buildSearchLikeParameter()` and `buildSearchPrefixParameter()` to reuse it. 
- Preserved existing SQL placeholder and binding behaviour; no changes to query text, schema files, or `psn100.sql` / `database.php` were made.

### Testing
- Linted the changed file and the test file with `php -l wwwroot/classes/SearchQueryHelper.php` and `php -l tests/SearchQueryHelperTest.php` and ran a repository-wide PHP lint check. 
- Executed the full test suite with `php tests/run.php`. 
- Result: all tests passed (430/430) and no syntax errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3f0f9e50832fa3b30638a2e83444)