### PR TITLE
Refactor TrophyMetaRepository for PHP 8.5 statement reuse

### DIFF
--- a/wwwroot/classes/TrophyMetaRepository.php
+++ b/wwwroot/classes/TrophyMetaRepository.php
@@ -2,74 +2,88 @@
 
 declare(strict_types=1);
 
-class TrophyMetaRepository
+final class TrophyMetaRepository
 {
+    private const SELECT_TROPHY_ID_SQL = <<<'SQL'
+        SELECT id
+        FROM trophy
+        WHERE np_communication_id = :np_communication_id
+          AND group_id = :group_id
+          AND order_id = :order_id
+    SQL;
+
+    private const SQLITE_INSERT_META_SQL = <<<'SQL'
+        INSERT OR IGNORE INTO trophy_meta (
+            trophy_id,
+            rarity_percent,
+            rarity_point,
+            status,
+            owners,
+            rarity_name
+        ) VALUES (
+            :trophy_id,
+            0,
+            0,
+            0,
+            0,
+            'NONE'
+        )
+    SQL;
+
+    private const MYSQL_INSERT_META_SQL = <<<'SQL'
+        INSERT INTO trophy_meta (
+            trophy_id,
+            rarity_percent,
+            rarity_point,
+            status,
+            owners,
+            rarity_name
+        ) VALUES (
+            :trophy_id,
+            0,
+            0,
+            0,
+            0,
+            'NONE'
+        ) AS new_meta
+        ON DUPLICATE KEY UPDATE
+            trophy_id = new_meta.trophy_id
+    SQL;
+
+    private ?PDOStatement $selectTrophyIdStatement = null;
+    private ?PDOStatement $insertMetaStatement = null;
+
     public function __construct(private readonly PDO $database)
     {
     }
 
     public function ensureExists(string $npCommunicationId, string $groupId, int $orderId): void
     {
-        $trophyIdQuery = $this->database->prepare(
-            'SELECT id FROM trophy WHERE np_communication_id = :np_communication_id AND group_id = :group_id AND order_id = :order_id'
-        );
-        $trophyIdQuery->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $trophyIdQuery->bindValue(':group_id', $groupId, PDO::PARAM_STR);
-        $trophyIdQuery->bindValue(':order_id', $orderId, PDO::PARAM_INT);
-        $trophyIdQuery->execute();
+        $selectTrophyId = $this->selectTrophyIdStatement ??= $this->database->prepare(self::SELECT_TROPHY_ID_SQL);
+        $selectTrophyId->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $selectTrophyId->bindValue(':group_id', $groupId, PDO::PARAM_STR);
+        $selectTrophyId->bindValue(':order_id', $orderId, PDO::PARAM_INT);
+        $selectTrophyId->execute();
 
-        $trophyId = $trophyIdQuery->fetchColumn();
+        $trophyId = $selectTrophyId->fetchColumn();
 
         if ($trophyId === false) {
             return;
         }
 
-        $trophyId = (int) $trophyId;
+        $insertMeta = $this->insertMetaStatement ??= $this->database->prepare($this->resolveInsertSql());
+        $insertMeta->bindValue(':trophy_id', (int) $trophyId, PDO::PARAM_INT);
+        $insertMeta->execute();
+    }
 
+    private function resolveInsertSql(): string
+    {
         $driver = $this->database->getAttribute(PDO::ATTR_DRIVER_NAME);
 
-        $insertQuery = match ($driver) {
-            'sqlite' => <<<'SQL'
-                INSERT OR IGNORE INTO trophy_meta (
-                    trophy_id,
-                    rarity_percent,
-                    rarity_point,
-                    status,
-                    owners,
-                    rarity_name
-                ) VALUES (
-                    :trophy_id,
-                    0,
-                    0,
-                    0,
-                    0,
-                    'NONE'
-                )
-            SQL,
-            'mysql' => <<<'SQL'
-                INSERT INTO trophy_meta (
-                    trophy_id,
-                    rarity_percent,
-                    rarity_point,
-                    status,
-                    owners,
-                    rarity_name
-                ) VALUES (
-                    :trophy_id,
-                    0,
-                    0,
-                    0,
-                    0,
-                    'NONE'
-                ) AS new_meta
-                ON DUPLICATE KEY UPDATE
-                    trophy_id = new_meta.trophy_id
-            SQL,
+        return match ($driver) {
+            'sqlite' => self::SQLITE_INSERT_META_SQL,
+            'mysql' => self::MYSQL_INSERT_META_SQL,
             default => throw new RuntimeException("Unsupported PDO driver: {$driver}"),
         };
-
-        $insertMeta = $this->database->prepare($insertQuery);
-        $insertMeta->bindValue(':trophy_id', $trophyId, PDO::PARAM_INT);
-        $insertMeta->execute();
     }
 }


### PR DESCRIPTION
### Motivation
- Modernize the trophy meta repository for PHP 8.5-era idioms and reduce runtime overhead by avoiding repeated `PDO::prepare()` calls in hot paths.
- Improve readability and maintainability by centralizing SQL and keeping driver-specific upsert logic for MySQL and SQLite while preserving existing behavior.
- Keep database schema and configuration files unchanged by not modifying `database/psn100.sql` or `wwwroot/database.php`.

### Description
- Converted `TrophyMetaRepository` into a `final` class and extracted SQL into named class constants for `SELECT`, SQLite insert, and MySQL upsert SQL.
- Added lazy memoization of prepared statements with nullable `PDOStatement` properties and `??=` initialization to reuse `SELECT` and `INSERT` statements across calls.
- Centralized driver resolution into a `resolveInsertSql()` method that uses a `match` expression and throws on unsupported drivers.
- Preserved the original `ensureExists()` semantics while simplifying flow and ensuring `:trophy_id` is bound as an `int` when executing the insert.

### Testing
- Performed a syntax check with `php -l wwwroot/classes/TrophyMetaRepository.php` which reported no errors.
- Executed the full test suite with `php tests/run.php` and observed that all tests passed (`431` tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b93ddbd50832fb363014e835c6e4f)