### PR TITLE
Add NpServiceNamePolicy; centralize NP service-name query variants and add lookup variant logging

### DIFF
--- a/tests/NpServiceNamePolicyTest.php
+++ b/tests/NpServiceNamePolicyTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/Policy/NpServiceNamePolicy.php';
+
+final class NpServiceNamePolicyTest extends TestCase
+{
+    public function testResolvePreferredNpServiceNamePrefersLegacyServiceForLegacyPlatform(): void
+    {
+        $policy = new NpServiceNamePolicy();
+
+        $this->assertSame('trophy', $policy->resolvePreferredNpServiceName('PS3,PS5'));
+    }
+
+    public function testResolvePreferredNpServiceNamePrefersTrophy2ForModernPlatform(): void
+    {
+        $policy = new NpServiceNamePolicy();
+
+        $this->assertSame('trophy2', $policy->resolvePreferredNpServiceName('PS5'));
+    }
+
+    public function testBuildLookupQueryVariantsHonorsPreferredServiceAndKeepsUniqueVariants(): void
+    {
+        $policy = new NpServiceNamePolicy();
+
+        $variants = $policy->buildLookupQueryVariants('trophy2');
+
+        $this->assertSame(['npServiceName' => 'trophy2'], $variants[0]);
+        $this->assertSame(3, count($variants));
+    }
+
+    public function testResolveAlternateQueryVariantReturnsFirstDifferentQuery(): void
+    {
+        $policy = new NpServiceNamePolicy();
+        $variants = $policy->buildLookupQueryVariants(null);
+
+        $alternate = $policy->resolveAlternateQueryVariant(
+            $variants,
+            []
+        );
+
+        $this->assertSame(['npServiceName' => 'trophy'], $alternate);
+    }
+}

--- a/tests/PsnGameLookupServiceTest.php
+++ b/tests/PsnGameLookupServiceTest.php
@@ -62,7 +62,7 @@ final class PsnGameLookupServiceTest extends TestCase
             'https://m.np.playstation.com/api/trophy/v1/npCommunicationIds/NPWR12345_00/trophyGroups/all/trophies',
             $capturedCalls[0]['path']
         );
-        $this->assertSame(['npLanguage' => 'en-US'], $capturedCalls[0]['query']);
+        $this->assertSame([], $capturedCalls[0]['query']);
         $this->assertSame(['content-type' => 'application/json'], $capturedCalls[0]['headers']);
         $this->assertSame(42, $result['game']['id']);
         $this->assertSame('NPWR12345_00', $result['game']['npCommunicationId']);
@@ -111,7 +111,7 @@ final class PsnGameLookupServiceTest extends TestCase
 
         $service->lookupByGameId('77');
 
-        $this->assertSame(['npLanguage' => 'en-US', 'npServiceName' => 'trophy2'], $attempts[0]);
+        $this->assertSame(['npServiceName' => 'trophy2'], $attempts[0]);
     }
 
     public function testFetchTrophyDataForNpCommunicationIdUsesProvidedAuthenticatedClient(): void
@@ -509,9 +509,9 @@ final class PsnGameLookupServiceTest extends TestCase
 
         $result = $service->lookupByGameId('54139');
 
-        $this->assertSame(['npLanguage' => 'en-US'], $attempts[0]);
-        $this->assertSame(['npLanguage' => 'en-US', 'npServiceName' => 'trophy'], $attempts[1]);
-        $this->assertSame(['npLanguage' => 'en-US', 'npServiceName' => 'trophy2'], $attempts[2]);
+        $this->assertSame([], $attempts[0]);
+        $this->assertSame(['npServiceName' => 'trophy'], $attempts[1]);
+        $this->assertSame(['npServiceName' => 'trophy2'], $attempts[2]);
         $this->assertSame(7, $result['trophyData']['trophyGroups'][0]['trophies'][0]['trophyId']);
     }
 
@@ -529,17 +529,17 @@ final class PsnGameLookupServiceTest extends TestCase
                         $attempts[] = ['path' => $path, 'query' => $query];
 
                         if (str_ends_with($path, '/all/trophies')) {
-                            if ($query === ['npLanguage' => 'en-US']) {
+                            if ($query === []) {
                                 throw new GameLookupHttpException(404);
                             }
 
-                            if ($query === ['npLanguage' => 'en-US', 'npServiceName' => 'trophy']) {
+                            if ($query === ['npServiceName' => 'trophy']) {
                                 return (object) ['trophies' => [(object) ['trophyGroupId' => 'all', 'trophyId' => 41]]];
                             }
                         }
 
                         if (str_ends_with($path, '/trophyGroups')
-                            && $query === ['npLanguage' => 'en-US', 'npServiceName' => 'trophy']) {
+                            && $query === ['npServiceName' => 'trophy']) {
                             return (object) ['trophyGroups' => [(object) ['trophyGroupId' => 'all']]];
                         }
 
@@ -553,9 +553,9 @@ final class PsnGameLookupServiceTest extends TestCase
 
         $this->assertSame(41, $result['trophyGroups'][0]['trophies'][0]['trophyId']);
         $this->assertCount(3, $attempts);
-        $this->assertSame(['npLanguage' => 'en-US'], $attempts[0]['query']);
-        $this->assertSame(['npLanguage' => 'en-US', 'npServiceName' => 'trophy'], $attempts[1]['query']);
-        $this->assertSame(['npLanguage' => 'en-US', 'npServiceName' => 'trophy'], $attempts[2]['query']);
+        $this->assertSame([], $attempts[0]['query']);
+        $this->assertSame(['npServiceName' => 'trophy'], $attempts[1]['query']);
+        $this->assertSame(['npServiceName' => 'trophy'], $attempts[2]['query']);
         $this->assertTrue(str_ends_with($attempts[2]['path'], '/trophyGroups'));
     }
 
@@ -572,21 +572,21 @@ final class PsnGameLookupServiceTest extends TestCase
                     profileHandler: static function (string $path, array $query) use (&$attempts): object {
                         $attempts[] = ['path' => $path, 'query' => $query];
 
-                        if (str_ends_with($path, '/all/trophies') && $query === ['npLanguage' => 'en-US']) {
+                        if (str_ends_with($path, '/all/trophies') && $query === []) {
                             return (object) ['trophies' => [(object) ['trophyGroupId' => 'all', 'trophyId' => 51]]];
                         }
 
-                        if (str_ends_with($path, '/trophyGroups') && $query === ['npLanguage' => 'en-US']) {
+                        if (str_ends_with($path, '/trophyGroups') && $query === []) {
                             throw new GameLookupHttpException(404);
                         }
 
                         if (str_ends_with($path, '/all/trophies')
-                            && $query === ['npLanguage' => 'en-US', 'npServiceName' => 'trophy']) {
+                            && $query === ['npServiceName' => 'trophy']) {
                             return (object) ['trophies' => [(object) ['trophyGroupId' => 'all', 'trophyId' => 52]]];
                         }
 
                         if (str_ends_with($path, '/trophyGroups')
-                            && $query === ['npLanguage' => 'en-US', 'npServiceName' => 'trophy']) {
+                            && $query === ['npServiceName' => 'trophy']) {
                             return (object) ['trophyGroups' => [(object) ['trophyGroupId' => 'all']]];
                         }
 
@@ -601,13 +601,13 @@ final class PsnGameLookupServiceTest extends TestCase
         $this->assertSame(52, $result['trophyGroups'][0]['trophies'][0]['trophyId']);
         $this->assertCount(4, $attempts);
         $this->assertTrue(str_ends_with($attempts[0]['path'], '/all/trophies'));
-        $this->assertSame(['npLanguage' => 'en-US'], $attempts[0]['query']);
+        $this->assertSame([], $attempts[0]['query']);
         $this->assertTrue(str_ends_with($attempts[1]['path'], '/trophyGroups'));
-        $this->assertSame(['npLanguage' => 'en-US'], $attempts[1]['query']);
+        $this->assertSame([], $attempts[1]['query']);
         $this->assertTrue(str_ends_with($attempts[2]['path'], '/all/trophies'));
-        $this->assertSame(['npLanguage' => 'en-US', 'npServiceName' => 'trophy'], $attempts[2]['query']);
+        $this->assertSame(['npServiceName' => 'trophy'], $attempts[2]['query']);
         $this->assertTrue(str_ends_with($attempts[3]['path'], '/trophyGroups'));
-        $this->assertSame(['npLanguage' => 'en-US', 'npServiceName' => 'trophy'], $attempts[3]['query']);
+        $this->assertSame(['npServiceName' => 'trophy'], $attempts[3]['query']);
     }
 
     public function testLookupByGameIdRetriesForKnownHasteExceptionWithoutStatusCode(): void
@@ -638,8 +638,8 @@ final class PsnGameLookupServiceTest extends TestCase
 
         $result = $service->lookupByGameId('54139');
 
-        $this->assertSame(['npLanguage' => 'en-US'], $attempts[0]);
-        $this->assertSame(['npLanguage' => 'en-US', 'npServiceName' => 'trophy'], $attempts[1]);
+        $this->assertSame([], $attempts[0]);
+        $this->assertSame(['npServiceName' => 'trophy'], $attempts[1]);
         $this->assertSame(8, $result['trophyData']['trophyGroups'][0]['trophies'][0]['trophyId']);
     }
 
@@ -675,7 +675,7 @@ final class PsnGameLookupServiceTest extends TestCase
         } catch (PsnGameLookupException $exception) {
             $this->assertStringContainsString('Failed to retrieve trophy data from PlayStation Network', $exception->getMessage());
             $this->assertCount(1, $attempts);
-            $this->assertSame(['npLanguage' => 'en-US'], $attempts[0]);
+            $this->assertSame([], $attempts[0]);
         }
     }
 }

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/PsnGameLookupException.php';
 require_once __DIR__ . '/../PlayStation/Contracts/PlayStationApiClientInterface.php';
 require_once __DIR__ . '/../PlayStation/Contracts/PlayStationClientFactoryInterface.php';
 require_once __DIR__ . '/../PlayStation/Contracts/TrophyClientInterface.php';
+require_once __DIR__ . '/../PlayStation/Policy/NpServiceNamePolicy.php';
 require_once __DIR__ . '/../PlayStation/PlayStationClientFactory.php';
 
 final class PsnGameLookupService
@@ -18,6 +19,7 @@ final class PsnGameLookupService
     private readonly \Closure $workerFetcher;
 
     private readonly PlayStationClientFactoryInterface $playStationClientFactory;
+    private readonly NpServiceNamePolicy $npServiceNamePolicy;
 
     public function __construct(
         private readonly PDO $database,
@@ -26,6 +28,7 @@ final class PsnGameLookupService
     ) {
         $this->workerFetcher = \Closure::fromCallable($workerFetcher);
         $this->playStationClientFactory = $this->normalizePlayStationClientFactory($playStationClientFactory);
+        $this->npServiceNamePolicy = new NpServiceNamePolicy();
     }
 
     public static function fromDatabase(
@@ -223,9 +226,15 @@ final class PsnGameLookupService
                     throw $trophyGroupsException;
                 }
 
-                $fallbackQuery = $this->resolveAlternateQueryVariant(
-                    $this->buildLookupQueryVariants($preferredNpServiceName),
+                $fallbackQuery = $this->npServiceNamePolicy->resolveAlternateQueryVariant(
+                    $this->npServiceNamePolicy->buildLookupQueryVariants($preferredNpServiceName),
                     $trophyRequestResult['query']
+                );
+                $this->logLookupVariantSelection(
+                    'trophyGroups',
+                    $fallbackQuery ?? $trophyRequestResult['query'],
+                    $this->describeFallbackTriggerReason($trophyGroupsException),
+                    $fallbackQuery !== null
                 );
 
                 if ($fallbackQuery === null) {
@@ -383,23 +392,7 @@ final class PsnGameLookupService
             return null;
         }
 
-        $platforms = array_values(array_filter(array_map(
-            static fn (string $value): string => strtoupper(trim($value)),
-            explode(',', (string) $platform)
-        ), static fn (string $value): bool => $value !== ''));
-
-        if ($platforms === []) {
-            return null;
-        }
-
-        $legacyPlatforms = ['PS3', 'PS4', 'PSVR', 'PSVITA'];
-        foreach ($platforms as $platformValue) {
-            if (in_array($platformValue, $legacyPlatforms, true)) {
-                return 'trophy';
-            }
-        }
-
-        return 'trophy2';
+        return $this->npServiceNamePolicy->resolvePreferredNpServiceName((string) $platform);
     }
 
     /**
@@ -475,8 +468,8 @@ final class PsnGameLookupService
     }
 
     /**
-     * @param array{npLanguage: string, npServiceName?: string}|null $pinnedQuery
-     * @return array{payload: mixed, query: array{npLanguage: string, npServiceName?: string}}
+     * @param array{npServiceName?: string}|null $pinnedQuery
+     * @return array{payload: mixed, query: array{npServiceName?: string}}
      */
     private function executeLookupRequest(
         TrophyClientInterface $client,
@@ -486,19 +479,31 @@ final class PsnGameLookupService
     ): array
     {
         $queryVariants = $pinnedQuery === null
-            ? $this->buildLookupQueryVariants($preferredNpServiceName)
+            ? $this->npServiceNamePolicy->buildLookupQueryVariants($preferredNpServiceName)
             : [$pinnedQuery];
 
         $lastException = null;
 
         foreach ($queryVariants as $query) {
             try {
+                $this->logLookupVariantSelection(
+                    $path,
+                    $query,
+                    null,
+                    false
+                );
                 return [
                     'payload' => $client->requestTrophyEndpoint($path, $query, ['content-type' => 'application/json']),
                     'query' => $query,
                 ];
             } catch (Throwable $exception) {
                 $lastException = $exception;
+                $this->logLookupVariantSelection(
+                    $path,
+                    $query,
+                    $this->describeFallbackTriggerReason($exception),
+                    true
+                );
 
                 if ($pinnedQuery !== null || !$this->shouldRetryWithDifferentServiceName($exception)) {
                     throw $exception;
@@ -513,45 +518,38 @@ final class PsnGameLookupService
         throw new RuntimeException('Unable to retrieve trophy data from PlayStation Network.');
     }
 
-    /**
-     * @return list<array{npLanguage: string, npServiceName?: string}>
-     */
-    private function buildLookupQueryVariants(?string $preferredNpServiceName): array
+    private function describeFallbackTriggerReason(Throwable $exception): string
     {
-        $queryVariants = [];
-        $addVariant = static function (array $variant) use (&$queryVariants): void {
-            if (!in_array($variant, $queryVariants, true)) {
-                $queryVariants[] = $variant;
-            }
-        };
-
-        if ($preferredNpServiceName === 'trophy' || $preferredNpServiceName === 'trophy2') {
-            $addVariant(['npLanguage' => 'en-US', 'npServiceName' => $preferredNpServiceName]);
-        } else {
-            $addVariant(['npLanguage' => 'en-US']);
+        $statusCode = $this->determineStatusCode($exception);
+        if ($statusCode !== null) {
+            return sprintf('http_status:%d', $statusCode);
         }
 
-        $addVariant(['npLanguage' => 'en-US', 'npServiceName' => 'trophy']);
-        $addVariant(['npLanguage' => 'en-US', 'npServiceName' => 'trophy2']);
-        $addVariant(['npLanguage' => 'en-US']);
-
-        return $queryVariants;
+        return sprintf('exception:%s', $exception::class);
     }
 
     /**
-     * @param list<array{npLanguage: string, npServiceName?: string}> $queryVariants
-     * @param array{npLanguage: string, npServiceName?: string} $winningQuery
-     * @return array{npLanguage: string, npServiceName?: string}|null
+     * @param array{npServiceName?: string} $queryVariant
      */
-    private function resolveAlternateQueryVariant(array $queryVariants, array $winningQuery): ?array
-    {
-        foreach ($queryVariants as $queryVariant) {
-            if ($queryVariant !== $winningQuery) {
-                return $queryVariant;
-            }
-        }
+    private function logLookupVariantSelection(
+        string $endpoint,
+        array $queryVariant,
+        ?string $fallbackTriggerReason,
+        bool $isFallbackCandidate
+    ): void {
+        $payload = [
+            'event' => 'psn_lookup_variant_selected',
+            'endpoint' => $endpoint,
+            'queryVariant' => $queryVariant,
+            'isFallbackCandidate' => $isFallbackCandidate,
+            'fallbackTriggerReason' => $fallbackTriggerReason,
+        ];
 
-        return null;
+        try {
+            error_log((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
+        } catch (JsonException) {
+            error_log('{"event":"psn_lookup_variant_selected","error":"failed_to_encode_log_payload"}');
+        }
     }
 
     private function shouldRetryWithDifferentServiceName(Throwable $exception): bool

--- a/wwwroot/classes/PlayStation/Policy/NpServiceNamePolicy.php
+++ b/wwwroot/classes/PlayStation/Policy/NpServiceNamePolicy.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+final class NpServiceNamePolicy
+{
+    /**
+     * @return list<array{npServiceName?: string}>
+     */
+    public function buildLookupQueryVariants(?string $preferredNpServiceName): array
+    {
+        $queryVariants = [];
+        $addVariant = static function (array $variant) use (&$queryVariants): void {
+            if (!in_array($variant, $queryVariants, true)) {
+                $queryVariants[] = $variant;
+            }
+        };
+
+        if ($preferredNpServiceName === 'trophy' || $preferredNpServiceName === 'trophy2') {
+            $addVariant(['npServiceName' => $preferredNpServiceName]);
+        } else {
+            $addVariant([]);
+        }
+
+        $addVariant(['npServiceName' => 'trophy']);
+        $addVariant(['npServiceName' => 'trophy2']);
+        $addVariant([]);
+
+        return $queryVariants;
+    }
+
+    /**
+     * @param list<array{npServiceName?: string}> $queryVariants
+     * @param array{npServiceName?: string} $winningQuery
+     * @return array{npServiceName?: string}|null
+     */
+    public function resolveAlternateQueryVariant(array $queryVariants, array $winningQuery): ?array
+    {
+        foreach ($queryVariants as $queryVariant) {
+            if ($queryVariant !== $winningQuery) {
+                return $queryVariant;
+            }
+        }
+
+        return null;
+    }
+
+    public function resolvePreferredNpServiceName(?string $platform): ?string
+    {
+        if ($platform === null) {
+            return null;
+        }
+
+        $platforms = array_values(array_filter(array_map(
+            static fn (string $value): string => strtoupper(trim($value)),
+            explode(',', $platform)
+        ), static fn (string $value): bool => $value !== ''));
+
+        if ($platforms === []) {
+            return null;
+        }
+
+        $legacyPlatforms = ['PS3', 'PS4', 'PSVR', 'PSVITA'];
+        foreach ($platforms as $platformValue) {
+            if (in_array($platformValue, $legacyPlatforms, true)) {
+                return 'trophy';
+            }
+        }
+
+        return 'trophy2';
+    }
+}


### PR DESCRIPTION
### Motivation
- Encapsulate PlayStation NP service-name selection and query-variant logic into a single policy to simplify `PsnGameLookupService` and make variant selection testable.
- Remove the hardcoded `npLanguage` query parameter from lookup variants and standardize the query shape to only include `npServiceName` when necessary.
- Add logging and a fallback-reason description to aid diagnosing which query variant was used or triggered a fallback.

### Description
- Added `PlayStation/Policy/NpServiceNamePolicy.php` which implements `buildLookupQueryVariants`, `resolveAlternateQueryVariant`, and `resolvePreferredNpServiceName` to centralize NP service name policy and variant ordering.
- Updated `Admin/PsnGameLookupService.php` to require and instantiate `NpServiceNamePolicy`, delegate preferred-service resolution to it, and use its `buildLookupQueryVariants` and `resolveAlternateQueryVariant` methods instead of inline logic.
- Removed `npLanguage` from query shapes and adjusted the documented types for `executeLookupRequest` to use `array{npServiceName?: string}`; updated lookup flow to iterate policy-provided variants and pin/resume correctly.
- Added `describeFallbackTriggerReason` to produce compact fallback reason strings (including HTTP status when available) and `logLookupVariantSelection` to emit structured JSON logs via `error_log` when variants are tried or chosen.
- Added unit tests `tests/NpServiceNamePolicyTest.php` and updated `tests/PsnGameLookupServiceTest.php` expectations to reflect the new query shapes and behavior.

### Testing
- Ran the PHPUnit test suite including `PsnGameLookupServiceTest` and the new `NpServiceNamePolicyTest` against the modified codebase; all tests passed.
- Verified tests that previously expected `npLanguage` in queries were updated and now assert the new `npServiceName`-only query variants passed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2bf9a67c0832f9bab19359fe8891c)