### PR TITLE
Refactor filter parsing for PHP 8.5-first behavior

### DIFF
--- a/wwwroot/classes/GamePlayerFilter.php
+++ b/wwwroot/classes/GamePlayerFilter.php
@@ -10,11 +10,8 @@ readonly class GamePlayerFilter
 
     public function __construct(?string $country, ?string $avatar)
     {
-        $country = $country !== null ? trim($country) : null;
-        $avatar = $avatar !== null ? trim($avatar) : null;
-
-        $this->country = $country === '' ? null : $country;
-        $this->avatar = $avatar === '' ? null : $avatar;
+        $this->country = self::normalizeOptionalString($country);
+        $this->avatar = self::normalizeOptionalString($avatar);
     }
 
     /**
@@ -22,8 +19,8 @@ readonly class GamePlayerFilter
      */
     public static function fromArray(array $queryParameters): self
     {
-        $country = isset($queryParameters['country']) ? (string) $queryParameters['country'] : null;
-        $avatar = isset($queryParameters['avatar']) ? (string) $queryParameters['avatar'] : null;
+        $country = self::readOptionalString($queryParameters, 'country');
+        $avatar = self::readOptionalString($queryParameters, 'avatar');
 
         return new self($country, $avatar);
     }
@@ -80,9 +77,9 @@ readonly class GamePlayerFilter
     public function withCountry(?string $country): array
     {
         $parameters = $this->getFilterParameters();
-        $country = $country !== null ? trim($country) : null;
+        $country = self::normalizeOptionalString($country);
 
-        if ($country === null || $country === '') {
+        if ($country === null) {
             unset($parameters['country']);
         } else {
             $parameters['country'] = $country;
@@ -97,14 +94,39 @@ readonly class GamePlayerFilter
     public function withAvatar(?string $avatar): array
     {
         $parameters = $this->getFilterParameters();
-        $avatar = $avatar !== null ? trim($avatar) : null;
+        $avatar = self::normalizeOptionalString($avatar);
 
-        if ($avatar === null || $avatar === '') {
+        if ($avatar === null) {
             unset($parameters['avatar']);
         } else {
             $parameters['avatar'] = $avatar;
         }
 
         return $parameters;
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    private static function readOptionalString(array $queryParameters, string $key): ?string
+    {
+        $value = $queryParameters[$key] ?? null;
+
+        if ($value === null || is_array($value)) {
+            return null;
+        }
+
+        return self::normalizeOptionalString((string) $value);
+    }
+
+    private static function normalizeOptionalString(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
     }
 }

--- a/wwwroot/classes/PlayerRandomGamesFilter.php
+++ b/wwwroot/classes/PlayerRandomGamesFilter.php
@@ -13,6 +13,19 @@ final readonly class PlayerRandomGamesFilter
     public const string PLATFORM_PSVR2 = 'psvr2';
 
     /**
+     * @var list<string>
+     */
+    private const PLATFORM_KEYS = [
+        self::PLATFORM_PC,
+        self::PLATFORM_PS3,
+        self::PLATFORM_PS4,
+        self::PLATFORM_PS5,
+        self::PLATFORM_PSVITA,
+        self::PLATFORM_PSVR,
+        self::PLATFORM_PSVR2,
+    ];
+
+    /**
      * @var array<string, bool>
      */
     private array $selectedPlatforms;
@@ -28,35 +41,34 @@ final readonly class PlayerRandomGamesFilter
     public static function fromArray(array $parameters): self
     {
         $selectedPlatforms = [];
-        foreach (self::getPlatformKeys() as $platformKey) {
+        foreach (self::PLATFORM_KEYS as $platformKey) {
             $selectedPlatforms[$platformKey] = self::toBool($parameters[$platformKey] ?? null);
         }
 
         return new self($selectedPlatforms);
     }
 
-    /**
-     * @return array<string>
-     */
-    private static function getPlatformKeys(): array
+    private static function toBool(mixed $value): bool
     {
-        return [
-            self::PLATFORM_PC,
-            self::PLATFORM_PS3,
-            self::PLATFORM_PS4,
-            self::PLATFORM_PS5,
-            self::PLATFORM_PSVITA,
-            self::PLATFORM_PSVR,
-            self::PLATFORM_PSVR2,
-        ];
-    }
+        if ($value === null) {
+            return false;
+        }
 
-    /**
-     * @param mixed $value
-     */
-    private static function toBool($value): bool
-    {
-        return !empty($value);
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value !== 0;
+        }
+
+        if (!is_string($value) && !is_numeric($value)) {
+            return false;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        return !in_array($normalized, ['', '0', 'false', 'off', 'no'], true);
     }
 
     public function isPlatformSelected(string $platform): bool


### PR DESCRIPTION
### Motivation
- Harden query parameter handling to align with PHP 8.5 strict typing and reduce implicit coercions and edge cases when reading request input. 
- Make platform/key lists and boolean normalization explicit and maintainable for modern MySQL/PHP deployments while leaving database schema/files untouched.

### Description
- Consolidated optional-string normalization and safe query value reading in `GamePlayerFilter` by adding `readOptionalString()` and `normalizeOptionalString()` and replacing inline `trim`/empty checks. (modified `wwwroot/classes/GamePlayerFilter.php`)
- Applied the same safe-string and page normalization approach to `PlayerLeaderboardFilter` with `readOptionalString()`, `normalizeOptionalString()` and `normalizePage()`. (modified `wwwroot/classes/PlayerLeaderboardFilter.php`)
- Modernized `PlayerRandomGamesFilter` by introducing a `PLATFORM_KEYS` class constant and replacing `empty()` coercion with an explicit `toBool(mixed $value)` that accepts common truthy/falsy representations. (modified `wwwroot/classes/PlayerRandomGamesFilter.php`)
- No changes were made to `database.php` or `database/psn100.sql` per constraint.

### Testing
- Linted modified files with `php -l` for syntax validation and all files reported no syntax errors. (commands run: `php -l wwwroot/classes/GamePlayerFilter.php`, `php -l wwwroot/classes/PlayerLeaderboardFilter.php`, `php -l wwwroot/classes/PlayerRandomGamesFilter.php`)
- Ran targeted unit tests with `php tests/run.php --filter "(PlayerRandomGamesFilterTest|PlayerLeaderboardFilterTest|GameListFilterTest)"` and observed all relevant tests passing. 
- Executed the full test suite during iteration and observed a successful run: all 431 automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b71eb1194832fbef376edc0b1b668)