### PR TITLE
Add PlayStationAuthManager to handle worker NPSSO authentication and rotation

### DIFF
--- a/wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php
+++ b/wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php
@@ -38,12 +38,16 @@ final class PlayStationAuthManager
      */
     public function authenticateWorker(int $retryDelaySeconds = 3): array
     {
+        $retryDelaySeconds = $this->normalizeSleepDelay($retryDelaySeconds);
+
         while (true) {
             $workers = $this->fetchWorkersInFailoverOrder();
             $availableWorkers = $this->filterWorkersByCooldown($workers);
 
             if ($availableWorkers === []) {
-                $sleepSeconds = max(1, $this->secondsUntilNextWorkerAvailable());
+                $sleepSeconds = $workers === []
+                    ? $retryDelaySeconds
+                    : max(1, $this->secondsUntilNextWorkerAvailable());
                 $this->logAuthResult(0, sprintf('no workers available; sleeping %d second(s)', $sleepSeconds), false);
                 sleep($sleepSeconds);
                 continue;
@@ -180,5 +184,10 @@ final class PlayStationAuthManager
         $query = $this->database->prepare('INSERT INTO log(message) VALUES(:message)');
         $query->bindValue(':message', $message, PDO::PARAM_STR);
         $query->execute();
+    }
+
+    private function normalizeSleepDelay(int $delaySeconds): int
+    {
+        return max(0, $delaySeconds);
     }
 }

--- a/wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php
+++ b/wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../Contracts/PlayStationApiClientInterface.php';
+require_once __DIR__ . '/../Contracts/PlayStationClientFactoryInterface.php';
+require_once __DIR__ . '/../PlayStationClientFactory.php';
+
+final class PlayStationAuthManager
+{
+    /**
+     * @var array<int, int>
+     */
+    private array $workerBlockedUntil = [];
+
+    private readonly PlayStationClientFactoryInterface $playStationClientFactory;
+
+    /**
+     * @var null|\Closure(string): void
+     */
+    private readonly ?\Closure $logListener;
+
+    public function __construct(
+        private readonly PDO $database,
+        PlayStationClientFactoryInterface|null $playStationClientFactory = null,
+        ?callable $logListener = null
+    ) {
+        $this->playStationClientFactory = $playStationClientFactory ?? new PlayStationClientFactory();
+        $this->logListener = $logListener === null ? null : \Closure::fromCallable($logListener);
+    }
+
+    /**
+     * Authenticates using NPSSO values from the setting table.
+     *
+     * Workers are attempted in ascending id order to preserve existing failover behavior.
+     *
+     * @return array{worker_id: int, client: PlayStationApiClientInterface}
+     */
+    public function authenticateWorker(int $retryDelaySeconds = 3): array
+    {
+        while (true) {
+            $workers = $this->fetchWorkersInFailoverOrder();
+            $availableWorkers = $this->filterWorkersByCooldown($workers);
+
+            if ($availableWorkers === []) {
+                $sleepSeconds = max(1, $this->secondsUntilNextWorkerAvailable());
+                $this->logAuthResult(0, sprintf('no workers available; sleeping %d second(s)', $sleepSeconds), false);
+                sleep($sleepSeconds);
+                continue;
+            }
+
+            foreach ($availableWorkers as $worker) {
+                $workerId = (int) $worker['id'];
+                $npsso = trim((string) ($worker['npsso'] ?? ''));
+
+                if ($npsso === '') {
+                    $this->logAuthResult($workerId, 'empty NPSSO; skipping', false);
+                    continue;
+                }
+
+                try {
+                    $client = $this->playStationClientFactory->createClient();
+                    $client->loginWithNpsso($npsso);
+                    $this->workerBlockedUntil[$workerId] = 0;
+                    $this->logAuthResult($workerId, 'authenticated', true);
+
+                    return [
+                        'worker_id' => $workerId,
+                        'client' => $client,
+                    ];
+                } catch (Throwable $throwable) {
+                    $this->logAuthResult(
+                        $workerId,
+                        sprintf('authentication failed: %s', $throwable::class),
+                        false
+                    );
+                }
+            }
+
+            $this->logAuthResult(0, sprintf('all workers failed; sleeping %d second(s)', $retryDelaySeconds), false);
+            sleep($retryDelaySeconds);
+        }
+    }
+
+    /**
+     * Refreshes a worker session and returns whether the token appears usable.
+     */
+    public function refreshSession(int $workerId, PlayStationApiClientInterface $client): bool
+    {
+        try {
+            $client->refreshAccessToken();
+            $accessToken = $client->acquireAccessToken();
+
+            $success = is_string($accessToken) && $accessToken !== '';
+            $this->logAuthResult($workerId, $success ? 'session refresh succeeded' : 'session refresh returned empty token', $success);
+
+            return $success;
+        } catch (Throwable $throwable) {
+            $this->logAuthResult(
+                $workerId,
+                sprintf('session refresh failed: %s', $throwable::class),
+                false
+            );
+
+            return false;
+        }
+    }
+
+    /**
+     * Marks a worker as unavailable and rotates authentication attempts to the next worker.
+     */
+    public function invalidateAndRotateWorkerOnAuthFailure(int $workerId, int $cooldownSeconds = 1800): void
+    {
+        $blockedUntil = time() + max(1, $cooldownSeconds);
+        $this->workerBlockedUntil[$workerId] = $blockedUntil;
+
+        $this->logAuthResult(
+            $workerId,
+            sprintf('worker invalidated for %d second(s)', max(1, $cooldownSeconds)),
+            false
+        );
+    }
+
+    /**
+     * @return list<array{id: int|string, npsso: string|null}>
+     */
+    private function fetchWorkersInFailoverOrder(): array
+    {
+        $query = $this->database->prepare('SELECT id, npsso FROM setting ORDER BY id');
+        $query->execute();
+
+        /** @var list<array{id: int|string, npsso: string|null}> $workers */
+        $workers = $query->fetchAll(PDO::FETCH_ASSOC);
+
+        return $workers;
+    }
+
+    /**
+     * @param list<array{id: int|string, npsso: string|null}> $workers
+     *
+     * @return list<array{id: int|string, npsso: string|null}>
+     */
+    private function filterWorkersByCooldown(array $workers): array
+    {
+        $now = time();
+
+        return array_values(array_filter(
+            $workers,
+            fn (array $worker): bool => ($this->workerBlockedUntil[(int) $worker['id']] ?? 0) <= $now
+        ));
+    }
+
+    private function secondsUntilNextWorkerAvailable(): int
+    {
+        if ($this->workerBlockedUntil === []) {
+            return 1;
+        }
+
+        $now = time();
+        $nextAvailableUnix = min($this->workerBlockedUntil);
+
+        return max(1, $nextAvailableUnix - $now);
+    }
+
+    private function logAuthResult(int $workerId, string $result, bool $success): void
+    {
+        $message = sprintf(
+            '[auth] worker=%d result=%s status=%s',
+            $workerId,
+            $result,
+            $success ? 'success' : 'failure'
+        );
+
+        if ($this->logListener !== null) {
+            ($this->logListener)($message);
+
+            return;
+        }
+
+        $query = $this->database->prepare('INSERT INTO log(message) VALUES(:message)');
+        $query->bindValue(':message', $message, PDO::PARAM_STR);
+        $query->execute();
+    }
+}

--- a/wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php
+++ b/wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php
@@ -188,6 +188,6 @@ final class PlayStationAuthManager
 
     private function normalizeSleepDelay(int $delaySeconds): int
     {
-        return max(0, $delaySeconds);
+        return max(1, $delaySeconds);
     }
 }


### PR DESCRIPTION
### Motivation
- Centralize worker authentication and token/session handling for NPSSO-based PlayStation clients used by scan/rescan jobs.
- Preserve existing failover semantics (attempt workers in ascending `id` order) and the retry/sleep cadence used by current jobs.
- Provide explicit operations to refresh sessions and to mark/rotate failing workers while emitting operational logs that include the worker id.

### Description
- Add `PlayStationAuthManager` at `wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php` which reads `setting` rows via `PDO` and attempts authentication in `ORDER BY id` failover order.
- Implement `authenticateWorker()` which cycles available workers, respects per-worker cooldowns, retries with a configurable `retryDelaySeconds` (default `3`), and returns `['worker_id' => int, 'client' => PlayStationApiClientInterface]` on success.
- Implement `refreshSession()` to call `refreshAccessToken()`/`acquireAccessToken()` and return whether a usable token was obtained, and implement `invalidateAndRotateWorkerOnAuthFailure()` to set an in-memory cooldown (default `1800` seconds) for a failed worker.
- Emit structured auth logs in the format `[auth] worker=<id> result=<...> status=<success|failure>` and support an optional callback logger or fall back to inserting into the `log` table.

### Testing
- Syntax check passed with `php -l wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php` (no syntax errors).
- Composer metadata validation passed with `cd wwwroot && composer validate --no-check-publish` and produced only non-blocking warnings about package metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e33fc21c64832fa7920d67216c95ae)