### PR TITLE
Add shadow→new promotion policy, per-service overrides, comparison metrics, and runbook

### DIFF
--- a/docs/shadow-mismatch-observability.md
+++ b/docs/shadow-mismatch-observability.md
@@ -7,6 +7,7 @@
 Build dashboard widgets from JSON fields below:
 
 - mismatch rate by `service` + `operation`
+- comparison quality from `comparisonMetrics.totalCompared`, `comparisonMetrics.matched`, `comparisonMetrics.mismatched`, `comparisonMetrics.skippedNormalizationFailure`, `comparisonMetrics.newClientErrors`
 - identifier coverage using `identifiers.onlineId`, `identifiers.accountId`, `identifiers.npCommunicationId`
 - top changed field paths from `diffSummary.changedPaths`
 - rate-limited versus sampled volume from `sampling.sampleRate` and `sampling.rateLimitPerMinute`
@@ -26,6 +27,24 @@ WHERE JSON_UNQUOTE(JSON_EXTRACT(payload, '$.event')) = 'psn_shadow_mismatch'
   AND timestamp >= NOW() - INTERVAL 24 HOUR
 GROUP BY service, operation
 ORDER BY mismatch_events DESC;
+```
+
+### Promotion-policy rollup counters (1h window)
+
+```sql
+SELECT
+  JSON_UNQUOTE(JSON_EXTRACT(payload, '$.service')) AS service,
+  JSON_UNQUOTE(JSON_EXTRACT(payload, '$.operation')) AS operation,
+  SUM(JSON_EXTRACT(payload, '$.comparisonMetrics.totalCompared')) AS total_compared,
+  SUM(JSON_EXTRACT(payload, '$.comparisonMetrics.matched')) AS matched,
+  SUM(JSON_EXTRACT(payload, '$.comparisonMetrics.mismatched')) AS mismatched,
+  SUM(JSON_EXTRACT(payload, '$.comparisonMetrics.skippedNormalizationFailure')) AS normalization_skips,
+  SUM(JSON_EXTRACT(payload, '$.comparisonMetrics.newClientErrors')) AS new_client_errors
+FROM observability_logs
+WHERE JSON_UNQUOTE(JSON_EXTRACT(payload, '$.event')) = 'psn_shadow_comparison_result'
+  AND timestamp >= NOW() - INTERVAL 1 HOUR
+GROUP BY service, operation
+ORDER BY total_compared DESC;
 ```
 
 ### Identifier coverage

--- a/docs/shadow-promotion-runbook.md
+++ b/docs/shadow-promotion-runbook.md
@@ -56,6 +56,6 @@ Use per-service overrides to promote incrementally:
 
 - `psn_player_lookup`: `shadow` → `new`
 - `psn_game_lookup`: stay `shadow` until stable
-- `psn_worker_login`: stay `legacy` until dependencies are validated
+- `playstation_client_factory`: stay `legacy` until dependencies are validated
 
 This avoids requiring a global cutover and reduces blast radius.

--- a/docs/shadow-promotion-runbook.md
+++ b/docs/shadow-promotion-runbook.md
@@ -1,0 +1,61 @@
+# Shadow → New promotion runbook
+
+This runbook defines objective promotion gates for moving PSN integrations from `shadow` to `new`.
+
+## 1) Configure thresholds
+
+Configure thresholds in `wwwroot/config/app.php` under:
+
+- `psn.shadow_promotion_policy.thresholds.default`
+- optional service/operation overrides in `psn.shadow_promotion_policy.thresholds.services`
+
+Threshold keys:
+
+- `maxMismatchRate` (per window, e.g. `1h`, `24h`, `7d`)
+- `minCompared` (minimum `totalCompared` volume per window)
+- `maxNewClientErrorRate` (new-client failures per compared request)
+- `maxNormalizationSkipRate` (normalization failures per compared request)
+
+## 2) Build and monitor comparison metrics
+
+`ShadowExecutionUtility` now emits `psn_shadow_comparison_result` with these counters:
+
+- `comparisonMetrics.totalCompared`
+- `comparisonMetrics.matched`
+- `comparisonMetrics.mismatched`
+- `comparisonMetrics.skippedNormalizationFailure`
+- `comparisonMetrics.newClientErrors`
+
+Aggregate these counters by `service` + `operation` over rolling windows (1h/24h/7d).
+
+## 3) Enter shadow for a target service
+
+1. Keep global `PSN_CLIENT_MODE=legacy` (or current production mode).
+2. Set a per-service override (via config or `PSN_CLIENT_MODE_OVERRIDES_JSON`) for the target service to `shadow`.
+3. Verify traffic starts emitting `psn_shadow_comparison_result` and (when applicable) `psn_shadow_mismatch` events.
+
+## 4) Promote to new when thresholds pass
+
+1. Evaluate the last 1h, 24h, and 7d windows for the target service/operation.
+2. Confirm all configured thresholds pass simultaneously.
+3. Change the service override from `shadow` to `new`.
+4. Keep monitoring comparison/mismatch dashboards for at least one additional 24h period.
+
+## 5) Roll back quickly on regression
+
+If mismatch rate or new-client errors regress:
+
+1. Set the affected service override to `legacy` immediately.
+2. If regression is broad, temporarily revert global mode to `legacy`.
+3. Capture top changed paths (`diffSummary.changedPaths`) and failure signatures for triage.
+4. Re-enter `shadow` only after fix validation.
+
+## Progressive rollout pattern (recommended)
+
+Use per-service overrides to promote incrementally:
+
+- `psn_player_lookup`: `shadow` → `new`
+- `psn_game_lookup`: stay `shadow` until stable
+- `psn_worker_login`: stay `legacy` until dependencies are validated
+
+This avoids requiring a global cutover and reduces blast radius.

--- a/tests/GameRescanServicePsnClientModeTest.php
+++ b/tests/GameRescanServicePsnClientModeTest.php
@@ -37,6 +37,30 @@ final class GameRescanServicePsnClientModeTest extends TestCase
         $this->assertSame(1, $newCounter->count);
     }
 
+
+    public function testGameLookupServiceRetainsItsOwnServiceOverrideWhenRescanModeDiffers(): void
+    {
+        putenv('PSN_CLIENT_MODE_OVERRIDES_JSON={"psn_game_lookup":"shadow"}');
+
+        $service = new GameRescanService(
+            $this->database,
+            new TrophyCalculator($this->database),
+            psnClientMode: PsnClientMode::fromValue('new')
+        );
+
+        $gameLookupServiceProperty = new ReflectionProperty(GameRescanService::class, 'psnGameLookupService');
+        $gameLookupServiceProperty->setAccessible(true);
+        $gameLookupService = $gameLookupServiceProperty->getValue($service);
+
+        $gameLookupModeProperty = new ReflectionProperty(PsnGameLookupService::class, 'psnClientMode');
+        $gameLookupModeProperty->setAccessible(true);
+        $gameLookupMode = $gameLookupModeProperty->getValue($gameLookupService);
+
+        $this->assertSame('shadow', $gameLookupMode->value());
+
+        putenv('PSN_CLIENT_MODE_OVERRIDES_JSON');
+    }
+
     public function testCreateAuthenticatedClientInShadowModeKeepsLegacyTruthAndOptionallyRunsShadow(): void
     {
         $legacyCounter = (object) ['count' => 0];

--- a/tests/PsnShadowPromotionPolicyTest.php
+++ b/tests/PsnShadowPromotionPolicyTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PsnClientMode.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/Shadow/ShadowPromotionPolicy.php';
+
+final class PsnShadowPromotionPolicyTest extends TestCase
+{
+    public function testServiceModeOverrideUsesEnvironmentConfiguration(): void
+    {
+        putenv('PSN_CLIENT_MODE=legacy');
+        putenv('PSN_CLIENT_MODE_OVERRIDES_JSON={"psn_player_lookup":"shadow","psn_game_lookup":"new"}');
+
+        $this->assertSame('shadow', PsnClientMode::forService('psn_player_lookup')->value());
+        $this->assertSame('new', PsnClientMode::forService('psn_game_lookup')->value());
+        $this->assertSame('legacy', PsnClientMode::forService('unknown_service')->value());
+
+        putenv('PSN_CLIENT_MODE_OVERRIDES_JSON');
+        putenv('PSN_CLIENT_MODE');
+    }
+
+    public function testPromotionPolicyPassesWhenAllThresholdsPass(): void
+    {
+        $policy = new ShadowPromotionPolicy([
+            'thresholds' => [
+                'default' => [
+                    'maxMismatchRate' => ['1h' => 0.03],
+                    'minCompared' => ['1h' => 100],
+                    'maxNewClientErrorRate' => ['1h' => 0.02],
+                    'maxNormalizationSkipRate' => ['1h' => 0.01],
+                ],
+            ],
+        ]);
+
+        $result = $policy->evaluate('psn_player_lookup', 'player_profile_lookup', [
+            '1h' => [
+                'totalCompared' => 200,
+                'matched' => 196,
+                'mismatched' => 4,
+                'skippedNormalizationFailure' => 1,
+                'newClientErrors' => 2,
+            ],
+        ]);
+
+        $this->assertTrue($result['promote']);
+        $this->assertCount(0, $result['reasons']);
+    }
+
+    public function testPromotionPolicyFailsWhenOperationOverrideThresholdFails(): void
+    {
+        $policy = new ShadowPromotionPolicy([
+            'thresholds' => [
+                'default' => [
+                    'maxMismatchRate' => ['1h' => 0.03],
+                    'minCompared' => ['1h' => 100],
+                ],
+                'services' => [
+                    'psn_player_lookup' => [
+                        'operations' => [
+                            'player_profile_lookup' => [
+                                'maxMismatchRate' => ['1h' => 0.01],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $policy->evaluate('psn_player_lookup', 'player_profile_lookup', [
+            '1h' => [
+                'totalCompared' => 200,
+                'matched' => 194,
+                'mismatched' => 6,
+                'skippedNormalizationFailure' => 0,
+                'newClientErrors' => 0,
+            ],
+        ]);
+
+        $this->assertFalse($result['promote']);
+        $this->assertSame('maxMismatchRate', $result['checks'][0]['metric']);
+        $this->assertTrue(count($result['reasons']) >= 1);
+    }
+}

--- a/tests/ShadowPlayStationUtilityTest.php
+++ b/tests/ShadowPlayStationUtilityTest.php
@@ -528,4 +528,100 @@ final class ShadowPlayStationUtilityTest extends TestCase
         ShadowExecutionUtility::resetStateForTests();
     }
 
+    public function testExecuteWithLegacyTruthEmitsComparisonMetricsForMatchedResponses(): void
+    {
+        if (
+            !function_exists('pcntl_signal')
+            || !function_exists('pcntl_async_signals')
+            || !function_exists('pcntl_setitimer')
+        ) {
+            return;
+        }
+
+        ShadowExecutionUtility::resetStateForTests();
+        $events = [];
+        ShadowExecutionUtility::setEventEmitter(static function (array $event) use (&$events): void {
+            $events[] = $event;
+        });
+
+        ShadowExecutionUtility::executeWithLegacyTruth(
+            PsnClientMode::fromValue('shadow'),
+            'player_profile_lookup',
+            static fn (): array => ['profile' => ['title' => 'same']],
+            static fn (): array => ['profile' => ['title' => 'same']],
+            static fn (mixed $value): array => is_array($value) ? $value : [],
+            350,
+            ['service' => 'psn_player_lookup']
+        );
+
+        $comparisonEvent = null;
+        foreach ($events as $event) {
+            if (($event['event'] ?? null) === 'psn_shadow_comparison_result') {
+                $comparisonEvent = $event;
+                break;
+            }
+        }
+
+        if (!is_array($comparisonEvent)) {
+            $this->fail('Expected psn_shadow_comparison_result event to be emitted.');
+        }
+
+        $this->assertSame(1, $comparisonEvent['comparisonMetrics']['totalCompared']);
+        $this->assertSame(1, $comparisonEvent['comparisonMetrics']['matched']);
+        $this->assertSame(0, $comparisonEvent['comparisonMetrics']['mismatched']);
+        $this->assertSame(0, $comparisonEvent['comparisonMetrics']['newClientErrors']);
+        $this->assertSame(0, $comparisonEvent['comparisonMetrics']['skippedNormalizationFailure']);
+
+        ShadowExecutionUtility::resetStateForTests();
+    }
+
+    public function testExecuteWithLegacyTruthEmitsComparisonMetricsForNewClientErrors(): void
+    {
+        if (
+            !function_exists('pcntl_signal')
+            || !function_exists('pcntl_async_signals')
+            || !function_exists('pcntl_setitimer')
+        ) {
+            return;
+        }
+
+        ShadowExecutionUtility::resetStateForTests();
+        $events = [];
+        ShadowExecutionUtility::setEventEmitter(static function (array $event) use (&$events): void {
+            $events[] = $event;
+        });
+
+        ShadowExecutionUtility::executeWithLegacyTruth(
+            PsnClientMode::fromValue('shadow'),
+            'player_profile_lookup',
+            static fn (): array => ['profile' => ['title' => 'legacy']],
+            static function (): array {
+                throw new RuntimeException('shadow exploded');
+            },
+            static fn (mixed $value): array => is_array($value) ? $value : [],
+            350,
+            ['service' => 'psn_player_lookup']
+        );
+
+        $comparisonEvent = null;
+        foreach ($events as $event) {
+            if (($event['event'] ?? null) === 'psn_shadow_comparison_result') {
+                $comparisonEvent = $event;
+                break;
+            }
+        }
+
+        if (!is_array($comparisonEvent)) {
+            $this->fail('Expected psn_shadow_comparison_result event to be emitted.');
+        }
+
+        $this->assertSame(0, $comparisonEvent['comparisonMetrics']['totalCompared']);
+        $this->assertSame(0, $comparisonEvent['comparisonMetrics']['matched']);
+        $this->assertSame(0, $comparisonEvent['comparisonMetrics']['mismatched']);
+        $this->assertSame(1, $comparisonEvent['comparisonMetrics']['newClientErrors']);
+        $this->assertSame(0, $comparisonEvent['comparisonMetrics']['skippedNormalizationFailure']);
+
+        ShadowExecutionUtility::resetStateForTests();
+    }
+
 }

--- a/tests/ThirtyMinuteCronJobPsnClientModeTest.php
+++ b/tests/ThirtyMinuteCronJobPsnClientModeTest.php
@@ -59,6 +59,33 @@ final class ThirtyMinuteCronJobPsnClientModeTest extends TestCase
         $this->assertSame(1, $newCounter->count);
     }
 
+
+    public function testGameLookupServiceRetainsItsOwnServiceOverrideWhenCronModeDiffers(): void
+    {
+        putenv('PSN_CLIENT_MODE_OVERRIDES_JSON={"psn_game_lookup":"shadow"}');
+
+        $cronJob = new ThirtyMinuteCronJob(
+            $this->database,
+            new TrophyCalculator($this->database),
+            new Psn100Logger($this->database),
+            new TrophyHistoryRecorder($this->database),
+            1,
+            psnClientMode: PsnClientMode::fromValue('new')
+        );
+
+        $gameLookupServiceProperty = new ReflectionProperty(ThirtyMinuteCronJob::class, 'psnGameLookupService');
+        $gameLookupServiceProperty->setAccessible(true);
+        $gameLookupService = $gameLookupServiceProperty->getValue($cronJob);
+
+        $gameLookupModeProperty = new ReflectionProperty(PsnGameLookupService::class, 'psnClientMode');
+        $gameLookupModeProperty->setAccessible(true);
+        $gameLookupMode = $gameLookupModeProperty->getValue($gameLookupService);
+
+        $this->assertSame('shadow', $gameLookupMode->value());
+
+        putenv('PSN_CLIENT_MODE_OVERRIDES_JSON');
+    }
+
     public function testCreateAuthenticatedClientInShadowModeKeepsLegacyTruthAndOptionallyRunsShadow(): void
     {
         $legacyCounter = (object) ['count' => 0];

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -72,8 +72,7 @@ class GameRescanService
         $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase(
             $database,
             $this->playStationClientFactory,
-            $this->shadowPlayStationClientFactory,
-            $this->psnClientMode
+            $this->shadowPlayStationClientFactory
         );
     }
 

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -67,7 +67,7 @@ class GameRescanService
         $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
         $this->playStationClientFactory = $playStationClientFactory ?? new PlayStationClientFactory();
         $this->shadowPlayStationClientFactory = $shadowPlayStationClientFactory ?? new PlayStationClientFactory();
-        $this->psnClientMode = $psnClientMode ?? PsnClientMode::current();
+        $this->psnClientMode = $psnClientMode ?? PsnClientMode::forService('game_rescan');
         $this->psnTrophyGroupMapper = new PsnTrophyGroupMapper(new PsnTrophyMapper());
         $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase(
             $database,

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -40,7 +40,7 @@ final class PsnGameLookupService
         $this->playStationClientFactory = $this->normalizePlayStationClientFactory($playStationClientFactory);
         $this->shadowPlayStationClientFactory = $shadowPlayStationClientFactory ?? new PlayStationClientFactory();
         $this->npServiceNamePolicy = new NpServiceNamePolicy();
-        $this->psnClientMode = $psnClientMode ?? PsnClientMode::current();
+        $this->psnClientMode = $psnClientMode ?? PsnClientMode::forService('psn_game_lookup');
     }
 
     public static function fromDatabase(

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -36,7 +36,7 @@ final class PsnPlayerLookupService
         $this->workerFetcher = \Closure::fromCallable($workerFetcher);
         $this->playStationClientFactory = $this->normalizePlayStationClientFactory($playStationClientFactory);
         $this->shadowPlayStationClientFactory = $shadowPlayStationClientFactory ?? new PlayStationClientFactory();
-        $this->psnClientMode = $psnClientMode ?? PsnClientMode::current();
+        $this->psnClientMode = $psnClientMode ?? PsnClientMode::forService('psn_player_lookup');
     }
 
     public static function fromDatabase(

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -76,8 +76,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase(
             $database,
             $this->playStationClientFactory,
-            $this->shadowPlayStationClientFactory,
-            $this->psnClientMode
+            $this->shadowPlayStationClientFactory
         );
     }
 

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -69,7 +69,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
         $this->playStationClientFactory = $playStationClientFactory ?? new PlayStationClientFactory();
         $this->shadowPlayStationClientFactory = $shadowPlayStationClientFactory ?? new PlayStationClientFactory();
-        $this->psnClientMode = $psnClientMode ?? PsnClientMode::current();
+        $this->psnClientMode = $psnClientMode ?? PsnClientMode::forService('thirty_minute_cron');
         $this->psnProfileMapper = new PsnProfileMapper();
         $this->psnTrophyMapper = new PsnTrophyMapper();
         $this->psnTrophyGroupMapper = new PsnTrophyGroupMapper($this->psnTrophyMapper);

--- a/wwwroot/classes/PlayStation/PlayStationClientFactory.php
+++ b/wwwroot/classes/PlayStation/PlayStationClientFactory.php
@@ -10,7 +10,7 @@ final class PlayStationClientFactory implements PlayStationClientFactoryInterfac
 {
     public function createClient(): PlayStationApiClientInterface
     {
-        $mode = PsnClientMode::current();
+        $mode = PsnClientMode::forService('playstation_client_factory');
 
         return match ($mode->value()) {
             PsnClientMode::LEGACY,

--- a/wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php
+++ b/wwwroot/classes/PlayStation/Shadow/ShadowExecutionUtility.php
@@ -73,12 +73,49 @@ final class ShadowExecutionUtility
             $shadowResponse = self::executeShadowWithTimeout($shadowExecutor, $remainingShadowBudgetMs);
             $shadowDurationMs = (int) ((hrtime(true) - $shadowStart) / 1_000_000);
 
-            $normalizedLegacyResponse = $normalizer($legacyResponse);
-            $normalizedShadowResponse = $normalizer($shadowResponse);
+            try {
+                $normalizedLegacyResponse = $normalizer($legacyResponse);
+                $normalizedShadowResponse = $normalizer($shadowResponse);
+            } catch (Throwable $normalizationException) {
+                self::emitEvent(array_merge($metricTags, [
+                    'event' => 'psn_shadow_comparison_result',
+                    'service' => self::toNullableString($metricTags['service'] ?? null) ?? 'unknown_service',
+                    'operation' => $operation,
+                    'comparisonMetrics' => self::buildComparisonMetricsPayload(
+                        totalCompared: 0,
+                        matched: 0,
+                        mismatched: 0,
+                        skippedNormalizationFailure: 1,
+                        newClientErrors: 0
+                    ),
+                    'normalizationErrorType' => $normalizationException::class,
+                    'message' => $normalizationException->getMessage(),
+                    'legacyDurationMs' => $legacyDurationMs,
+                    'shadowDurationMs' => $shadowDurationMs,
+                ]));
+
+                return $legacyResponse;
+            }
+
             $comparison = ShadowResponseComparator::compare(
                 $normalizedLegacyResponse,
                 $normalizedShadowResponse
             );
+
+            self::emitEvent(array_merge($metricTags, [
+                'event' => 'psn_shadow_comparison_result',
+                'service' => self::toNullableString($metricTags['service'] ?? null) ?? 'unknown_service',
+                'operation' => $operation,
+                'comparisonMetrics' => self::buildComparisonMetricsPayload(
+                    totalCompared: 1,
+                    matched: $comparison['hasMismatch'] ? 0 : 1,
+                    mismatched: $comparison['hasMismatch'] ? 1 : 0,
+                    skippedNormalizationFailure: 0,
+                    newClientErrors: 0
+                ),
+                'legacyDurationMs' => $legacyDurationMs,
+                'shadowDurationMs' => $shadowDurationMs,
+            ]));
 
             if ($comparison['hasMismatch']) {
                 $service = self::toNullableString($metricTags['service'] ?? null) ?? 'unknown_service';
@@ -139,6 +176,22 @@ final class ShadowExecutionUtility
             ]));
         } catch (Throwable $shadowException) {
             self::emitEvent(array_merge($metricTags, [
+                'event' => 'psn_shadow_comparison_result',
+                'service' => self::toNullableString($metricTags['service'] ?? null) ?? 'unknown_service',
+                'operation' => $operation,
+                'comparisonMetrics' => self::buildComparisonMetricsPayload(
+                    totalCompared: 0,
+                    matched: 0,
+                    mismatched: 0,
+                    skippedNormalizationFailure: 0,
+                    newClientErrors: 1
+                ),
+                'legacyDurationMs' => $legacyDurationMs,
+                'shadowDurationMs' => (int) ((hrtime(true) - $shadowStart) / 1_000_000),
+                'errorType' => $shadowException::class,
+                'message' => $shadowException->getMessage(),
+            ]));
+            self::emitEvent(array_merge($metricTags, [
                 'event' => 'psn_shadow_failure',
                 'operation' => $operation,
                 'legacyDurationMs' => $legacyDurationMs,
@@ -148,6 +201,25 @@ final class ShadowExecutionUtility
         }
 
         return $legacyResponse;
+    }
+
+    /**
+     * @return array{totalCompared: int, matched: int, mismatched: int, skippedNormalizationFailure: int, newClientErrors: int}
+     */
+    private static function buildComparisonMetricsPayload(
+        int $totalCompared,
+        int $matched,
+        int $mismatched,
+        int $skippedNormalizationFailure,
+        int $newClientErrors
+    ): array {
+        return [
+            'totalCompared' => $totalCompared,
+            'matched' => $matched,
+            'mismatched' => $mismatched,
+            'skippedNormalizationFailure' => $skippedNormalizationFailure,
+            'newClientErrors' => $newClientErrors,
+        ];
     }
 
     /**

--- a/wwwroot/classes/PlayStation/Shadow/ShadowPromotionPolicy.php
+++ b/wwwroot/classes/PlayStation/Shadow/ShadowPromotionPolicy.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+final class ShadowPromotionPolicy
+{
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    public function __construct(private readonly array $configuration)
+    {
+    }
+
+    /**
+     * @param array<string, array<string, int|float>> $windowMetrics
+     * @return array{promote: bool, checks: list<array{window: string, metric: string, passed: bool, actual: float|int, threshold: float|int, comparator: string}>, reasons: list<string>}
+     */
+    public function evaluate(string $service, string $operation, array $windowMetrics): array
+    {
+        $thresholds = $this->resolveThresholds($service, $operation);
+        $checks = [];
+        $reasons = [];
+
+        foreach ($thresholds as $metric => $windowThresholds) {
+            if (!is_array($windowThresholds)) {
+                continue;
+            }
+
+            foreach ($windowThresholds as $window => $thresholdValue) {
+                if (!is_string($window) || !is_numeric($thresholdValue)) {
+                    continue;
+                }
+
+                $metrics = $windowMetrics[$window] ?? [];
+                if (!is_array($metrics)) {
+                    $metrics = [];
+                }
+
+                $actualValue = $this->measureMetric($metric, $metrics);
+                [$passed, $comparator] = $this->evaluateThreshold($metric, $actualValue, (float) $thresholdValue);
+
+                $checks[] = [
+                    'window' => $window,
+                    'metric' => $metric,
+                    'passed' => $passed,
+                    'actual' => $actualValue,
+                    'threshold' => is_int($thresholdValue) ? (int) $thresholdValue : (float) $thresholdValue,
+                    'comparator' => $comparator,
+                ];
+
+                if (!$passed) {
+                    $reasons[] = sprintf(
+                        '%s failed for %s/%s in %s (actual=%s threshold=%s)',
+                        $metric,
+                        $service,
+                        $operation,
+                        $window,
+                        (string) $actualValue,
+                        (string) $thresholdValue
+                    );
+                }
+            }
+        }
+
+        return [
+            'promote' => $reasons === [],
+            'checks' => $checks,
+            'reasons' => array_values(array_unique($reasons)),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function resolveThresholds(string $service, string $operation): array
+    {
+        $thresholds = $this->configuration['thresholds'] ?? [];
+        if (!is_array($thresholds)) {
+            return [];
+        }
+
+        $resolved = [];
+        if (isset($thresholds['default']) && is_array($thresholds['default'])) {
+            $resolved = $thresholds['default'];
+        }
+
+        $serviceThresholds = $thresholds['services'][$service] ?? null;
+        if (is_array($serviceThresholds)) {
+            $resolved = array_replace_recursive($resolved, $serviceThresholds);
+
+            $operationThresholds = $serviceThresholds['operations'][$operation] ?? null;
+            if (is_array($operationThresholds)) {
+                $resolved = array_replace_recursive($resolved, $operationThresholds);
+            }
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param array<string, int|float> $metrics
+     */
+    private function measureMetric(string $metric, array $metrics): float|int
+    {
+        $totalCompared = max(0, (int) ($metrics['totalCompared'] ?? 0));
+        $mismatched = max(0, (int) ($metrics['mismatched'] ?? 0));
+        $newClientErrors = max(0, (int) ($metrics['newClientErrors'] ?? 0));
+        $normalizationSkips = max(0, (int) ($metrics['skippedNormalizationFailure'] ?? 0));
+
+        return match ($metric) {
+            'minCompared' => $totalCompared,
+            'maxMismatchRate' => $totalCompared === 0 ? 1.0 : $mismatched / $totalCompared,
+            'maxNewClientErrorRate' => $totalCompared === 0 ? 1.0 : $newClientErrors / $totalCompared,
+            'maxNormalizationSkipRate' => $totalCompared === 0 ? 1.0 : $normalizationSkips / $totalCompared,
+            default => 1.0,
+        };
+    }
+
+    /**
+     * @return array{bool, string}
+     */
+    private function evaluateThreshold(string $metric, float|int $actual, float $threshold): array
+    {
+        if ($metric === 'minCompared') {
+            return [$actual >= $threshold, '>='];
+        }
+
+        return [$actual <= $threshold, '<='];
+    }
+}

--- a/wwwroot/classes/PsnClientMode.php
+++ b/wwwroot/classes/PsnClientMode.php
@@ -30,6 +30,18 @@ final class PsnClientMode
         return self::$resolvedMode;
     }
 
+    public static function forService(string $service): self
+    {
+        $configuredOverrides = self::resolveConfiguredOverrides();
+        $normalizedService = strtolower(trim($service));
+
+        if ($normalizedService !== '' && isset($configuredOverrides[$normalizedService])) {
+            return self::fromValue($configuredOverrides[$normalizedService]);
+        }
+
+        return self::current();
+    }
+
     public static function fromValue(mixed $mode): self
     {
         if (!is_string($mode)) {
@@ -100,5 +112,52 @@ final class PsnClientMode
         $configuration = @include $configurationFile;
 
         return is_array($configuration) ? $configuration : [];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function resolveConfiguredOverrides(): array
+    {
+        $configuration = self::loadAppConfiguration();
+        $configuredOverrides = $configuration['psn']['client_mode_overrides'] ?? [];
+        $environmentOverrides = self::readOverridesFromEnvironment();
+
+        $combined = [];
+        foreach ([$configuredOverrides, $environmentOverrides] as $overrideSource) {
+            if (!is_array($overrideSource)) {
+                continue;
+            }
+
+            foreach ($overrideSource as $service => $mode) {
+                if (!is_string($service) || !is_string($mode)) {
+                    continue;
+                }
+
+                $normalizedService = strtolower(trim($service));
+                if ($normalizedService === '') {
+                    continue;
+                }
+
+                $combined[$normalizedService] = $mode;
+            }
+        }
+
+        return $combined;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function readOverridesFromEnvironment(): array
+    {
+        $rawValue = $_ENV['PSN_CLIENT_MODE_OVERRIDES_JSON'] ?? getenv('PSN_CLIENT_MODE_OVERRIDES_JSON');
+        if (!is_string($rawValue) || trim($rawValue) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($rawValue, true);
+
+        return is_array($decoded) ? $decoded : [];
     }
 }

--- a/wwwroot/config/app.php
+++ b/wwwroot/config/app.php
@@ -7,5 +7,33 @@ $psnClientMode = $_ENV['PSN_CLIENT_MODE'] ?? getenv('PSN_CLIENT_MODE');
 return [
     'psn' => [
         'client_mode' => $psnClientMode === false ? 'legacy' : $psnClientMode,
+        'client_mode_overrides' => [],
+        'shadow_promotion_policy' => [
+            'thresholds' => [
+                'default' => [
+                    'maxMismatchRate' => [
+                        '1h' => 0.02,
+                        '24h' => 0.01,
+                        '7d' => 0.005,
+                    ],
+                    'minCompared' => [
+                        '1h' => 200,
+                        '24h' => 2_000,
+                        '7d' => 10_000,
+                    ],
+                    'maxNewClientErrorRate' => [
+                        '1h' => 0.01,
+                        '24h' => 0.005,
+                        '7d' => 0.003,
+                    ],
+                    'maxNormalizationSkipRate' => [
+                        '1h' => 0.002,
+                        '24h' => 0.001,
+                        '7d' => 0.001,
+                    ],
+                ],
+                'services' => [],
+            ],
+        ],
     ],
 ];


### PR DESCRIPTION
### Motivation
- Provide an objective, data-driven gate to promote PSN integrations from `shadow` to `new` to reduce risk of regressions. 
- Emit compact comparison roll-up metrics so promotion decisions can be evaluated over rolling windows (1h/24h/7d) and automated dashboards/alerts can be built.
- Allow progressive, per-service rollout rather than a single global cutover to reduce blast radius and enable targeted rollbacks.

### Description
- Added configurable promotion thresholds and per-service override slot to `wwwroot/config/app.php` including `maxMismatchRate`, `minCompared`, `maxNewClientErrorRate`, and `maxNormalizationSkipRate` across `1h/24h/7d` windows.  
- Implemented `PsnClientMode::forService()` with support for `PSN_CLIENT_MODE_OVERRIDES_JSON` so client mode can be resolved per service.  
- Added `ShadowPromotionPolicy` evaluator (`wwwroot/classes/PlayStation/Shadow/ShadowPromotionPolicy.php`) that merges default and service/operation overrides and evaluates windowed metrics to produce pass/fail checks and human-readable reasons.  
- Extended `ShadowExecutionUtility` to emit `psn_shadow_comparison_result` events containing `comparisonMetrics` (`totalCompared`, `matched`, `mismatched`, `skippedNormalizationFailure`, `newClientErrors`), and added explicit emission for normalization failures and shadow/new-client exceptions; existing `psn_shadow_mismatch` emission is preserved.  
- Added operational runbook and observability docs (`docs/shadow-promotion-runbook.md`, updated `docs/shadow-mismatch-observability.md`) describing dashboards, SQL rollups, promotion steps, and rollback guidance.  
- Added tests: `tests/PsnShadowPromotionPolicyTest.php` for override resolution and policy evaluation, and additional tests in `tests/ShadowPlayStationUtilityTest.php` to assert `psn_shadow_comparison_result` emission in matched and error cases.

### Testing
- Linted modified PHP files with `php -l` (checked `ShadowExecutionUtility.php`, `PsnClientMode.php`, `app.php`, `ShadowPromotionPolicy.php`, and the modified tests) and all reported no syntax errors.  
- Ran the full test suite via `php tests/run.php`, which completed successfully with all tests passing (501 tests passed).  
- New unit tests added (`PsnShadowPromotionPolicyTest` and comparison-metric assertions in `ShadowPlayStationUtilityTest`) were included in the run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54dfde464832f8a1c6f008a80da6d)