### PR TITLE
Modernize changelog pagination and SQL for PHP 8.5/MySQL 8.4

### DIFF
--- a/wwwroot/classes/ChangelogPaginator.php
+++ b/wwwroot/classes/ChangelogPaginator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-class ChangelogPaginator
+final readonly class ChangelogPaginator
 {
     private int $currentPage;
     private int $totalCount;
@@ -11,15 +11,18 @@ class ChangelogPaginator
 
     public function __construct(int $requestedPage, int $totalCount, int $limit)
     {
-        $this->totalCount = max($totalCount, 0);
-        $this->limit = max($limit, 1);
-        $this->totalPages = $this->totalCount > 0 ? (int) ceil($this->totalCount / $this->limit) : 0;
+        $normalizedTotalCount = max($totalCount, 0);
+        $normalizedLimit = max($limit, 1);
+        $computedTotalPages = $normalizedTotalCount > 0
+            ? (int) ceil($normalizedTotalCount / $normalizedLimit)
+            : 0;
 
-        if ($this->totalPages > 0) {
-            $this->currentPage = min(max($requestedPage, 1), $this->totalPages);
-        } else {
-            $this->currentPage = 1;
-        }
+        $this->totalCount = $normalizedTotalCount;
+        $this->limit = $normalizedLimit;
+        $this->totalPages = $computedTotalPages;
+        $this->currentPage = $computedTotalPages > 0
+            ? min(max($requestedPage, 1), $computedTotalPages)
+            : 1;
     }
 
     public function getCurrentPage(): int

--- a/wwwroot/classes/ChangelogService.php
+++ b/wwwroot/classes/ChangelogService.php
@@ -21,13 +21,7 @@ class ChangelogService
         $query = $this->database->prepare('SELECT COUNT(*) FROM psn100_change');
         $query->execute();
 
-        $count = $query->fetchColumn();
-
-        if ($count === false) {
-            return 0;
-        }
-
-        return (int) $count;
+        return (int) ($query->fetchColumn() ?: 0);
     }
 
     /**
@@ -51,7 +45,7 @@ class ChangelogService
             LEFT JOIN trophy_title tt2 ON tt2.id = c.param_2
             LEFT JOIN trophy_title_meta ttm2 ON ttm2.np_communication_id = tt2.np_communication_id
             ORDER BY c.time DESC
-            LIMIT :offset, :limit
+            LIMIT :limit OFFSET :offset
             SQL
         );
         $query->bindValue(':offset', $paginator->getOffset(), PDO::PARAM_INT);


### PR DESCRIPTION
### Motivation
- Bring changelog pagination and query code up to modern PHP 8.5 style and align SQL pagination with MySQL 8.4 conventions while keeping behaviour identical.

### Description
- Refactored `ChangelogPaginator` into a `final readonly` value-like class and normalised constructor inputs to centralise page/limit/total calculations and ensure sane defaults (`wwwroot/classes/ChangelogPaginator.php`).
- Simplified total-count retrieval in `ChangelogService::getTotalChangeCount()` to a single casted expression for clarity (`wwwroot/classes/ChangelogService.php`).
- Modernised the changelog query pagination from `LIMIT :offset, :limit` to `LIMIT :limit OFFSET :offset` for clearer, more standard SQL on MySQL 8.4 (`wwwroot/classes/ChangelogService.php`).
- No changes were made to `database/psn100.sql` or `wwwroot/database.php` as requested.

### Testing
- Linted the modified files with `php -l wwwroot/classes/ChangelogPaginator.php` and `php -l wwwroot/classes/ChangelogService.php` with no syntax errors.
- Ran the full test suite with `php tests/run.php` and confirmed all tests passed (`430` tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b57a91df8832f8313e78a70f82373)