### PR TITLE
Fix failing queue progress formatting, trophy merge SQL, lookup grouping, and add test helper

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -102,6 +102,17 @@ abstract class TestCase
         }
     }
 
+
+    protected function assertArrayNotHasKey(string|int $key, array $array, string $message = ''): void
+    {
+        if (array_key_exists($key, $array)) {
+            $this->fail(
+                $message !== ''
+                    ? $message
+                    : sprintf('Failed asserting that array does not contain key %s.', var_export($key, true))
+            );
+        }
+    }
     protected function assertStringContainsString(string $needle, string $haystack, string $message = ''): void
     {
         if (!str_contains($haystack, $needle)) {

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -329,12 +329,17 @@ final class PsnGameLookupService
                 continue;
             }
 
+            $groupTrophies = is_array($trophiesByGroupId[$groupId] ?? null) ? $trophiesByGroupId[$groupId] : [];
+            if ($groupTrophies === [] && is_array($rawGroup['trophies'] ?? null)) {
+                $groupTrophies = $rawGroup['trophies'];
+            }
+
             $groups[] = [
                 'trophyGroupId' => $groupId,
                 'trophyGroupName' => (string) ($rawGroup['trophyGroupName'] ?? ''),
                 'trophyGroupDetail' => (string) ($rawGroup['trophyGroupDetail'] ?? ''),
                 'trophyGroupIconUrl' => (string) ($rawGroup['trophyGroupIconUrl'] ?? ''),
-                'trophies' => is_array($trophiesByGroupId[$groupId] ?? null) ? $trophiesByGroupId[$groupId] : [],
+                'trophies' => $groupTrophies,
             ];
         }
 

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -151,9 +151,9 @@ final class PlayerQueueResponseFactory
         }
 
         if (preg_match('/^(Updating|Fetching)\b/i', $normalizedTitle) === 1) {
-            $actionText = ucfirst($normalizedTitle);
+            $escapedActionText = $this->service->escapeHtml(lcfirst($normalizedTitle));
 
-            return $this->service->escapeHtml($actionText);
+            return ucfirst($escapedActionText);
         }
 
         if ($this->isErrorProgressTitle($normalizedTitle)) {

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -1125,8 +1125,26 @@ SQL
             sprintf('Found %d merged trophies to copy…', $total)
         );
 
-        $mergeSourceCte = <<<'SQL'
-            WITH merge_source AS (
+        $insertMissingParentEarned = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy_earned (
+                np_communication_id,
+                group_id,
+                order_id,
+                account_id,
+                earned_date,
+                progress,
+                earned
+            )
+            SELECT
+                source.parent_np_communication_id,
+                source.parent_group_id,
+                source.parent_order_id,
+                source.account_id,
+                source.earned_date,
+                source.progress,
+                source.earned
+            FROM (
                 SELECT
                     tm.parent_np_communication_id,
                     tm.parent_group_id,
@@ -1140,46 +1158,35 @@ SQL
                     AND child.group_id = tm.child_group_id
                     AND child.order_id = tm.child_order_id
                 WHERE tm.child_np_communication_id = :child_np_communication_id
-            )
-        SQL;
-
-        $insertMissingParentEarned = $this->database->prepare(
-            <<<'SQL'
-            INSERT INTO trophy_earned (
-                np_communication_id,
-                group_id,
-                order_id,
-                account_id,
-                earned_date,
-                progress,
-                earned
-            )
-        SQL
-            . "\n" . $mergeSourceCte . "\n"
-            . <<<'SQL'
-            SELECT
-                source.parent_np_communication_id,
-                source.parent_group_id,
-                source.parent_order_id,
-                source.account_id,
-                source.earned_date,
-                source.progress,
-                source.earned
-            FROM merge_source AS source
+            ) AS source
             LEFT JOIN trophy_earned AS parent ON parent.np_communication_id = source.parent_np_communication_id
                 AND parent.group_id = source.parent_group_id
                 AND parent.order_id = source.parent_order_id
                 AND parent.account_id = source.account_id
             WHERE parent.account_id IS NULL
-SQL
+            SQL
         );
         $insertMissingParentEarned->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
         $insertMissingParentEarned->execute();
 
         $synchronizeExistingEarned = $this->database->prepare(
-            $mergeSourceCte . <<<'SQL'
+            <<<'SQL'
             UPDATE trophy_earned AS parent
-            JOIN merge_source AS source ON source.parent_np_communication_id = parent.np_communication_id
+            JOIN (
+                SELECT
+                    tm.parent_np_communication_id,
+                    tm.parent_group_id,
+                    tm.parent_order_id,
+                    child.account_id,
+                    child.earned_date,
+                    child.progress,
+                    child.earned
+                FROM trophy_merge AS tm
+                JOIN trophy_earned AS child ON child.np_communication_id = tm.child_np_communication_id
+                    AND child.group_id = tm.child_group_id
+                    AND child.order_id = tm.child_order_id
+                WHERE tm.child_np_communication_id = :child_np_communication_id
+            ) AS source ON source.parent_np_communication_id = parent.np_communication_id
                 AND source.parent_group_id = parent.group_id
                 AND source.parent_order_id = parent.order_id
                 AND source.account_id = parent.account_id
@@ -1200,7 +1207,7 @@ SQL
                     WHEN source.earned = 1 THEN 1
                     ELSE parent.earned
                 END
-SQL
+            SQL
         );
         $synchronizeExistingEarned->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
         $synchronizeExistingEarned->execute();


### PR DESCRIPTION
### Motivation
- Several unit tests were failing due to mismatches between expected and actual behaviour for queue scan progress titles, the shape of SQL used when copying merged trophies, and PSN lookup payload shapes, and one test helper was missing which caused a runtime error. 
- The intent is to make output formatting, SQL query shape, and response normalization match the tests' expectations so the suite is green.

### Description
- Added `assertArrayNotHasKey()` to the custom `TestCase` to allow tests to assert absent array keys without throwing an error. 
- Changed `PlayerQueueResponseFactory::formatProgressTitle()` to escape the action-verb progress title using the lower-case input and then capitalize for display so escaped values and displayed text match expectations. 
- Rewrote the merged-trophy copy logic in `TrophyMergeService::copyMergedTrophies()` to use derived-table sources (`FROM ( ... ) AS source` and `JOIN ( ... ) AS source`) for both the `INSERT` and `UPDATE` statements instead of a CTE, matching the SQL shape the tests assert. 
- Updated `PsnGameLookupService::buildTrophyGroups()` to preserve trophies from grouped payloads when the flat `trophies` array is absent so grouped responses are assembled correctly.

### Testing
- Ran the full test suite with `php tests/run.php`, which completed successfully and all tests passed (`471/471`).
- Checked PHP syntax for modified files with `php -l` for `tests/TestCase.php`, `wwwroot/classes/PlayerQueueResponseFactory.php`, `wwwroot/classes/TrophyMergeService.php`, and `wwwroot/classes/Admin/PsnGameLookupService.php`, and no syntax errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40324e104832f88ff5c71dafb3fe1)