### PR TITLE
Add PlayStation contract interfaces and factory-based client wiring

### DIFF
--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -9,8 +9,11 @@ require_once __DIR__ . '/../ImageHashCalculator.php';
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../TrophyMetaRepository.php';
 require_once __DIR__ . '/PsnGameLookupService.php';
-
-use Tustin\PlayStation\Client;
+require_once __DIR__ . '/../PlayStation/Contracts/PlayStationApiClientInterface.php';
+require_once __DIR__ . '/../PlayStation/Contracts/PlayStationClientFactoryInterface.php';
+require_once __DIR__ . '/../PlayStation/Contracts/ProfileClientInterface.php';
+require_once __DIR__ . '/../PlayStation/Contracts/TrophyClientInterface.php';
+require_once __DIR__ . '/../PlayStation/PlayStationClientFactory.php';
 
 class GameRescanService
 {
@@ -30,6 +33,7 @@ class GameRescanService
 
     private ImageHashCalculator $imageHashCalculator;
     private PsnGameLookupService $psnGameLookupService;
+    private PlayStationClientFactoryInterface $playStationClientFactory;
 
     /**
      * @var \Closure(string):void|null
@@ -41,7 +45,8 @@ class GameRescanService
         TrophyCalculator $trophyCalculator,
         ?TrophyHistoryRecorder $historyRecorder = null,
         ?ImageHashCalculator $imageHashCalculator = null,
-        ?PsnGameLookupService $psnGameLookupService = null
+        ?PsnGameLookupService $psnGameLookupService = null,
+        ?PlayStationClientFactoryInterface $playStationClientFactory = null
     )
     {
         $this->database = $database;
@@ -49,7 +54,11 @@ class GameRescanService
         $this->historyRecorder = $historyRecorder ?? new TrophyHistoryRecorder($database);
         $this->trophyMetaRepository = new TrophyMetaRepository($database);
         $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
-        $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase($database);
+        $this->playStationClientFactory = $playStationClientFactory ?? new PlayStationClientFactory();
+        $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase(
+            $database,
+            $this->playStationClientFactory
+        );
     }
 
     /**
@@ -152,12 +161,12 @@ class GameRescanService
         return str_starts_with($npCommunicationId, self::ORIGINAL_GAME_PREFIX);
     }
 
-    private function loginToWorker(): Client
+    private function loginToWorker(): PlayStationApiClientInterface
     {
         while (true) {
             foreach ($this->fetchWorkers() as $worker) {
                 try {
-                    $client = new Client();
+                    $client = $this->playStationClientFactory->createClient();
                     $client->loginWithNpsso($worker['npsso']);
 
                     return $client;
@@ -193,7 +202,7 @@ class GameRescanService
         $query->execute();
     }
 
-    private function findAccessibleUserWithGame(Client $client, string $npCommunicationId): ?object
+    private function findAccessibleUserWithGame(ProfileClientInterface $client, string $npCommunicationId): ?object
     {
         $query = $this->database->prepare(
             'SELECT account_id
@@ -206,7 +215,7 @@ class GameRescanService
         $query->execute();
 
         while (($accountId = $query->fetchColumn()) !== false) {
-            $user = $client->users()->find((string) $accountId);
+            $user = $client->findUserByAccountId((string) $accountId);
 
             try {
                 $user->trophySummary()->level();
@@ -332,7 +341,7 @@ class GameRescanService
     }
 
     private function updateTrophyTitle(
-        Client $client,
+        TrophyClientInterface $client,
         object $trophyTitle,
         string $npCommunicationId,
         ?GameRescanProgressListener $progressListener,
@@ -596,7 +605,7 @@ class GameRescanService
     /**
      * @return array<int, array{group: object, trophies: array<int, object>}>
      */
-    private function fetchGameLookupGroupData(Client $client, string $npCommunicationId): array
+    private function fetchGameLookupGroupData(TrophyClientInterface $client, string $npCommunicationId): array
     {
         $trophyData = $this->psnGameLookupService->fetchTrophyDataForNpCommunicationId($npCommunicationId, $client);
         $rawGroups = $trophyData['trophyGroups'] ?? [];

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 require_once __DIR__ . '/WorkerService.php';
 require_once __DIR__ . '/Worker.php';
 require_once __DIR__ . '/PsnGameLookupException.php';
-
-use Tustin\PlayStation\Client;
+require_once __DIR__ . '/../PlayStation/Contracts/PlayStationApiClientInterface.php';
+require_once __DIR__ . '/../PlayStation/Contracts/PlayStationClientFactoryInterface.php';
+require_once __DIR__ . '/../PlayStation/Contracts/TrophyClientInterface.php';
+require_once __DIR__ . '/../PlayStation/PlayStationClientFactory.php';
 
 final class PsnGameLookupService
 {
@@ -15,27 +17,127 @@ final class PsnGameLookupService
      */
     private readonly \Closure $workerFetcher;
 
-    /**
-     * @var \Closure(): object
-     */
-    private readonly \Closure $clientFactory;
+    private readonly PlayStationClientFactoryInterface $playStationClientFactory;
 
     public function __construct(
         private readonly PDO $database,
         callable $workerFetcher,
-        ?callable $clientFactory = null
+        PlayStationClientFactoryInterface|callable|null $playStationClientFactory = null
     ) {
         $this->workerFetcher = \Closure::fromCallable($workerFetcher);
-        $this->clientFactory = \Closure::fromCallable(
-            $clientFactory ?? static fn (): object => new Client()
+        $this->playStationClientFactory = $this->normalizePlayStationClientFactory($playStationClientFactory);
+    }
+
+    public static function fromDatabase(
+        PDO $database,
+        PlayStationClientFactoryInterface|callable|null $playStationClientFactory = null
+    ): self {
+        $workerService = new WorkerService($database);
+
+        return new self(
+            $database,
+            static fn (): array => $workerService->fetchWorkers(),
+            $playStationClientFactory
         );
     }
 
-    public static function fromDatabase(PDO $database): self
-    {
-        $workerService = new WorkerService($database);
+    private function normalizePlayStationClientFactory(
+        PlayStationClientFactoryInterface|callable|null $playStationClientFactory
+    ): PlayStationClientFactoryInterface {
+        if ($playStationClientFactory instanceof PlayStationClientFactoryInterface) {
+            return $playStationClientFactory;
+        }
 
-        return new self($database, static fn (): array => $workerService->fetchWorkers());
+        if (is_callable($playStationClientFactory)) {
+            $legacyClientFactory = \Closure::fromCallable($playStationClientFactory);
+
+            return new class ($legacyClientFactory) implements PlayStationClientFactoryInterface {
+                /**
+                 * @var \Closure(): PlayStationApiClientInterface
+                 */
+                private readonly \Closure $legacyClientFactory;
+
+                /**
+                 * @param \Closure(): PlayStationApiClientInterface $legacyClientFactory
+                 */
+                public function __construct(\Closure $legacyClientFactory)
+                {
+                    $this->legacyClientFactory = $legacyClientFactory;
+                }
+
+                public function createClient(): PlayStationApiClientInterface
+                {
+                    $client = ($this->legacyClientFactory)();
+
+                    if ($client instanceof PlayStationApiClientInterface) {
+                        return $client;
+                    }
+
+                    if (!is_object($client)) {
+                        throw new RuntimeException('Invalid PlayStation client.');
+                    }
+
+                    return new class ($client) implements PlayStationApiClientInterface {
+                        public function __construct(private readonly object $client)
+                        {
+                        }
+
+                        public function loginWithNpsso(string $npsso): void
+                        {
+                            if (!method_exists($this->client, 'loginWithNpsso')) {
+                                throw new RuntimeException('The PlayStation client does not support NPSSO authentication.');
+                            }
+
+                            $this->client->loginWithNpsso($npsso);
+                        }
+
+                        public function acquireAccessToken(): ?string
+                        {
+                            return null;
+                        }
+
+                        public function refreshAccessToken(): void
+                        {
+                            throw new RuntimeException('The PlayStation client does not support token refresh.');
+                        }
+
+                        public function lookupProfileByOnlineId(string $onlineId): mixed
+                        {
+                            throw new RuntimeException('The PlayStation client does not support profile requests.');
+                        }
+
+                        public function findUserByAccountId(string $accountId): object
+                        {
+                            if (!method_exists($this->client, 'users')) {
+                                throw new RuntimeException('The PlayStation client does not support profile requests.');
+                            }
+
+                            return $this->client->users()->find($accountId);
+                        }
+
+                        public function requestTrophyEndpoint(string $path, array $query = [], array $headers = []): mixed
+                        {
+                            if (!method_exists($this->client, 'get')) {
+                                throw new RuntimeException('The PlayStation client does not support trophy requests.');
+                            }
+
+                            return $this->client->get($path, $query, $headers);
+                        }
+
+                        public function searchUsers(string $onlineId): iterable
+                        {
+                            if (!method_exists($this->client, 'users')) {
+                                return [];
+                            }
+
+                            return $this->client->users()->search($onlineId);
+                        }
+                    };
+                }
+            };
+        }
+
+        return new PlayStationClientFactory();
     }
 
     /**
@@ -68,14 +170,18 @@ final class PsnGameLookupService
     /**
      * @return array<string, mixed>
      */
-    public function fetchTrophyDataForNpCommunicationId(string $npCommunicationId, ?object $authenticatedClient = null): array
-    {
+    public function fetchTrophyDataForNpCommunicationId(
+        string $npCommunicationId,
+        ?object $authenticatedClient = null
+    ): array {
         $normalizedNpCommunicationId = trim($npCommunicationId);
         if ($normalizedNpCommunicationId === '') {
             throw new InvalidArgumentException('NP communication ID must be provided.');
         }
 
-        $client = $authenticatedClient ?? $this->createAuthenticatedClient();
+        $client = $authenticatedClient === null
+            ? $this->createAuthenticatedClient()
+            : $this->normalizeTrophyClient($authenticatedClient);
         $preferredNpServiceName = $this->resolvePreferredNpServiceName($normalizedNpCommunicationId);
 
         try {
@@ -320,10 +426,8 @@ final class PsnGameLookupService
         ];
     }
 
-    private function createAuthenticatedClient(): object
+    private function createAuthenticatedClient(): PlayStationApiClientInterface
     {
-        $factory = $this->clientFactory;
-
         foreach (($this->workerFetcher)() as $worker) {
             if (!$worker instanceof Worker) {
                 continue;
@@ -336,12 +440,7 @@ final class PsnGameLookupService
             }
 
             try {
-                $client = $factory();
-
-                if (!method_exists($client, 'loginWithNpsso')) {
-                    throw new RuntimeException('The PlayStation client does not support NPSSO authentication.');
-                }
-
+                $client = $this->playStationClientFactory->createClient();
                 $client->loginWithNpsso($npsso);
 
                 return $client;
@@ -353,21 +452,39 @@ final class PsnGameLookupService
         throw new RuntimeException('Unable to login to any worker accounts.');
     }
 
+    private function normalizeTrophyClient(object $client): TrophyClientInterface
+    {
+        if ($client instanceof TrophyClientInterface) {
+            return $client;
+        }
+
+        return new class ($client) implements TrophyClientInterface {
+            public function __construct(private readonly object $client)
+            {
+            }
+
+            public function requestTrophyEndpoint(string $path, array $query = [], array $headers = []): mixed
+            {
+                if (!method_exists($this->client, 'get')) {
+                    throw new RuntimeException('The PlayStation client does not support trophy requests.');
+                }
+
+                return $this->client->get($path, $query, $headers);
+            }
+        };
+    }
+
     /**
      * @param array{npLanguage: string, npServiceName?: string}|null $pinnedQuery
      * @return array{payload: mixed, query: array{npLanguage: string, npServiceName?: string}}
      */
     private function executeLookupRequest(
-        object $client,
+        TrophyClientInterface $client,
         string $path,
         ?string $preferredNpServiceName = null,
         ?array $pinnedQuery = null
     ): array
     {
-        if (!method_exists($client, 'get')) {
-            throw new RuntimeException('The PlayStation client does not support trophy requests.');
-        }
-
         $queryVariants = $pinnedQuery === null
             ? $this->buildLookupQueryVariants($preferredNpServiceName)
             : [$pinnedQuery];
@@ -377,7 +494,7 @@ final class PsnGameLookupService
         foreach ($queryVariants as $query) {
             try {
                 return [
-                    'payload' => $client->get($path, $query, ['content-type' => 'application/json']),
+                    'payload' => $client->requestTrophyEndpoint($path, $query, ['content-type' => 'application/json']),
                     'query' => $query,
                 ];
             } catch (Throwable $exception) {

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 require_once __DIR__ . '/WorkerService.php';
 require_once __DIR__ . '/Worker.php';
 require_once __DIR__ . '/PsnPlayerLookupException.php';
-
-use Tustin\PlayStation\Client;
+require_once __DIR__ . '/../PlayStation/Contracts/PlayStationClientFactoryInterface.php';
+require_once __DIR__ . '/../PlayStation/Contracts/PlayStationApiClientInterface.php';
+require_once __DIR__ . '/../PlayStation/Contracts/ProfileClientInterface.php';
+require_once __DIR__ . '/../PlayStation/PlayStationClientFactory.php';
 
 final class PsnPlayerLookupService
 {
@@ -15,30 +17,141 @@ final class PsnPlayerLookupService
      */
     private readonly \Closure $workerFetcher;
 
-    /**
-     * @var \Closure(): object
-     */
-    private readonly \Closure $clientFactory;
+    private readonly PlayStationClientFactoryInterface $playStationClientFactory;
 
     /**
      * @param callable(): iterable<Worker> $workerFetcher
-     * @param callable(): object|null $clientFactory
      */
-    public function __construct(callable $workerFetcher, ?callable $clientFactory = null)
-    {
+    public function __construct(
+        callable $workerFetcher,
+        PlayStationClientFactoryInterface|callable|null $playStationClientFactory = null
+    ) {
         $this->workerFetcher = \Closure::fromCallable($workerFetcher);
-        $this->clientFactory = \Closure::fromCallable(
-            $clientFactory ?? static function (): object {
-                return new Client();
-            }
+        $this->playStationClientFactory = $this->normalizePlayStationClientFactory($playStationClientFactory);
+    }
+
+    public static function fromDatabase(
+        PDO $database,
+        PlayStationClientFactoryInterface|callable|null $playStationClientFactory = null
+    ): self {
+        $workerService = new WorkerService($database);
+
+        return new self(
+            static fn (): array => $workerService->fetchWorkers(),
+            $playStationClientFactory
         );
     }
 
-    public static function fromDatabase(PDO $database): self
-    {
-        $workerService = new WorkerService($database);
+    private function normalizePlayStationClientFactory(
+        PlayStationClientFactoryInterface|callable|null $playStationClientFactory
+    ): PlayStationClientFactoryInterface {
+        if ($playStationClientFactory instanceof PlayStationClientFactoryInterface) {
+            return $playStationClientFactory;
+        }
 
-        return new self(static fn (): array => $workerService->fetchWorkers());
+        if (is_callable($playStationClientFactory)) {
+            $legacyClientFactory = \Closure::fromCallable($playStationClientFactory);
+
+            return new class ($legacyClientFactory) implements PlayStationClientFactoryInterface {
+                /**
+                 * @var \Closure(): PlayStationApiClientInterface
+                 */
+                private readonly \Closure $legacyClientFactory;
+
+                /**
+                 * @param \Closure(): PlayStationApiClientInterface $legacyClientFactory
+                 */
+                public function __construct(\Closure $legacyClientFactory)
+                {
+                    $this->legacyClientFactory = $legacyClientFactory;
+                }
+
+                public function createClient(): PlayStationApiClientInterface
+                {
+                    $client = ($this->legacyClientFactory)();
+
+                    if ($client instanceof PlayStationApiClientInterface) {
+                        return $client;
+                    }
+
+                    if (!is_object($client)) {
+                        throw new RuntimeException('Invalid PlayStation client.');
+                    }
+
+                    return new class ($client) implements PlayStationApiClientInterface {
+                        public function __construct(private readonly object $client)
+                        {
+                        }
+
+                        public function loginWithNpsso(string $npsso): void
+                        {
+                            if (!method_exists($this->client, 'loginWithNpsso')) {
+                                throw new RuntimeException('The PlayStation client does not support NPSSO authentication.');
+                            }
+
+                            $this->client->loginWithNpsso($npsso);
+                        }
+
+                        public function acquireAccessToken(): ?string
+                        {
+                            return null;
+                        }
+
+                        public function refreshAccessToken(): void
+                        {
+                            throw new RuntimeException('The PlayStation client does not support token refresh.');
+                        }
+
+                        public function lookupProfileByOnlineId(string $onlineId): mixed
+                        {
+                            if (!method_exists($this->client, 'get')) {
+                                throw new RuntimeException('The PlayStation client does not support profile requests.');
+                            }
+
+                            $path = sprintf(
+                                'https://us-prof.np.community.playstation.net/userProfile/v1/users/%s/profile2',
+                                rawurlencode($onlineId)
+                            );
+
+                            return $this->client->get(
+                                $path,
+                                ['fields' => 'accountId,onlineId,currentOnlineId,npId'],
+                                ['content-type' => 'application/json']
+                            );
+                        }
+
+                        public function findUserByAccountId(string $accountId): object
+                        {
+                            if (!method_exists($this->client, 'users')) {
+                                throw new RuntimeException('The PlayStation client does not support profile requests.');
+                            }
+
+                            return $this->client->users()->find($accountId);
+                        }
+
+                        public function requestTrophyEndpoint(string $path, array $query = [], array $headers = []): mixed
+                        {
+                            if (!method_exists($this->client, 'get')) {
+                                throw new RuntimeException('The PlayStation client does not support trophy requests.');
+                            }
+
+                            return $this->client->get($path, $query, $headers);
+                        }
+
+                        public function searchUsers(string $onlineId): iterable
+                        {
+                            if (!method_exists($this->client, 'users')) {
+                                return [];
+                            }
+
+                            return $this->client->users()->search($onlineId);
+                        }
+                    };
+                }
+            };
+        }
+
+        return new PlayStationClientFactory();
     }
 
     /**
@@ -77,9 +190,8 @@ final class PsnPlayerLookupService
         return $this->normalizeProfileResponse($profile);
     }
 
-    private function createAuthenticatedClient(): object
+    private function createAuthenticatedClient(): PlayStationApiClientInterface
     {
-        $factory = $this->clientFactory;
 
         foreach (($this->workerFetcher)() as $worker) {
             if (!$worker instanceof Worker) {
@@ -93,16 +205,7 @@ final class PsnPlayerLookupService
             }
 
             try {
-                $client = $factory();
-
-                if (!is_object($client)) {
-                    throw new RuntimeException('Invalid PlayStation client.');
-                }
-
-                if (!method_exists($client, 'loginWithNpsso')) {
-                    throw new RuntimeException('The PlayStation client does not support NPSSO authentication.');
-                }
-
+                $client = $this->playStationClientFactory->createClient();
                 $client->loginWithNpsso($npsso);
 
                 return $client;
@@ -114,22 +217,9 @@ final class PsnPlayerLookupService
         throw new RuntimeException('Unable to login to any worker accounts.');
     }
 
-    private function executeUserProfileRequest(object $client, string $onlineId): mixed
+    private function executeUserProfileRequest(ProfileClientInterface $client, string $onlineId): mixed
     {
-        if (!method_exists($client, 'get')) {
-            throw new RuntimeException('The PlayStation client does not support profile requests.');
-        }
-
-        $path = sprintf(
-            'https://us-prof.np.community.playstation.net/userProfile/v1/users/%s/profile2',
-            rawurlencode($onlineId)
-        );
-
-        $query = [
-            'fields' => 'accountId,onlineId,currentOnlineId,npId',
-        ];
-
-        return $client->get($path, $query, ['content-type' => 'application/json']);
+        return $client->lookupProfileByOnlineId($onlineId);
     }
 
     private function determineStatusCode(Throwable $exception): ?int

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -10,10 +10,14 @@ require_once __DIR__ . '/../Psn100Logger.php';
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../TrophyMergeService.php';
 require_once __DIR__ . '/../TrophyMetaRepository.php';
+require_once __DIR__ . '/../PlayStation/Contracts/PlayStationClientFactoryInterface.php';
+require_once __DIR__ . '/../PlayStation/Contracts/PlayStationApiClientInterface.php';
+require_once __DIR__ . '/../PlayStation/Contracts/ProfileClientInterface.php';
+require_once __DIR__ . '/../PlayStation/Contracts/UserSearchClientInterface.php';
+require_once __DIR__ . '/../PlayStation/PlayStationClientFactory.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\Haste\Exception\UnauthorizedHttpException;
-use Tustin\PlayStation\Client;
 
 final class ThirtyMinuteCronJob implements CronJobInterface
 {
@@ -28,6 +32,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
 
     private readonly ImageHashCalculator $imageHashCalculator;
     private readonly PsnGameLookupService $psnGameLookupService;
+    private readonly PlayStationClientFactoryInterface $playStationClientFactory;
 
     public function __construct(
         private readonly PDO $database,
@@ -38,14 +43,19 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         ?TrophyMetaRepository $trophyMetaRepository = null,
         ?AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService = null,
         ?ImageHashCalculator $imageHashCalculator = null,
-        ?PsnGameLookupService $psnGameLookupService = null
+        ?PsnGameLookupService $psnGameLookupService = null,
+        ?PlayStationClientFactoryInterface $playStationClientFactory = null
     )
     {
         $this->trophyMetaRepository = $trophyMetaRepository ?? new TrophyMetaRepository($database);
         $this->automaticTrophyTitleMergeService = $automaticTrophyTitleMergeService
             ?? new AutomaticTrophyTitleMergeService($database, new TrophyMergeService($database));
         $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
-        $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase($database);
+        $this->playStationClientFactory = $playStationClientFactory ?? new PlayStationClientFactory();
+        $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase(
+            $database,
+            $this->playStationClientFactory
+        );
     }
 
     private function setWaitingScanProgress(int $workerId, string $message): void
@@ -324,7 +334,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                 }
 
                 try {
-                    $client = new Client();
+                    $client = $this->playStationClientFactory->createClient();
                     $npsso = $worker["npsso"];
                     $client->loginWithNpsso($npsso);
 
@@ -512,7 +522,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                         }
 
                         $player['account_id'] = $profileAccountId;
-                        $user = $client->users()->find($profileAccountId);
+                        $user = $client->findUserByAccountId($profileAccountId);
 
                         $countryFromProfile = $this->extractCountryFromNpId($profile['npId'] ?? null);
                         $country = $countryFromProfile;
@@ -544,7 +554,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                         }
 
                         $player['account_id'] = $existingAccountId;
-                        $user = $client->users()->find($existingAccountId);
+                        $user = $client->findUserByAccountId($existingAccountId);
 
                         $resolvedOnlineId = (string) $user->onlineId();
 
@@ -2033,19 +2043,10 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             || (($exception->errorInfo[1] ?? null) === 1213);
     }
 
-    private function lookupPlayerProfile(Client $client, string $onlineId): ?array
+    private function lookupPlayerProfile(ProfileClientInterface $client, string $onlineId): ?array
     {
-        $path = sprintf(
-            'https://us-prof.np.community.playstation.net/userProfile/v1/users/%s/profile2',
-            rawurlencode($onlineId)
-        );
-
-        $query = [
-            'fields' => 'accountId,onlineId,currentOnlineId,npId',
-        ];
-
         try {
-            $profile = $client->get($path, $query, ['content-type' => 'application/json']);
+            $profile = $client->lookupProfileByOnlineId($onlineId);
         } catch (Throwable $exception) {
             if ($this->determineStatusCode($exception) === 404) {
                 return null;
@@ -2284,13 +2285,13 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         return [];
     }
 
-    private function findPlayerCountry(Client $client, string $onlineId): ?string
+    private function findPlayerCountry(UserSearchClientInterface $client, string $onlineId): ?string
     {
         $normalizedOnlineId = strtolower($onlineId);
         $userCounter = 0;
 
         try {
-            foreach ($client->users()->search($onlineId) as $result) {
+            foreach ($client->searchUsers($onlineId) as $result) {
                 if (strtolower($result->onlineId()) === $normalizedOnlineId) {
                     $country = $result->country();
 

--- a/wwwroot/classes/PlayStation/Contracts/AuthClientInterface.php
+++ b/wwwroot/classes/PlayStation/Contracts/AuthClientInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+interface AuthClientInterface
+{
+    public function loginWithNpsso(string $npsso): void;
+
+    public function acquireAccessToken(): ?string;
+
+    public function refreshAccessToken(): void;
+}

--- a/wwwroot/classes/PlayStation/Contracts/PlayStationApiClientInterface.php
+++ b/wwwroot/classes/PlayStation/Contracts/PlayStationApiClientInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/AuthClientInterface.php';
+require_once __DIR__ . '/ProfileClientInterface.php';
+require_once __DIR__ . '/TrophyClientInterface.php';
+require_once __DIR__ . '/UserSearchClientInterface.php';
+
+interface PlayStationApiClientInterface extends AuthClientInterface, ProfileClientInterface, TrophyClientInterface, UserSearchClientInterface
+{
+}

--- a/wwwroot/classes/PlayStation/Contracts/PlayStationClientFactoryInterface.php
+++ b/wwwroot/classes/PlayStation/Contracts/PlayStationClientFactoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayStationApiClientInterface.php';
+
+interface PlayStationClientFactoryInterface
+{
+    public function createClient(): PlayStationApiClientInterface;
+}

--- a/wwwroot/classes/PlayStation/Contracts/ProfileClientInterface.php
+++ b/wwwroot/classes/PlayStation/Contracts/ProfileClientInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+interface ProfileClientInterface
+{
+    public function lookupProfileByOnlineId(string $onlineId): mixed;
+
+    public function findUserByAccountId(string $accountId): object;
+}

--- a/wwwroot/classes/PlayStation/Contracts/TrophyClientInterface.php
+++ b/wwwroot/classes/PlayStation/Contracts/TrophyClientInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+interface TrophyClientInterface
+{
+    /**
+     * @param array<string, string> $query
+     * @param array<string, string> $headers
+     */
+    public function requestTrophyEndpoint(string $path, array $query = [], array $headers = []): mixed;
+}

--- a/wwwroot/classes/PlayStation/Contracts/UserSearchClientInterface.php
+++ b/wwwroot/classes/PlayStation/Contracts/UserSearchClientInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+interface UserSearchClientInterface
+{
+    /**
+     * @return iterable<object>
+     */
+    public function searchUsers(string $onlineId): iterable;
+}

--- a/wwwroot/classes/PlayStation/PlayStationClientFactory.php
+++ b/wwwroot/classes/PlayStation/PlayStationClientFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Contracts/PlayStationClientFactoryInterface.php';
+require_once __DIR__ . '/TustinPlayStationApiClient.php';
+
+final class PlayStationClientFactory implements PlayStationClientFactoryInterface
+{
+    public function createClient(): PlayStationApiClientInterface
+    {
+        return new TustinPlayStationApiClient();
+    }
+}

--- a/wwwroot/classes/PlayStation/TustinPlayStationApiClient.php
+++ b/wwwroot/classes/PlayStation/TustinPlayStationApiClient.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Contracts/PlayStationApiClientInterface.php';
+
+use Tustin\PlayStation\Client;
+
+final class TustinPlayStationApiClient implements PlayStationApiClientInterface
+{
+    private readonly Client $client;
+
+    public function __construct(?Client $client = null)
+    {
+        $this->client = $client ?? new Client();
+    }
+
+    public function loginWithNpsso(string $npsso): void
+    {
+        $this->client->loginWithNpsso($npsso);
+    }
+
+    public function acquireAccessToken(): ?string
+    {
+        if (method_exists($this->client, 'accessToken')) {
+            $token = $this->client->accessToken();
+
+            return is_string($token) && $token !== '' ? $token : null;
+        }
+
+        return null;
+    }
+
+    public function refreshAccessToken(): void
+    {
+        if (method_exists($this->client, 'refreshToken')) {
+            $this->client->refreshToken();
+
+            return;
+        }
+
+        throw new RuntimeException('The PlayStation client does not support token refresh.');
+    }
+
+    public function lookupProfileByOnlineId(string $onlineId): mixed
+    {
+        $path = sprintf(
+            'https://us-prof.np.community.playstation.net/userProfile/v1/users/%s/profile2',
+            rawurlencode($onlineId)
+        );
+
+        return $this->client->get(
+            $path,
+            ['fields' => 'accountId,onlineId,currentOnlineId,npId'],
+            ['content-type' => 'application/json']
+        );
+    }
+
+    public function findUserByAccountId(string $accountId): object
+    {
+        return $this->client->users()->find($accountId);
+    }
+
+    public function requestTrophyEndpoint(string $path, array $query = [], array $headers = []): mixed
+    {
+        return $this->client->get($path, $query, $headers);
+    }
+
+    public function searchUsers(string $onlineId): iterable
+    {
+        return $this->client->users()->search($onlineId);
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce contract-first interfaces to decouple PSN client usage from the concrete `Tustin\PlayStation\Client` and restrict surface area to PSN100 needs (auth, profile, trophy, user search).
- Provide a factory to centralize creation of PlayStation API clients so cron and admin services can depend on interfaces instead of concrete client instantiation.
- Replace direct `Tustin\PlayStation\Client` coupling in long-running workers and admin services to make test-adaptation and future client swaps easier while preserving existing runtime behavior.

### Description
- Added a new PlayStation module under `wwwroot/classes/PlayStation/` with PSN100-focused contracts: `AuthClientInterface`, `ProfileClientInterface`, `TrophyClientInterface`, `UserSearchClientInterface`, `PlayStationApiClientInterface`, and `PlayStationClientFactoryInterface`.
- Implemented `TustinPlayStationApiClient` as an adapter over `Tustin\PlayStation\Client` and a `PlayStationClientFactory` that constructs it; files created at `wwwroot/classes/PlayStation/TustinPlayStationApiClient.php` and `wwwroot/classes/PlayStation/PlayStationClientFactory.php`.
- Updated services to depend on the new contracts/factory rather than directly new-ing `Tustin\PlayStation\Client`: `wwwroot/classes/Cron/ThirtyMinuteCronJob.php`, `wwwroot/classes/Admin/GameRescanService.php`, `wwwroot/classes/Admin/PsnGameLookupService.php`, and `wwwroot/classes/Admin/PsnPlayerLookupService.php`.
- Preserved existing caller-facing semantics and retry flows by adapting legacy callable factories into the new `PlayStationClientFactoryInterface` when provided; trophy/profile/trophy-group calls are routed through `TrophyClientInterface` / `ProfileClientInterface` / `UserSearchClientInterface` respectively.

### Testing
- Ran PHP syntax checks (`php -l`) on all changed and new files and they reported no syntax errors.
- Ran the full test suite with `php tests/run.php`; the vast majority of tests passed after the change, and all touched PSN lookup tests behaved as expected under the new interface wiring.
- Test run revealed existing unrelated baseline problems in the repository: `PlayerQueueResponseFactoryTest::testCreateQueuedForScanResponseUsesActionVerbsForProgressTitle` and `TrophyMergeServiceCopyMergedTrophiesTest::testCopyMergedTrophiesBulkCopiesEarnedProgressWithDerivedTables` failed and one legacy test error surfaced during runs; these failures appear to be pre-existing and not caused by the PlayStation wiring changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a15426e4832fa5cdd4e9034d7298)