### PR TITLE
Modernize core PHP models for PHP 8.5 (SearchQueryHelper & GameLeaderboardRow)

### DIFF
--- a/wwwroot/classes/GameLeaderboardRow.php
+++ b/wwwroot/classes/GameLeaderboardRow.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 require_once __DIR__ . '/GamePlayerFilter.php';
 require_once __DIR__ . '/Utility.php';
 
-readonly class GameLeaderboardRow
+final readonly class GameLeaderboardRow
 {
-    private function __construct(
+    public function __construct(
         private string $accountId,
         private string $avatarUrl,
         private string $countryCode,
@@ -19,7 +19,7 @@ readonly class GameLeaderboardRow
         private int $goldCount,
         private int $platinumCount,
         private int $progress,
-        private string $lastKnownDate
+        private string $lastKnownDate,
     ) {
     }
 
@@ -29,28 +29,24 @@ readonly class GameLeaderboardRow
     public static function fromArray(array $row): self
     {
         return new self(
-            isset($row['account_id']) ? (string) $row['account_id'] : '',
-            (string) ($row['avatar_url'] ?? ''),
-            (string) ($row['country'] ?? ''),
-            (string) ($row['name'] ?? ''),
-            isset($row['trophy_count_npwr']) ? (int) $row['trophy_count_npwr'] : 0,
-            isset($row['trophy_count_sony']) ? (int) $row['trophy_count_sony'] : 0,
-            isset($row['bronze']) ? (int) $row['bronze'] : 0,
-            isset($row['silver']) ? (int) $row['silver'] : 0,
-            isset($row['gold']) ? (int) $row['gold'] : 0,
-            isset($row['platinum']) ? (int) $row['platinum'] : 0,
-            isset($row['progress']) ? (int) $row['progress'] : 0,
-            (string) ($row['last_known_date'] ?? '')
+            accountId: (string) ($row['account_id'] ?? ''),
+            avatarUrl: (string) ($row['avatar_url'] ?? ''),
+            countryCode: (string) ($row['country'] ?? ''),
+            onlineId: (string) ($row['name'] ?? ''),
+            trophyCountNpwr: (int) ($row['trophy_count_npwr'] ?? 0),
+            trophyCountSony: (int) ($row['trophy_count_sony'] ?? 0),
+            bronzeCount: (int) ($row['bronze'] ?? 0),
+            silverCount: (int) ($row['silver'] ?? 0),
+            goldCount: (int) ($row['gold'] ?? 0),
+            platinumCount: (int) ($row['platinum'] ?? 0),
+            progress: (int) ($row['progress'] ?? 0),
+            lastKnownDate: (string) ($row['last_known_date'] ?? ''),
         );
     }
 
     public function matchesAccountId(?string $accountId): bool
     {
-        if ($accountId === null || $accountId === '') {
-            return false;
-        }
-
-        return $this->accountId !== '' && $this->accountId === $accountId;
+        return $accountId !== null && $accountId !== '' && $this->accountId !== '' && $this->accountId === $accountId;
     }
 
     public function getAvatarUrl(): string

--- a/wwwroot/classes/SearchQueryHelper.php
+++ b/wwwroot/classes/SearchQueryHelper.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 final class SearchQueryHelper
 {
-    private const ROMAN_MIN = 1;
-    private const ROMAN_MAX = 3999;
-    private const ROMAN_CONVERSION_MAP = [
+    private const int ROMAN_MIN = 1;
+    private const int ROMAN_MAX = 3999;
+    private const array ROMAN_CONVERSION_MAP = [
         'M' => 1000,
         'CM' => 900,
         'D' => 500,
@@ -21,7 +21,7 @@ final class SearchQueryHelper
         'IV' => 4,
         'I' => 1,
     ];
-    private const ROMAN_VALUE_MAP = [
+    private const array ROMAN_VALUE_MAP = [
         'M' => 1000,
         'D' => 500,
         'C' => 100,
@@ -238,9 +238,9 @@ final class SearchQueryHelper
     {
         return (string) preg_replace_callback(
             '/\b\d+\b/u',
-            function (array $matches): string {
+            static function (array $matches): string {
                 $number = (int) $matches[0];
-                $roman = $this->convertIntToRoman($number);
+                $roman = self::convertIntToRoman($number);
 
                 return $roman ?? $matches[0];
             },
@@ -252,15 +252,15 @@ final class SearchQueryHelper
     {
         return (string) preg_replace_callback(
             '/\b[ivxlcdm]+\b/ui',
-            function (array $matches): string {
+            static function (array $matches): string {
                 $roman = strtoupper($matches[0]);
-                $number = $this->convertRomanToInt($roman);
+                $number = self::convertRomanToInt($roman);
 
                 if ($number === null) {
                     return $matches[0];
                 }
 
-                $normalizedRoman = $this->convertIntToRoman($number);
+                $normalizedRoman = self::convertIntToRoman($number);
                 if ($normalizedRoman !== $roman) {
                     return $matches[0];
                 }
@@ -271,7 +271,7 @@ final class SearchQueryHelper
         );
     }
 
-    private function convertIntToRoman(int $number): ?string
+    private static function convertIntToRoman(int $number): ?string
     {
         if ($number < self::ROMAN_MIN || $number > self::ROMAN_MAX) {
             return null;
@@ -288,7 +288,7 @@ final class SearchQueryHelper
         return $result;
     }
 
-    private function convertRomanToInt(string $roman): ?int
+    private static function convertRomanToInt(string $roman): ?int
     {
         if ($roman === '') {
             return null;


### PR DESCRIPTION
### Motivation
- Align core codepaths with PHP 8.5-era idioms and strict typing to improve clarity, static analyzability and runtime performance.
- Reduce accidental object binding and express immutable DTO intent using modern language features.

### Description
- Replace untyped roman-related constants with typed class constants (`private const int` / `private const array`) in `SearchQueryHelper` and mark conversion helpers as `private static` for clearer invariants.
- Convert anonymous callbacks used in `preg_replace_callback` to `static` closures and switch internal calls to `self::`, removing unnecessary `$this` binding.
- Make `GameLeaderboardRow` a `final readonly` DTO with a public constructor and update `fromArray()` to use named arguments and concise null-coalescing casts for consistent, modern hydration.
- Simplify `matchesAccountId()` into a single boolean expression while preserving original behavior.

### Testing
- Ran syntax checks with `php -l wwwroot/classes/SearchQueryHelper.php` and `php -l wwwroot/classes/GameLeaderboardRow.php`, which succeeded.
- Executed the full test suite with `php tests/run.php`, and all tests passed (`All 431 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b93ddbd50832fb363014e835c6e4f)