### PR TITLE
Add PSN shadow execution utility with normalizer/comparator and integrate into lookup services

### DIFF
--- a/tests/PsnGameLookupServiceTest.php
+++ b/tests/PsnGameLookupServiceTest.php
@@ -798,7 +798,12 @@ final class PsnGameLookupServiceTest extends TestCase
         $result = $service->fetchTrophyDataForNpCommunicationId('NPWR00000_00', $providedClient);
 
         $this->assertSame(7, $result['trophyGroups'][0]['trophies'][0]['trophyId']);
-        $this->assertSame(1, $shadowFactoryCounter->count);
+        $expectedShadowExecutions = (
+            function_exists('pcntl_signal')
+            && function_exists('pcntl_async_signals')
+            && function_exists('pcntl_setitimer')
+        ) ? 1 : 0;
+        $this->assertSame($expectedShadowExecutions, $shadowFactoryCounter->count);
     }
 }
 

--- a/tests/PsnGameLookupServiceTest.php
+++ b/tests/PsnGameLookupServiceTest.php
@@ -805,6 +805,172 @@ final class PsnGameLookupServiceTest extends TestCase
         ) ? 1 : 0;
         $this->assertSame($expectedShadowExecutions, $shadowFactoryCounter->count);
     }
+
+    public function testFetchTrophyDataInShadowModeReusesLegacyWorkerSessionForShadowLookup(): void
+    {
+        if (
+            !function_exists('pcntl_signal')
+            || !function_exists('pcntl_async_signals')
+            || !function_exists('pcntl_setitimer')
+        ) {
+            return;
+        }
+
+        $workers = [
+            new Worker(1, 'legacy-worker-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null),
+            new Worker(2, 'secondary-worker-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null),
+        ];
+        $legacyLogins = [];
+        $shadowLogins = [];
+
+        $legacyFactory = new class ($legacyLogins) implements PlayStationClientFactoryInterface {
+            /** @var array<int, string> */
+            private array $legacyLogins;
+
+            /**
+             * @param array<int, string> $legacyLogins
+             */
+            public function __construct(array &$legacyLogins)
+            {
+                $this->legacyLogins = &$legacyLogins;
+            }
+
+            public function createClient(): PlayStationApiClientInterface
+            {
+                return new class ($this->legacyLogins) implements PlayStationApiClientInterface {
+                    /** @var array<int, string> */
+                    private array $legacyLogins;
+
+                    /**
+                     * @param array<int, string> $legacyLogins
+                     */
+                    public function __construct(array &$legacyLogins)
+                    {
+                        $this->legacyLogins = &$legacyLogins;
+                    }
+
+                    public function loginWithNpsso(string $npsso): void
+                    {
+                        $this->legacyLogins[] = $npsso;
+                    }
+
+                    public function acquireAccessToken(): ?string
+                    {
+                        return null;
+                    }
+
+                    public function refreshAccessToken(): void
+                    {
+                    }
+
+                    public function lookupProfileByOnlineId(string $onlineId): mixed
+                    {
+                        return (object) [];
+                    }
+
+                    public function findUserByAccountId(string $accountId): object
+                    {
+                        return (object) [];
+                    }
+
+                    public function requestTrophyEndpoint(string $path, array $query = [], array $headers = []): mixed
+                    {
+                        if (str_contains($path, '/trophyGroups/all/trophies')) {
+                            return (object) ['trophies' => [(object) ['trophyGroupId' => 'all', 'trophyId' => 101]]];
+                        }
+
+                        return (object) ['trophyGroups' => [(object) ['trophyGroupId' => 'all']]];
+                    }
+
+                    public function searchUsers(string $onlineId): iterable
+                    {
+                        return [];
+                    }
+                };
+            }
+        };
+
+        $shadowFactory = new class ($shadowLogins) implements PlayStationClientFactoryInterface {
+            /** @var array<int, string> */
+            private array $shadowLogins;
+
+            /**
+             * @param array<int, string> $shadowLogins
+             */
+            public function __construct(array &$shadowLogins)
+            {
+                $this->shadowLogins = &$shadowLogins;
+            }
+
+            public function createClient(): PlayStationApiClientInterface
+            {
+                return new class ($this->shadowLogins) implements PlayStationApiClientInterface {
+                    /** @var array<int, string> */
+                    private array $shadowLogins;
+
+                    /**
+                     * @param array<int, string> $shadowLogins
+                     */
+                    public function __construct(array &$shadowLogins)
+                    {
+                        $this->shadowLogins = &$shadowLogins;
+                    }
+
+                    public function loginWithNpsso(string $npsso): void
+                    {
+                        $this->shadowLogins[] = $npsso;
+                    }
+
+                    public function acquireAccessToken(): ?string
+                    {
+                        return null;
+                    }
+
+                    public function refreshAccessToken(): void
+                    {
+                    }
+
+                    public function lookupProfileByOnlineId(string $onlineId): mixed
+                    {
+                        return (object) [];
+                    }
+
+                    public function findUserByAccountId(string $accountId): object
+                    {
+                        return (object) [];
+                    }
+
+                    public function requestTrophyEndpoint(string $path, array $query = [], array $headers = []): mixed
+                    {
+                        if (str_contains($path, '/trophyGroups/all/trophies')) {
+                            return (object) ['trophies' => [(object) ['trophyGroupId' => 'all', 'trophyId' => 999]]];
+                        }
+
+                        return (object) ['trophyGroups' => [(object) ['trophyGroupId' => 'all']]];
+                    }
+
+                    public function searchUsers(string $onlineId): iterable
+                    {
+                        return [];
+                    }
+                };
+            }
+        };
+
+        $service = new PsnGameLookupService(
+            $this->database,
+            static fn (): array => $workers,
+            $legacyFactory,
+            $shadowFactory,
+            PsnClientMode::fromValue('shadow')
+        );
+
+        $result = $service->fetchTrophyDataForNpCommunicationId('NPWR00000_00');
+
+        $this->assertSame(101, $result['trophyGroups'][0]['trophies'][0]['trophyId']);
+        $this->assertSame(['legacy-worker-npsso'], $legacyLogins);
+        $this->assertSame(['legacy-worker-npsso'], $shadowLogins);
+    }
 }
 
 final class GameLookupStubClient

--- a/tests/PsnGameLookupServiceTest.php
+++ b/tests/PsnGameLookupServiceTest.php
@@ -748,6 +748,58 @@ final class PsnGameLookupServiceTest extends TestCase
 
         $this->assertSame('7', $result['trophyData']['trophyGroups'][0]['trophies'][0]['trophyId']);
     }
+
+    public function testFetchTrophyDataInShadowModeWithProvidedClientExecutesShadowPath(): void
+    {
+        $worker = new Worker(1, 'worker-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+        $shadowFactoryCounter = (object) ['count' => 0];
+
+        $legacyFactory = new class () implements PlayStationClientFactoryInterface {
+            public function createClient(): PlayStationApiClientInterface
+            {
+                return new ShadowGameClientStub(
+                    static fn (): object => (object) ['trophies' => [(object) ['trophyGroupId' => 'all', 'trophyId' => 1]]],
+                    static fn (): object => (object) ['trophyGroups' => [(object) ['trophyGroupId' => 'all']]]
+                );
+            }
+        };
+        $shadowFactory = new class ($shadowFactoryCounter) implements PlayStationClientFactoryInterface {
+            private object $counter;
+
+            public function __construct(object $counter)
+            {
+                $this->counter = $counter;
+            }
+
+            public function createClient(): PlayStationApiClientInterface
+            {
+                $this->counter->count++;
+
+                return new ShadowGameClientStub(
+                    static fn (): object => (object) ['trophies' => [(object) ['trophyGroupId' => 'all', 'trophyId' => 999]]],
+                    static fn (): object => (object) ['trophyGroups' => [(object) ['trophyGroupId' => 'all']]]
+                );
+            }
+        };
+
+        $service = new PsnGameLookupService(
+            $this->database,
+            static fn (): array => [$worker],
+            $legacyFactory,
+            $shadowFactory,
+            PsnClientMode::fromValue('shadow')
+        );
+
+        $providedClient = new ShadowGameClientStub(
+            static fn (): object => (object) ['trophies' => [(object) ['trophyGroupId' => 'all', 'trophyId' => 7]]],
+            static fn (): object => (object) ['trophyGroups' => [(object) ['trophyGroupId' => 'all']]]
+        );
+
+        $result = $service->fetchTrophyDataForNpCommunicationId('NPWR00000_00', $providedClient);
+
+        $this->assertSame(7, $result['trophyGroups'][0]['trophies'][0]['trophyId']);
+        $this->assertSame(1, $shadowFactoryCounter->count);
+    }
 }
 
 final class GameLookupStubClient

--- a/tests/PsnGameLookupServiceTest.php
+++ b/tests/PsnGameLookupServiceTest.php
@@ -6,6 +6,9 @@ require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/PsnGameLookupService.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/PsnGameLookupRequestHandler.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/Worker.php';
+require_once __DIR__ . '/../wwwroot/classes/PsnClientMode.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/Contracts/PlayStationApiClientInterface.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/Contracts/PlayStationClientFactoryInterface.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayStation/Exception/PlayStationNotFoundException.php';
 
 final class PsnGameLookupServiceTest extends TestCase
@@ -708,6 +711,43 @@ final class PsnGameLookupServiceTest extends TestCase
         $this->assertSame(['npServiceName' => 'trophy'], $attempts[1]);
         $this->assertSame(9, $result['trophyData']['trophyGroups'][0]['trophies'][0]['trophyId']);
     }
+
+    public function testLookupInShadowModeReturnsLegacyTrophyPayload(): void
+    {
+        $this->database->exec("INSERT INTO trophy_title (id, np_communication_id, name) VALUES (88, 'NPWR88888_00', 'Shadow Game')");
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $legacyFactory = new class () implements PlayStationClientFactoryInterface {
+            public function createClient(): PlayStationApiClientInterface
+            {
+                return new ShadowGameClientStub(
+                    static fn (): object => (object) ['trophies' => [(object) ['trophyGroupId' => 'all', 'trophyId' => '7']]],
+                    static fn (): object => (object) ['trophyGroups' => [(object) ['trophyGroupId' => 'all']]]
+                );
+            }
+        };
+        $shadowFactory = new class () implements PlayStationClientFactoryInterface {
+            public function createClient(): PlayStationApiClientInterface
+            {
+                return new ShadowGameClientStub(
+                    static fn (): object => (object) ['trophies' => [(object) ['trophyGroupId' => 'all', 'trophyId' => 999]]],
+                    static fn (): object => (object) ['trophyGroups' => [(object) ['trophyGroupId' => 'all']]]
+                );
+            }
+        };
+
+        $service = new PsnGameLookupService(
+            $this->database,
+            static fn (): array => [$worker],
+            $legacyFactory,
+            $shadowFactory,
+            PsnClientMode::fromValue('shadow')
+        );
+
+        $result = $service->lookupByGameId('88');
+
+        $this->assertSame('7', $result['trophyData']['trophyGroups'][0]['trophies'][0]['trophyId']);
+    }
 }
 
 final class GameLookupStubClient
@@ -760,4 +800,56 @@ final class GameLookupHttpException extends RuntimeException
 
 final class GameLookupNotFoundHttpException extends Exception
 {
+}
+
+final class ShadowGameClientStub implements PlayStationApiClientInterface
+{
+    /** @var callable(): object */
+    private $trophiesHandler;
+
+    /** @var callable(): object */
+    private $groupsHandler;
+
+    public function __construct(callable $trophiesHandler, callable $groupsHandler)
+    {
+        $this->trophiesHandler = $trophiesHandler;
+        $this->groupsHandler = $groupsHandler;
+    }
+
+    public function loginWithNpsso(string $npsso): void
+    {
+    }
+
+    public function acquireAccessToken(): ?string
+    {
+        return null;
+    }
+
+    public function refreshAccessToken(): void
+    {
+    }
+
+    public function lookupProfileByOnlineId(string $onlineId): mixed
+    {
+        return (object) [];
+    }
+
+    public function findUserByAccountId(string $accountId): object
+    {
+        return (object) [];
+    }
+
+    public function requestTrophyEndpoint(string $path, array $query = [], array $headers = []): mixed
+    {
+        if (str_ends_with($path, '/all/trophies')) {
+            return ($this->trophiesHandler)();
+        }
+
+        return ($this->groupsHandler)();
+    }
+
+    public function searchUsers(string $onlineId): iterable
+    {
+        return [];
+    }
 }

--- a/tests/PsnPlayerLookupServiceTest.php
+++ b/tests/PsnPlayerLookupServiceTest.php
@@ -6,6 +6,9 @@ require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/PsnPlayerLookupService.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/PsnPlayerLookupRequestHandler.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/Worker.php';
+require_once __DIR__ . '/../wwwroot/classes/PsnClientMode.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/Contracts/PlayStationClientFactoryInterface.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/Contracts/PlayStationApiClientInterface.php';
 
 final class PsnPlayerLookupServiceTest extends TestCase
 {
@@ -224,6 +227,90 @@ final class PsnPlayerLookupServiceTest extends TestCase
         $this->assertSame(null, $handled->getErrorMessage());
         $this->assertSame('example@a6.us', $handled->getDecodedNpId());
         $this->assertSame('US', $handled->getNpCountry());
+    }
+
+    public function testLookupInShadowModeKeepsLegacyResponseAsSourceOfTruth(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $legacyFactory = new class () implements PlayStationClientFactoryInterface {
+            public function createClient(): PlayStationApiClientInterface
+            {
+                return new ShadowPlayerClientStub(
+                    profileResponse: (object) [
+                        'profile' => (object) [
+                            'onlineId' => 'LegacyName',
+                            'accountId' => '100',
+                        ],
+                    ]
+                );
+            }
+        };
+        $shadowFactory = new class () implements PlayStationClientFactoryInterface {
+            public function createClient(): PlayStationApiClientInterface
+            {
+                return new ShadowPlayerClientStub(
+                    profileResponse: (object) [
+                        'profile' => (object) [
+                            'onlineId' => 'ShadowName',
+                            'accountId' => 100,
+                        ],
+                    ]
+                );
+            }
+        };
+
+        $service = new PsnPlayerLookupService(
+            static fn (): array => [$worker],
+            $legacyFactory,
+            $shadowFactory,
+            PsnClientMode::fromValue('shadow')
+        );
+
+        $result = $service->lookup('Example');
+
+        $this->assertSame('LegacyName', $result['profile']['onlineId']);
+        $this->assertSame('100', $result['profile']['accountId']);
+    }
+}
+
+final class ShadowPlayerClientStub implements PlayStationApiClientInterface
+{
+    public function __construct(private readonly object $profileResponse)
+    {
+    }
+
+    public function loginWithNpsso(string $npsso): void
+    {
+    }
+
+    public function acquireAccessToken(): ?string
+    {
+        return null;
+    }
+
+    public function refreshAccessToken(): void
+    {
+    }
+
+    public function lookupProfileByOnlineId(string $onlineId): mixed
+    {
+        return $this->profileResponse;
+    }
+
+    public function findUserByAccountId(string $accountId): object
+    {
+        return (object) [];
+    }
+
+    public function requestTrophyEndpoint(string $path, array $query = [], array $headers = []): mixed
+    {
+        return (object) [];
+    }
+
+    public function searchUsers(string $onlineId): iterable
+    {
+        return [];
     }
 }
 

--- a/tests/ShadowPlayStationUtilityTest.php
+++ b/tests/ShadowPlayStationUtilityTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PsnClientMode.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/Shadow/ShadowResponseNormalizer.php';
+
+final class ShadowPlayStationUtilityTest extends TestCase
+{
+    public function testCanonicalizePreservesDigitOnlyStringsByDefault(): void
+    {
+        $normalized = ShadowResponseNormalizer::canonicalize([
+            'onlineId' => '000123',
+            'npId' => '0123456789',
+        ]);
+
+        $this->assertSame('000123', $normalized['onlineId']);
+        $this->assertSame('0123456789', $normalized['npId']);
+    }
+
+    public function testNormalizePlayerProfileLookupPreservesStringIdentifiers(): void
+    {
+        $normalized = ShadowResponseNormalizer::normalizePlayerProfileLookup((object) [
+            'profile' => (object) [
+                'accountId' => '42',
+                'onlineId' => '000123',
+                'currentOnlineId' => '001122',
+                'npId' => '0000000001',
+            ],
+        ]);
+
+        $this->assertSame(42, $normalized['profile']['accountId']);
+        $this->assertSame('000123', $normalized['profile']['onlineId']);
+        $this->assertSame('001122', $normalized['profile']['currentOnlineId']);
+        $this->assertSame('0000000001', $normalized['profile']['npId']);
+    }
+
+    public function testExecuteWithLegacyTruthSkipsShadowWhenTimeoutSupportIsUnavailable(): void
+    {
+        if (
+            function_exists('pcntl_signal')
+            && function_exists('pcntl_async_signals')
+            && function_exists('pcntl_setitimer')
+        ) {
+            return;
+        }
+
+        $shadowExecutions = 0;
+
+        $result = ShadowExecutionUtility::executeWithLegacyTruth(
+            PsnClientMode::fromValue('shadow'),
+            'test_operation',
+            static fn (): array => ['legacy' => true],
+            static function () use (&$shadowExecutions): array {
+                $shadowExecutions++;
+
+                return ['shadow' => true];
+            },
+            static fn (mixed $value): array => is_array($value) ? $value : [],
+            350
+        );
+
+        $this->assertSame(['legacy' => true], $result);
+        $this->assertSame(0, $shadowExecutions);
+    }
+}

--- a/tests/ShadowPlayStationUtilityTest.php
+++ b/tests/ShadowPlayStationUtilityTest.php
@@ -65,4 +65,38 @@ final class ShadowPlayStationUtilityTest extends TestCase
         $this->assertSame(['legacy' => true], $result);
         $this->assertSame(0, $shadowExecutions);
     }
+
+    public function testExecuteWithLegacyTruthUsesRemainingShadowBudgetAfterLegacyExecution(): void
+    {
+        if (
+            !function_exists('pcntl_signal')
+            || !function_exists('pcntl_async_signals')
+            || !function_exists('pcntl_setitimer')
+        ) {
+            return;
+        }
+
+        $shadowCompleted = 0;
+
+        $result = ShadowExecutionUtility::executeWithLegacyTruth(
+            PsnClientMode::fromValue('shadow'),
+            'test_operation',
+            static function (): array {
+                usleep(120_000);
+
+                return ['legacy' => true];
+            },
+            static function () use (&$shadowCompleted): array {
+                usleep(80_000);
+                $shadowCompleted++;
+
+                return ['shadow' => true];
+            },
+            static fn (mixed $value): array => is_array($value) ? $value : [],
+            150
+        );
+
+        $this->assertSame(['legacy' => true], $result);
+        $this->assertSame(0, $shadowCompleted);
+    }
 }

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -13,6 +13,9 @@ require_once __DIR__ . '/../PlayStation/Exception/PlayStationNotFoundException.p
 require_once __DIR__ . '/../PlayStation/Exception/PlayStationTransientUpstreamException.php';
 require_once __DIR__ . '/../PlayStation/Policy/NpServiceNamePolicy.php';
 require_once __DIR__ . '/../PlayStation/PlayStationClientFactory.php';
+require_once __DIR__ . '/../PlayStation/Shadow/ShadowExecutionUtility.php';
+require_once __DIR__ . '/../PlayStation/Shadow/ShadowResponseNormalizer.php';
+require_once __DIR__ . '/../PsnClientMode.php';
 
 final class PsnGameLookupService
 {
@@ -22,28 +25,38 @@ final class PsnGameLookupService
     private readonly \Closure $workerFetcher;
 
     private readonly PlayStationClientFactoryInterface $playStationClientFactory;
+    private readonly PlayStationClientFactoryInterface $shadowPlayStationClientFactory;
     private readonly NpServiceNamePolicy $npServiceNamePolicy;
+    private readonly PsnClientMode $psnClientMode;
 
     public function __construct(
         private readonly PDO $database,
         callable $workerFetcher,
-        PlayStationClientFactoryInterface|callable|null $playStationClientFactory = null
+        PlayStationClientFactoryInterface|callable|null $playStationClientFactory = null,
+        ?PlayStationClientFactoryInterface $shadowPlayStationClientFactory = null,
+        ?PsnClientMode $psnClientMode = null
     ) {
         $this->workerFetcher = \Closure::fromCallable($workerFetcher);
         $this->playStationClientFactory = $this->normalizePlayStationClientFactory($playStationClientFactory);
+        $this->shadowPlayStationClientFactory = $shadowPlayStationClientFactory ?? new PlayStationClientFactory();
         $this->npServiceNamePolicy = new NpServiceNamePolicy();
+        $this->psnClientMode = $psnClientMode ?? PsnClientMode::current();
     }
 
     public static function fromDatabase(
         PDO $database,
-        PlayStationClientFactoryInterface|callable|null $playStationClientFactory = null
+        PlayStationClientFactoryInterface|callable|null $playStationClientFactory = null,
+        ?PlayStationClientFactoryInterface $shadowPlayStationClientFactory = null,
+        ?PsnClientMode $psnClientMode = null
     ): self {
         $workerService = new WorkerService($database);
 
         return new self(
             $database,
             static fn (): array => $workerService->fetchWorkers(),
-            $playStationClientFactory
+            $playStationClientFactory,
+            $shadowPlayStationClientFactory,
+            $psnClientMode
         );
     }
 
@@ -185,9 +198,31 @@ final class PsnGameLookupService
             throw new InvalidArgumentException('NP communication ID must be provided.');
         }
 
-        $client = $authenticatedClient === null
-            ? $this->createAuthenticatedClient()
-            : $this->normalizeTrophyClient($authenticatedClient);
+        if ($authenticatedClient !== null || !$this->psnClientMode->isShadow()) {
+            $client = $authenticatedClient === null
+                ? $this->createAuthenticatedClient()
+                : $this->normalizeTrophyClient($authenticatedClient);
+
+            return $this->fetchTrophyDataFromClient($normalizedNpCommunicationId, $client);
+        }
+
+        $session = $this->createAuthenticatedClientSession();
+        $legacyClient = $session['client'];
+
+        return ShadowExecutionUtility::executeWithLegacyTruth(
+            $this->psnClientMode,
+            'game_trophy_lookup',
+            fn (): array => $this->fetchTrophyDataFromClient($normalizedNpCommunicationId, $legacyClient),
+            fn (): array => $this->executeShadowTrophyLookup($session['npsso'], $normalizedNpCommunicationId),
+            static fn (mixed $payload): array => ShadowResponseNormalizer::normalizeTrophyLookup($payload)
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchTrophyDataFromClient(string $normalizedNpCommunicationId, TrophyClientInterface $client): array
+    {
         $preferredNpServiceName = $this->resolvePreferredNpServiceName($normalizedNpCommunicationId);
 
         try {
@@ -294,6 +329,17 @@ final class PsnGameLookupService
         );
 
         return $normalizedResponse;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function executeShadowTrophyLookup(string $npsso, string $npCommunicationId): array
+    {
+        $shadowClient = $this->shadowPlayStationClientFactory->createClient();
+        $shadowClient->loginWithNpsso($npsso);
+
+        return $this->fetchTrophyDataFromClient($npCommunicationId, $shadowClient);
     }
 
     /**
@@ -429,6 +475,14 @@ final class PsnGameLookupService
 
     private function createAuthenticatedClient(): PlayStationApiClientInterface
     {
+        return $this->createAuthenticatedClientSession()['client'];
+    }
+
+    /**
+     * @return array{client: PlayStationApiClientInterface, npsso: string}
+     */
+    private function createAuthenticatedClientSession(): array
+    {
         foreach (($this->workerFetcher)() as $worker) {
             if (!$worker instanceof Worker) {
                 continue;
@@ -444,7 +498,10 @@ final class PsnGameLookupService
                 $client = $this->playStationClientFactory->createClient();
                 $client->loginWithNpsso($npsso);
 
-                return $client;
+                return [
+                    'client' => $client,
+                    'npsso' => $npsso,
+                ];
             } catch (Throwable) {
                 continue;
             }

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -206,27 +206,21 @@ final class PsnGameLookupService
             return $this->fetchTrophyDataFromClient($normalizedNpCommunicationId, $client);
         }
 
-        $legacyClient = $authenticatedClient === null
-            ? $this->createAuthenticatedClientSession()['client']
-            : $this->normalizeTrophyClient($authenticatedClient);
+        $legacySession = $authenticatedClient === null ? $this->createAuthenticatedClientSession() : null;
+        $legacyClient = $legacySession === null
+            ? $this->normalizeTrophyClient($authenticatedClient)
+            : $legacySession['client'];
 
         return ShadowExecutionUtility::executeWithLegacyTruth(
             $this->psnClientMode,
             'game_trophy_lookup',
             fn (): array => $this->fetchTrophyDataFromClient($normalizedNpCommunicationId, $legacyClient),
-            fn (): array => $this->executeShadowTrophyLookupWithWorkerSession($normalizedNpCommunicationId),
+            fn (): array => $this->executeShadowTrophyLookup(
+                $legacySession['npsso'] ?? $this->createAuthenticatedClientSession()['npsso'],
+                $normalizedNpCommunicationId
+            ),
             static fn (mixed $payload): array => ShadowResponseNormalizer::normalizeTrophyLookup($payload)
         );
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function executeShadowTrophyLookupWithWorkerSession(string $npCommunicationId): array
-    {
-        $session = $this->createAuthenticatedClientSession();
-
-        return $this->executeShadowTrophyLookup($session['npsso'], $npCommunicationId);
     }
 
     /**

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -198,7 +198,7 @@ final class PsnGameLookupService
             throw new InvalidArgumentException('NP communication ID must be provided.');
         }
 
-        if ($authenticatedClient !== null || !$this->psnClientMode->isShadow()) {
+        if (!$this->psnClientMode->isShadow()) {
             $client = $authenticatedClient === null
                 ? $this->createAuthenticatedClient()
                 : $this->normalizeTrophyClient($authenticatedClient);
@@ -206,16 +206,27 @@ final class PsnGameLookupService
             return $this->fetchTrophyDataFromClient($normalizedNpCommunicationId, $client);
         }
 
-        $session = $this->createAuthenticatedClientSession();
-        $legacyClient = $session['client'];
+        $legacyClient = $authenticatedClient === null
+            ? $this->createAuthenticatedClientSession()['client']
+            : $this->normalizeTrophyClient($authenticatedClient);
 
         return ShadowExecutionUtility::executeWithLegacyTruth(
             $this->psnClientMode,
             'game_trophy_lookup',
             fn (): array => $this->fetchTrophyDataFromClient($normalizedNpCommunicationId, $legacyClient),
-            fn (): array => $this->executeShadowTrophyLookup($session['npsso'], $normalizedNpCommunicationId),
+            fn (): array => $this->executeShadowTrophyLookupWithWorkerSession($normalizedNpCommunicationId),
             static fn (mixed $payload): array => ShadowResponseNormalizer::normalizeTrophyLookup($payload)
         );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function executeShadowTrophyLookupWithWorkerSession(string $npCommunicationId): array
+    {
+        $session = $this->createAuthenticatedClientSession();
+
+        return $this->executeShadowTrophyLookup($session['npsso'], $npCommunicationId);
     }
 
     /**

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -9,6 +9,9 @@ require_once __DIR__ . '/../PlayStation/Contracts/PlayStationClientFactoryInterf
 require_once __DIR__ . '/../PlayStation/Contracts/PlayStationApiClientInterface.php';
 require_once __DIR__ . '/../PlayStation/Contracts/ProfileClientInterface.php';
 require_once __DIR__ . '/../PlayStation/PlayStationClientFactory.php';
+require_once __DIR__ . '/../PlayStation/Shadow/ShadowExecutionUtility.php';
+require_once __DIR__ . '/../PlayStation/Shadow/ShadowResponseNormalizer.php';
+require_once __DIR__ . '/../PsnClientMode.php';
 
 final class PsnPlayerLookupService
 {
@@ -18,27 +21,37 @@ final class PsnPlayerLookupService
     private readonly \Closure $workerFetcher;
 
     private readonly PlayStationClientFactoryInterface $playStationClientFactory;
+    private readonly PlayStationClientFactoryInterface $shadowPlayStationClientFactory;
+    private readonly PsnClientMode $psnClientMode;
 
     /**
      * @param callable(): iterable<Worker> $workerFetcher
      */
     public function __construct(
         callable $workerFetcher,
-        PlayStationClientFactoryInterface|callable|null $playStationClientFactory = null
+        PlayStationClientFactoryInterface|callable|null $playStationClientFactory = null,
+        ?PlayStationClientFactoryInterface $shadowPlayStationClientFactory = null,
+        ?PsnClientMode $psnClientMode = null
     ) {
         $this->workerFetcher = \Closure::fromCallable($workerFetcher);
         $this->playStationClientFactory = $this->normalizePlayStationClientFactory($playStationClientFactory);
+        $this->shadowPlayStationClientFactory = $shadowPlayStationClientFactory ?? new PlayStationClientFactory();
+        $this->psnClientMode = $psnClientMode ?? PsnClientMode::current();
     }
 
     public static function fromDatabase(
         PDO $database,
-        PlayStationClientFactoryInterface|callable|null $playStationClientFactory = null
+        PlayStationClientFactoryInterface|callable|null $playStationClientFactory = null,
+        ?PlayStationClientFactoryInterface $shadowPlayStationClientFactory = null,
+        ?PsnClientMode $psnClientMode = null
     ): self {
         $workerService = new WorkerService($database);
 
         return new self(
             static fn (): array => $workerService->fetchWorkers(),
-            $playStationClientFactory
+            $playStationClientFactory,
+            $shadowPlayStationClientFactory,
+            $psnClientMode
         );
     }
 
@@ -165,32 +178,27 @@ final class PsnPlayerLookupService
             throw new InvalidArgumentException('Online ID cannot be blank.');
         }
 
-        $client = $this->createAuthenticatedClient();
+        $session = $this->createAuthenticatedClientSession();
+        $legacyClient = $session['client'];
 
-        try {
-            $profile = $this->executeUserProfileRequest($client, $normalizedOnlineId);
-        } catch (Throwable $exception) {
-            $statusCode = $this->determineStatusCode($exception);
-
-            if ($statusCode === 404) {
-                throw new PsnPlayerLookupException(
-                    sprintf('Player "%s" was not found.', $normalizedOnlineId),
-                    $statusCode,
-                    $exception
-                );
-            }
-
-            throw new PsnPlayerLookupException(
-                'Failed to retrieve the player profile from PlayStation Network. Please try again later.',
-                $statusCode,
-                $exception
-            );
-        }
+        $profile = ShadowExecutionUtility::executeWithLegacyTruth(
+            $this->psnClientMode,
+            'player_profile_lookup',
+            fn (): mixed => $this->executeUserProfileRequest($legacyClient, $normalizedOnlineId),
+            fn (): mixed => $this->executeShadowUserProfileRequest(
+                $session['npsso'],
+                $normalizedOnlineId
+            ),
+            static fn (mixed $payload): array => ShadowResponseNormalizer::normalizePlayerProfileLookup($payload)
+        );
 
         return $this->normalizeProfileResponse($profile);
     }
 
-    private function createAuthenticatedClient(): PlayStationApiClientInterface
+    /**
+     * @return array{client: PlayStationApiClientInterface, npsso: string}
+     */
+    private function createAuthenticatedClientSession(): array
     {
 
         foreach (($this->workerFetcher)() as $worker) {
@@ -208,7 +216,10 @@ final class PsnPlayerLookupService
                 $client = $this->playStationClientFactory->createClient();
                 $client->loginWithNpsso($npsso);
 
-                return $client;
+                return [
+                    'client' => $client,
+                    'npsso' => $npsso,
+                ];
             } catch (Throwable) {
                 continue;
             }
@@ -217,9 +228,35 @@ final class PsnPlayerLookupService
         throw new RuntimeException('Unable to login to any worker accounts.');
     }
 
+    private function executeShadowUserProfileRequest(string $npsso, string $onlineId): mixed
+    {
+        $shadowClient = $this->shadowPlayStationClientFactory->createClient();
+        $shadowClient->loginWithNpsso($npsso);
+
+        return $this->executeUserProfileRequest($shadowClient, $onlineId);
+    }
+
     private function executeUserProfileRequest(ProfileClientInterface $client, string $onlineId): mixed
     {
-        return $client->lookupProfileByOnlineId($onlineId);
+        try {
+            return $client->lookupProfileByOnlineId($onlineId);
+        } catch (Throwable $exception) {
+            $statusCode = $this->determineStatusCode($exception);
+
+            if ($statusCode === 404) {
+                throw new PsnPlayerLookupException(
+                    sprintf('Player "%s" was not found.', $onlineId),
+                    $statusCode,
+                    $exception
+                );
+            }
+
+            throw new PsnPlayerLookupException(
+                'Failed to retrieve the player profile from PlayStation Network. Please try again later.',
+                $statusCode,
+                $exception
+            );
+        }
     }
 
     private function determineStatusCode(Throwable $exception): ?int

--- a/wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php
+++ b/wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php
@@ -49,9 +49,11 @@ final class ShadowExecutionUtility
             return $legacyResponse;
         }
 
+        $remainingShadowBudgetMs = $shadowLatencyBudgetMs - $legacyDurationMs;
+
         $shadowStart = hrtime(true);
         try {
-            $shadowResponse = self::executeShadowWithTimeout($shadowExecutor, $shadowLatencyBudgetMs);
+            $shadowResponse = self::executeShadowWithTimeout($shadowExecutor, $remainingShadowBudgetMs);
             $shadowDurationMs = (int) ((hrtime(true) - $shadowStart) / 1_000_000);
 
             $comparison = ShadowResponseComparator::compare(

--- a/wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php
+++ b/wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php
@@ -8,6 +8,10 @@ final class ShadowExecutionTimeoutException extends RuntimeException
 {
 }
 
+final class ShadowTimeoutSupportUnavailableException extends RuntimeException
+{
+}
+
 final class ShadowExecutionUtility
 {
     /**
@@ -64,6 +68,15 @@ final class ShadowExecutionUtility
                     'mismatch' => $comparison,
                 ]);
             }
+        } catch (ShadowTimeoutSupportUnavailableException $unsupportedException) {
+            self::emitEvent([
+                'event' => 'psn_shadow_skipped',
+                'operation' => $operation,
+                'reason' => 'shadow_timeout_support_unavailable',
+                'legacyDurationMs' => $legacyDurationMs,
+                'shadowLatencyBudgetMs' => $shadowLatencyBudgetMs,
+                'message' => $unsupportedException->getMessage(),
+            ]);
         } catch (ShadowExecutionTimeoutException $timeoutException) {
             self::emitEvent([
                 'event' => 'psn_shadow_skipped',
@@ -90,22 +103,24 @@ final class ShadowExecutionUtility
     {
         if (
             !function_exists('pcntl_signal')
-            || !function_exists('pcntl_alarm')
             || !function_exists('pcntl_async_signals')
+            || !function_exists('pcntl_setitimer')
         ) {
-            return $shadowExecutor();
+            throw new ShadowTimeoutSupportUnavailableException('Shadow timeout support is unavailable on this runtime.');
         }
+
+        $budgetSeconds = $shadowLatencyBudgetMs / 1000;
 
         pcntl_async_signals(true);
         pcntl_signal(SIGALRM, static function (): void {
             throw new ShadowExecutionTimeoutException('Shadow execution exceeded latency budget.');
         });
-        pcntl_alarm((int) ceil($shadowLatencyBudgetMs / 1000));
+        pcntl_setitimer(ITIMER_REAL, $budgetSeconds);
 
         try {
             return $shadowExecutor();
         } finally {
-            pcntl_alarm(0);
+            pcntl_setitimer(ITIMER_REAL, 0.0);
             pcntl_async_signals(false);
             pcntl_signal(SIGALRM, SIG_DFL);
         }

--- a/wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php
+++ b/wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/ShadowResponseComparator.php';
 
+final class ShadowExecutionTimeoutException extends RuntimeException
+{
+}
+
 final class ShadowExecutionUtility
 {
     /**
@@ -43,18 +47,8 @@ final class ShadowExecutionUtility
 
         $shadowStart = hrtime(true);
         try {
-            $shadowResponse = $shadowExecutor();
+            $shadowResponse = self::executeShadowWithTimeout($shadowExecutor, $shadowLatencyBudgetMs);
             $shadowDurationMs = (int) ((hrtime(true) - $shadowStart) / 1_000_000);
-
-            if ($shadowDurationMs > $shadowLatencyBudgetMs) {
-                self::emitEvent([
-                    'event' => 'psn_shadow_sla_warning',
-                    'operation' => $operation,
-                    'legacyDurationMs' => $legacyDurationMs,
-                    'shadowDurationMs' => $shadowDurationMs,
-                    'shadowLatencyBudgetMs' => $shadowLatencyBudgetMs,
-                ]);
-            }
 
             $comparison = ShadowResponseComparator::compare(
                 $normalizer($legacyResponse),
@@ -70,6 +64,15 @@ final class ShadowExecutionUtility
                     'mismatch' => $comparison,
                 ]);
             }
+        } catch (ShadowExecutionTimeoutException $timeoutException) {
+            self::emitEvent([
+                'event' => 'psn_shadow_skipped',
+                'operation' => $operation,
+                'reason' => 'shadow_latency_budget_exhausted',
+                'legacyDurationMs' => $legacyDurationMs,
+                'shadowLatencyBudgetMs' => $shadowLatencyBudgetMs,
+                'message' => $timeoutException->getMessage(),
+            ]);
         } catch (Throwable $shadowException) {
             self::emitEvent([
                 'event' => 'psn_shadow_failure',
@@ -81,6 +84,31 @@ final class ShadowExecutionUtility
         }
 
         return $legacyResponse;
+    }
+
+    private static function executeShadowWithTimeout(callable $shadowExecutor, int $shadowLatencyBudgetMs): mixed
+    {
+        if (
+            !function_exists('pcntl_signal')
+            || !function_exists('pcntl_alarm')
+            || !function_exists('pcntl_async_signals')
+        ) {
+            return $shadowExecutor();
+        }
+
+        pcntl_async_signals(true);
+        pcntl_signal(SIGALRM, static function (): void {
+            throw new ShadowExecutionTimeoutException('Shadow execution exceeded latency budget.');
+        });
+        pcntl_alarm((int) ceil($shadowLatencyBudgetMs / 1000));
+
+        try {
+            return $shadowExecutor();
+        } finally {
+            pcntl_alarm(0);
+            pcntl_async_signals(false);
+            pcntl_signal(SIGALRM, SIG_DFL);
+        }
     }
 
     /**

--- a/wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php
+++ b/wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/ShadowResponseComparator.php';
+
+final class ShadowExecutionUtility
+{
+    /**
+     * @template T
+     * @param callable(): T $legacyExecutor
+     * @param callable(): mixed $shadowExecutor
+     * @param callable(mixed): array<string, mixed> $normalizer
+     * @return T
+     */
+    public static function executeWithLegacyTruth(
+        PsnClientMode $mode,
+        string $operation,
+        callable $legacyExecutor,
+        callable $shadowExecutor,
+        callable $normalizer,
+        int $shadowLatencyBudgetMs = 350
+    ): mixed {
+        $legacyStart = hrtime(true);
+        $legacyResponse = $legacyExecutor();
+        $legacyDurationMs = (int) ((hrtime(true) - $legacyStart) / 1_000_000);
+
+        if (!$mode->isShadow()) {
+            return $legacyResponse;
+        }
+
+        if ($legacyDurationMs >= $shadowLatencyBudgetMs) {
+            self::emitEvent([
+                'event' => 'psn_shadow_skipped',
+                'operation' => $operation,
+                'reason' => 'legacy_latency_budget_exhausted',
+                'legacyDurationMs' => $legacyDurationMs,
+                'shadowLatencyBudgetMs' => $shadowLatencyBudgetMs,
+            ]);
+
+            return $legacyResponse;
+        }
+
+        $shadowStart = hrtime(true);
+        try {
+            $shadowResponse = $shadowExecutor();
+            $shadowDurationMs = (int) ((hrtime(true) - $shadowStart) / 1_000_000);
+
+            if ($shadowDurationMs > $shadowLatencyBudgetMs) {
+                self::emitEvent([
+                    'event' => 'psn_shadow_sla_warning',
+                    'operation' => $operation,
+                    'legacyDurationMs' => $legacyDurationMs,
+                    'shadowDurationMs' => $shadowDurationMs,
+                    'shadowLatencyBudgetMs' => $shadowLatencyBudgetMs,
+                ]);
+            }
+
+            $comparison = ShadowResponseComparator::compare(
+                $normalizer($legacyResponse),
+                $normalizer($shadowResponse)
+            );
+
+            if ($comparison['hasMismatch']) {
+                self::emitEvent([
+                    'event' => 'psn_shadow_mismatch',
+                    'operation' => $operation,
+                    'legacyDurationMs' => $legacyDurationMs,
+                    'shadowDurationMs' => $shadowDurationMs,
+                    'mismatch' => $comparison,
+                ]);
+            }
+        } catch (Throwable $shadowException) {
+            self::emitEvent([
+                'event' => 'psn_shadow_failure',
+                'operation' => $operation,
+                'legacyDurationMs' => $legacyDurationMs,
+                'errorType' => $shadowException::class,
+                'message' => $shadowException->getMessage(),
+            ]);
+        }
+
+        return $legacyResponse;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function emitEvent(array $payload): void
+    {
+        $encoded = json_encode($payload);
+
+        if (!is_string($encoded) || $encoded === '') {
+            return;
+        }
+
+        error_log($encoded);
+    }
+}

--- a/wwwroot/classes/PlayStation/Shadow/ShadowResponseComparator.php
+++ b/wwwroot/classes/PlayStation/Shadow/ShadowResponseComparator.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+final class ShadowResponseComparator
+{
+    /**
+     * @return array{hasMismatch: bool, mismatches: list<array{path: string, legacy: mixed, shadow: mixed, type: string}>}
+     */
+    public static function compare(mixed $legacy, mixed $shadow): array
+    {
+        $mismatches = [];
+        self::walk('', $legacy, $shadow, $mismatches);
+
+        return [
+            'hasMismatch' => $mismatches !== [],
+            'mismatches' => $mismatches,
+        ];
+    }
+
+    /**
+     * @param list<array{path: string, legacy: mixed, shadow: mixed, type: string}> $mismatches
+     */
+    private static function walk(string $path, mixed $legacy, mixed $shadow, array &$mismatches): void
+    {
+        if (gettype($legacy) !== gettype($shadow)) {
+            $mismatches[] = [
+                'path' => $path,
+                'legacy' => $legacy,
+                'shadow' => $shadow,
+                'type' => 'type_mismatch',
+            ];
+
+            return;
+        }
+
+        if (is_array($legacy) && is_array($shadow)) {
+            $keys = array_values(array_unique(array_merge(array_keys($legacy), array_keys($shadow))));
+
+            foreach ($keys as $key) {
+                $nextPath = $path === '' ? (string) $key : sprintf('%s.%s', $path, (string) $key);
+                $legacyHasKey = array_key_exists($key, $legacy);
+                $shadowHasKey = array_key_exists($key, $shadow);
+
+                if (!$legacyHasKey || !$shadowHasKey) {
+                    $mismatches[] = [
+                        'path' => $nextPath,
+                        'legacy' => $legacyHasKey ? $legacy[$key] : null,
+                        'shadow' => $shadowHasKey ? $shadow[$key] : null,
+                        'type' => 'missing_field',
+                    ];
+
+                    continue;
+                }
+
+                self::walk($nextPath, $legacy[$key], $shadow[$key], $mismatches);
+            }
+
+            return;
+        }
+
+        if ($legacy !== $shadow) {
+            $mismatches[] = [
+                'path' => $path,
+                'legacy' => $legacy,
+                'shadow' => $shadow,
+                'type' => 'value_mismatch',
+            ];
+        }
+    }
+}

--- a/wwwroot/classes/PlayStation/Shadow/ShadowResponseNormalizer.php
+++ b/wwwroot/classes/PlayStation/Shadow/ShadowResponseNormalizer.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+final class ShadowResponseNormalizer
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function normalizePlayerProfileLookup(mixed $payload): array
+    {
+        $normalized = self::canonicalize($payload);
+
+        if (isset($normalized['profile']) && is_array($normalized['profile'])) {
+            $profile = $normalized['profile'];
+            $profile['accountId'] = self::normalizeNullableScalar($profile['accountId'] ?? null, true);
+            $profile['onlineId'] = self::normalizeNullableScalar($profile['onlineId'] ?? null, false);
+            $profile['currentOnlineId'] = self::normalizeNullableScalar($profile['currentOnlineId'] ?? null, false);
+            $profile['npId'] = self::normalizeNullableScalar($profile['npId'] ?? null, false);
+            ksort($profile);
+            $normalized['profile'] = $profile;
+        }
+
+        return self::canonicalize($normalized);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function normalizeTrophyLookup(mixed $payload): array
+    {
+        $normalized = self::canonicalize($payload);
+
+        if (isset($normalized['trophyGroups']) && is_array($normalized['trophyGroups'])) {
+            $groups = [];
+
+            foreach ($normalized['trophyGroups'] as $group) {
+                if (!is_array($group)) {
+                    continue;
+                }
+
+                $group['trophyGroupId'] = (string) ($group['trophyGroupId'] ?? '');
+                $group['trophyGroupName'] = (string) ($group['trophyGroupName'] ?? '');
+                $group['trophyGroupDetail'] = (string) ($group['trophyGroupDetail'] ?? '');
+                $group['trophyGroupIconUrl'] = (string) ($group['trophyGroupIconUrl'] ?? '');
+
+                if (isset($group['trophies']) && is_array($group['trophies'])) {
+                    $group['trophies'] = array_map(static function (mixed $trophy): array {
+                        if (!is_array($trophy)) {
+                            return [];
+                        }
+
+                        if (array_key_exists('trophyId', $trophy)) {
+                            $trophy['trophyId'] = self::normalizeNullableScalar($trophy['trophyId'], true);
+                        }
+
+                        return self::canonicalize($trophy);
+                    }, $group['trophies']);
+                } else {
+                    $group['trophies'] = [];
+                }
+
+                $groups[] = self::canonicalize($group);
+            }
+
+            $normalized['trophyGroups'] = $groups;
+        }
+
+        return self::canonicalize($normalized);
+    }
+
+    /**
+     * @return array<string, mixed>|list<mixed>|int|string|float|bool|null
+     */
+    public static function canonicalize(mixed $value): mixed
+    {
+        if (is_object($value)) {
+            $value = get_object_vars($value);
+        }
+
+        if (!is_array($value)) {
+            return self::normalizeNullableScalar($value, true);
+        }
+
+        $isList = array_is_list($value);
+        $normalized = [];
+
+        foreach ($value as $key => $item) {
+            $normalized[$key] = self::canonicalize($item);
+        }
+
+        if (!$isList) {
+            ksort($normalized);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return int|string|float|bool|null
+     */
+    private static function normalizeNullableScalar(mixed $value, bool $coerceNumericString): mixed
+    {
+        if ($value === '') {
+            return null;
+        }
+
+        if ($coerceNumericString && is_string($value) && ctype_digit($value)) {
+            return (int) $value;
+        }
+
+        return $value;
+    }
+}

--- a/wwwroot/classes/PlayStation/Shadow/ShadowResponseNormalizer.php
+++ b/wwwroot/classes/PlayStation/Shadow/ShadowResponseNormalizer.php
@@ -72,21 +72,21 @@ final class ShadowResponseNormalizer
     /**
      * @return array<string, mixed>|list<mixed>|int|string|float|bool|null
      */
-    public static function canonicalize(mixed $value): mixed
+    public static function canonicalize(mixed $value, bool $coerceNumericString = false): mixed
     {
         if (is_object($value)) {
             $value = get_object_vars($value);
         }
 
         if (!is_array($value)) {
-            return self::normalizeNullableScalar($value, true);
+            return self::normalizeNullableScalar($value, $coerceNumericString);
         }
 
         $isList = array_is_list($value);
         $normalized = [];
 
         foreach ($value as $key => $item) {
-            $normalized[$key] = self::canonicalize($item);
+            $normalized[$key] = self::canonicalize($item, $coerceNumericString);
         }
 
         if (!$isList) {


### PR DESCRIPTION
### Motivation

- Introduce a reusable shadow execution path so PSN operations can run a parallel/new client in `shadow` mode while preserving the legacy client as the source-of-truth to avoid functional regressions. 
- Provide operation-specific normalization and a comparator to reliably identify field-level differences between legacy and shadow responses. 
- Ensure shadow runs are isolated and bounded so they cannot break SLA or affect returned behavior.

### Description

- Added a reusable shadow runner `ShadowExecutionUtility` that runs legacy and shadow executors, enforces a shadow latency budget, isolates shadow errors, and emits structured telemetry via `error_log` events. (`wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php`).
- Added `ShadowResponseNormalizer` with operation-specific normalizers for player profile and trophy payloads (canonicalization, stable key ordering, null/default normalization, numeric coercion). (`wwwroot/classes/PlayStation/Shadow/ShadowResponseNormalizer.php`).
- Added `ShadowResponseComparator` to produce structured, field-level mismatch objects with path/type/legacy/shadow entries. (`wwwroot/classes/PlayStation/Shadow/ShadowResponseComparator.php`).
- Integrated shadow execution into `PsnPlayerLookupService::lookup` and `PsnGameLookupService::fetchTrophyDataForNpCommunicationId`, including session-based auth reuse and shadow-client execution flows while always returning the legacy-normalized result when in `shadow` mode. (`wwwroot/classes/Admin/PsnPlayerLookupService.php`, `wwwroot/classes/Admin/PsnGameLookupService.php`).
- Added unit test coverage and lightweight stubs that exercise shadow mode and assert the legacy response remains the returned source-of-truth for both player and game lookup flows. (`tests/PsnPlayerLookupServiceTest.php`, `tests/PsnGameLookupServiceTest.php`).

### Testing

- Ran syntax checks with `php -l` against the new and modified PHP files and they reported no syntax errors. 
- Ran the full test suite with `php tests/run.php` and all tests passed: 473 tests executed and passed. 
- Verified targeted tests exercising shadow behavior were added and passed (`PsnPlayerLookupServiceTest::testLookupInShadowModeKeepsLegacyResponseAsSourceOfTruth` and `PsnGameLookupServiceTest::testLookupInShadowModeReturnsLegacyTrophyPayload`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40a60fff4832f976d8041c666a5c1)