### PR TITLE
Modernize MySQL upserts for queue and trophy meta writes

### DIFF
--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -79,10 +79,12 @@ class PlayerQueueService
     {
         $query = $this->prepareAndBind(
             <<<'SQL'
-            INSERT IGNORE INTO
+            INSERT INTO
                 player_queue (online_id, ip_address)
             VALUES
-                (:online_id, :ip_address)
+                (:online_id, :ip_address) AS new_submission
+            ON DUPLICATE KEY UPDATE
+                online_id = new_submission.online_id
             SQL,
             [
                 ':online_id' => [$playerName, PDO::PARAM_STR],

--- a/wwwroot/classes/TrophyMetaRepository.php
+++ b/wwwroot/classes/TrophyMetaRepository.php
@@ -47,7 +47,7 @@ class TrophyMetaRepository
                 )
             SQL,
             'mysql' => <<<'SQL'
-                INSERT IGNORE INTO trophy_meta (
+                INSERT INTO trophy_meta (
                     trophy_id,
                     rarity_percent,
                     rarity_point,
@@ -61,7 +61,9 @@ class TrophyMetaRepository
                     0,
                     0,
                     'NONE'
-                )
+                ) AS new_meta
+                ON DUPLICATE KEY UPDATE
+                    trophy_id = new_meta.trophy_id
             SQL,
             default => throw new RuntimeException("Unsupported PDO driver: {$driver}"),
         };


### PR DESCRIPTION
### Motivation
- Update deduplicated database writes to use modern MySQL 8.4 upsert syntax for clarity and consistency with the targeted MySQL version.
- Keep existing behaviour and avoid touching `database.php` and `database/psn100.sql` as requested.

### Description
- Replaced `INSERT IGNORE` in `PlayerQueueService::addPlayerToQueue()` with `INSERT ... AS new_submission ON DUPLICATE KEY UPDATE` to perform a no-op upsert while preserving deduplication semantics. (file: `wwwroot/classes/PlayerQueueService.php`)
- Replaced the MySQL branch in `TrophyMetaRepository::ensureExists()` from `INSERT IGNORE` to an aliased `INSERT ... AS new_meta ON DUPLICATE KEY UPDATE` for the same consistent upsert pattern. (file: `wwwroot/classes/TrophyMetaRepository.php`)

### Testing
- Performed syntax checks with `php -l wwwroot/classes/PlayerQueueService.php` and `php -l wwwroot/classes/TrophyMetaRepository.php`, which reported no syntax errors. 
- Executed the full test suite with `php tests/run.php` and all tests passed (`431/431`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b71eb1194832fbef376edc0b1b668)