### PR TITLE
Make cron shadow login latency budget configurable

### DIFF
--- a/tests/ThirtyMinuteCronJobPsnClientModeTest.php
+++ b/tests/ThirtyMinuteCronJobPsnClientModeTest.php
@@ -11,12 +11,28 @@ require_once __DIR__ . '/../wwwroot/classes/Cron/ThirtyMinuteCronJob.php';
 final class ThirtyMinuteCronJobPsnClientModeTest extends TestCase
 {
     private PDO $database;
+    /** @var list<array<string, mixed>> */
+    private array $capturedShadowEvents = [];
 
     protected function setUp(): void
     {
         $this->database = new PDO('sqlite::memory:');
         $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $this->database->exec('CREATE TABLE log (message TEXT NOT NULL)');
+        putenv('PSN_CRON_SHADOW_LOGIN_LATENCY_BUDGET_MS');
+        $this->capturedShadowEvents = [];
+
+        ShadowExecutionUtility::resetStateForTests();
+        ShadowExecutionUtility::setEventEmitter(function (array $payload): void {
+            $this->capturedShadowEvents[] = $payload;
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        ShadowExecutionUtility::setEventEmitter(null);
+        ShadowExecutionUtility::resetStateForTests();
+        putenv('PSN_CRON_SHADOW_LOGIN_LATENCY_BUDGET_MS');
     }
 
     public function testCreateAuthenticatedClientUsesNewFactoryInNewMode(): void
@@ -70,6 +86,39 @@ final class ThirtyMinuteCronJobPsnClientModeTest extends TestCase
             && function_exists('pcntl_setitimer')
         ) ? 1 : 0;
         $this->assertSame($expectedShadowExecutions, $newCounter->count);
+    }
+
+    public function testCreateAuthenticatedClientUsesConfiguredShadowLoginLatencyBudget(): void
+    {
+        putenv('PSN_CRON_SHADOW_LOGIN_LATENCY_BUDGET_MS=1');
+        $legacyCounter = (object) ['count' => 0];
+        $newCounter = (object) ['count' => 0];
+
+        $cronJob = new ThirtyMinuteCronJob(
+            $this->database,
+            new TrophyCalculator($this->database),
+            new Psn100Logger($this->database),
+            new TrophyHistoryRecorder($this->database),
+            1,
+            playStationClientFactory: new CronCountingPlayStationClientFactory($legacyCounter),
+            shadowPlayStationClientFactory: new CronCountingPlayStationClientFactory($newCounter),
+            psnClientMode: PsnClientMode::fromValue('shadow')
+        );
+
+        $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'createAuthenticatedClient');
+        $method->setAccessible(true);
+        $method->invoke($cronJob, 'worker-token');
+
+        $this->assertSame(1, $legacyCounter->count);
+        $this->assertSame(0, $newCounter->count);
+        $this->assertTrue($this->capturedShadowEvents !== []);
+
+        $latestEvent = $this->capturedShadowEvents[count($this->capturedShadowEvents) - 1];
+        $this->assertSame('psn_shadow_skipped', $latestEvent['event'] ?? null);
+        $this->assertTrue(
+            in_array($latestEvent['reason'] ?? null, ['legacy_latency_budget_exhausted', 'shadow_timeout_support_unavailable'], true)
+        );
+        $this->assertSame(1, $latestEvent['shadowLatencyBudgetMs'] ?? null);
     }
 }
 

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -28,6 +28,8 @@ require_once __DIR__ . '/../PsnClientMode.php';
 
 final class ThirtyMinuteCronJob implements CronJobInterface
 {
+    private const int DEFAULT_SHADOW_LOGIN_LATENCY_BUDGET_MS = 700;
+    private const string SHADOW_LOGIN_LATENCY_BUDGET_ENV = 'PSN_CRON_SHADOW_LOGIN_LATENCY_BUDGET_MS';
     private const string TITLE_ICON_DIRECTORY = '/home/psn100/public_html/img/title/';
     private const string GROUP_ICON_DIRECTORY = '/home/psn100/public_html/img/group/';
     private const string TROPHY_ICON_DIRECTORY = '/home/psn100/public_html/img/trophy/';
@@ -2017,9 +2019,30 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             fn (): PlayStationApiClientInterface => $this->createAndLoginClient($this->playStationClientFactory, $npsso),
             fn (): bool => $this->executeShadowLogin($npsso),
             static fn (mixed $payload): array => ['authenticated' => (bool) $payload],
-            700,
+            $this->resolveShadowLoginLatencyBudgetMs(),
             ['service' => 'thirty_minute_cron']
         );
+    }
+
+    private function resolveShadowLoginLatencyBudgetMs(): int
+    {
+        $configuredBudget = getenv(self::SHADOW_LOGIN_LATENCY_BUDGET_ENV);
+
+        if (!is_string($configuredBudget) || $configuredBudget === '') {
+            return self::DEFAULT_SHADOW_LOGIN_LATENCY_BUDGET_MS;
+        }
+
+        $validatedBudget = filter_var(
+            $configuredBudget,
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]]
+        );
+
+        if (!is_int($validatedBudget)) {
+            return self::DEFAULT_SHADOW_LOGIN_LATENCY_BUDGET_MS;
+        }
+
+        return $validatedBudget;
     }
 
     private function executeShadowLogin(string $npsso): bool


### PR DESCRIPTION
### Motivation

- Avoid a hard-coded `700ms` shadow login latency budget in the thirty-minute cron so the budget can be tuned per-environment via an env var. 
- Add test coverage to verify environment-driven behavior and that shadow skip telemetry is emitted when the budget is exhausted.

### Description

- Added `DEFAULT_SHADOW_LOGIN_LATENCY_BUDGET_MS` and `SHADOW_LOGIN_LATENCY_BUDGET_ENV` constants to `ThirtyMinuteCronJob` and replaced the literal `700` with `resolveShadowLoginLatencyBudgetMs()` in `createAuthenticatedClient()`.
- Implemented `resolveShadowLoginLatencyBudgetMs()` to read `PSN_CRON_SHADOW_LOGIN_LATENCY_BUDGET_MS`, validate it as an integer >= 1, and fall back to the `700ms` default when unset or invalid.
- Extended `ThirtyMinuteCronJobPsnClientModeTest` to capture shadow events via `ShadowExecutionUtility::setEventEmitter`, reset shadow state between tests, and add `testCreateAuthenticatedClientUsesConfiguredShadowLoginLatencyBudget()` which sets the env var and asserts the resolved budget is propagated into emitted telemetry.
- Adjusted assertions in the test to be compatible with the project test harness (replacing unavailable helpers with `assertTrue` + `in_array`).

### Testing

- Ran PHP syntax checks with `php -l` on the modified files and they reported no syntax errors.
- Ran the full test suite with `php tests/run.php` and observed all tests pass (496 tests passed).
- Verified shadow telemetry emission in the new test which asserts the emitted event includes `event == "psn_shadow_skipped"` and the configured `shadowLatencyBudgetMs` value.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e548eeffc4832fb5f5e9d90ad42979)