### PR TITLE
Refactor SearchQueryHelper variant deduplication flow

### DIFF
--- a/wwwroot/classes/SearchQueryHelper.php
+++ b/wwwroot/classes/SearchQueryHelper.php
@@ -208,23 +208,30 @@ final class SearchQueryHelper
             return $this->searchVariantsCache[$searchTerm];
         }
 
-        $variants = [$searchTerm];
-        $deduplicated = [$searchTerm => true];
+        $variants = [];
+        $deduplicated = [];
 
-        $romanVariant = $this->replaceDigitsWithRomans($searchTerm);
-        if ($romanVariant !== $searchTerm && !isset($deduplicated[$romanVariant])) {
-            $variants[] = $romanVariant;
-            $deduplicated[$romanVariant] = true;
-        }
-
-        $numericVariant = $this->replaceRomansWithDigits($searchTerm);
-        if ($numericVariant !== $searchTerm && !isset($deduplicated[$numericVariant])) {
-            $variants[] = $numericVariant;
-        }
+        $this->appendVariant($variants, $deduplicated, $searchTerm);
+        $this->appendVariant($variants, $deduplicated, $this->replaceDigitsWithRomans($searchTerm));
+        $this->appendVariant($variants, $deduplicated, $this->replaceRomansWithDigits($searchTerm));
 
         $this->searchVariantsCache[$searchTerm] = $variants;
 
         return $variants;
+    }
+
+    /**
+     * @param list<string> $variants
+     * @param array<string, true> $deduplicated
+     */
+    private function appendVariant(array &$variants, array &$deduplicated, string $variant): void
+    {
+        if (isset($deduplicated[$variant])) {
+            return;
+        }
+
+        $variants[] = $variant;
+        $deduplicated[$variant] = true;
     }
 
     private function replaceDigitsWithRomans(string $value): string


### PR DESCRIPTION
### Motivation
- Simplify and centralize variant deduplication in `SearchQueryHelper::getSearchVariants()` to improve readability and maintainability while aligning with modern PHP 8.5 coding style.

### Description
- Introduced a private helper `appendVariant(array &$variants, array &$deduplicated, string $variant): void` to encapsulate deduplication and consistent insertion of variants.
- Rewrote `getSearchVariants()` to initialize containers consistently and call `appendVariant()` for the original term, the digit→Roman variant, and the Roman→digit variant while preserving existing behavior and ordering.

### Testing
- Verified syntax with `php -l wwwroot/classes/SearchQueryHelper.php` and found no errors.
- Ran the full test suite with `php tests/run.php` and confirmed all 431 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b86e3df74832f8c2e66721ab457cf)