### PR TITLE
Add PlayStation fixtures, fixture loader, and normalization parity tests for lookup/rescan

### DIFF
--- a/tests/GameRescanTransformationParityTest.php
+++ b/tests/GameRescanTransformationParityTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/PlayStationFixtureLoader.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyCalculator.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanService.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/Contracts/TrophyClientInterface.php';
+
+final class GameRescanTransformationParityTest extends TestCase
+{
+    private PDO $database;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    }
+
+    public function testRescanLookupTransformationParityAcrossServiceVariants(): void
+    {
+        $trophyFixture = PlayStationFixtureLoader::loadJson('trophies/groups-and-trophies-trophy.json');
+        $trophy2Fixture = PlayStationFixtureLoader::loadJson('trophies/groups-and-trophies-trophy2.json');
+
+        $service = $this->buildRescanService();
+        $method = new ReflectionMethod(GameRescanService::class, 'fetchGameLookupGroupData');
+        $method->setAccessible(true);
+
+        $legacyGroups = $method->invoke(
+            $service,
+            new FixtureTrophyClient($trophyFixture),
+            'NPWR12345_00'
+        );
+        $newGroups = $method->invoke(
+            $service,
+            new FixtureTrophyClient($trophy2Fixture),
+            'NPWR12345_00'
+        );
+
+        $this->assertSame(count($legacyGroups), count($newGroups));
+        $this->assertSame((string) $legacyGroups[0]->id(), (string) $newGroups[0]->id());
+        $this->assertSame((string) $legacyGroups[0]->trophies()[0]->id(), (string) $newGroups[0]->trophies()[0]->id());
+        $this->assertSame((string) $legacyGroups[0]->trophies()[0]->name(), (string) $newGroups[0]->trophies()[0]->name());
+    }
+
+    public function testRescanLookupTransformationNormalizesFieldsUsedByTrophyCalculations(): void
+    {
+        $partialFixture = PlayStationFixtureLoader::loadJson('malformed/trophy-groups-partial.json');
+
+        $service = $this->buildRescanService();
+        $method = new ReflectionMethod(GameRescanService::class, 'fetchGameLookupGroupData');
+        $method->setAccessible(true);
+
+        $groups = $method->invoke(
+            $service,
+            new FixtureTrophyClient($partialFixture),
+            'NPWR12345_00'
+        );
+
+        $this->assertSame('dlc1', $groups[0]->id());
+        $this->assertSame('', $groups[0]->name());
+
+        $trophy = $groups[0]->trophies()[0];
+        $this->assertTrue($trophy->hidden());
+        $this->assertSame('silver', $trophy->type());
+        $this->assertSame('15', $trophy->progressTargetValue());
+        $this->assertSame('DLC Badge', $trophy->rewardName());
+        $this->assertSame(null, $trophy->rewardImageUrl());
+    }
+
+    public function testFixtureContainsTrophyTitleListingShapeUsedForRankingMetadata(): void
+    {
+        $fixture = PlayStationFixtureLoader::loadJson('trophies/titles-listing.json');
+
+        $this->assertTrue(isset($fixture['trophyTitles']) && is_array($fixture['trophyTitles']));
+        $this->assertSame('NPWR77777_00', $fixture['trophyTitles'][0]['npCommunicationId']);
+        $this->assertSame('PS5', $fixture['trophyTitles'][0]['trophyTitlePlatform']);
+        $this->assertSame('01.00', $fixture['trophyTitles'][0]['trophySetVersion']);
+    }
+
+    private function buildRescanService(): GameRescanService
+    {
+        return new GameRescanService(
+            $this->database,
+            new TrophyCalculator($this->database)
+        );
+    }
+}
+
+final class FixtureTrophyClient implements TrophyClientInterface
+{
+    /** @param array<string, mixed> $fixture */
+    public function __construct(private readonly array $fixture)
+    {
+    }
+
+    public function requestTrophyEndpoint(string $path, array $query = [], array $headers = []): mixed
+    {
+        if (str_ends_with($path, '/all/trophies')) {
+            return (object) ($this->fixture['allTrophies'] ?? []);
+        }
+
+        return (object) ($this->fixture['trophyGroups'] ?? []);
+    }
+}

--- a/tests/PlayStationFixtureLoader.php
+++ b/tests/PlayStationFixtureLoader.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+final class PlayStationFixtureLoader
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function loadJson(string $relativePath): array
+    {
+        $absolutePath = __DIR__ . '/fixtures/playstation/' . ltrim($relativePath, '/');
+        $raw = file_get_contents($absolutePath);
+
+        if (!is_string($raw)) {
+            throw new RuntimeException(sprintf('Unable to read fixture: %s', $absolutePath));
+        }
+
+        $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($decoded)) {
+            throw new RuntimeException(sprintf('Fixture did not decode to array: %s', $absolutePath));
+        }
+
+        return $decoded;
+    }
+}

--- a/tests/PsnGameLookupServiceTest.php
+++ b/tests/PsnGameLookupServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/PlayStationFixtureLoader.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/PsnGameLookupService.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/PsnGameLookupRequestHandler.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/Worker.php';
@@ -1015,6 +1016,101 @@ final class PsnGameLookupServiceTest extends TestCase
 
         $this->assertSame(44, $result['trophyData']['trophyGroups'][0]['trophies'][0]['trophyId']);
         $this->assertSame(0, $legacyFactoryCounter->count);
+    }
+
+    public function testFetchTrophyDataNormalizationHasParityAcrossFixtureServiceVariants(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+        $trophyFixture = PlayStationFixtureLoader::loadJson('trophies/groups-and-trophies-trophy.json');
+        $trophy2Fixture = PlayStationFixtureLoader::loadJson('trophies/groups-and-trophies-trophy2.json');
+
+        $service = new PsnGameLookupService(
+            $this->database,
+            static fn (): array => [$worker],
+            static fn (): object => new GameLookupStubClient()
+        );
+
+        $payloadFromTrophy = $service->fetchTrophyDataForNpCommunicationId(
+            'NPWR12345_00',
+            new GameLookupStubClient(
+                profileHandler: static fn (string $path): object => str_ends_with($path, '/all/trophies')
+                    ? (object) $trophyFixture['allTrophies']
+                    : (object) $trophyFixture['trophyGroups']
+            )
+        );
+        $payloadFromTrophy2 = $service->fetchTrophyDataForNpCommunicationId(
+            'NPWR12345_00',
+            new GameLookupStubClient(
+                profileHandler: static fn (string $path): object => str_ends_with($path, '/all/trophies')
+                    ? (object) $trophy2Fixture['allTrophies']
+                    : (object) $trophy2Fixture['trophyGroups']
+            )
+        );
+
+        $legacyTrophy = $payloadFromTrophy['trophyGroups'][0]['trophies'][0];
+        $newTrophy = $payloadFromTrophy2['trophyGroups'][0]['trophies'][0];
+
+        $this->assertSame((string) $legacyTrophy['trophyId'], (string) $newTrophy['trophyId']);
+        $this->assertSame((string) $legacyTrophy['trophyName'], (string) $newTrophy['trophyName']);
+        $this->assertSame(strtolower((string) $legacyTrophy['trophyType']), strtolower((string) $newTrophy['trophyType']));
+        $this->assertSame('all', $payloadFromTrophy2['trophyGroups'][0]['trophyGroupId']);
+    }
+
+    public function testFetchTrophyDataNormalizesPartialFixturePayloadForRankingFields(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+        $partialFixture = PlayStationFixtureLoader::loadJson('malformed/trophy-groups-partial.json');
+
+        $service = new PsnGameLookupService(
+            $this->database,
+            static fn (): array => [$worker],
+            static fn (): object => new GameLookupStubClient()
+        );
+
+        $payload = $service->fetchTrophyDataForNpCommunicationId(
+            'NPWR12345_00',
+            new GameLookupStubClient(
+                profileHandler: static fn (string $path): object => str_ends_with($path, '/all/trophies')
+                    ? (object) $partialFixture['allTrophies']
+                    : (object) $partialFixture['trophyGroups']
+            )
+        );
+
+        $trophy = $payload['trophyGroups'][0]['trophies'][0];
+        $this->assertSame('dlc1', $payload['trophyGroups'][0]['trophyGroupId']);
+        $this->assertSame('silver', strtolower((string) $trophy['trophyType']));
+        $this->assertSame('15', (string) $trophy['trophyProgressTargetValue']);
+        $this->assertSame('DLC Badge', $trophy['trophyRewardName']);
+    }
+
+    public function testFetchTrophyDataMapsFixturePrivateStatusToLookupException(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+        $fixture = PlayStationFixtureLoader::loadJson('profile/private.json');
+
+        $service = new PsnGameLookupService(
+            $this->database,
+            static fn (): array => [$worker],
+            static fn (): object => new GameLookupStubClient()
+        );
+
+        try {
+            $service->fetchTrophyDataForNpCommunicationId(
+                'NPWR12345_00',
+                new GameLookupStubClient(
+                    profileHandler: static function () use ($fixture): object {
+                        throw new GameLookupHttpException((int) $fixture['statusCode']);
+                    }
+                )
+            );
+            $this->fail('Expected private trophy payload status to be mapped to lookup exception.');
+        } catch (PsnGameLookupException $exception) {
+            $this->assertSame(403, $exception->getStatusCode());
+            $this->assertSame(
+                'Failed to retrieve trophy data from PlayStation Network. Please try again later.',
+                $exception->getMessage()
+            );
+        }
     }
 }
 

--- a/tests/PsnPlayerLookupServiceTest.php
+++ b/tests/PsnPlayerLookupServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/PlayStationFixtureLoader.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/PsnPlayerLookupService.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/PsnPlayerLookupRequestHandler.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/Worker.php';
@@ -323,6 +324,93 @@ final class PsnPlayerLookupServiceTest extends TestCase
         $this->assertSame('NewName', $result['profile']['onlineId']);
         $this->assertSame('200', $result['profile']['accountId']);
         $this->assertSame(0, $legacyFactoryCounter->count);
+    }
+
+    public function testLookupNormalizesFixtureSuccessPayload(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+        $fixture = PlayStationFixtureLoader::loadJson('profile/success.json');
+
+        $service = new PsnPlayerLookupService(
+            static fn (): array => [$worker],
+            static fn (): object => new StubClient(
+                profileHandler: static fn (): object => (object) $fixture
+            )
+        );
+
+        $result = $service->lookup('FixtureHunter');
+
+        $this->assertSame('FixtureHunter', $result['profile']['onlineId']);
+        $this->assertSame('1000000000001', $result['profile']['accountId']);
+        $this->assertSame('FixtureHunterLive', $result['profile']['currentOnlineId']);
+    }
+
+    public function testLookupMapsPrivateFixturePayloadToLookupExceptionWithStatusCode(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+        $fixture = PlayStationFixtureLoader::loadJson('profile/private.json');
+
+        $service = new PsnPlayerLookupService(
+            static fn (): array => [$worker],
+            static fn (): object => new StubClient(
+                profileHandler: static function () use ($fixture): object {
+                    throw new StubHttpException((string) $fixture['message'], new StubResponse((int) $fixture['statusCode']));
+                }
+            )
+        );
+
+        try {
+            $service->lookup('PrivatePlayer');
+            $this->fail('Expected private profile lookup to raise an exception.');
+        } catch (PsnPlayerLookupException $exception) {
+            $this->assertSame(403, $exception->getStatusCode());
+            $this->assertSame(
+                'Failed to retrieve the player profile from PlayStation Network. Please try again later.',
+                $exception->getMessage()
+            );
+        }
+    }
+
+    public function testLookupMapsNotFoundFixturePayloadToNotFoundException(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+        $fixture = PlayStationFixtureLoader::loadJson('profile/not-found.json');
+
+        $service = new PsnPlayerLookupService(
+            static fn (): array => [$worker],
+            static fn (): object => new StubClient(
+                profileHandler: static function () use ($fixture): object {
+                    throw new StubHttpException((string) $fixture['message'], new StubResponse((int) $fixture['statusCode']));
+                }
+            )
+        );
+
+        try {
+            $service->lookup('MissingFixturePlayer');
+            $this->fail('Expected missing profile lookup to raise a not found exception.');
+        } catch (PsnPlayerLookupException $exception) {
+            $this->assertSame(404, $exception->getStatusCode());
+            $this->assertSame('Player "MissingFixturePlayer" was not found.', $exception->getMessage());
+        }
+    }
+
+    public function testLookupNormalizesMalformedFixturePayloadWithoutProfileNode(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+        $fixture = PlayStationFixtureLoader::loadJson('malformed/profile-missing-profile-node.json');
+
+        $service = new PsnPlayerLookupService(
+            static fn (): array => [$worker],
+            static fn (): object => new StubClient(
+                profileHandler: static fn (): object => (object) $fixture
+            )
+        );
+
+        $result = $service->lookup('FixtureHunter');
+
+        $this->assertTrue(array_key_exists('status', $result));
+        $this->assertTrue(array_key_exists('data', $result));
+        $this->assertSame('FixtureHunter', $result['data']['onlineId']);
     }
 }
 

--- a/tests/fixtures/playstation/malformed/profile-missing-profile-node.json
+++ b/tests/fixtures/playstation/malformed/profile-missing-profile-node.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "data": {
+    "onlineId": "FixtureHunter"
+  }
+}

--- a/tests/fixtures/playstation/malformed/trophy-groups-partial.json
+++ b/tests/fixtures/playstation/malformed/trophy-groups-partial.json
@@ -1,0 +1,26 @@
+{
+  "allTrophies": {
+    "trophies": [
+      {
+        "trophyId": "2",
+        "trophyGroupId": "dlc1",
+        "trophyType": "SILVER",
+        "trophyName": "DLC Win",
+        "trophyDetail": null,
+        "trophyIconUrl": "https://image.api.playstation.com/trophy/np/NPWR12345_00_DEF/icon.png",
+        "trophyHidden": "1",
+        "trophyProgressTargetValue": "15",
+        "trophyRewardName": "DLC Badge",
+        "trophyRewardImageUrl": ""
+      }
+    ]
+  },
+  "trophyGroups": {
+    "trophyGroups": [
+      {
+        "trophyGroupId": "dlc1",
+        "trophyGroupDetail": "Extra challenges"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/playstation/profile/not-found.json
+++ b/tests/fixtures/playstation/profile/not-found.json
@@ -1,0 +1,4 @@
+{
+  "statusCode": 404,
+  "message": "Profile was not found"
+}

--- a/tests/fixtures/playstation/profile/private.json
+++ b/tests/fixtures/playstation/profile/private.json
@@ -1,0 +1,4 @@
+{
+  "statusCode": 403,
+  "message": "Profile is private"
+}

--- a/tests/fixtures/playstation/profile/success.json
+++ b/tests/fixtures/playstation/profile/success.json
@@ -1,0 +1,8 @@
+{
+  "profile": {
+    "onlineId": "FixtureHunter",
+    "accountId": "1000000000001",
+    "currentOnlineId": "FixtureHunterLive",
+    "npId": "Zml4dHVyZWh1bnRlckBhNi51cw=="
+  }
+}

--- a/tests/fixtures/playstation/trophies/groups-and-trophies-trophy.json
+++ b/tests/fixtures/playstation/trophies/groups-and-trophies-trophy.json
@@ -1,0 +1,31 @@
+{
+  "allTrophies": {
+    "trophies": [
+      {
+        "trophyId": "1",
+        "trophyGroupId": "all",
+        "trophyGroupName": "",
+        "trophyGroupDetail": "",
+        "trophyGroupIconUrl": "",
+        "trophyHidden": false,
+        "trophyType": "BRONZE",
+        "trophyName": "First Steps",
+        "trophyDetail": "Finish tutorial",
+        "trophyIconUrl": "https://image.api.playstation.com/trophy/np/NPWR12345_00_ABC/icon.png",
+        "trophyProgressTargetValue": "",
+        "trophyRewardName": "",
+        "trophyRewardImageUrl": ""
+      }
+    ]
+  },
+  "trophyGroups": {
+    "trophyGroups": [
+      {
+        "trophyGroupId": "all",
+        "trophyGroupName": "Base",
+        "trophyGroupDetail": "Base game",
+        "trophyGroupIconUrl": "https://example.com/group/all.png"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/playstation/trophies/groups-and-trophies-trophy2.json
+++ b/tests/fixtures/playstation/trophies/groups-and-trophies-trophy2.json
@@ -1,0 +1,31 @@
+{
+  "allTrophies": {
+    "trophies": [
+      {
+        "trophyId": 1,
+        "trophyGroupId": "all",
+        "trophyGroupName": "",
+        "trophyGroupDetail": "",
+        "trophyGroupIconUrl": "",
+        "trophyHidden": 0,
+        "trophyType": "bronze",
+        "trophyName": "First Steps",
+        "trophyDetail": "Finish tutorial",
+        "trophyIconUrl": "https://image.api.playstation.com/trophy/np/NPWR12345_00_ABC/icon.png",
+        "trophyProgressTargetValue": null,
+        "trophyRewardName": "",
+        "trophyRewardImageUrl": null
+      }
+    ]
+  },
+  "trophyGroups": {
+    "trophyGroups": [
+      {
+        "trophyGroupId": "all",
+        "trophyGroupName": "Base",
+        "trophyGroupDetail": "Base game",
+        "trophyGroupIconUrl": "https://example.com/group/all.png"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/playstation/trophies/titles-listing.json
+++ b/tests/fixtures/playstation/trophies/titles-listing.json
@@ -1,0 +1,16 @@
+{
+  "trophyTitles": [
+    {
+      "npCommunicationId": "NPWR77777_00",
+      "trophyTitleName": "Fixture Game",
+      "trophyTitlePlatform": "PS5",
+      "trophySetVersion": "01.00"
+    },
+    {
+      "npCommunicationId": "NPWR12345_00",
+      "trophyTitleName": "Fixture Legacy Game",
+      "trophyTitlePlatform": "PS4",
+      "trophySetVersion": "02.10"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Ensure PlayStation API response shapes (legacy and new) are normalized consistently for trophy and profile lookups and for the game rescan flow.
- Provide deterministic fixtures to exercise edge cases such as malformed payloads, private profiles, and not-found responses.

### Description
- Add `PlayStationFixtureLoader` helper to load JSON fixtures from `tests/fixtures/playstation` and validate decoding with `JSON_THROW_ON_ERROR`.
- Add a suite of JSON fixtures under `tests/fixtures/playstation` covering trophies, title listings, profile success/private/not-found, and malformed payloads used by tests.
- Add `GameRescanTransformationParityTest` to validate that `GameRescanService::fetchGameLookupGroupData` normalizes legacy/new trophy payload variants and handles partially malformed group/trophy payloads.
- Extend `PsnGameLookupServiceTest` and `PsnPlayerLookupServiceTest` with tests that verify normalization parity between variants, mapping of private/not-found fixture payloads to the appropriate exceptions, and normalization of malformed payloads.

### Testing
- Ran the unit tests targeting the modified and added tests: `GameRescanTransformationParityTest`, extensions in `PsnGameLookupServiceTest`, and extensions in `PsnPlayerLookupServiceTest` using the fixture loader and JSON fixtures via `phpunit`.
- All added and existing assertions in the affected tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55d88ac18832fa99b68844697184d)