### PR TITLE
Improve changelog page responsiveness on mobile

### DIFF
--- a/wwwroot/changelog.php
+++ b/wwwroot/changelog.php
@@ -39,7 +39,7 @@ require_once("header.php");
                 </div>
 
                 <?php foreach ($entries as $presenter) { ?>
-                    <div class="col-1">
+                    <div class="col-4 col-sm-2 col-md-1 text-nowrap small text-body-secondary">
                         <time
                             class="js-localized-changelog-time"
                             datetime="<?= htmlspecialchars($presenter->getIsoTimestamp(), ENT_QUOTES, 'UTF-8'); ?>"
@@ -47,7 +47,7 @@ require_once("header.php");
                             <?= $presenter->getTimeLabel(); ?>
                         </time>
                     </div>
-                    <div class="col-11">
+                    <div class="col-8 col-sm-10 col-md-11">
                         <?= $presenter->getMessage(); ?>
                     </div>
                 <?php } ?>
@@ -172,7 +172,7 @@ require_once("header.php");
 
                 group.entries.forEach((entry) => {
                     const timeColumn = document.createElement('div');
-                    timeColumn.className = 'col-1';
+                    timeColumn.className = 'col-4 col-sm-2 col-md-1 text-nowrap small text-body-secondary';
 
                     const timeElement = document.createElement('time');
                     timeElement.className = 'js-localized-changelog-time';
@@ -183,7 +183,7 @@ require_once("header.php");
                     rowElement.appendChild(timeColumn);
 
                     const messageColumn = document.createElement('div');
-                    messageColumn.className = 'col-11';
+                    messageColumn.className = 'col-8 col-sm-10 col-md-11';
                     messageColumn.innerHTML = entry.messageHtml;
 
                     rowElement.appendChild(messageColumn);


### PR DESCRIPTION
### Motivation
- The changelog list used fixed `col-1/col-11` columns which made entries cramped on narrow viewports, so the layout needs to better accommodate mobile screens while keeping desktop proportions.

### Description
- Updated `wwwroot/changelog.php` to use responsive Bootstrap column classes (`time` column: `col-4 col-sm-2 col-md-1 text-nowrap small text-body-secondary`; `message` column: `col-8 col-sm-10 col-md-11`) and mirrored the same classes in the client-side regrouping script so JS-rendered rows match the server-rendered layout.

### Testing
- Ran `php -l wwwroot/changelog.php` and the full test suite via `php tests/run.php`, and all tests passed (`All 430 tests passed`).
- Attempted to run a local PHP dev server and capture a mobile screenshot with Playwright, but the app returned a database connection error in this environment (server started successfully but the request to `/changelog` failed due to local DB config).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b55fa0ad4832facde1a3997dea495)