### PR TITLE
Add PSN client mode config with validation and centralized accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ PSN 100% is not a community for discussion (forum), gaming/boosting sessions or 
 - **PHP:** 8.5
 - **MySQL:** 8.4
 
+
+## Application configuration
+
+The canonical service config file is `wwwroot/config/app.php`.
+
+### PSN client mode
+
+Set `PSN_CLIENT_MODE` to control which PSN client mode is used by PSN lookup, rescan, and cron flows.
+
+- `legacy` (default): use the current production behavior.
+- `shadow`: run the shadow mode configuration path while still using legacy client behavior.
+- `new`: run the new mode configuration path (currently mapped to the same client implementation as `legacy` until rollout is complete).
+
+The app validates the configured mode on first use and fails fast with a clear error if the value is not one of `legacy`, `shadow`, or `new`.
+
 ## Merge Guideline Priorities
 1. Available > Delisted
 2. English language > Other language

--- a/wwwroot/classes/PlayStation/PlayStationClientFactory.php
+++ b/wwwroot/classes/PlayStation/PlayStationClientFactory.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/Contracts/PlayStationClientFactoryInterface.php';
 require_once __DIR__ . '/TustinPlayStationApiClient.php';
+require_once __DIR__ . '/../PsnClientMode.php';
 
 final class PlayStationClientFactory implements PlayStationClientFactoryInterface
 {
     public function createClient(): PlayStationApiClientInterface
     {
-        return new TustinPlayStationApiClient();
+        $mode = PsnClientMode::current();
+
+        return match ($mode->value()) {
+            PsnClientMode::LEGACY,
+            PsnClientMode::SHADOW,
+            PsnClientMode::NEW => new TustinPlayStationApiClient(),
+        };
     }
 }

--- a/wwwroot/classes/PsnClientMode.php
+++ b/wwwroot/classes/PsnClientMode.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+final class PsnClientMode
+{
+    public const string LEGACY = 'legacy';
+    public const string SHADOW = 'shadow';
+    public const string NEW = 'new';
+
+    private const string ENVIRONMENT_KEY = 'PSN_CLIENT_MODE';
+
+    private static ?self $resolvedMode = null;
+
+    private function __construct(private string $value)
+    {
+    }
+
+    public static function current(): self
+    {
+        if (self::$resolvedMode !== null) {
+            return self::$resolvedMode;
+        }
+
+        $configuration = self::loadAppConfiguration();
+        $mode = $configuration['psn']['client_mode'] ?? self::LEGACY;
+
+        self::$resolvedMode = self::fromValue($mode);
+
+        return self::$resolvedMode;
+    }
+
+    public static function fromValue(mixed $mode): self
+    {
+        if (!is_string($mode)) {
+            throw new RuntimeException(
+                sprintf(
+                    'Invalid PSN client mode configuration. Expected one of [%s] in %s.',
+                    implode(', ', self::allowedValues()),
+                    self::ENVIRONMENT_KEY
+                )
+            );
+        }
+
+        $normalized = strtolower(trim($mode));
+
+        if (!in_array($normalized, self::allowedValues(), true)) {
+            throw new RuntimeException(
+                sprintf(
+                    'Invalid PSN client mode "%s". Allowed values: %s. Set %s accordingly.',
+                    $mode,
+                    implode(', ', self::allowedValues()),
+                    self::ENVIRONMENT_KEY
+                )
+            );
+        }
+
+        return new self($normalized);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedValues(): array
+    {
+        return [self::LEGACY, self::SHADOW, self::NEW];
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function isLegacy(): bool
+    {
+        return $this->value === self::LEGACY;
+    }
+
+    public function isShadow(): bool
+    {
+        return $this->value === self::SHADOW;
+    }
+
+    public function isNew(): bool
+    {
+        return $this->value === self::NEW;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function loadAppConfiguration(): array
+    {
+        $configurationFile = __DIR__ . '/../config/app.php';
+
+        if (!is_file($configurationFile)) {
+            return [];
+        }
+
+        $configuration = @include $configurationFile;
+
+        return is_array($configuration) ? $configuration : [];
+    }
+}

--- a/wwwroot/config/app.php
+++ b/wwwroot/config/app.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'psn' => [
+        'client_mode' => $_ENV['PSN_CLIENT_MODE'] ?? getenv('PSN_CLIENT_MODE') ?: 'legacy',
+    ],
+];

--- a/wwwroot/config/app.php
+++ b/wwwroot/config/app.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+$psnClientMode = $_ENV['PSN_CLIENT_MODE'] ?? getenv('PSN_CLIENT_MODE');
+
 return [
     'psn' => [
-        'client_mode' => $_ENV['PSN_CLIENT_MODE'] ?? getenv('PSN_CLIENT_MODE') ?: 'legacy',
+        'client_mode' => $psnClientMode === false ? 'legacy' : $psnClientMode,
     ],
 ];


### PR DESCRIPTION
### Motivation
- Provide a single, operator-configurable switch for PSN client behavior with a clear canonical source of truth. 
- Fail fast on invalid configuration to avoid subtle runtime differences across lookup/rescan/cron flows. 
- Ensure all PSN client creation and related flows read the mode from one shared accessor.

### Description
- Added a canonical application config file `wwwroot/config/app.php` that wires `psn.client_mode` to the `PSN_CLIENT_MODE` environment variable and defaults to `legacy`.
- Introduced `PsnClientMode` (`wwwroot/classes/PsnClientMode.php`) as a centralized accessor and guard that defines allowed values (`legacy`, `shadow`, `new`), loads the canonical config, normalizes and validates the value, and throws a clear `RuntimeException` on invalid configuration.
- Wired client construction to use the centralized accessor by updating `PlayStationClientFactory` (`wwwroot/classes/PlayStation/PlayStationClientFactory.php`) to call `PsnClientMode::current()` and select behavior via the mode value.
- Documented the new configuration and modes in `README.md` under an "Application configuration" section describing the env var, available modes, and fail-fast validation behavior.

### Testing
- Ran the full PHP test suite with `php /workspace/psn100/tests/run.php`, which completed successfully (all tests passed).
- Performed syntax checks with `php -l` on `wwwroot/config/app.php`, `wwwroot/classes/PsnClientMode.php`, and `wwwroot/classes/PlayStation/PlayStationClientFactory.php`, all reporting no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e406ba3e2c832fa4ecceadcbfa7910)