### PR TITLE
Modernize admin worker sorting using PHP enums

### DIFF
--- a/wwwroot/classes/Admin/WorkerService.php
+++ b/wwwroot/classes/Admin/WorkerService.php
@@ -6,6 +6,8 @@ require_once __DIR__ . '/Worker.php';
 require_once __DIR__ . '/CommandExecutionResult.php';
 require_once __DIR__ . '/CommandExecutorInterface.php';
 require_once __DIR__ . '/SystemCommandExecutor.php';
+require_once __DIR__ . '/WorkerSortField.php';
+require_once __DIR__ . '/WorkerSortDirection.php';
 
 final class WorkerService
 {
@@ -27,17 +29,13 @@ final class WorkerService
      */
     public function fetchWorkers(string $orderBy = 'scan_start', string $direction = 'ASC'): array
     {
-        $orderColumn = match (strtolower($orderBy)) {
-            'id' => 'id',
-            default => 'scan_start',
-        };
-
-        $orderDirection = strtoupper($direction) === 'DESC' ? 'DESC' : 'ASC';
+        $sortField = WorkerSortField::fromMixed($orderBy);
+        $sortDirection = WorkerSortDirection::fromMixed($direction);
 
         $statement = $this->database->query(sprintf(
             'SELECT id, npsso, scanning, scan_start, scan_progress FROM setting ORDER BY %s %s',
-            $orderColumn,
-            $orderDirection
+            $sortField->toSqlColumn(),
+            $sortDirection->toSqlKeyword()
         ));
 
         if ($statement === false) {

--- a/wwwroot/classes/Admin/WorkerSortDirection.php
+++ b/wwwroot/classes/Admin/WorkerSortDirection.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+enum WorkerSortDirection: string
+{
+    case Asc = 'asc';
+    case Desc = 'desc';
+
+    public static function fromMixed(mixed $value): self
+    {
+        if (!is_string($value)) {
+            return self::Asc;
+        }
+
+        return self::tryFrom(strtolower(trim($value))) ?? self::Asc;
+    }
+
+    public function toSqlKeyword(): string
+    {
+        return strtoupper($this->value);
+    }
+
+    public function indicator(): string
+    {
+        return $this === self::Asc ? ' ▲' : ' ▼';
+    }
+
+    public function toggled(): self
+    {
+        return $this === self::Asc ? self::Desc : self::Asc;
+    }
+}

--- a/wwwroot/classes/Admin/WorkerSortField.php
+++ b/wwwroot/classes/Admin/WorkerSortField.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+enum WorkerSortField: string
+{
+    case Id = 'id';
+    case ScanStart = 'scan_start';
+
+    public static function fromMixed(mixed $value): self
+    {
+        if (!is_string($value)) {
+            return self::ScanStart;
+        }
+
+        return self::tryFrom(strtolower(trim($value))) ?? self::ScanStart;
+    }
+
+    public function toSqlColumn(): string
+    {
+        return $this->value;
+    }
+}


### PR DESCRIPTION
### Motivation

- Move admin worker sorting logic to a PHP 8.5-first style using native types and features to improve clarity and reduce ad-hoc string handling.  
- Replace manual sort normalization and string comparisons with strongly-typed enums to make intent explicit and reduce risk of SQL injection via whitelisted column/direction values.  
- Improve maintenance and readability of sort indicator/toggle logic in the admin UI by centralizing behavior in enums.

### Description

- Added `WorkerSortField` enum (`wwwroot/classes/Admin/WorkerSortField.php`) to represent allowed sort columns and provide a `toSqlColumn()` whitelist.  
- Added `WorkerSortDirection` enum (`wwwroot/classes/Admin/WorkerSortDirection.php`) to represent allowed directions and provide `toSqlKeyword()`, `indicator()` and `toggled()` helpers.  
- Refactored `WorkerPage` (`wwwroot/classes/Admin/WorkerPage.php`) to parse query parameters with `WorkerSortField::fromMixed()` and `WorkerSortDirection::fromMixed()`, to build sort links using enum values, and to emit the normalized `sort`/`direction` values in the `WorkerPageResult`.  
- Refactored `WorkerService::fetchWorkers()` (`wwwroot/classes/Admin/WorkerService.php`) to drive the ORDER BY clause from the enums (`toSqlColumn()` / `toSqlKeyword()`), replacing prior string normalization logic.

### Testing

- Ran a PHP syntax sweep with `rg --files -g '*.php' | xargs -n 1 php -l` and observed no syntax errors.  
- Ran the full test suite with `php tests/run.php` and all tests passed (431 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b807db83c832f997ecfcfe71e6ad0)