### PR TITLE
Use MySQL 8 window function for game list paging

### DIFF
--- a/wwwroot/classes/GameListPage.php
+++ b/wwwroot/classes/GameListPage.php
@@ -7,27 +7,27 @@ require_once __DIR__ . '/GameListFilter.php';
 
 class GameListPage
 {
-    private GameListService $gameListService;
+    private readonly GameListService $gameListService;
 
-    private GameListFilter $filter;
+    private readonly GameListFilter $filter;
 
-    private int $limit;
+    private readonly int $limit;
 
-    private int $offset;
+    private readonly int $offset;
 
-    private int $totalGames;
+    private readonly int $totalGames;
 
-    private int $totalPages;
+    private readonly int $totalPages;
 
     /**
      * @var GameListItem[]
      */
-    private array $games;
+    private readonly array $games;
 
     /**
      * @var array<string, string>
      */
-    private array $paginationParameters;
+    private readonly array $paginationParameters;
 
     public function __construct(GameListService $gameListService, GameListFilter $filter)
     {
@@ -35,11 +35,12 @@ class GameListPage
         $this->filter = $filter->withPlayer($gameListService->resolvePlayer($filter->getPlayer()));
         $this->limit = $this->gameListService->getLimit();
         $this->offset = $this->gameListService->getOffset($this->filter);
-        $this->totalGames = $this->gameListService->countGames($this->filter);
+        $result = $this->gameListService->getGamesPage($this->filter);
+        $this->totalGames = $result->totalGames;
         $this->totalPages = $this->totalGames > 0
             ? (int) ceil($this->totalGames / $this->limit)
             : 0;
-        $this->games = $this->gameListService->getGames($this->filter);
+        $this->games = $result->games;
         $this->paginationParameters = $this->filter->getQueryParametersForPagination();
     }
 

--- a/wwwroot/classes/GameListPageResult.php
+++ b/wwwroot/classes/GameListPageResult.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+final readonly class GameListPageResult
+{
+    /**
+     * @param list<GameListItem> $games
+     */
+    public function __construct(
+        public array $games,
+        public int $totalGames
+    ) {
+    }
+}
+


### PR DESCRIPTION
### Motivation
- Reduce database round-trips when rendering paginated game lists by using MySQL 8 window functions to return both rows and the total count in a single query.
- Modernize the code to leverage PHP 8.5 language features (readonly DTOs and constructor property promotion) and improve immutability of page objects.

### Description
- Added a new readonly DTO `GameListPageResult` to carry the page `games` and `totalGames` in one typed object (`wwwroot/classes/GameListPageResult.php`).
- Refactored `GameListService` to expose `getGamesPage()` that executes a single query including `COUNT(*) OVER() AS total_games` and to return a `GameListPageResult`, while preserving `countGames()` and `getGames()` public APIs with an out-of-range fallback to the old count query (`wwwroot/classes/GameListService.php`).
- Updated `GameListPage` to consume the new page result and converted several properties to `readonly` to reflect immutability after construction (`wwwroot/classes/GameListPage.php`).
- Kept search binding and condition-building logic intact, only adding an optional `total_games` select column and a `fetchCount()` helper for fallback counting.

### Testing
- Ran syntax checks with `php -l` on the modified files (`GameListPageResult.php`, `GameListService.php`, `GameListPage.php`) and on all PHP files, and the linter reported no syntax errors.
- Ran `composer validate --no-check-publish` inside `wwwroot` and the composer file was reported valid (warnings only).
- No unit test suite run was performed in this change; only linting and composer validation were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3f0f9e50832fa3b30638a2e83444)