### PR TITLE
Refactor Game player DTOs to final readonly value objects (PHP 8.5)

### DIFF
--- a/wwwroot/classes/Game/GamePlayerProgress.php
+++ b/wwwroot/classes/Game/GamePlayerProgress.php
@@ -2,31 +2,17 @@
 
 declare(strict_types=1);
 
-class GamePlayerProgress
+final readonly class GamePlayerProgress
 {
-    private string $npCommunicationId;
-
-    private string $accountId;
-
-    private int $bronze;
-
-    private int $silver;
-
-    private int $gold;
-
-    private int $platinum;
-
-    private int $progress;
-
-    private function __construct()
-    {
-        $this->npCommunicationId = '';
-        $this->accountId = '';
-        $this->bronze = 0;
-        $this->silver = 0;
-        $this->gold = 0;
-        $this->platinum = 0;
-        $this->progress = 0;
+    public function __construct(
+        private string $npCommunicationId,
+        private string $accountId,
+        private int $bronze,
+        private int $silver,
+        private int $gold,
+        private int $platinum,
+        private int $progress,
+    ) {
     }
 
     /**
@@ -34,16 +20,15 @@ class GamePlayerProgress
      */
     public static function fromArray(array $row): self
     {
-        $player = new self();
-        $player->npCommunicationId = (string) ($row['np_communication_id'] ?? '');
-        $player->accountId = (string) ($row['account_id'] ?? '');
-        $player->bronze = (int) ($row['bronze'] ?? 0);
-        $player->silver = (int) ($row['silver'] ?? 0);
-        $player->gold = (int) ($row['gold'] ?? 0);
-        $player->platinum = (int) ($row['platinum'] ?? 0);
-        $player->progress = (int) ($row['progress'] ?? 0);
-
-        return $player;
+        return new self(
+            npCommunicationId: (string) ($row['np_communication_id'] ?? ''),
+            accountId: (string) ($row['account_id'] ?? ''),
+            bronze: (int) ($row['bronze'] ?? 0),
+            silver: (int) ($row['silver'] ?? 0),
+            gold: (int) ($row['gold'] ?? 0),
+            platinum: (int) ($row['platinum'] ?? 0),
+            progress: (int) ($row['progress'] ?? 0),
+        );
     }
 
     public function getNpCommunicationId(): string

--- a/wwwroot/classes/GameRecentPlayer.php
+++ b/wwwroot/classes/GameRecentPlayer.php
@@ -5,58 +5,22 @@ declare(strict_types=1);
 require_once __DIR__ . '/GamePlayerFilter.php';
 require_once __DIR__ . '/Utility.php';
 
-class GameRecentPlayer
+final readonly class GameRecentPlayer
 {
-    private string $accountId;
-
-    private string $avatarUrl;
-
-    private string $countryCode;
-
-    private string $onlineId;
-
-    private int $trophyCountNpwr;
-
-    private int $trophyCountSony;
-
-    private int $bronzeCount;
-
-    private int $silverCount;
-
-    private int $goldCount;
-
-    private int $platinumCount;
-
-    private int $progress;
-
-    private string $lastKnownDate;
-
-    private function __construct(
-        string $accountId,
-        string $avatarUrl,
-        string $countryCode,
-        string $onlineId,
-        int $trophyCountNpwr,
-        int $trophyCountSony,
-        int $bronzeCount,
-        int $silverCount,
-        int $goldCount,
-        int $platinumCount,
-        int $progress,
-        string $lastKnownDate
+    public function __construct(
+        private string $accountId,
+        private string $avatarUrl,
+        private string $countryCode,
+        private string $onlineId,
+        private int $trophyCountNpwr,
+        private int $trophyCountSony,
+        private int $bronzeCount,
+        private int $silverCount,
+        private int $goldCount,
+        private int $platinumCount,
+        private int $progress,
+        private string $lastKnownDate,
     ) {
-        $this->accountId = $accountId;
-        $this->avatarUrl = $avatarUrl;
-        $this->countryCode = $countryCode;
-        $this->onlineId = $onlineId;
-        $this->trophyCountNpwr = $trophyCountNpwr;
-        $this->trophyCountSony = $trophyCountSony;
-        $this->bronzeCount = $bronzeCount;
-        $this->silverCount = $silverCount;
-        $this->goldCount = $goldCount;
-        $this->platinumCount = $platinumCount;
-        $this->progress = $progress;
-        $this->lastKnownDate = $lastKnownDate;
     }
 
     /**
@@ -65,18 +29,18 @@ class GameRecentPlayer
     public static function fromArray(array $row): self
     {
         return new self(
-            isset($row['account_id']) ? (string) $row['account_id'] : '',
-            (string) ($row['avatar_url'] ?? ''),
-            (string) ($row['country'] ?? ''),
-            (string) ($row['name'] ?? ''),
-            isset($row['trophy_count_npwr']) ? (int) $row['trophy_count_npwr'] : 0,
-            isset($row['trophy_count_sony']) ? (int) $row['trophy_count_sony'] : 0,
-            isset($row['bronze']) ? (int) $row['bronze'] : 0,
-            isset($row['silver']) ? (int) $row['silver'] : 0,
-            isset($row['gold']) ? (int) $row['gold'] : 0,
-            isset($row['platinum']) ? (int) $row['platinum'] : 0,
-            isset($row['progress']) ? (int) $row['progress'] : 0,
-            (string) ($row['last_known_date'] ?? '')
+            accountId: (string) ($row['account_id'] ?? ''),
+            avatarUrl: (string) ($row['avatar_url'] ?? ''),
+            countryCode: (string) ($row['country'] ?? ''),
+            onlineId: (string) ($row['name'] ?? ''),
+            trophyCountNpwr: (int) ($row['trophy_count_npwr'] ?? 0),
+            trophyCountSony: (int) ($row['trophy_count_sony'] ?? 0),
+            bronzeCount: (int) ($row['bronze'] ?? 0),
+            silverCount: (int) ($row['silver'] ?? 0),
+            goldCount: (int) ($row['gold'] ?? 0),
+            platinumCount: (int) ($row['platinum'] ?? 0),
+            progress: (int) ($row['progress'] ?? 0),
+            lastKnownDate: (string) ($row['last_known_date'] ?? ''),
         );
     }
 


### PR DESCRIPTION
### Motivation
- Modernize and simplify player-related DTOs using PHP 8.5 features to reduce mutability and boilerplate while preserving existing behaviour.

### Description
- Convert `GamePlayerProgress` into a `final readonly` class with constructor property promotion and a promoted public constructor.
- Convert `GameRecentPlayer` into a `final readonly` class with constructor property promotion and a promoted public constructor.
- Simplify `fromArray()` hydration for both classes using null-coalescing and named arguments to reduce post-construction mutation while keeping public accessors and behaviour unchanged.
- No changes were made to `psn100.sql` or `wwwroot/database.php`.

### Testing
- Verified syntax with `php -l wwwroot/classes/Game/GamePlayerProgress.php` and `php -l wwwroot/classes/GameRecentPlayer.php` and both returned no syntax errors. 
- Ran the full test suite with `php tests/run.php` and all tests passed (431 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8e34cf28832f9c1cff5b108ce4a6)