### PR TITLE
Add optional shadow fallback when runtime lacks timeout primitives

### DIFF
--- a/tests/ShadowPlayStationUtilityTest.php
+++ b/tests/ShadowPlayStationUtilityTest.php
@@ -100,6 +100,27 @@ final class ShadowPlayStationUtilityTest extends TestCase
         $this->assertSame(0, $shadowCompleted);
     }
 
+    public function testShouldExecuteWithoutTimeoutEnvFlagParsing(): void
+    {
+        $method = new ReflectionMethod(ShadowExecutionUtility::class, 'shouldExecuteWithoutTimeout');
+        $method->setAccessible(true);
+
+        putenv('PSN_SHADOW_EXECUTE_WITHOUT_TIMEOUT=true');
+        $this->assertTrue($method->invoke(null));
+
+        putenv('PSN_SHADOW_EXECUTE_WITHOUT_TIMEOUT=1');
+        $this->assertTrue($method->invoke(null));
+
+        putenv('PSN_SHADOW_EXECUTE_WITHOUT_TIMEOUT=false');
+        $this->assertFalse($method->invoke(null));
+
+        putenv('PSN_SHADOW_EXECUTE_WITHOUT_TIMEOUT=0');
+        $this->assertFalse($method->invoke(null));
+
+        putenv('PSN_SHADOW_EXECUTE_WITHOUT_TIMEOUT');
+        $this->assertFalse($method->invoke(null));
+    }
+
     public function testExecuteWithLegacyTruthInNewModeUsesPrimaryExecutorOnly(): void
     {
         $legacyExecutions = 0;

--- a/wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php
+++ b/wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php
@@ -14,6 +14,7 @@ final class ShadowTimeoutSupportUnavailableException extends RuntimeException
 
 final class ShadowExecutionUtility
 {
+    private const string EXECUTE_WITHOUT_TIMEOUT_ENV = 'PSN_SHADOW_EXECUTE_WITHOUT_TIMEOUT';
     private const float DEFAULT_MISMATCH_SAMPLE_RATE = 0.2;
     private const int DEFAULT_MISMATCH_RATE_LIMIT_PER_MINUTE = 60;
     private const int MAX_MISMATCH_SAMPLES = 3;
@@ -187,6 +188,10 @@ final class ShadowExecutionUtility
             || !function_exists('pcntl_async_signals')
             || !function_exists('pcntl_setitimer')
         ) {
+            if (self::shouldExecuteWithoutTimeout()) {
+                return $shadowExecutor();
+            }
+
             throw new ShadowTimeoutSupportUnavailableException('Shadow timeout support is unavailable on this runtime.');
         }
 
@@ -205,6 +210,16 @@ final class ShadowExecutionUtility
             pcntl_async_signals(false);
             pcntl_signal(SIGALRM, SIG_DFL);
         }
+    }
+
+    private static function shouldExecuteWithoutTimeout(): bool
+    {
+        $configured = getenv(self::EXECUTE_WITHOUT_TIMEOUT_ENV);
+        if (!is_string($configured)) {
+            return false;
+        }
+
+        return filter_var($configured, FILTER_VALIDATE_BOOL) === true;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Allow shadow-mode shadow executors to run on runtimes that lack `pcntl_*` timer primitives by providing an opt-in override, so shadow behavior can still be tested or exercised in such environments. 
- Preserve the current default behavior of skipping shadow execution and emitting structured skip events when timeout primitives are unavailable unless explicitly opted into.

### Description
- Add `PSN_SHADOW_EXECUTE_WITHOUT_TIMEOUT` env flag and `EXECUTE_WITHOUT_TIMEOUT_ENV` constant to `ShadowExecutionUtility` to control the opt-in fallback behavior. 
- When `pcntl_signal`/`pcntl_async_signals`/`pcntl_setitimer` are unavailable and the env flag is truthy, run the shadow executor without timeout enforcement instead of throwing `ShadowTimeoutSupportUnavailableException`. 
- Add the private helper method `shouldExecuteWithoutTimeout()` to parse the boolean env value using `filter_var`. 
- Add unit coverage in `tests/ShadowPlayStationUtilityTest.php` via `testShouldExecuteWithoutTimeoutEnvFlagParsing` to validate `true/1/false/0/unset` parsing semantics.

### Testing
- Ran PHP syntax checks with `php -l` on `wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php` and `tests/ShadowPlayStationUtilityTest.php`, both succeeded. 
- Ran the focused test runner with `php tests/TestRunner.php tests/ShadowPlayStationUtilityTest.php`, which completed successfully. 
- Ran the full test runner with `php tests/TestRunner.php`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5454da1b0832f807bffc7dd3eba7d)