### PR TITLE
Fix ChangelogService test to match GAME_RESCAN/GAME_VERSION filtering

### DIFF
--- a/tests/ChangelogServiceTest.php
+++ b/tests/ChangelogServiceTest.php
@@ -69,17 +69,18 @@ final class ChangelogServiceTest extends TestCase
     }
 
 
-    public function testGetChangesAndCountExcludeGameUpdateAndGameVersion(): void
+    public function testGetChangesAndCountExcludeGameRescanAndGameVersion(): void
     {
         $this->database->exec(
             "INSERT INTO psn100_change (time, change_type, param_1, param_2, extra) VALUES " .
             "('2024-01-03 00:00:00', 'GAME_MERGE', 1, 2, NULL), " .
             "('2024-01-02 00:00:00', 'GAME_VERSION', 1, 2, NULL), " .
             "('2024-01-01 00:00:00', 'GAME_UPDATE', 1, 2, NULL), " .
+            "('2023-12-31 12:00:00', 'GAME_RESCAN', 1, 2, NULL), " .
             "('2023-12-31 00:00:00', 'PLAYER_CREATE', 1, 2, NULL)"
         );
 
-        $this->assertSame(2, $this->service->getTotalChangeCount());
+        $this->assertSame(3, $this->service->getTotalChangeCount());
 
         $pageOnePaginator = new ChangelogPaginator(1, 1, 1);
         $pageOneEntries = $this->service->getChanges($pageOnePaginator);
@@ -87,14 +88,14 @@ final class ChangelogServiceTest extends TestCase
         $this->assertCount(1, $pageOneEntries);
         $this->assertSame(ChangelogEntryType::GAME_MERGE, $pageOneEntries[0]->getChangeType());
 
-        $pageTwoPaginator = new ChangelogPaginator(2, 2, 1);
+        $pageTwoPaginator = new ChangelogPaginator(2, 3, 1);
         $pageTwoEntries = $this->service->getChanges($pageTwoPaginator);
 
         $this->assertCount(1, $pageTwoEntries);
-        $this->assertSame(ChangelogEntryType::UNKNOWN, $pageTwoEntries[0]->getChangeType());
-        $this->assertSame('PLAYER_CREATE', $pageTwoEntries[0]->getChangeTypeValue());
+        $this->assertSame(ChangelogEntryType::GAME_UPDATE, $pageTwoEntries[0]->getChangeType());
+        $this->assertSame('GAME_UPDATE', $pageTwoEntries[0]->getChangeTypeValue());
 
-        $pageThreePaginator = new ChangelogPaginator(3, 2, 1);
+        $pageThreePaginator = new ChangelogPaginator(3, 3, 1);
         $pageThreeEntries = $this->service->getChanges($pageThreePaginator);
 
         $this->assertCount(1, $pageThreeEntries);
@@ -120,4 +121,3 @@ final class ChangelogServiceTest extends TestCase
         $metaStatement->execute();
     }
 }
-


### PR DESCRIPTION
### Motivation
- The existing changelog test expected the service to filter out `GAME_UPDATE` as well, but the service actually only excludes `GAME_RESCAN` and `GAME_VERSION`, so the test needed to be updated to reflect the real behavior.
- Keep `ChangelogService.php` unchanged and make the unit expectations match the SQL filtering and ordering used by the service.

### Description
- Updated `tests/ChangelogServiceTest.php` by renaming the test to `testGetChangesAndCountExcludeGameRescanAndGameVersion` and adding a `GAME_RESCAN` fixture row to the seeded `psn100_change` data.
- Adjusted the expected total count from `2` to `3`, changed paginator parameters, and updated page assertions to expect `GAME_UPDATE` on page 2 and `PLAYER_CREATE` on page 3 so they reflect `ORDER BY time DESC` after the actual exclusion list.
- No changes were made to `wwwroot/classes/ChangelogService.php` or any production code; only test expectations were modified.

### Testing
- Ran `php -l tests/ChangelogServiceTest.php` to validate syntax, which passed. 
- Executed the full test suite with `php tests/run.php`, and all tests passed: 431 tests, 0 failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b707d5084832faaabd257be5a1993)