### PR TITLE
Add worker-specific authentication to PlayStationAuthManager

### DIFF
--- a/tests/PlayStationAuthManagerTest.php
+++ b/tests/PlayStationAuthManagerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/Contracts/PlayStationClientFactoryInterface.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/Contracts/PlayStationApiClientInterface.php';
+
+final class PlayStationAuthManagerTest extends TestCase
+{
+    public function testAuthenticateSpecificWorkerReturnsRequestedWorker(): void
+    {
+        $database = $this->createDatabaseWithWorkers([
+            ['id' => 1, 'npsso' => 'worker-1-npsso'],
+            ['id' => 2, 'npsso' => 'worker-2-npsso'],
+        ]);
+
+        $factory = new PlayStationAuthManagerTestFactory();
+        $manager = new PlayStationAuthManager($database, $factory);
+
+        $result = $manager->authenticateSpecificWorker(2);
+
+        $this->assertSame(2, $result['worker_id']);
+        $this->assertSame(['worker-2-npsso'], $factory->getLoggedInNpssoValues());
+    }
+
+    public function testAuthenticateSpecificWorkerThrowsWhenWorkerDoesNotExist(): void
+    {
+        $database = $this->createDatabaseWithWorkers([
+            ['id' => 1, 'npsso' => 'worker-1-npsso'],
+        ]);
+
+        $manager = new PlayStationAuthManager($database, new PlayStationAuthManagerTestFactory());
+
+        try {
+            $manager->authenticateSpecificWorker(999);
+            $this->fail('Expected RuntimeException for missing worker.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Worker 999 not found in setting table.', $exception->getMessage());
+        }
+    }
+
+    public function testAuthenticateSpecificWorkerThrowsWhenWorkerCannotAuthenticate(): void
+    {
+        $database = $this->createDatabaseWithWorkers([
+            ['id' => 1, 'npsso' => ''],
+        ]);
+
+        $manager = new PlayStationAuthManager($database, new PlayStationAuthManagerTestFactory());
+
+        try {
+            $manager->authenticateSpecificWorker(1);
+            $this->fail('Expected RuntimeException for unauthenticated worker.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Unable to authenticate worker 1.', $exception->getMessage());
+        }
+    }
+
+    /**
+     * @param list<array{id: int, npsso: string}> $workers
+     */
+    private function createDatabaseWithWorkers(array $workers): PDO
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY, npsso TEXT)');
+        $database->exec('CREATE TABLE log (message TEXT NOT NULL)');
+
+        $insert = $database->prepare('INSERT INTO setting (id, npsso) VALUES (:id, :npsso)');
+
+        foreach ($workers as $worker) {
+            $insert->bindValue(':id', $worker['id'], PDO::PARAM_INT);
+            $insert->bindValue(':npsso', $worker['npsso'], PDO::PARAM_STR);
+            $insert->execute();
+        }
+
+        return $database;
+    }
+}
+
+final class PlayStationAuthManagerTestFactory implements PlayStationClientFactoryInterface
+{
+    /**
+     * @var list<string>
+     */
+    private array $loggedInNpssoValues = [];
+
+    public function createClient(): PlayStationApiClientInterface
+    {
+        return new class($this) implements PlayStationApiClientInterface {
+            public function __construct(private readonly PlayStationAuthManagerTestFactory $factory)
+            {
+            }
+
+            public function loginWithNpsso(string $npsso): void
+            {
+                $this->factory->recordNpssoLogin($npsso);
+            }
+
+            public function acquireAccessToken(): ?string
+            {
+                return 'token';
+            }
+
+            public function refreshAccessToken(): void
+            {
+            }
+
+            public function lookupProfileByOnlineId(string $onlineId): mixed
+            {
+                return (object) [];
+            }
+
+            public function findUserByAccountId(string $accountId): object
+            {
+                return (object) [];
+            }
+
+            public function requestTrophyEndpoint(string $path, array $query = [], array $headers = []): mixed
+            {
+                return (object) [];
+            }
+
+            public function searchUsers(string $onlineId): iterable
+            {
+                return [];
+            }
+        };
+    }
+
+    public function recordNpssoLogin(string $npsso): void
+    {
+        $this->loggedInNpssoValues[] = $npsso;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getLoggedInNpssoValues(): array
+    {
+        return $this->loggedInNpssoValues;
+    }
+}

--- a/wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php
+++ b/wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php
@@ -54,36 +54,39 @@ final class PlayStationAuthManager
             }
 
             foreach ($availableWorkers as $worker) {
-                $workerId = (int) $worker['id'];
-                $npsso = trim((string) ($worker['npsso'] ?? ''));
-
-                if ($npsso === '') {
-                    $this->logAuthResult($workerId, 'empty NPSSO; skipping', false);
-                    continue;
-                }
-
-                try {
-                    $client = $this->playStationClientFactory->createClient();
-                    $client->loginWithNpsso($npsso);
-                    $this->workerBlockedUntil[$workerId] = 0;
-                    $this->logAuthResult($workerId, 'authenticated', true);
-
-                    return [
-                        'worker_id' => $workerId,
-                        'client' => $client,
-                    ];
-                } catch (Throwable $throwable) {
-                    $this->logAuthResult(
-                        $workerId,
-                        sprintf('authentication failed: %s', $throwable::class),
-                        false
-                    );
+                $authenticatedWorker = $this->authenticateWorkerRecord($worker);
+                if ($authenticatedWorker !== null) {
+                    return $authenticatedWorker;
                 }
             }
 
             $this->logAuthResult(0, sprintf('all workers failed; sleeping %d second(s)', $retryDelaySeconds), false);
             sleep($retryDelaySeconds);
         }
+    }
+
+    /**
+     * Authenticates a specific worker by id.
+     *
+     * @return array{worker_id: int, client: PlayStationApiClientInterface}
+     */
+    public function authenticateSpecificWorker(int $workerId): array
+    {
+        $worker = $this->fetchWorkerById($workerId);
+        if ($worker === null) {
+            throw new RuntimeException(sprintf('Worker %d not found in setting table.', $workerId));
+        }
+
+        if (($this->workerBlockedUntil[$workerId] ?? 0) > time()) {
+            throw new RuntimeException(sprintf('Worker %d is currently in cooldown.', $workerId));
+        }
+
+        $authenticatedWorker = $this->authenticateWorkerRecord($worker);
+        if ($authenticatedWorker === null) {
+            throw new RuntimeException(sprintf('Unable to authenticate worker %d.', $workerId));
+        }
+
+        return $authenticatedWorker;
     }
 
     /**
@@ -140,6 +143,24 @@ final class PlayStationAuthManager
     }
 
     /**
+     * @return array{id: int|string, npsso: string|null}|null
+     */
+    private function fetchWorkerById(int $workerId): ?array
+    {
+        $query = $this->database->prepare('SELECT id, npsso FROM setting WHERE id = :worker_id LIMIT 1');
+        $query->bindValue(':worker_id', $workerId, PDO::PARAM_INT);
+        $query->execute();
+
+        $worker = $query->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($worker)) {
+            return null;
+        }
+
+        return $worker;
+    }
+
+    /**
      * @param list<array{id: int|string, npsso: string|null}> $workers
      *
      * @return list<array{id: int|string, npsso: string|null}>
@@ -189,5 +210,42 @@ final class PlayStationAuthManager
     private function normalizeSleepDelay(int $delaySeconds): int
     {
         return max(1, $delaySeconds);
+    }
+
+    /**
+     * @param array{id: int|string, npsso: string|null} $worker
+     *
+     * @return array{worker_id: int, client: PlayStationApiClientInterface}|null
+     */
+    private function authenticateWorkerRecord(array $worker): ?array
+    {
+        $workerId = (int) $worker['id'];
+        $npsso = trim((string) ($worker['npsso'] ?? ''));
+
+        if ($npsso === '') {
+            $this->logAuthResult($workerId, 'empty NPSSO; skipping', false);
+
+            return null;
+        }
+
+        try {
+            $client = $this->playStationClientFactory->createClient();
+            $client->loginWithNpsso($npsso);
+            $this->workerBlockedUntil[$workerId] = 0;
+            $this->logAuthResult($workerId, 'authenticated', true);
+
+            return [
+                'worker_id' => $workerId,
+                'client' => $client,
+            ];
+        } catch (Throwable $throwable) {
+            $this->logAuthResult(
+                $workerId,
+                sprintf('authentication failed: %s', $throwable::class),
+                false
+            );
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- The 30th-minute cron flow needs a way to authenticate a specific worker id instead of only using the existing failover loop. 
- Centralize and reuse login logic to keep behavior consistent between failover and targeted authentication.

### Description
- Added `authenticateSpecificWorker(int $workerId)` to `wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php` which fetches a single worker and attempts login, and raises clear `RuntimeException`s for missing worker, cooldown, or auth failure. 
- Introduced `fetchWorkerById()` to retrieve a single worker row and `authenticateWorkerRecord()` to encapsulate the login+logging flow, and refactored `authenticateWorker()` to call the new helper. 
- Kept existing failover behavior intact while reusing the shared login helper. 
- Added unit tests in `tests/PlayStationAuthManagerTest.php` covering successful specific-worker auth, missing worker, and non-authenticating worker cases.

### Testing
- Ran syntax checks with `php -l wwwroot/classes/PlayStation/Auth/PlayStationAuthManager.php` and `php -l tests/PlayStationAuthManagerTest.php`, both reported no syntax errors. 
- Executed the repository test runner with `php tests/run.php`, which completed but the test suite contained unrelated pre-existing failures (2 failure(s) and 1 error(s) out of 471 tests). 
- Ran the new `PlayStationAuthManagerTest` individually and it passed when executed via the test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40122b29c832fba207b0bf1547a2b)