### PR TITLE
Refactor leaderboard filters to reuse shared parsing

### DIFF
--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-readonly class GameLeaderboardFilter extends GamePlayerFilter
+final readonly class GameLeaderboardFilter extends GamePlayerFilter
 {
     private int $page;
 
@@ -17,8 +17,9 @@ readonly class GameLeaderboardFilter extends GamePlayerFilter
      */
     public static function fromArray(array $queryParameters): self
     {
-        $country = isset($queryParameters['country']) ? (string) $queryParameters['country'] : null;
-        $avatar = isset($queryParameters['avatar']) ? (string) $queryParameters['avatar'] : null;
+        $baseFilter = parent::fromArray($queryParameters);
+        $country = $baseFilter->getCountry();
+        $avatar = $baseFilter->getAvatar();
 
         $pageValue = $queryParameters['page'] ?? 1;
         $page = is_numeric($pageValue) ? (int) $pageValue : 1;

--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -2,16 +2,13 @@
 
 declare(strict_types=1);
 
-readonly class PlayerLeaderboardFilter
+final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
 {
-    private ?string $country;
-    private ?string $avatar;
     private int $page;
 
     public function __construct(?string $country, ?string $avatar, int $page)
     {
-        $this->country = self::normalizeOptionalString($country);
-        $this->avatar = self::normalizeOptionalString($avatar);
+        parent::__construct($country, $avatar);
         $this->page = max($page, 1);
     }
 
@@ -20,31 +17,12 @@ readonly class PlayerLeaderboardFilter
      */
     public static function fromArray(array $queryParameters): self
     {
-        $country = self::readOptionalString($queryParameters, 'country');
-        $avatar = self::readOptionalString($queryParameters, 'avatar');
+        $baseFilter = parent::fromArray($queryParameters);
+        $country = $baseFilter->getCountry();
+        $avatar = $baseFilter->getAvatar();
         $page = self::normalizePage($queryParameters['page'] ?? null);
 
         return new self($country, $avatar, $page);
-    }
-
-    public function getCountry(): ?string
-    {
-        return $this->country;
-    }
-
-    public function hasCountry(): bool
-    {
-        return $this->country !== null;
-    }
-
-    public function getAvatar(): ?string
-    {
-        return $this->avatar;
-    }
-
-    public function hasAvatar(): bool
-    {
-        return $this->avatar !== null;
     }
 
     public function getPage(): int
@@ -62,17 +40,7 @@ readonly class PlayerLeaderboardFilter
      */
     public function getFilterParameters(): array
     {
-        $parameters = [];
-
-        if ($this->country !== null) {
-            $parameters['country'] = $this->country;
-        }
-
-        if ($this->avatar !== null) {
-            $parameters['avatar'] = $this->avatar;
-        }
-
-        return $parameters;
+        return parent::getFilterParameters();
     }
 
     /**
@@ -92,31 +60,6 @@ readonly class PlayerLeaderboardFilter
         $parameters['page'] = max($page, 1);
 
         return $parameters;
-    }
-
-    /**
-     * @param array<string, mixed> $queryParameters
-     */
-    private static function readOptionalString(array $queryParameters, string $key): ?string
-    {
-        $value = $queryParameters[$key] ?? null;
-
-        if ($value === null || is_array($value)) {
-            return null;
-        }
-
-        return self::normalizeOptionalString((string) $value);
-    }
-
-    private static function normalizeOptionalString(?string $value): ?string
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        $value = trim($value);
-
-        return $value === '' ? null : $value;
     }
 
     private static function normalizePage(mixed $value): int


### PR DESCRIPTION
### Motivation
- Remove duplicated parsing/normalization logic between leaderboard filter classes and align them with the project's PHP 8.5 style.
- Make country/avatar parsing a single responsibility in `GamePlayerFilter` so leaderboard-specific classes only handle paging concerns.

### Description
- Updated `PlayerLeaderboardFilter` to extend `GamePlayerFilter`, delegating country/avatar normalization to the parent and removing duplicated properties and helper methods.
- Simplified `PlayerLeaderboardFilter::getFilterParameters()` to return `parent::getFilterParameters()` and kept page handling in the child.
- Reworked `GameLeaderboardFilter::fromArray()` to reuse `parent::fromArray()` for consistent parsing across leaderboard filters.
- Marked both leaderboard filter classes as `final readonly` to enforce immutability and modern PHP 8.5 style.

### Testing
- Linted modified files with `php -l` for `wwwroot/classes/PlayerLeaderboardFilter.php` and `wwwroot/classes/GameLeaderboardFilter.php`, both passed.
- Ran the full test suite with `php tests/run.php`, all tests passed (431 tests).
- No changes were made to `database/psn100.sql` or `wwwroot/database.php` as requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8e34cf28832f9c1cff5b108ce4a6)