### PR TITLE
Add PSN DTOs and mappers and refactor Cron/Rescan reads to use them

### DIFF
--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -14,6 +14,10 @@ require_once __DIR__ . '/../PlayStation/Contracts/PlayStationClientFactoryInterf
 require_once __DIR__ . '/../PlayStation/Contracts/ProfileClientInterface.php';
 require_once __DIR__ . '/../PlayStation/Contracts/TrophyClientInterface.php';
 require_once __DIR__ . '/../PlayStation/PlayStationClientFactory.php';
+require_once __DIR__ . '/../PlayStation/Dto/PsnTrophyDto.php';
+require_once __DIR__ . '/../PlayStation/Dto/PsnTrophyGroupDto.php';
+require_once __DIR__ . '/../PlayStation/Mapper/PsnTrophyGroupMapper.php';
+require_once __DIR__ . '/../PlayStation/Mapper/PsnTrophyMapper.php';
 
 class GameRescanService
 {
@@ -34,6 +38,7 @@ class GameRescanService
     private ImageHashCalculator $imageHashCalculator;
     private PsnGameLookupService $psnGameLookupService;
     private PlayStationClientFactoryInterface $playStationClientFactory;
+    private PsnTrophyGroupMapper $psnTrophyGroupMapper;
 
     /**
      * @var \Closure(string):void|null
@@ -55,6 +60,7 @@ class GameRescanService
         $this->trophyMetaRepository = new TrophyMetaRepository($database);
         $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
         $this->playStationClientFactory = $playStationClientFactory ?? new PlayStationClientFactory();
+        $this->psnTrophyGroupMapper = new PsnTrophyGroupMapper(new PsnTrophyMapper());
         $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase(
             $database,
             $this->playStationClientFactory
@@ -377,11 +383,7 @@ class GameRescanService
         $query->execute();
 
         $groupData = $this->fetchGameLookupGroupData($client, $npCommunicationId);
-        $totalSteps = array_reduce(
-            $groupData,
-            static fn (int $carry, array $data): int => $carry + 1 + count($data['trophies']),
-            0
-        );
+        $totalSteps = array_reduce($groupData, static fn (int $carry, PsnTrophyGroupDto $group): int => $carry + 1 + count($group->trophies()), 0);
 
         if ($groupData === []) {
             $this->notifyProgress($progressListener, 70, 'Refreshing trophy details…');
@@ -393,8 +395,7 @@ class GameRescanService
         $totalGroups = count($groupData);
         $processedGroups = 0;
 
-        foreach ($groupData as $data) {
-            $trophyGroup = $data['group'];
+        foreach ($groupData as $trophyGroup) {
             $groupId = (string) $trophyGroup->id();
             $existingGroup = $existingGroupData[$groupId] ?? [
                 'name' => null,
@@ -447,10 +448,10 @@ class GameRescanService
                 )
             );
 
-            $groupTrophyCount = count($data['trophies']);
+            $groupTrophyCount = count($trophyGroup->trophies());
             $processedTrophiesInGroup = 0;
 
-            foreach ($data['trophies'] as $trophy) {
+            foreach ($trophyGroup->trophies() as $trophy) {
                 $orderId = (int) $trophy->id();
                 $trophyHidden = (int) $trophy->hidden();
                 $existingTrophy = $existingTrophyData[$groupId][$orderId] ?? [
@@ -497,7 +498,7 @@ class GameRescanService
                     $trophyContextLabel,
                     'Type',
                     $existingTrophy['type'],
-                    $trophy->type()->value
+                    $trophy->type()
                 );
                 $differenceTracker->recordTrophyChange(
                     $groupId,
@@ -596,14 +597,11 @@ class GameRescanService
             }
         }
 
-        return array_map(
-            static fn (array $data) => $data['group'],
-            $groupData
-        );
+        return $groupData;
     }
 
     /**
-     * @return array<int, array{group: object, trophies: array<int, object>}>
+     * @return array<int, PsnTrophyGroupDto>
      */
     private function fetchGameLookupGroupData(TrophyClientInterface $client, string $npCommunicationId): array
     {
@@ -621,137 +619,15 @@ class GameRescanService
                 continue;
             }
 
-            $groupId = (string) ($rawGroup['trophyGroupId'] ?? '');
-            $rawTrophies = $rawGroup['trophies'] ?? [];
-
-            if (!is_array($rawTrophies)) {
-                $rawTrophies = [];
+            $mappedGroup = $this->psnTrophyGroupMapper->mapFromLookupArray($rawGroup);
+            if ($mappedGroup->id() === '') {
+                continue;
             }
 
-            $trophies = [];
-            foreach ($rawTrophies as $rawTrophy) {
-                if (!is_array($rawTrophy)) {
-                    continue;
-                }
-
-                $trophies[] = $this->createTrophyApiAdapter($rawTrophy);
-            }
-
-            $groupData[] = [
-                'group' => $this->createTrophyGroupApiAdapter($groupId, $rawGroup),
-                'trophies' => $trophies,
-            ];
+            $groupData[] = $mappedGroup;
         }
 
         return $groupData;
-    }
-
-    /**
-     * @param array<string, mixed> $rawGroup
-     */
-    private function createTrophyGroupApiAdapter(string $groupId, array $rawGroup): object
-    {
-        return new class ($groupId, $rawGroup) {
-            /**
-             * @param array<string, mixed> $rawGroup
-             */
-            public function __construct(
-                private readonly string $groupId,
-                private readonly array $rawGroup
-            ) {
-            }
-
-            public function id(): string
-            {
-                return $this->groupId;
-            }
-
-            public function name(): string
-            {
-                return (string) ($this->rawGroup['trophyGroupName'] ?? '');
-            }
-
-            public function detail(): string
-            {
-                return (string) ($this->rawGroup['trophyGroupDetail'] ?? '');
-            }
-
-            public function iconUrl(): string
-            {
-                return (string) ($this->rawGroup['trophyGroupIconUrl'] ?? '');
-            }
-        };
-    }
-
-    /**
-     * @param array<string, mixed> $rawTrophy
-     */
-    private function createTrophyApiAdapter(array $rawTrophy): object
-    {
-        return new class ($rawTrophy) {
-            /**
-             * @param array<string, mixed> $rawTrophy
-             */
-            public function __construct(private readonly array $rawTrophy)
-            {
-            }
-
-            public function id(): int
-            {
-                return (int) ($this->rawTrophy['trophyId'] ?? 0);
-            }
-
-            public function hidden(): bool
-            {
-                return (bool) ($this->rawTrophy['trophyHidden'] ?? false);
-            }
-
-            public function type(): object
-            {
-                return new class ((string) ($this->rawTrophy['trophyType'] ?? 'bronze')) {
-                    public function __construct(public readonly string $value)
-                    {
-                    }
-                };
-            }
-
-            public function name(): string
-            {
-                return (string) ($this->rawTrophy['trophyName'] ?? '');
-            }
-
-            public function detail(): string
-            {
-                return (string) ($this->rawTrophy['trophyDetail'] ?? '');
-            }
-
-            public function iconUrl(): string
-            {
-                return (string) ($this->rawTrophy['trophyIconUrl'] ?? '');
-            }
-
-            public function progressTargetValue(): string
-            {
-                $value = $this->rawTrophy['trophyProgressTargetValue'] ?? '';
-
-                return is_scalar($value) ? (string) $value : '';
-            }
-
-            public function rewardName(): string
-            {
-                return (string) ($this->rawTrophy['trophyRewardName'] ?? '');
-            }
-
-            public function rewardImageUrl(): ?string
-            {
-                $rewardImageUrl = $this->rawTrophy['trophyRewardImageUrl'] ?? null;
-                if (!is_string($rewardImageUrl) || $rewardImageUrl === '') {
-                    return null;
-                }
-
-                return $rewardImageUrl;
-            }
-        };
     }
 
     private function recalculateTrophies(
@@ -877,7 +753,7 @@ class GameRescanService
         $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
         $query->bindValue(':order_id', $trophy->id(), PDO::PARAM_INT);
         $query->bindValue(':hidden', (int) $trophy->hidden(), PDO::PARAM_INT);
-        $query->bindValue(':type', $trophy->type()->value, PDO::PARAM_STR);
+        $query->bindValue(':type', $trophy->type(), PDO::PARAM_STR);
         $query->bindValue(':name', $trophy->name(), PDO::PARAM_STR);
         $query->bindValue(':detail', $trophy->detail(), PDO::PARAM_STR);
         $query->bindValue(':icon_url', $iconFilename, PDO::PARAM_STR);

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -506,7 +506,13 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                 try {
                     $originalOnlineId = (string) $player['online_id'];
                     $existingAccountId = $this->normalizeAccountIdValue($player['account_id'] ?? null);
-                    $profileLookup = $this->lookupPlayerProfile($client, $originalOnlineId);
+                    try {
+                        $profileLookup = $this->lookupPlayerProfile($client, $originalOnlineId);
+                    } catch (UnexpectedValueException) {
+                        $this->markPlayerAsPrivate($originalOnlineId);
+
+                        continue 2;
+                    }
                     $country = 'zz';
 
                     if ($profileLookup !== null) {
@@ -2086,7 +2092,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
 
         $mappedProfile = $this->psnProfileMapper->mapLookupResponse($profile);
         if ($mappedProfile === null) {
-            throw new TypeError('Malformed profile lookup payload.');
+            throw new UnexpectedValueException('Malformed profile lookup payload.');
         }
 
         return $mappedProfile;

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -15,6 +15,12 @@ require_once __DIR__ . '/../PlayStation/Contracts/PlayStationApiClientInterface.
 require_once __DIR__ . '/../PlayStation/Contracts/ProfileClientInterface.php';
 require_once __DIR__ . '/../PlayStation/Contracts/UserSearchClientInterface.php';
 require_once __DIR__ . '/../PlayStation/PlayStationClientFactory.php';
+require_once __DIR__ . '/../PlayStation/Dto/PsnProfileDto.php';
+require_once __DIR__ . '/../PlayStation/Dto/PsnTrophyGroupDto.php';
+require_once __DIR__ . '/../PlayStation/Dto/PsnTrophyDto.php';
+require_once __DIR__ . '/../PlayStation/Mapper/PsnProfileMapper.php';
+require_once __DIR__ . '/../PlayStation/Mapper/PsnTrophyGroupMapper.php';
+require_once __DIR__ . '/../PlayStation/Mapper/PsnTrophyMapper.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\Haste\Exception\UnauthorizedHttpException;
@@ -33,6 +39,9 @@ final class ThirtyMinuteCronJob implements CronJobInterface
     private readonly ImageHashCalculator $imageHashCalculator;
     private readonly PsnGameLookupService $psnGameLookupService;
     private readonly PlayStationClientFactoryInterface $playStationClientFactory;
+    private readonly PsnProfileMapper $psnProfileMapper;
+    private readonly PsnTrophyGroupMapper $psnTrophyGroupMapper;
+    private readonly PsnTrophyMapper $psnTrophyMapper;
 
     public function __construct(
         private readonly PDO $database,
@@ -52,6 +61,9 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             ?? new AutomaticTrophyTitleMergeService($database, new TrophyMergeService($database));
         $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
         $this->playStationClientFactory = $playStationClientFactory ?? new PlayStationClientFactory();
+        $this->psnProfileMapper = new PsnProfileMapper();
+        $this->psnTrophyMapper = new PsnTrophyMapper();
+        $this->psnTrophyGroupMapper = new PsnTrophyGroupMapper($this->psnTrophyMapper);
         $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase(
             $database,
             $this->playStationClientFactory
@@ -498,21 +510,14 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                     $country = 'zz';
 
                     if ($profileLookup !== null) {
-                        $profile = $profileLookup['profile'] ?? null;
+                        $profileAccountId = $profileLookup->accountId();
 
-                        if (!is_array($profile)) {
+                        if ($profileAccountId === '') {
                             $this->markPlayerAsPrivate($originalOnlineId);
                             continue 2;
                         }
 
-                        $profileAccountId = $profile['accountId'] ?? null;
-
-                        if (!is_string($profileAccountId) || $profileAccountId === '') {
-                            $this->markPlayerAsPrivate($originalOnlineId);
-                            continue 2;
-                        }
-
-                        $resolvedOnlineId = $this->determineResolvedOnlineId($profile, $originalOnlineId);
+                        $resolvedOnlineId = $this->determineResolvedOnlineId($profileLookup, $originalOnlineId);
 
                         if ($resolvedOnlineId !== '' && strcasecmp($resolvedOnlineId, $originalOnlineId) !== 0) {
                             $this->updateQueuedOnlineId((int) $worker['id'], $originalOnlineId, $resolvedOnlineId);
@@ -524,7 +529,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                         $player['account_id'] = $profileAccountId;
                         $user = $client->findUserByAccountId($profileAccountId);
 
-                        $countryFromProfile = $this->extractCountryFromNpId($profile['npId'] ?? null);
+                        $countryFromProfile = $this->extractCountryFromNpId($profileLookup->npId());
                         $country = $countryFromProfile;
 
                         if ($country === null || strtolower($country) === 'zz') {
@@ -1077,43 +1082,18 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 break;
                             }
 
-                            $trophyGroups = $trophyData['trophyGroups'] ?? [];
-                            if (!is_array($trophyGroups)) {
-                                $trophyGroups = [];
-                            }
-
-                            $topLevelTrophies = $trophyData['trophies'] ?? [];
-                            if (!is_array($topLevelTrophies)) {
-                                $topLevelTrophies = [];
-                            }
-
-                            $fallbackGroupTrophies = [];
-                            foreach ($topLevelTrophies as $topLevelTrophy) {
-                                if (!is_array($topLevelTrophy)) {
-                                    continue;
-                                }
-
-                                $topLevelTrophyGroupId = (string) ($topLevelTrophy['trophyGroupId'] ?? '');
-                                if ($topLevelTrophyGroupId === '') {
-                                    continue;
-                                }
-
-                                $fallbackGroupTrophies[$topLevelTrophyGroupId][] = $topLevelTrophy;
-                            }
+                            $trophyGroups = $this->mapTrophyGroupsFromLookupData($trophyData);
+                            $fallbackGroupTrophies = $this->mapFallbackGroupTrophiesFromLookupData($trophyData);
 
                             foreach ($trophyGroups as $trophyGroup) {
-                                if (!is_array($trophyGroup)) {
-                                    continue;
-                                }
-
-                                $trophyGroupId = (string) ($trophyGroup['trophyGroupId'] ?? '');
+                                $trophyGroupId = $trophyGroup->id();
                                 if ($trophyGroupId === '') {
                                     continue;
                                 }
 
-                                $trophyGroupName = (string) ($trophyGroup['trophyGroupName'] ?? '');
-                                $trophyGroupDetail = (string) ($trophyGroup['trophyGroupDetail'] ?? '');
-                                $trophyGroupIconUrl = (string) ($trophyGroup['trophyGroupIconUrl'] ?? '');
+                                $trophyGroupName = $trophyGroup->name();
+                                $trophyGroupDetail = $trophyGroup->detail();
+                                $trophyGroupIconUrl = $trophyGroup->iconUrl();
                                 $groupNewTrophies = false;
                                 // Add trophy group (game + dlcs) into database
                                 $existingGroupQuery = $this->database->prepare(
@@ -1177,10 +1157,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                     }
                                 }
 
-                                $groupTrophies = $trophyGroup['trophies'] ?? [];
-                                if (!is_array($groupTrophies)) {
-                                    $groupTrophies = [];
-                                }
+                                $groupTrophies = $trophyGroup->trophies();
 
                                 if ($groupTrophies === [] && isset($fallbackGroupTrophies[$trophyGroupId])) {
                                     $groupTrophies = $fallbackGroupTrophies[$trophyGroupId];
@@ -1197,19 +1174,14 @@ final class ThirtyMinuteCronJob implements CronJobInterface
 
                                     break;
                                 }
-
+                                
                                 // Add trophies into database
                                 foreach ($groupTrophies as $trophy) {
-                                    if (!is_array($trophy)) {
+                                    if (!$trophy->hasValidId()) {
                                         continue;
                                     }
 
-                                    $rawTrophyOrderId = $trophy['trophyId'] ?? null;
-                                    if (!is_numeric($rawTrophyOrderId)) {
-                                        continue;
-                                    }
-
-                                    $trophyOrderId = (int) $rawTrophyOrderId;
+                                    $trophyOrderId = $trophy->id();
                                     if ($trophyOrderId < 0) {
                                         continue;
                                     }
@@ -1227,9 +1199,9 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                     $existingTrophyQuery->execute();
                                     $existingTrophy = $existingTrophyQuery->fetch(PDO::FETCH_ASSOC) ?: null;
 
-                                    $trophyHidden = (int) ($trophy['trophyHidden'] ?? 0);
+                                    $trophyHidden = (int) $trophy->hidden();
 
-                                    $rawProgressTargetValue = $trophy['trophyProgressTargetValue'] ?? null;
+                                    $rawProgressTargetValue = $trophy->progressTargetValue();
 
                                     $existingProgressTargetValue = null;
                                     $existingRewardName = null;
@@ -1249,20 +1221,20 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                         ? null
                                         : (int) $rawProgressTargetValue;
 
-                                    $rewardName = (string) ($trophy['trophyRewardName'] ?? '');
+                                    $rewardName = $trophy->rewardName();
                                     $rewardName = $rewardName === '' ? null : $rewardName;
 
-                                    $rewardImageUrl = $trophy['trophyRewardImageUrl'] ?? null;
+                                    $rewardImageUrl = $trophy->rewardImageUrl();
                                     $rewardImageShouldBeNull = $rewardImageUrl === null || $rewardImageUrl === '';
 
-                                    $trophyTypeEnumValue = strtolower((string) ($trophy['trophyType'] ?? ''));
+                                    $trophyTypeEnumValue = strtolower($trophy->type());
                                     if ($trophyTypeEnumValue === '') {
                                         $trophyTypeEnumValue = 'bronze';
                                     }
 
-                                    $trophyName = (string) ($trophy['trophyName'] ?? '');
-                                    $trophyDetail = (string) ($trophy['trophyDetail'] ?? '');
-                                    $trophyIconUrl = (string) ($trophy['trophyIconUrl'] ?? '');
+                                    $trophyName = $trophy->name();
+                                    $trophyDetail = $trophy->detail();
+                                    $trophyIconUrl = $trophy->iconUrl();
 
                                     $trophyNeedsUpdate = $existingTrophy === null
                                         || (int) ($existingTrophy['hidden'] ?? -1) !== $trophyHidden
@@ -2043,7 +2015,64 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             || (($exception->errorInfo[1] ?? null) === 1213);
     }
 
-    private function lookupPlayerProfile(ProfileClientInterface $client, string $onlineId): ?array
+    /**
+     * @param array<string, mixed> $trophyData
+     * @return array<int, PsnTrophyGroupDto>
+     */
+    private function mapTrophyGroupsFromLookupData(array $trophyData): array
+    {
+        $rawGroups = $trophyData['trophyGroups'] ?? [];
+        if (!is_array($rawGroups)) {
+            return [];
+        }
+
+        $groups = [];
+
+        foreach ($rawGroups as $rawGroup) {
+            if (!is_array($rawGroup)) {
+                continue;
+            }
+
+            $group = $this->psnTrophyGroupMapper->mapFromLookupArray($rawGroup);
+            if ($group->id() === '') {
+                continue;
+            }
+
+            $groups[] = $group;
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @param array<string, mixed> $trophyData
+     * @return array<string, array<int, PsnTrophyDto>>
+     */
+    private function mapFallbackGroupTrophiesFromLookupData(array $trophyData): array
+    {
+        $rawTopLevelTrophies = $trophyData['trophies'] ?? [];
+        if (!is_array($rawTopLevelTrophies)) {
+            return [];
+        }
+
+        $grouped = [];
+        foreach ($rawTopLevelTrophies as $rawTrophy) {
+            if (!is_array($rawTrophy)) {
+                continue;
+            }
+
+            $groupId = (string) ($rawTrophy['trophyGroupId'] ?? '');
+            if ($groupId === '') {
+                continue;
+            }
+
+            $grouped[$groupId][] = $this->psnTrophyMapper->mapFromLookupArray($rawTrophy);
+        }
+
+        return $grouped;
+    }
+
+    private function lookupPlayerProfile(ProfileClientInterface $client, string $onlineId): ?PsnProfileDto
     {
         try {
             $profile = $client->lookupProfileByOnlineId($onlineId);
@@ -2055,23 +2084,18 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             throw $exception;
         }
 
-        $normalized = $this->normalizePlayerProfileResponse($profile);
-
-        return is_array($normalized) ? $normalized : null;
+        return $this->psnProfileMapper->mapLookupResponse($profile);
     }
 
-    /**
-     * @param array<string, mixed> $profile
-     */
-    private function determineResolvedOnlineId(array $profile, string $fallbackOnlineId): string
+    private function determineResolvedOnlineId(PsnProfileDto $profile, string $fallbackOnlineId): string
     {
-        $currentOnlineId = $profile['currentOnlineId'] ?? null;
-        if (is_string($currentOnlineId) && $currentOnlineId !== '') {
+        $currentOnlineId = $profile->currentOnlineId();
+        if ($currentOnlineId !== '') {
             return $currentOnlineId;
         }
 
-        $onlineId = $profile['onlineId'] ?? null;
-        if (is_string($onlineId) && $onlineId !== '') {
+        $onlineId = $profile->onlineId();
+        if ($onlineId !== '') {
             return $onlineId;
         }
 
@@ -2259,30 +2283,6 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         }
 
         return null;
-    }
-
-    private function normalizePlayerProfileResponse(mixed $profile): array
-    {
-        if (is_array($profile)) {
-            return $profile;
-        }
-
-        if (is_object($profile)) {
-            try {
-                $encoded = json_encode($profile, JSON_THROW_ON_ERROR);
-                $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
-
-                if (is_array($decoded)) {
-                    return $decoded;
-                }
-            } catch (JsonException) {
-                // Fall back to exposing public properties.
-            }
-
-            return get_object_vars($profile);
-        }
-
-        return [];
     }
 
     private function findPlayerCountry(UserSearchClientInterface $client, string $onlineId): ?string

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -2084,7 +2084,12 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             throw $exception;
         }
 
-        return $this->psnProfileMapper->mapLookupResponse($profile);
+        $mappedProfile = $this->psnProfileMapper->mapLookupResponse($profile);
+        if ($mappedProfile === null) {
+            throw new TypeError('Malformed profile lookup payload.');
+        }
+
+        return $mappedProfile;
     }
 
     private function determineResolvedOnlineId(PsnProfileDto $profile, string $fallbackOnlineId): string

--- a/wwwroot/classes/PlayStation/Dto/PsnProfileDto.php
+++ b/wwwroot/classes/PlayStation/Dto/PsnProfileDto.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+final class PsnProfileDto
+{
+    public function __construct(
+        private readonly string $accountId,
+        private readonly string $onlineId,
+        private readonly string $currentOnlineId,
+        private readonly string $npId
+    ) {
+    }
+
+    public function accountId(): string
+    {
+        return $this->accountId;
+    }
+
+    public function onlineId(): string
+    {
+        return $this->onlineId;
+    }
+
+    public function currentOnlineId(): string
+    {
+        return $this->currentOnlineId;
+    }
+
+    public function npId(): string
+    {
+        return $this->npId;
+    }
+}

--- a/wwwroot/classes/PlayStation/Dto/PsnTrophyDto.php
+++ b/wwwroot/classes/PlayStation/Dto/PsnTrophyDto.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+final class PsnTrophyDto
+{
+    public function __construct(
+        private readonly int $id,
+        private readonly bool $hasValidId,
+        private readonly bool $hidden,
+        private readonly string $type,
+        private readonly string $name,
+        private readonly string $detail,
+        private readonly string $iconUrl,
+        private readonly string $earnedDateTime,
+        private readonly string $progress,
+        private readonly string $progressTargetValue,
+        private readonly string $rewardName,
+        private readonly ?string $rewardImageUrl
+    ) {
+    }
+
+    public function id(): int { return $this->id; }
+    public function hasValidId(): bool { return $this->hasValidId; }
+    public function hidden(): bool { return $this->hidden; }
+    public function type(): string { return $this->type; }
+    public function name(): string { return $this->name; }
+    public function detail(): string { return $this->detail; }
+    public function iconUrl(): string { return $this->iconUrl; }
+    public function earnedDateTime(): string { return $this->earnedDateTime; }
+    public function progress(): string { return $this->progress; }
+    public function progressTargetValue(): string { return $this->progressTargetValue; }
+    public function rewardName(): string { return $this->rewardName; }
+    public function rewardImageUrl(): ?string { return $this->rewardImageUrl; }
+}

--- a/wwwroot/classes/PlayStation/Dto/PsnTrophyGroupDto.php
+++ b/wwwroot/classes/PlayStation/Dto/PsnTrophyGroupDto.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+final class PsnTrophyGroupDto
+{
+    /**
+     * @param array<int, PsnTrophyDto> $trophies
+     */
+    public function __construct(
+        private readonly string $id,
+        private readonly string $name,
+        private readonly string $detail,
+        private readonly string $iconUrl,
+        private readonly array $trophies
+    ) {
+    }
+
+    public function id(): string { return $this->id; }
+    public function name(): string { return $this->name; }
+    public function detail(): string { return $this->detail; }
+    public function iconUrl(): string { return $this->iconUrl; }
+
+    /**
+     * @return array<int, PsnTrophyDto>
+     */
+    public function trophies(): array
+    {
+        return $this->trophies;
+    }
+}

--- a/wwwroot/classes/PlayStation/Dto/PsnTrophySummaryDto.php
+++ b/wwwroot/classes/PlayStation/Dto/PsnTrophySummaryDto.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+final class PsnTrophySummaryDto
+{
+    public function __construct(
+        private readonly int $level,
+        private readonly int $progress,
+        private readonly int $platinum,
+        private readonly int $gold,
+        private readonly int $silver,
+        private readonly int $bronze
+    ) {
+    }
+
+    public function level(): int
+    {
+        return $this->level;
+    }
+
+    public function progress(): int
+    {
+        return $this->progress;
+    }
+
+    public function platinum(): int
+    {
+        return $this->platinum;
+    }
+
+    public function gold(): int
+    {
+        return $this->gold;
+    }
+
+    public function silver(): int
+    {
+        return $this->silver;
+    }
+
+    public function bronze(): int
+    {
+        return $this->bronze;
+    }
+}

--- a/wwwroot/classes/PlayStation/Dto/PsnTrophyTitleDto.php
+++ b/wwwroot/classes/PlayStation/Dto/PsnTrophyTitleDto.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+final class PsnTrophyTitleDto
+{
+    /**
+     * @param array<int, string> $platforms
+     */
+    public function __construct(
+        private readonly string $npCommunicationId,
+        private readonly string $name,
+        private readonly string $detail,
+        private readonly string $iconUrl,
+        private readonly string $lastUpdatedDateTime,
+        private readonly string $trophySetVersion,
+        private readonly array $platforms
+    ) {
+    }
+
+    public function npCommunicationId(): string { return $this->npCommunicationId; }
+    public function name(): string { return $this->name; }
+    public function detail(): string { return $this->detail; }
+    public function iconUrl(): string { return $this->iconUrl; }
+    public function lastUpdatedDateTime(): string { return $this->lastUpdatedDateTime; }
+    public function trophySetVersion(): string { return $this->trophySetVersion; }
+
+    /**
+     * @return array<int, string>
+     */
+    public function platforms(): array
+    {
+        return $this->platforms;
+    }
+}

--- a/wwwroot/classes/PlayStation/Mapper/PsnProfileMapper.php
+++ b/wwwroot/classes/PlayStation/Mapper/PsnProfileMapper.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../Dto/PsnProfileDto.php';
+
+final class PsnProfileMapper
+{
+    public function mapLookupResponse(mixed $lookupResponse): ?PsnProfileDto
+    {
+        $normalized = $this->normalizeLookupResponse($lookupResponse);
+        $profile = $normalized['profile'] ?? null;
+
+        if (!is_array($profile)) {
+            return null;
+        }
+
+        $accountId = (string) ($profile['accountId'] ?? '');
+        if ($accountId === '') {
+            return null;
+        }
+
+        return new PsnProfileDto(
+            $accountId,
+            (string) ($profile['onlineId'] ?? ''),
+            (string) ($profile['currentOnlineId'] ?? ''),
+            (string) ($profile['npId'] ?? '')
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeLookupResponse(mixed $profile): array
+    {
+        if (is_array($profile)) {
+            return $profile;
+        }
+
+        if (is_object($profile)) {
+            try {
+                $encoded = json_encode($profile, JSON_THROW_ON_ERROR);
+                $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
+
+                if (is_array($decoded)) {
+                    return $decoded;
+                }
+            } catch (JsonException) {
+                // Fall back to exposing public properties.
+            }
+
+            return get_object_vars($profile);
+        }
+
+        return [];
+    }
+}

--- a/wwwroot/classes/PlayStation/Mapper/PsnProfileMapper.php
+++ b/wwwroot/classes/PlayStation/Mapper/PsnProfileMapper.php
@@ -23,10 +23,19 @@ final class PsnProfileMapper
 
         return new PsnProfileDto(
             $accountId,
-            (string) ($profile['onlineId'] ?? ''),
-            (string) ($profile['currentOnlineId'] ?? ''),
-            (string) ($profile['npId'] ?? '')
+            $this->normalizeStringField($profile['onlineId'] ?? null),
+            $this->normalizeStringField($profile['currentOnlineId'] ?? null),
+            $this->normalizeStringField($profile['npId'] ?? null)
         );
+    }
+
+    private function normalizeStringField(mixed $value): string
+    {
+        if (!is_string($value)) {
+            return '';
+        }
+
+        return $value;
     }
 
     /**

--- a/wwwroot/classes/PlayStation/Mapper/PsnProfileMapper.php
+++ b/wwwroot/classes/PlayStation/Mapper/PsnProfileMapper.php
@@ -15,10 +15,11 @@ final class PsnProfileMapper
             return null;
         }
 
-        $accountId = (string) ($profile['accountId'] ?? '');
-        if ($accountId === '') {
+        $rawAccountId = $profile['accountId'] ?? null;
+        if (!is_string($rawAccountId) || $rawAccountId === '') {
             return null;
         }
+        $accountId = $rawAccountId;
 
         return new PsnProfileDto(
             $accountId,

--- a/wwwroot/classes/PlayStation/Mapper/PsnTrophyGroupMapper.php
+++ b/wwwroot/classes/PlayStation/Mapper/PsnTrophyGroupMapper.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../Dto/PsnTrophyGroupDto.php';
+require_once __DIR__ . '/PsnTrophyMapper.php';
+
+final class PsnTrophyGroupMapper
+{
+    public function __construct(
+        private readonly ?PsnTrophyMapper $trophyMapper = null
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $rawGroup
+     */
+    public function mapFromLookupArray(array $rawGroup): PsnTrophyGroupDto
+    {
+        $rawTrophies = $rawGroup['trophies'] ?? [];
+        if (!is_array($rawTrophies)) {
+            $rawTrophies = [];
+        }
+
+        $mapper = $this->trophyMapper ?? new PsnTrophyMapper();
+        $trophies = [];
+
+        foreach ($rawTrophies as $rawTrophy) {
+            if (!is_array($rawTrophy)) {
+                continue;
+            }
+
+            $trophies[] = $mapper->mapFromLookupArray($rawTrophy);
+        }
+
+        return new PsnTrophyGroupDto(
+            (string) ($rawGroup['trophyGroupId'] ?? ''),
+            (string) ($rawGroup['trophyGroupName'] ?? ''),
+            (string) ($rawGroup['trophyGroupDetail'] ?? ''),
+            (string) ($rawGroup['trophyGroupIconUrl'] ?? ''),
+            $trophies
+        );
+    }
+}

--- a/wwwroot/classes/PlayStation/Mapper/PsnTrophyMapper.php
+++ b/wwwroot/classes/PlayStation/Mapper/PsnTrophyMapper.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../Dto/PsnTrophyDto.php';
+
+final class PsnTrophyMapper
+{
+    /**
+     * @param array<string, mixed> $rawTrophy
+     */
+    public function mapFromLookupArray(array $rawTrophy): PsnTrophyDto
+    {
+        $progressTarget = $rawTrophy['trophyProgressTargetValue'] ?? '';
+        $rawTrophyId = $rawTrophy['trophyId'] ?? null;
+
+        $rewardImageUrl = $rawTrophy['trophyRewardImageUrl'] ?? null;
+        if (!is_string($rewardImageUrl) || $rewardImageUrl === '') {
+            $rewardImageUrl = null;
+        }
+
+        return new PsnTrophyDto(
+            (int) $rawTrophyId,
+            is_numeric($rawTrophyId),
+            (bool) ($rawTrophy['trophyHidden'] ?? false),
+            strtolower((string) ($rawTrophy['trophyType'] ?? 'bronze')),
+            (string) ($rawTrophy['trophyName'] ?? ''),
+            (string) ($rawTrophy['trophyDetail'] ?? ''),
+            (string) ($rawTrophy['trophyIconUrl'] ?? ''),
+            (string) ($rawTrophy['earnedDateTime'] ?? ''),
+            is_scalar($rawTrophy['progress'] ?? null) ? (string) $rawTrophy['progress'] : '',
+            is_scalar($progressTarget) ? (string) $progressTarget : '',
+            (string) ($rawTrophy['trophyRewardName'] ?? ''),
+            $rewardImageUrl
+        );
+    }
+}

--- a/wwwroot/classes/PlayStation/Mapper/PsnTrophySummaryMapper.php
+++ b/wwwroot/classes/PlayStation/Mapper/PsnTrophySummaryMapper.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../Dto/PsnTrophySummaryDto.php';
+
+final class PsnTrophySummaryMapper
+{
+    public function mapFromApiSummary(object $summary): PsnTrophySummaryDto
+    {
+        return new PsnTrophySummaryDto(
+            (int) $summary->level(),
+            (int) $summary->progress(),
+            (int) $summary->platinum(),
+            (int) $summary->gold(),
+            (int) $summary->silver(),
+            (int) $summary->bronze()
+        );
+    }
+}

--- a/wwwroot/classes/PlayStation/Mapper/PsnTrophyTitleMapper.php
+++ b/wwwroot/classes/PlayStation/Mapper/PsnTrophyTitleMapper.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../Dto/PsnTrophyTitleDto.php';
+
+final class PsnTrophyTitleMapper
+{
+    public function mapFromApiTitle(object $trophyTitle): PsnTrophyTitleDto
+    {
+        $platforms = $trophyTitle->platforms();
+        if ($platforms instanceof Traversable) {
+            $platforms = iterator_to_array($platforms, false);
+        }
+
+        if (!is_array($platforms)) {
+            $platforms = [];
+        }
+
+        $normalizedPlatforms = [];
+        foreach ($platforms as $platform) {
+            if (!is_string($platform) || $platform === '') {
+                continue;
+            }
+
+            $normalizedPlatforms[] = $platform;
+        }
+
+        return new PsnTrophyTitleDto(
+            (string) $trophyTitle->npCommunicationId(),
+            (string) $trophyTitle->name(),
+            (string) $trophyTitle->detail(),
+            (string) $trophyTitle->iconUrl(),
+            (string) $trophyTitle->lastUpdatedDateTime(),
+            (string) $trophyTitle->trophySetVersion(),
+            $normalizedPlatforms
+        );
+    }
+}


### PR DESCRIPTION
### Motivation

- Move ad-hoc array/object access to explicit typed DTOs to centralize and normalize PlayStation API payload parsing used during scans and rescans.
- Reduce inline anonymous adapters and make mapping logic reusable and testable while preserving existing DB write and computed behavior.

### Description

- Added DTOs under `wwwroot/classes/PlayStation/Dto/`: `PsnProfileDto`, `PsnTrophySummaryDto`, `PsnTrophyTitleDto`, `PsnTrophyGroupDto`, and `PsnTrophyDto` with fields required by existing logic (e.g., `accountId`, `onlineId`, `npCommunicationId`, icon URLs, earned/progress/reward fields).
- Added mappers under `wwwroot/classes/PlayStation/Mapper/`: `PsnProfileMapper`, `PsnTrophySummaryMapper`, `PsnTrophyTitleMapper`, `PsnTrophyGroupMapper`, and `PsnTrophyMapper` to normalize API payloads into DTO instances.
- Refactored `ThirtyMinuteCronJob` to use `PsnProfileDto` from `PsnProfileMapper` for profile lookups and to map trophy lookup responses into `PsnTrophyGroupDto`/`PsnTrophyDto` types before processing, keeping all DB writes and computed flows intact.
- Refactored `GameRescanService` to consume `PsnTrophyGroupDto`/`PsnTrophyDto` instead of the previous inline anonymous adapters, and updated related loop/aggregation logic to use DTO accessors while preserving upserts, diffs and progress calculations.
- Kept existing database update and upsert behavior and all computed values unchanged; changes are focused on read/mapping paths and introducing reusable mapping utilities.

### Testing

- Ran syntax checks with `php -l` on all modified/added files and they passed without errors.
- Ran the full test suite with `php tests/run.php`; the suite executed but reported pre-existing issues not introduced by these changes: two failing tests and one error — `PlayerQueueResponseFactoryTest::testCreateQueuedForScanResponseUsesActionVerbsForProgressTitle`, `TrophyMergeServiceCopyMergedTrophiesTest::testCopyMergedTrophiesBulkCopiesEarnedProgressWithDerivedTables`, and `PsnGameLookupServiceTest::testFetchTrophyDataForNpCommunicationIdPreservesGroupedPayloadWhenFlatTrophiesMissing` (error due to an undefined assertion helper in the environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2b5c3b184832fb019e8f611f3e6b8)