### PR TITLE
Fix missing GamePlayerFilter include in PlayerLeaderboardFilter

### DIFF
--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/GamePlayerFilter.php';
+
 final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
 {
     private int $page;


### PR DESCRIPTION
### Motivation
- Prevent a runtime fatal error where `PlayerLeaderboardFilter` could be loaded before its parent `GamePlayerFilter`, causing a `Class "GamePlayerFilter" not found` exception when rendering leaderboards.

### Description
- Add an explicit `require_once __DIR__ . '/GamePlayerFilter.php';` to the top of `wwwroot/classes/PlayerLeaderboardFilter.php` so the parent class is always available before `PlayerLeaderboardFilter` is declared.

### Testing
- Ran `php -l wwwroot/classes/PlayerLeaderboardFilter.php` to verify syntax and `php tests/run.php` which completed successfully with all 431 tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b9166ad60832fbc0d3e6d4681f870)