### PR TITLE
Validate PSN trophy API payload npCommunicationId and add tests

### DIFF
--- a/tests/PsnGameLookupServiceTest.php
+++ b/tests/PsnGameLookupServiceTest.php
@@ -371,6 +371,95 @@ final class PsnGameLookupServiceTest extends TestCase
         }
     }
 
+    public function testFetchTrophyDataForNpCommunicationIdThrowsWhenPayloadContainsConflictingNpCommunicationIds(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $service = new PsnGameLookupService(
+            $this->database,
+            static fn (): array => [$worker],
+            static fn (): object => new GameLookupStubClient()
+        );
+
+        $providedClient = new GameLookupStubClient(
+            profileHandler: static fn (string $path): object => str_ends_with($path, '/all/trophies')
+                ? (object) [
+                    'npCommunicationId' => 'NPWR12345_00',
+                    'trophies' => [
+                        (object) [
+                            'trophyGroupId' => 'all',
+                            'trophyId' => 1,
+                            'npCommunicationId' => 'NPWR99999_00',
+                        ],
+                    ],
+                ]
+                : (object) [
+                    'trophyGroups' => [],
+                ]
+        );
+
+        try {
+            $service->fetchTrophyDataForNpCommunicationId('NPWR12345_00', $providedClient);
+            $this->fail('Expected PsnGameLookupException when payload contains conflicting npCommunicationIds.');
+        } catch (PsnGameLookupException $exception) {
+            $this->assertStringContainsString(
+                'PSN response integrity check failed for endpoint "all/trophies"',
+                $exception->getMessage()
+            );
+            $this->assertStringContainsString('NPWR12345_00', $exception->getMessage());
+            $this->assertStringContainsString('NPWR99999_00', $exception->getMessage());
+        }
+    }
+
+    public function testFetchTrophyDataForNpCommunicationIdThrowsWhenTrophyGroupsContainConflictingNestedIds(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $service = new PsnGameLookupService(
+            $this->database,
+            static fn (): array => [$worker],
+            static fn (): object => new GameLookupStubClient()
+        );
+
+        $providedClient = new GameLookupStubClient(
+            profileHandler: static fn (string $path): object => str_ends_with($path, '/all/trophies')
+                ? (object) [
+                    'trophies' => [
+                        (object) [
+                            'trophyGroupId' => 'all',
+                            'trophyId' => 1,
+                        ],
+                    ],
+                ]
+                : (object) [
+                    'trophyGroups' => [
+                        (object) [
+                            'npCommunicationId' => 'NPWR12345_00',
+                            'trophies' => [
+                                (object) [
+                                    'trophyGroupId' => 'all',
+                                    'trophyId' => 2,
+                                    'trophyIconUrl' => 'https://image.api.playstation.com/trophy/np/NPWR99999_00_HASH/ICON.PNG',
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+        );
+
+        try {
+            $service->fetchTrophyDataForNpCommunicationId('NPWR12345_00', $providedClient);
+            $this->fail('Expected PsnGameLookupException when trophyGroups contains conflicting nested IDs.');
+        } catch (PsnGameLookupException $exception) {
+            $this->assertStringContainsString(
+                'PSN response integrity check failed for endpoint "trophyGroups"',
+                $exception->getMessage()
+            );
+            $this->assertStringContainsString('NPWR12345_00', $exception->getMessage());
+            $this->assertStringContainsString('NPWR99999_00', $exception->getMessage());
+        }
+    }
+
     public function testRequestHandlerReturnsValidationErrorMessage(): void
     {
         $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);

--- a/tests/PsnGameLookupServiceTest.php
+++ b/tests/PsnGameLookupServiceTest.php
@@ -220,6 +220,114 @@ final class PsnGameLookupServiceTest extends TestCase
         $this->assertSame('https://example.com/group-icon.png', $result['trophyGroups'][0]['trophyGroupIconUrl']);
     }
 
+    public function testFetchTrophyDataForNpCommunicationIdAcceptsMatchingPayloadNpCommunicationId(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $service = new PsnGameLookupService(
+            $this->database,
+            static fn (): array => [$worker],
+            static fn (): object => new GameLookupStubClient()
+        );
+
+        $providedClient = new GameLookupStubClient(
+            profileHandler: static fn (string $path): object => str_ends_with($path, '/all/trophies')
+                ? (object) [
+                    'trophies' => [
+                        (object) [
+                            'trophyGroupId' => 'all',
+                            'trophyId' => 1,
+                            'trophyIconUrl' => 'https://image.api.playstation.com/trophy/np/NPWR12345_00_HASH/ICON.PNG',
+                        ],
+                    ],
+                ]
+                : (object) [
+                    'trophyGroups' => [
+                        (object) [
+                            'npCommunicationId' => 'NPWR12345_00',
+                            'trophyGroupId' => 'all',
+                        ],
+                    ],
+                ]
+        );
+
+        $result = $service->fetchTrophyDataForNpCommunicationId(' NPWR12345_00 ', $providedClient);
+
+        $this->assertSame(1, $result['trophyGroups'][0]['trophies'][0]['trophyId']);
+    }
+
+    public function testFetchTrophyDataForNpCommunicationIdThrowsForMismatchedPayloadNpCommunicationId(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $service = new PsnGameLookupService(
+            $this->database,
+            static fn (): array => [$worker],
+            static fn (): object => new GameLookupStubClient()
+        );
+
+        $providedClient = new GameLookupStubClient(
+            profileHandler: static fn (string $path): object => str_ends_with($path, '/all/trophies')
+                ? (object) [
+                    'trophies' => [
+                        (object) [
+                            'trophyGroupId' => 'all',
+                            'trophyIconUrl' => 'https://image.api.playstation.com/trophy/np/NPWR99999_00_HASH/ICON.PNG',
+                        ],
+                    ],
+                ]
+                : (object) [
+                    'trophyGroups' => [],
+                ]
+        );
+
+        try {
+            $service->fetchTrophyDataForNpCommunicationId('NPWR12345_00', $providedClient);
+            $this->fail('Expected PsnGameLookupException to be thrown for mismatched payload ID.');
+        } catch (PsnGameLookupException $exception) {
+            $this->assertStringContainsString(
+                'PSN response integrity check failed for endpoint "all/trophies"',
+                $exception->getMessage()
+            );
+            $this->assertStringContainsString('NPWR12345_00', $exception->getMessage());
+            $this->assertStringContainsString('NPWR99999_00', $exception->getMessage());
+        }
+    }
+
+    public function testFetchTrophyDataForNpCommunicationIdDoesNotFailWhenPayloadHasNoDetectableNpCommunicationId(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $service = new PsnGameLookupService(
+            $this->database,
+            static fn (): array => [$worker],
+            static fn (): object => new GameLookupStubClient()
+        );
+
+        $providedClient = new GameLookupStubClient(
+            profileHandler: static fn (string $path): object => str_ends_with($path, '/all/trophies')
+                ? (object) [
+                    'trophies' => [
+                        (object) [
+                            'trophyGroupId' => 'all',
+                            'trophyId' => 1,
+                        ],
+                    ],
+                ]
+                : (object) [
+                    'trophyGroups' => [
+                        (object) [
+                            'trophyGroupId' => 'all',
+                        ],
+                    ],
+                ]
+        );
+
+        $result = $service->fetchTrophyDataForNpCommunicationId('NPWR12345_00', $providedClient);
+
+        $this->assertSame(1, $result['trophyGroups'][0]['trophies'][0]['trophyId']);
+    }
+
     public function testRequestHandlerReturnsValidationErrorMessage(): void
     {
         $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);

--- a/tests/PsnGameLookupServiceTest.php
+++ b/tests/PsnGameLookupServiceTest.php
@@ -328,6 +328,49 @@ final class PsnGameLookupServiceTest extends TestCase
         $this->assertSame(1, $result['trophyGroups'][0]['trophies'][0]['trophyId']);
     }
 
+    public function testFetchTrophyDataForNpCommunicationIdThrowsForMismatchedTrophyGroupsNpCommunicationId(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $service = new PsnGameLookupService(
+            $this->database,
+            static fn (): array => [$worker],
+            static fn (): object => new GameLookupStubClient()
+        );
+
+        $providedClient = new GameLookupStubClient(
+            profileHandler: static fn (string $path): object => str_ends_with($path, '/all/trophies')
+                ? (object) [
+                    'trophies' => [
+                        (object) [
+                            'trophyGroupId' => 'all',
+                            'trophyId' => 1,
+                        ],
+                    ],
+                ]
+                : (object) [
+                    'trophyGroups' => [
+                        (object) [
+                            'trophyGroupId' => 'all',
+                            'npCommunicationId' => 'NPWR99999_00',
+                        ],
+                    ],
+                ]
+        );
+
+        try {
+            $service->fetchTrophyDataForNpCommunicationId('NPWR12345_00', $providedClient);
+            $this->fail('Expected PsnGameLookupException to be thrown for mismatched trophyGroups payload ID.');
+        } catch (PsnGameLookupException $exception) {
+            $this->assertStringContainsString(
+                'PSN response integrity check failed for endpoint "trophyGroups"',
+                $exception->getMessage()
+            );
+            $this->assertStringContainsString('NPWR12345_00', $exception->getMessage());
+            $this->assertStringContainsString('NPWR99999_00', $exception->getMessage());
+        }
+    }
+
     public function testRequestHandlerReturnsValidationErrorMessage(): void
     {
         $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -88,6 +88,11 @@ final class PsnGameLookupService
                 $preferredNpServiceName
             );
             $normalizedResponse = $this->normalizeResponse($trophyRequestResult['payload']);
+            $this->assertPayloadMatchesRequestedNpCommunicationId(
+                $normalizedNpCommunicationId,
+                $normalizedResponse,
+                'all/trophies'
+            );
 
             $trophyGroupsPath = sprintf(
                 'https://m.np.playstation.com/api/trophy/v1/npCommunicationIds/%s/trophyGroups',
@@ -102,6 +107,11 @@ final class PsnGameLookupService
                     $trophyRequestResult['query']
                 );
                 $normalizedGroupResponse = $this->normalizeResponse($trophyGroupRequestResult['payload']);
+                $this->assertPayloadMatchesRequestedNpCommunicationId(
+                    $normalizedNpCommunicationId,
+                    $normalizedGroupResponse,
+                    'trophyGroups'
+                );
             } catch (Throwable $trophyGroupsException) {
                 if (!$this->shouldRetryWithDifferentServiceName($trophyGroupsException)) {
                     throw $trophyGroupsException;
@@ -126,6 +136,11 @@ final class PsnGameLookupService
                     $fallbackQuery
                 );
                 $normalizedResponse = $this->normalizeResponse($trophyRequestResult['payload']);
+                $this->assertPayloadMatchesRequestedNpCommunicationId(
+                    $normalizedNpCommunicationId,
+                    $normalizedResponse,
+                    'all/trophies'
+                );
 
                 $trophyGroupRequestResult = $this->executeLookupRequest(
                     $client,
@@ -134,8 +149,17 @@ final class PsnGameLookupService
                     $fallbackQuery
                 );
                 $normalizedGroupResponse = $this->normalizeResponse($trophyGroupRequestResult['payload']);
+                $this->assertPayloadMatchesRequestedNpCommunicationId(
+                    $normalizedNpCommunicationId,
+                    $normalizedGroupResponse,
+                    'trophyGroups'
+                );
             }
         } catch (Throwable $exception) {
+            if ($exception instanceof PsnGameLookupException) {
+                throw $exception;
+            }
+
             $statusCode = $this->determineStatusCode($exception);
 
             throw new PsnGameLookupException(
@@ -547,5 +571,83 @@ final class PsnGameLookupService
         }
 
         return [];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function extractNpCommunicationIdFromPayload(array $payload): ?string
+    {
+        $candidate = $this->extractNpCommunicationIdFromArray($payload);
+        if ($candidate !== null) {
+            return $candidate;
+        }
+
+        $trophies = $payload['trophies'] ?? null;
+        if (!is_array($trophies) || $trophies === []) {
+            return null;
+        }
+
+        $firstTrophy = $trophies[0] ?? null;
+        if (!is_array($firstTrophy)) {
+            return null;
+        }
+
+        $candidate = $this->extractNpCommunicationIdFromArray($firstTrophy);
+        if ($candidate !== null) {
+            return $candidate;
+        }
+
+        $trophyIconUrl = $firstTrophy['trophyIconUrl'] ?? null;
+        if (!is_string($trophyIconUrl) || trim($trophyIconUrl) === '') {
+            return null;
+        }
+
+        if (preg_match('/\/(NP[A-Z0-9]{2}[0-9]{5}_[0-9]{2})_/i', $trophyIconUrl, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function extractNpCommunicationIdFromArray(array $payload): ?string
+    {
+        $topLevelCandidateKeys = ['npCommunicationId', 'np_communication_id'];
+        foreach ($topLevelCandidateKeys as $candidateKey) {
+            $candidate = $payload[$candidateKey] ?? null;
+            if (is_string($candidate) && trim($candidate) !== '') {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function assertPayloadMatchesRequestedNpCommunicationId(string $requested, array $payload, string $endpointLabel): void
+    {
+        $detected = $this->extractNpCommunicationIdFromPayload($payload);
+        if ($detected === null) {
+            return;
+        }
+
+        $normalizedRequested = strtoupper(trim($requested));
+        $normalizedDetected = strtoupper(trim($detected));
+
+        if ($normalizedDetected === $normalizedRequested) {
+            return;
+        }
+
+        throw new PsnGameLookupException(sprintf(
+            'PSN response integrity check failed for endpoint "%s": requested npCommunicationId "%s" but received "%s".',
+            $endpointLabel,
+            $normalizedRequested,
+            $normalizedDetected
+        ));
     }
 }

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -583,7 +583,37 @@ final class PsnGameLookupService
             return $candidate;
         }
 
-        $trophies = $payload['trophies'] ?? null;
+        $candidate = $this->extractNpCommunicationIdFromTrophies($payload['trophies'] ?? null);
+        if ($candidate !== null) {
+            return $candidate;
+        }
+
+        $trophyGroups = $payload['trophyGroups'] ?? null;
+        if (!is_array($trophyGroups) || $trophyGroups === []) {
+            return null;
+        }
+
+        foreach ($trophyGroups as $trophyGroup) {
+            if (!is_array($trophyGroup)) {
+                continue;
+            }
+
+            $candidate = $this->extractNpCommunicationIdFromArray($trophyGroup);
+            if ($candidate !== null) {
+                return $candidate;
+            }
+
+            $candidate = $this->extractNpCommunicationIdFromTrophies($trophyGroup['trophies'] ?? null);
+            if ($candidate !== null) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private function extractNpCommunicationIdFromTrophies(mixed $trophies): ?string
+    {
         if (!is_array($trophies) || $trophies === []) {
             return null;
         }

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -576,21 +576,26 @@ final class PsnGameLookupService
     /**
      * @param array<string, mixed> $payload
      */
-    private function extractNpCommunicationIdFromPayload(array $payload): ?string
+    private function extractNpCommunicationIdsFromPayload(array $payload): array
     {
-        $candidate = $this->extractNpCommunicationIdFromArray($payload);
-        if ($candidate !== null) {
-            return $candidate;
-        }
+        $detected = [];
+        $seen = [];
 
-        $candidate = $this->extractNpCommunicationIdFromTrophies($payload['trophies'] ?? null);
-        if ($candidate !== null) {
-            return $candidate;
-        }
+        $this->addNpCommunicationIdCandidates(
+            $this->extractNpCommunicationIdFromArray($payload),
+            $detected,
+            $seen
+        );
+
+        $this->addNpCommunicationIdCandidates(
+            $this->extractNpCommunicationIdFromTrophies($payload['trophies'] ?? null),
+            $detected,
+            $seen
+        );
 
         $trophyGroups = $payload['trophyGroups'] ?? null;
-        if (!is_array($trophyGroups) || $trophyGroups === []) {
-            return null;
+        if (!is_array($trophyGroups)) {
+            return $detected;
         }
 
         foreach ($trophyGroups as $trophyGroup) {
@@ -598,46 +603,85 @@ final class PsnGameLookupService
                 continue;
             }
 
-            $candidate = $this->extractNpCommunicationIdFromArray($trophyGroup);
-            if ($candidate !== null) {
-                return $candidate;
-            }
+            $this->addNpCommunicationIdCandidates(
+                $this->extractNpCommunicationIdFromArray($trophyGroup),
+                $detected,
+                $seen
+            );
 
-            $candidate = $this->extractNpCommunicationIdFromTrophies($trophyGroup['trophies'] ?? null);
-            if ($candidate !== null) {
-                return $candidate;
-            }
+            $this->addNpCommunicationIdCandidates(
+                $this->extractNpCommunicationIdFromTrophies($trophyGroup['trophies'] ?? null),
+                $detected,
+                $seen
+            );
         }
 
-        return null;
+        return $detected;
     }
 
-    private function extractNpCommunicationIdFromTrophies(mixed $trophies): ?string
+    private function extractNpCommunicationIdFromTrophies(mixed $trophies): array
     {
         if (!is_array($trophies) || $trophies === []) {
-            return null;
+            return [];
         }
 
-        $firstTrophy = $trophies[0] ?? null;
-        if (!is_array($firstTrophy)) {
-            return null;
+        $detected = [];
+        $seen = [];
+
+        foreach ($trophies as $trophy) {
+            if (!is_array($trophy)) {
+                continue;
+            }
+
+            $this->addNpCommunicationIdCandidates(
+                $this->extractNpCommunicationIdFromArray($trophy),
+                $detected,
+                $seen
+            );
+
+            $trophyIconUrl = $trophy['trophyIconUrl'] ?? null;
+            if (!is_string($trophyIconUrl) || trim($trophyIconUrl) === '') {
+                continue;
+            }
+
+            if (preg_match('/\/(NP[A-Z0-9]{2}[0-9]{5}_[0-9]{2})_/i', $trophyIconUrl, $matches) !== 1) {
+                continue;
+            }
+
+            $this->addNpCommunicationIdCandidates($matches[1], $detected, $seen);
         }
 
-        $candidate = $this->extractNpCommunicationIdFromArray($firstTrophy);
-        if ($candidate !== null) {
-            return $candidate;
+        return $detected;
+    }
+
+    /**
+     * @param list<string>|string|null $candidates
+     * @param list<string>             $detected
+     * @param array<string, true>      $seen
+     */
+    private function addNpCommunicationIdCandidates(array|string|null $candidates, array &$detected, array &$seen): void
+    {
+        if ($candidates === null) {
+            return;
         }
 
-        $trophyIconUrl = $firstTrophy['trophyIconUrl'] ?? null;
-        if (!is_string($trophyIconUrl) || trim($trophyIconUrl) === '') {
-            return null;
+        if (is_string($candidates)) {
+            $candidates = [$candidates];
         }
 
-        if (preg_match('/\/(NP[A-Z0-9]{2}[0-9]{5}_[0-9]{2})_/i', $trophyIconUrl, $matches) === 1) {
-            return $matches[1];
-        }
+        foreach ($candidates as $candidate) {
+            if (!is_string($candidate) || trim($candidate) === '') {
+                continue;
+            }
 
-        return null;
+            $normalizedCandidate = strtoupper(trim($candidate));
+            if (isset($seen[$normalizedCandidate])) {
+                continue;
+            }
+
+            $detected[] = $normalizedCandidate;
+            $seen[$normalizedCandidate] = true;
+        }
     }
 
     /**
@@ -661,23 +705,23 @@ final class PsnGameLookupService
      */
     private function assertPayloadMatchesRequestedNpCommunicationId(string $requested, array $payload, string $endpointLabel): void
     {
-        $detected = $this->extractNpCommunicationIdFromPayload($payload);
-        if ($detected === null) {
+        $detected = $this->extractNpCommunicationIdsFromPayload($payload);
+        if ($detected === []) {
             return;
         }
 
         $normalizedRequested = strtoupper(trim($requested));
-        $normalizedDetected = strtoupper(trim($detected));
+        foreach ($detected as $normalizedDetected) {
+            if ($normalizedDetected === $normalizedRequested) {
+                continue;
+            }
 
-        if ($normalizedDetected === $normalizedRequested) {
-            return;
+            throw new PsnGameLookupException(sprintf(
+                'PSN response integrity check failed for endpoint "%s": requested npCommunicationId "%s" but received "%s".',
+                $endpointLabel,
+                $normalizedRequested,
+                $normalizedDetected
+            ));
         }
-
-        throw new PsnGameLookupException(sprintf(
-            'PSN response integrity check failed for endpoint "%s": requested npCommunicationId "%s" but received "%s".',
-            $endpointLabel,
-            $normalizedRequested,
-            $normalizedDetected
-        ));
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure responses from the PlayStation trophy API actually correspond to the requested `npCommunicationId` to avoid data integrity issues when the service returns mismatched payloads.
- Allow detection of the `npCommunicationId` from common payload shapes including top-level keys and `trophyIconUrl`, and tolerate cases where no detectable ID is present.

### Description

- Added runtime payload verification by calling `assertPayloadMatchesRequestedNpCommunicationId` after fetching the `all/trophies` and `trophyGroups` endpoints to validate the response matches the requested ID.
- Implemented `extractNpCommunicationIdFromPayload`, `extractNpCommunicationIdFromArray`, and `assertPayloadMatchesRequestedNpCommunicationId` to detect IDs from top-level fields or via a regex from `trophyIconUrl`, and to throw `PsnGameLookupException` when a mismatch is found.
- Preserve existing error semantics by rethrowing `PsnGameLookupException` instances unchanged instead of wrapping them, and keep previous fallback/query retry flows intact.
- Added unit tests in `tests/PsnGameLookupServiceTest.php` to cover matching payloads (including trimmed input), mismatched payloads (asserting exception messages), and payloads lacking a detectable `npCommunicationId`.

### Testing

- Added tests: `testFetchTrophyDataForNpCommunicationIdAcceptsMatchingPayloadNpCommunicationId`, `testFetchTrophyDataForNpCommunicationIdThrowsForMismatchedPayloadNpCommunicationId`, and `testFetchTrophyDataForNpCommunicationIdDoesNotFailWhenPayloadHasNoDetectableNpCommunicationId` in `PsnGameLookupServiceTest.php`.
- Ran the unit test suite for the service with `phpunit --filter PsnGameLookupServiceTest` and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1e0221f90832faf29d50abe85ee29)