### PR TITLE
Refactor PlayerGamesService for MySQL 8.4-only completion label logic

### DIFF
--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -18,13 +18,10 @@ final class PlayerGamesService
         PlayerGamesFilter::PLATFORM_PSVR2 => "tt.platform LIKE '%PSVR2%'",
     ];
 
-    private readonly string $databaseDriver;
-
     public function __construct(
         private readonly PDO $database,
         private readonly SearchQueryHelper $searchQueryHelper
     ) {
-        $this->databaseDriver = (string) $this->database->getAttribute(PDO::ATTR_DRIVER_NAME);
     }
 
     public function countPlayerGames(int $accountId, PlayerGamesFilter $filter): int
@@ -203,77 +200,6 @@ final class PlayerGamesService
             return [];
         }
 
-        if ($this->databaseDriver === 'mysql') {
-            return $this->fetchCompletionLabelsFromMySql($accountId, $npCommunicationIds);
-        }
-
-        return $this->fetchCompletionLabelsWithDateRange($accountId, $npCommunicationIds);
-    }
-
-    /**
-     * @param list<string> $npCommunicationIds
-     * @return array<string, string>
-     */
-    private function fetchCompletionLabelsFromMySql(int $accountId, array $npCommunicationIds): array
-    {
-        $placeholders = array_map(
-            static fn(int $index): string => ':np_' . $index,
-            array_keys($npCommunicationIds)
-        );
-
-        $sql = sprintf(
-            'WITH completion_window AS (
-                SELECT
-                    np_communication_id,
-                    MIN(earned_date) AS first_trophy,
-                    MAX(earned_date) AS last_trophy,
-                    TIMESTAMPDIFF(SECOND, MIN(earned_date), MAX(earned_date)) AS completion_seconds
-                FROM trophy_earned
-                WHERE account_id = :account_id
-                    AND earned = 1
-                    AND np_communication_id IN (%s)
-                GROUP BY np_communication_id
-            )
-            SELECT np_communication_id, first_trophy, last_trophy
-            FROM completion_window
-            WHERE completion_seconds > 0',
-            implode(', ', $placeholders)
-        );
-
-        $statement = $this->database->prepare($sql);
-        $statement->bindValue(':account_id', $accountId, PDO::PARAM_INT);
-
-        foreach ($npCommunicationIds as $index => $npCommunicationId) {
-            $statement->bindValue(':np_' . $index, $npCommunicationId, PDO::PARAM_STR);
-        }
-
-        $statement->execute();
-        $completionRows = $statement->fetchAll(PDO::FETCH_ASSOC);
-        if (!is_array($completionRows)) {
-            return [];
-        }
-
-        $labels = [];
-        foreach ($completionRows as $completionRow) {
-            $npCommunicationId = (string) ($completionRow['np_communication_id'] ?? '');
-            $label = $this->formatCompletionLabel(
-                $completionRow['first_trophy'] ?? null,
-                $completionRow['last_trophy'] ?? null
-            );
-            if ($npCommunicationId !== '' && $label !== null) {
-                $labels[$npCommunicationId] = $label;
-            }
-        }
-
-        return $labels;
-    }
-
-    /**
-     * @param list<string> $npCommunicationIds
-     * @return array<string, string>
-     */
-    private function fetchCompletionLabelsWithDateRange(int $accountId, array $npCommunicationIds): array
-    {
         $placeholders = array_map(
             static fn(int $index): string => ':np_' . $index,
             array_keys($npCommunicationIds)
@@ -285,16 +211,13 @@ final class PlayerGamesService
             WHERE account_id = :account_id
                 AND earned = 1
                 AND np_communication_id IN (%s)
-            GROUP BY np_communication_id',
+            GROUP BY np_communication_id
+            HAVING MIN(earned_date) <> MAX(earned_date)',
             implode(', ', $placeholders)
         );
 
         $statement = $this->database->prepare($sql);
-        $statement->bindValue(':account_id', $accountId, PDO::PARAM_INT);
-
-        foreach ($npCommunicationIds as $index => $npCommunicationId) {
-            $statement->bindValue(':np_' . $index, $npCommunicationId, PDO::PARAM_STR);
-        }
+        $this->bindCompletionLabelParameters($statement, $accountId, $npCommunicationIds);
 
         $statement->execute();
         $completionRows = $statement->fetchAll(PDO::FETCH_ASSOC);
@@ -316,6 +239,18 @@ final class PlayerGamesService
         }
 
         return $labels;
+    }
+
+    /**
+     * @param list<string> $npCommunicationIds
+     */
+    private function bindCompletionLabelParameters(PDOStatement $statement, int $accountId, array $npCommunicationIds): void
+    {
+        $statement->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+
+        foreach ($npCommunicationIds as $index => $npCommunicationId) {
+            $statement->bindValue(':np_' . $index, $npCommunicationId, PDO::PARAM_STR);
+        }
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Align the completion-label logic with the project target runtime (`PHP 8.5` / `MySQL 8.4`) and remove legacy branching that supported non-MySQL backends.
- Simplify and modernize the `PlayerGamesService` implementation to reduce duplication and surface fewer runtime branches.

### Description
- Removed the driver-detection state and branching logic from `PlayerGamesService` by deleting the `$databaseDriver` field and its use in completion-label selection.
- Unified completion-label fetching into a single MySQL-optimized SQL path that uses `GROUP BY` + `HAVING MIN(earned_date) <> MAX(earned_date)` to skip zero-duration completions within the query.
- Extracted parameter binding for the completion-label query into a new helper method `bindCompletionLabelParameters` to avoid duplicated binding code.
- Kept public API unchanged (`countPlayerGames` / `getPlayerGames`) and simplified the constructor by removing driver-related initialization.

### Testing
- Ran syntax check with `php -l wwwroot/classes/PlayerGamesService.php` which reported no syntax errors.
- Ran the full test suite with `php tests/run.php` and observed that all tests completed successfully (`All 430 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3f0f9e50832fa3b30638a2e83444)