### PR TITLE
Refactor router path parsing and optimize search variant deduplication

### DIFF
--- a/wwwroot/classes/Router.php
+++ b/wwwroot/classes/Router.php
@@ -47,22 +47,22 @@ class Router
     {
         $path = parse_url($requestUri, PHP_URL_PATH);
         $path = is_string($path) ? $path : '';
-        $path = ltrim($path, '/');
+        $normalizedPath = trim($path, '/');
 
-        $segments = $path === '' ? [] : explode('/', $path);
-
-        if ($segments === [] || $segments[0] === '') {
+        if ($normalizedPath === '') {
             return $this->defaultHandler->handle([]);
         }
 
-        $route = array_shift($segments);
+        $segments = explode('/', $normalizedPath);
+        $route = $segments[0];
+        $routeSegments = array_slice($segments, 1);
 
-        $handler = $route !== null ? ($this->routeHandlers[$route] ?? null) : null;
+        $handler = $this->routeHandlers[$route] ?? null;
 
         if (!$handler instanceof RouteHandlerInterface) {
             return RouteResult::notFound();
         }
 
-        return $handler->handle($segments);
+        return $handler->handle($routeSegments);
     }
 }

--- a/wwwroot/classes/SearchQueryHelper.php
+++ b/wwwroot/classes/SearchQueryHelper.php
@@ -35,6 +35,7 @@ final class SearchQueryHelper
      * @var array<string, list<string>>
      */
     private array $searchVariantsCache = [];
+
     /**
      * @param array<int, string> $columns
      * @return array<int, string>
@@ -208,14 +209,16 @@ final class SearchQueryHelper
         }
 
         $variants = [$searchTerm];
+        $deduplicated = [$searchTerm => true];
 
         $romanVariant = $this->replaceDigitsWithRomans($searchTerm);
-        if ($romanVariant !== $searchTerm && !in_array($romanVariant, $variants, true)) {
+        if ($romanVariant !== $searchTerm && !isset($deduplicated[$romanVariant])) {
             $variants[] = $romanVariant;
+            $deduplicated[$romanVariant] = true;
         }
 
         $numericVariant = $this->replaceRomansWithDigits($searchTerm);
-        if ($numericVariant !== $searchTerm && !in_array($numericVariant, $variants, true)) {
+        if ($numericVariant !== $searchTerm && !isset($deduplicated[$numericVariant])) {
             $variants[] = $numericVariant;
         }
 


### PR DESCRIPTION
### Motivation
- Modernize routing and search helper internals to be clearer and more efficient under the PHP 8.5 / MySQL 8.4 target while avoiding changes to database files (`psn100.sql` and `database.php`).

### Description
- Normalize request paths once and short-circuit home-route handling in `Router::dispatch()` while replacing the `array_shift()` mutation with direct indexing and `array_slice()` to produce route segments.  
- Replace repeated `in_array()` duplicate checks in `SearchQueryHelper::getSearchVariants()` with an associative-array (hash) based deduplication to reduce lookup overhead and guarantee unique variants.  
- No changes were made to `database.php` or `database/psn100.sql`.

### Testing
- Ran syntax checks with `php -l` on the modified files and executed the full test suite via `php tests/run.php`.  
- All automated tests completed successfully: the test runner executed 430 tests and they all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b57a91df8832f8313e78a70f82373)