### PR TITLE
Filter changelog listing/count to exclude update/version entries

### DIFF
--- a/tests/ChangelogServiceTest.php
+++ b/tests/ChangelogServiceTest.php
@@ -68,6 +68,39 @@ final class ChangelogServiceTest extends TestCase
         $this->assertSame('US', $entry->getParam2Region());
     }
 
+
+    public function testGetChangesAndCountExcludeGameUpdateAndGameVersion(): void
+    {
+        $this->database->exec(
+            "INSERT INTO psn100_change (time, change_type, param_1, param_2, extra) VALUES " .
+            "('2024-01-03 00:00:00', 'GAME_MERGE', 1, 2, NULL), " .
+            "('2024-01-02 00:00:00', 'GAME_VERSION', 1, 2, NULL), " .
+            "('2024-01-01 00:00:00', 'GAME_UPDATE', 1, 2, NULL), " .
+            "('2023-12-31 00:00:00', 'PLAYER_CREATE', 1, 2, NULL)"
+        );
+
+        $this->assertSame(2, $this->service->getTotalChangeCount());
+
+        $pageOnePaginator = new ChangelogPaginator(1, 1, 1);
+        $pageOneEntries = $this->service->getChanges($pageOnePaginator);
+
+        $this->assertCount(1, $pageOneEntries);
+        $this->assertSame(ChangelogEntryType::GAME_MERGE, $pageOneEntries[0]->getChangeType());
+
+        $pageTwoPaginator = new ChangelogPaginator(2, 2, 1);
+        $pageTwoEntries = $this->service->getChanges($pageTwoPaginator);
+
+        $this->assertCount(1, $pageTwoEntries);
+        $this->assertSame(ChangelogEntryType::UNKNOWN, $pageTwoEntries[0]->getChangeType());
+        $this->assertSame('PLAYER_CREATE', $pageTwoEntries[0]->getChangeTypeValue());
+
+        $pageThreePaginator = new ChangelogPaginator(3, 2, 1);
+        $pageThreeEntries = $this->service->getChanges($pageThreePaginator);
+
+        $this->assertCount(1, $pageThreeEntries);
+        $this->assertSame('PLAYER_CREATE', $pageThreeEntries[0]->getChangeTypeValue());
+    }
+
     private function insertTitle(int $id, string $npCommunicationId, string $name, string $platform, string $region): void
     {
         $titleStatement = $this->database->prepare(

--- a/wwwroot/classes/ChangelogService.php
+++ b/wwwroot/classes/ChangelogService.php
@@ -18,7 +18,7 @@ class ChangelogService
 
     public function getTotalChangeCount(): int
     {
-        $query = $this->database->prepare('SELECT COUNT(*) FROM psn100_change');
+        $query = $this->database->prepare("SELECT COUNT(*) FROM psn100_change WHERE change_type NOT IN ('GAME_UPDATE', 'GAME_VERSION')");
         $query->execute();
 
         return (int) ($query->fetchColumn() ?: 0);
@@ -44,6 +44,7 @@ class ChangelogService
             LEFT JOIN trophy_title_meta ttm1 ON ttm1.np_communication_id = tt1.np_communication_id
             LEFT JOIN trophy_title tt2 ON tt2.id = c.param_2
             LEFT JOIN trophy_title_meta ttm2 ON ttm2.np_communication_id = tt2.np_communication_id
+            WHERE c.change_type NOT IN ('GAME_UPDATE', 'GAME_VERSION')
             ORDER BY c.time DESC
             LIMIT :limit OFFSET :offset
             SQL


### PR DESCRIPTION
### Motivation
- The changelog listing and paginator should not surface internal `GAME_UPDATE` and `GAME_VERSION` rows, so the total and paged results must be computed from the same filtered dataset.

### Description
- Updated `ChangelogService::getTotalChangeCount()` to use `SELECT COUNT(*) FROM psn100_change WHERE change_type NOT IN ('GAME_UPDATE', 'GAME_VERSION')` so the paginator total excludes those types.
- Updated `ChangelogService::getChanges(ChangelogPaginator $paginator)` to add `WHERE c.change_type NOT IN ('GAME_UPDATE', 'GAME_VERSION')` before `ORDER BY c.time DESC` so visible entries are filtered consistently while keeping `:limit` and `:offset` binding unchanged.
- Added a unit test `testGetChangesAndCountExcludeGameUpdateAndGameVersion` in `tests/ChangelogServiceTest.php` that verifies filtered counts, visible entries ordering, and page-by-page paginator behaviour.

### Testing
- Ran syntax checks with `php -l wwwroot/classes/ChangelogService.php` and `php -l tests/ChangelogServiceTest.php`, both succeeded.
- Executed the full test suite with `php tests/run.php`, and all tests passed (431 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b6dd7842c832fa6ec389098ca9197)