### PR TITLE
Fix Native Client authentication for worker logins

### DIFF
--- a/tests/NativePlayStationApiClientTest.php
+++ b/tests/NativePlayStationApiClientTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStation/NativePlayStationApiClient.php';
+
+final class NativePlayStationApiClientTest extends TestCase
+{
+    public function testOauthClientSecretMatchesCurrentNativeClientSecret(): void
+    {
+        $reflection = new ReflectionClass(NativePlayStationApiClient::class);
+        $clientSecret = $reflection->getConstant('OAUTH_CLIENT_SECRET');
+
+        $this->assertSame('ucPjka5tntB2KqsP', $clientSecret);
+    }
+}

--- a/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
+++ b/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
@@ -11,7 +11,7 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
     private const OAUTH_AUTHORIZE_URL = 'https://ca.account.sony.com/api/authz/v3/oauth/authorize';
     private const OAUTH_TOKEN_URL = 'https://ca.account.sony.com/api/authz/v3/oauth/token';
     private const OAUTH_CLIENT_ID = '09515159-7237-4370-9b40-3806e67c0891';
-    private const OAUTH_CLIENT_SECRET = 'XMB9w0L5xEN7VBdT';
+    private const OAUTH_CLIENT_SECRET = 'ucPjka5tntB2KqsP';
     private const OAUTH_SCOPE = 'psn:mobile.v2.core psn:clientapp';
     private const OAUTH_REDIRECT_URI = 'com.scee.psxandroid.scecompcall://redirect';
 


### PR DESCRIPTION
### Motivation
- Worker logins were failing with 401s after switching to the Native client because the OAuth client secret used for the NPSSO → access token exchange was outdated.

### Description
- Update the `OAUTH_CLIENT_SECRET` constant in `NativePlayStationApiClient` to the current native client secret and add `tests/NativePlayStationApiClientTest.php` to assert the client secret remains the expected value.

### Testing
- Ran the full test suite with `php tests/run.php` and all tests passed.
- Ran PHP syntax checks on changed files with `php -l` and no syntax errors were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c36382ac832f8c03b2a613aa7277)