### PR TITLE
Remove deprecated curl_close usage in NativePlayStationApiClient

### DIFF
--- a/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
+++ b/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
@@ -276,12 +276,10 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
         $rawBody = curl_exec($curl);
         if (!is_string($rawBody)) {
             $error = curl_error($curl);
-            curl_close($curl);
             throw new RuntimeException($error === '' ? 'Unknown cURL failure.' : $error);
         }
 
         $status = (int) curl_getinfo($curl, CURLINFO_RESPONSE_CODE);
-        curl_close($curl);
 
         if ($status >= 400) {
             throw new RuntimeException(sprintf('PlayStation API request failed with HTTP %d.', $status), $status);


### PR DESCRIPTION
### Motivation
- Remove PHP 8.5 deprecation warnings by eliminating no-op `curl_close()` calls from the PlayStation API client.

### Description
- Deleted two `curl_close($curl)` invocations in `wwwroot/classes/PlayStation/NativePlayStationApiClient.php::request()` while preserving existing error handling and status checks.

### Testing
- Verified syntax with `php -l wwwroot/classes/PlayStation/NativePlayStationApiClient.php` and ran the full test suite via `php tests/run.php`, with all `511` tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c204396c832f80d678ebe8d0e0fa)