### PR TITLE
Increase PSN shadow latency budgets for lookup and worker login

### DIFF
--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -212,7 +212,7 @@ class GameRescanService
             fn (): PlayStationApiClientInterface => $this->createAndLoginClient($this->playStationClientFactory, $npsso),
             fn (): bool => $this->executeShadowLogin($npsso),
             static fn (mixed $payload): array => ['authenticated' => (bool) $payload],
-            350,
+            700,
             ['service' => 'game_rescan']
         );
     }

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -230,7 +230,7 @@ final class PsnGameLookupService
                 $normalizedNpCommunicationId
             ),
             static fn (mixed $payload): array => ShadowResponseNormalizer::normalizeTrophyLookup($payload),
-            350,
+            700,
             ['service' => 'psn_game_lookup', 'npCommunicationId' => $normalizedNpCommunicationId]
         );
     }

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -2017,7 +2017,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             fn (): PlayStationApiClientInterface => $this->createAndLoginClient($this->playStationClientFactory, $npsso),
             fn (): bool => $this->executeShadowLogin($npsso),
             static fn (mixed $payload): array => ['authenticated' => (bool) $payload],
-            350,
+            700,
             ['service' => 'thirty_minute_cron']
         );
     }


### PR DESCRIPTION
### Motivation
- Logs show many `psn_shadow_skipped` events with `reason: legacy_latency_budget_exhausted` when legacy calls take ~400–600ms, causing the shadow path to be skipped prematurely.
- Increase the shadow latency budget to reduce noisy skip events and give shadow executions a fairer chance to run when legacy calls are slower than the previous 350ms budget.

### Description
- Raised the shadow latency budget from `350` to `700` ms for `game_trophy_lookup` in `PsnGameLookupService` (`wwwroot/classes/Admin/PsnGameLookupService.php`).
- Raised the shadow latency budget from `350` to `700` ms for `rescan_worker_login` in `GameRescanService` (`wwwroot/classes/Admin/GameRescanService.php`).
- Raised the shadow latency budget from `350` to `700` ms for `cron_worker_login` in `ThirtyMinuteCronJob` (`wwwroot/classes/Cron/ThirtyMinuteCronJob.php`).

### Testing
- Ran lint checks with `php -l` against the modified files and they reported no syntax errors.
- Executed the project test runner with `php tests/run.php`, and the suite completed with `All 494 tests passed.`
- Attempted `phpunit tests/ShadowPlayStationUtilityTest.php` but `phpunit` is not installed in this environment (command failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e541ddbd84832f915b0f9575591889)