### PR TITLE
Use MySQL 8 CTE for merged trophy copy in TrophyMergeService

### DIFF
--- a/tests/TrophyMergeServiceCopyMergedTrophiesTest.php
+++ b/tests/TrophyMergeServiceCopyMergedTrophiesTest.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyMergeProgressListener.ph
 
 final class TrophyMergeServiceCopyMergedTrophiesTest extends TestCase
 {
-    public function testCopyMergedTrophiesBulkCopiesEarnedProgressWithoutCtes(): void
+    public function testCopyMergedTrophiesBulkCopiesEarnedProgressWithCtes(): void
     {
         $pdo = new RecordingPDO(2);
         $service = new TrophyMergeService($pdo);
@@ -28,9 +28,9 @@ final class TrophyMergeServiceCopyMergedTrophiesTest extends TestCase
         $this->assertCount(1, $insertStatements, 'Expected insert statement for merged trophies.');
 
         $this->assertTrue(
-            str_contains($insertStatements[0], 'FROM (')
-                && str_contains($insertStatements[0], ') AS source'),
-            'Insert statement should use a derived table alias for merge source data.'
+            str_contains($insertStatements[0], 'WITH merge_source AS (')
+                && str_contains($insertStatements[0], 'FROM merge_source AS source'),
+            'Insert statement should use a CTE-backed merge source alias.'
         );
 
         $updateStatements = array_values(array_filter(
@@ -41,9 +41,9 @@ final class TrophyMergeServiceCopyMergedTrophiesTest extends TestCase
         $this->assertCount(1, $updateStatements, 'Expected update statement for merged trophies.');
 
         $this->assertTrue(
-            str_contains($updateStatements[0], 'JOIN (')
-                && str_contains($updateStatements[0], ') AS source ON'),
-            'Update statement should join a derived table alias for merge source data.'
+            str_contains($updateStatements[0], 'WITH merge_source AS (')
+                && str_contains($updateStatements[0], 'JOIN merge_source AS source ON'),
+            'Update statement should join the CTE-backed merge source alias.'
         );
 
         $expectedParameters = [':child_np_communication_id' => 'NP_CHILD'];

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -1125,8 +1125,26 @@ SQL
             sprintf('Found %d merged trophies to copy…', $total)
         );
 
+        $mergeSourceCte = <<<'SQL'
+            WITH merge_source AS (
+                SELECT
+                    tm.parent_np_communication_id,
+                    tm.parent_group_id,
+                    tm.parent_order_id,
+                    child.account_id,
+                    child.earned_date,
+                    child.progress,
+                    child.earned
+                FROM trophy_merge AS tm
+                JOIN trophy_earned AS child ON child.np_communication_id = tm.child_np_communication_id
+                    AND child.group_id = tm.child_group_id
+                    AND child.order_id = tm.child_order_id
+                WHERE tm.child_np_communication_id = :child_np_communication_id
+            )
+        SQL;
+
         $insertMissingParentEarned = $this->database->prepare(
-            <<<'SQL'
+            $mergeSourceCte . <<<'SQL'
             INSERT INTO trophy_earned (
                 np_communication_id,
                 group_id,
@@ -1144,21 +1162,7 @@ SQL
                 source.earned_date,
                 source.progress,
                 source.earned
-            FROM (
-                SELECT
-                    tm.parent_np_communication_id,
-                    tm.parent_group_id,
-                    tm.parent_order_id,
-                    child.account_id,
-                    child.earned_date,
-                    child.progress,
-                    child.earned
-                FROM trophy_merge AS tm
-                JOIN trophy_earned AS child ON child.np_communication_id = tm.child_np_communication_id
-                    AND child.group_id = tm.child_group_id
-                    AND child.order_id = tm.child_order_id
-                WHERE tm.child_np_communication_id = :child_np_communication_id
-            ) AS source
+            FROM merge_source AS source
             LEFT JOIN trophy_earned AS parent ON parent.np_communication_id = source.parent_np_communication_id
                 AND parent.group_id = source.parent_group_id
                 AND parent.order_id = source.parent_order_id
@@ -1170,23 +1174,9 @@ SQL
         $insertMissingParentEarned->execute();
 
         $synchronizeExistingEarned = $this->database->prepare(
-            <<<'SQL'
+            $mergeSourceCte . <<<'SQL'
             UPDATE trophy_earned AS parent
-            JOIN (
-                SELECT
-                    tm.parent_np_communication_id,
-                    tm.parent_group_id,
-                    tm.parent_order_id,
-                    child.account_id,
-                    child.earned_date,
-                    child.progress,
-                    child.earned
-                FROM trophy_merge AS tm
-                JOIN trophy_earned AS child ON child.np_communication_id = tm.child_np_communication_id
-                    AND child.group_id = tm.child_group_id
-                    AND child.order_id = tm.child_order_id
-                WHERE tm.child_np_communication_id = :child_np_communication_id
-            ) AS source ON source.parent_np_communication_id = parent.np_communication_id
+            JOIN merge_source AS source ON source.parent_np_communication_id = parent.np_communication_id
                 AND source.parent_group_id = parent.group_id
                 AND source.parent_order_id = parent.order_id
                 AND source.account_id = parent.account_id


### PR DESCRIPTION
### Motivation
- Modernize the merge-copy path to leverage MySQL 8.4 features and reduce duplicated SQL in the trophy merge flow.
- Reduce maintenance risk by centralizing the merge source selection into a single reusable query block.
- Ensure the SQL shape is explicit and testable for the project's current PHP 8.5 / MySQL 8.4 stack.

### Description
- Reworked `TrophyMergeService::copyMergedTrophies()` to define a reusable `WITH merge_source AS (...)` CTE and consume it from both the bulk `INSERT` and the synchronization `UPDATE` statements, replacing duplicated derived-table subqueries.
- Updated the unit test to assert the new CTE-backed SQL shape and renamed the test to reflect the CTE-based implementation (`tests/TrophyMergeServiceCopyMergedTrophiesTest.php`).
- Changes are limited to `wwwroot/classes/TrophyMergeService.php` and the corresponding test file, leaving `psn100.sql` and `wwwroot/database.php` unchanged.

### Testing
- Ran PHP lint on modified files with `php -l wwwroot/classes/TrophyMergeService.php` and `php -l tests/TrophyMergeServiceCopyMergedTrophiesTest.php` which reported no syntax errors.
- Executed the full test suite via `php tests/run.php` and observed all tests passing (431 tests passed).
- The affected unit verifies the new SQL contains the `WITH merge_source` CTE and that the parameter binding and progress events remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b807db83c832f997ecfcfe71e6ad0)