### PR TITLE
Fallback user-search on 404 and map avatars/Plus flag in account lookup

### DIFF
--- a/tests/NativePlayStationApiClientTest.php
+++ b/tests/NativePlayStationApiClientTest.php
@@ -135,6 +135,19 @@ final class NativePlayStationApiClientTest extends TestCase
         );
     }
 
+    public function testIsRecoverableTrophySummaryStatusCodeTreats401403404AsRecoverable(): void
+    {
+        $client = new NativePlayStationApiClient();
+        $method = new ReflectionMethod(NativePlayStationApiClient::class, 'isRecoverableTrophySummaryStatusCode');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($client, 401));
+        $this->assertTrue($method->invoke($client, 403));
+        $this->assertTrue($method->invoke($client, 404));
+        $this->assertFalse($method->invoke($client, 500));
+        $this->assertFalse($method->invoke($client, null));
+    }
+
     public function testMergeAccountLookupPayloadWithTrophySummaryUsesNestedProfileWhenPresent(): void
     {
         $client = new NativePlayStationApiClient();

--- a/tests/NativePlayStationApiClientTest.php
+++ b/tests/NativePlayStationApiClientTest.php
@@ -44,6 +44,7 @@ final class NativePlayStationApiClientTest extends TestCase
             [[
                 'accountId' => '1882371903386905898',
                 'onlineId' => 'Ragowit',
+                'currentOnlineId' => null,
                 'country' => 'PL',
                 'aboutMe' => null,
             ]],
@@ -69,10 +70,38 @@ final class NativePlayStationApiClientTest extends TestCase
             [[
                 'accountId' => '100',
                 'onlineId' => 'CurrentName',
+                'currentOnlineId' => 'CurrentName',
                 'country' => null,
                 'aboutMe' => 'Bio',
             ]],
             $result
         );
     }
+
+    public function testExtractUserSearchCandidatesPreservesBothOnlineIdFields(): void
+    {
+        $client = new NativePlayStationApiClient();
+        $method = new ReflectionMethod(NativePlayStationApiClient::class, 'extractUserSearchCandidates');
+        $method->setAccessible(true);
+
+        $payload = [
+            'accountId' => '200',
+            'onlineId' => 'LegacyName',
+            'currentOnlineId' => 'CurrentName',
+        ];
+
+        $result = $method->invoke($client, $payload);
+
+        $this->assertSame(
+            [[
+                'accountId' => '200',
+                'onlineId' => 'LegacyName',
+                'currentOnlineId' => 'CurrentName',
+                'country' => null,
+                'aboutMe' => null,
+            ]],
+            $result
+        );
+    }
+
 }

--- a/tests/NativePlayStationApiClientTest.php
+++ b/tests/NativePlayStationApiClientTest.php
@@ -104,6 +104,37 @@ final class NativePlayStationApiClientTest extends TestCase
         );
     }
 
+    public function testExtractUserSearchCandidatesNormalizesNumericAccountIds(): void
+    {
+        $client = new NativePlayStationApiClient();
+        $method = new ReflectionMethod(NativePlayStationApiClient::class, 'extractUserSearchCandidates');
+        $method->setAccessible(true);
+
+        $payload = [
+            'domainResponses' => [[
+                'results' => [[
+                    'socialMetadata' => [
+                        'accountId' => 123456789,
+                        'onlineId' => 'PlayerOne',
+                    ],
+                ]],
+            ]],
+        ];
+
+        $result = $method->invoke($client, $payload);
+
+        $this->assertSame(
+            [[
+                'accountId' => '123456789',
+                'onlineId' => 'PlayerOne',
+                'currentOnlineId' => null,
+                'country' => null,
+                'aboutMe' => null,
+            ]],
+            $result
+        );
+    }
+
     public function testMergeAccountLookupPayloadWithTrophySummaryUsesNestedProfileWhenPresent(): void
     {
         $client = new NativePlayStationApiClient();

--- a/tests/NativePlayStationApiClientTest.php
+++ b/tests/NativePlayStationApiClientTest.php
@@ -164,7 +164,7 @@ final class NativePlayStationApiClientTest extends TestCase
         $this->assertSame('PlayerOne', $result['profile']['onlineId']);
     }
 
-    public function testMapUserSearchResultsPrefersCurrentOnlineIdWhenAvailable(): void
+    public function testMapUserSearchResultsPrefersCurrentOnlineIdWhenAvailableAndQueryDoesNotMatchLegacyId(): void
     {
         $client = new NativePlayStationApiClient();
         $method = new ReflectionMethod(NativePlayStationApiClient::class, 'mapUserSearchResults');
@@ -188,7 +188,7 @@ final class NativePlayStationApiClientTest extends TestCase
             ],
         ];
 
-        $results = iterator_to_array($method->invoke($client, $payload), false);
+        $results = iterator_to_array($method->invoke($client, $payload, 'DifferentQuery'), false);
 
         $this->assertSame(
             [[
@@ -199,4 +199,41 @@ final class NativePlayStationApiClientTest extends TestCase
             $results
         );
     }
+
+    public function testMapUserSearchResultsPreservesQueriedLegacyOnlineIdWhenCurrentOnlineIdAlsoExists(): void
+    {
+        $client = new NativePlayStationApiClient();
+        $method = new ReflectionMethod(NativePlayStationApiClient::class, 'mapUserSearchResults');
+        $method->setAccessible(true);
+
+        $payload = [
+            'domainResponses' => [
+                [
+                    'results' => [
+                        [
+                            'socialMetadata' => [
+                                'accountId' => '300',
+                                'onlineId' => 'LegacyName',
+                                'currentOnlineId' => 'CurrentName',
+                                'country' => 'US',
+                                'aboutMe' => 'Bio',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $results = iterator_to_array($method->invoke($client, $payload, 'LegacyName'), false);
+
+        $this->assertSame(
+            [[
+                'onlineId' => 'LegacyName',
+                'country' => 'US',
+                'aboutMe' => 'Bio',
+            ]],
+            $results
+        );
+    }
+
 }

--- a/tests/NativePlayStationApiClientTest.php
+++ b/tests/NativePlayStationApiClientTest.php
@@ -14,4 +14,65 @@ final class NativePlayStationApiClientTest extends TestCase
 
         $this->assertSame('ucPjka5tntB2KqsP', $clientSecret);
     }
+
+    public function testExtractUserSearchCandidatesFindsNestedAccountEntries(): void
+    {
+        $client = new NativePlayStationApiClient();
+        $method = new ReflectionMethod(NativePlayStationApiClient::class, 'extractUserSearchCandidates');
+        $method->setAccessible(true);
+
+        $payload = [
+            'domainResponses' => [
+                [
+                    'domain' => 'SocialAllAccounts',
+                    'results' => [
+                        [
+                            'socialMetadata' => [
+                                'accountId' => '1882371903386905898',
+                                'onlineId' => 'Ragowit',
+                                'country' => 'PL',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $method->invoke($client, $payload);
+
+        $this->assertSame(
+            [[
+                'accountId' => '1882371903386905898',
+                'onlineId' => 'Ragowit',
+                'country' => 'PL',
+                'aboutMe' => null,
+            ]],
+            $result
+        );
+    }
+
+    public function testExtractUserSearchCandidatesAcceptsCurrentOnlineIdFallback(): void
+    {
+        $client = new NativePlayStationApiClient();
+        $method = new ReflectionMethod(NativePlayStationApiClient::class, 'extractUserSearchCandidates');
+        $method->setAccessible(true);
+
+        $payload = [
+            'accountId' => '100',
+            'currentOnlineId' => 'CurrentName',
+            'aboutMe' => 'Bio',
+        ];
+
+        $result = $method->invoke($client, $payload);
+
+        $this->assertSame(
+            [[
+                'accountId' => '100',
+                'onlineId' => 'CurrentName',
+                'country' => null,
+                'aboutMe' => 'Bio',
+            ]],
+            $result
+        );
+    }
 }

--- a/tests/NativePlayStationApiClientTest.php
+++ b/tests/NativePlayStationApiClientTest.php
@@ -104,4 +104,33 @@ final class NativePlayStationApiClientTest extends TestCase
         );
     }
 
+    public function testMergeAccountLookupPayloadWithTrophySummaryUsesNestedProfileWhenPresent(): void
+    {
+        $client = new NativePlayStationApiClient();
+        $method = new ReflectionMethod(NativePlayStationApiClient::class, 'mergeAccountLookupPayloadWithTrophySummary');
+        $method->setAccessible(true);
+
+        $payload = [
+            'profile' => [
+                'accountId' => '123',
+                'onlineId' => 'PlayerOne',
+            ],
+        ];
+        $trophySummaryPayload = [
+            'level' => 321,
+            'progress' => 99,
+            'earnedTrophies' => [
+                'platinum' => 1,
+                'gold' => 2,
+                'silver' => 3,
+                'bronze' => 4,
+            ],
+        ];
+
+        $result = $method->invoke($client, $payload, $trophySummaryPayload);
+
+        $this->assertSame($trophySummaryPayload, $result['profile']['trophySummary']);
+        $this->assertSame('PlayerOne', $result['profile']['onlineId']);
+    }
+
 }

--- a/tests/NativePlayStationApiClientTest.php
+++ b/tests/NativePlayStationApiClientTest.php
@@ -133,4 +133,39 @@ final class NativePlayStationApiClientTest extends TestCase
         $this->assertSame('PlayerOne', $result['profile']['onlineId']);
     }
 
+    public function testMapUserSearchResultsPrefersCurrentOnlineIdWhenAvailable(): void
+    {
+        $client = new NativePlayStationApiClient();
+        $method = new ReflectionMethod(NativePlayStationApiClient::class, 'mapUserSearchResults');
+        $method->setAccessible(true);
+
+        $payload = [
+            'domainResponses' => [
+                [
+                    'results' => [
+                        [
+                            'socialMetadata' => [
+                                'accountId' => '300',
+                                'onlineId' => 'LegacyName',
+                                'currentOnlineId' => 'CurrentName',
+                                'country' => 'US',
+                                'aboutMe' => 'Bio',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $results = iterator_to_array($method->invoke($client, $payload), false);
+
+        $this->assertSame(
+            [[
+                'onlineId' => 'CurrentName',
+                'country' => 'US',
+                'aboutMe' => 'Bio',
+            ]],
+            $results
+        );
+    }
 }

--- a/tests/NativePlayStationApiClientTest.php
+++ b/tests/NativePlayStationApiClientTest.php
@@ -135,7 +135,7 @@ final class NativePlayStationApiClientTest extends TestCase
         );
     }
 
-    public function testIsRecoverableTrophySummaryStatusCodeTreats401403404AsRecoverable(): void
+    public function testIsRecoverableTrophySummaryStatusCodeTreatsExpectedStatusesAsRecoverable(): void
     {
         $client = new NativePlayStationApiClient();
         $method = new ReflectionMethod(NativePlayStationApiClient::class, 'isRecoverableTrophySummaryStatusCode');
@@ -144,8 +144,42 @@ final class NativePlayStationApiClientTest extends TestCase
         $this->assertTrue($method->invoke($client, 401));
         $this->assertTrue($method->invoke($client, 403));
         $this->assertTrue($method->invoke($client, 404));
-        $this->assertFalse($method->invoke($client, 500));
+        $this->assertTrue($method->invoke($client, 429));
+        $this->assertTrue($method->invoke($client, 500));
+        $this->assertTrue($method->invoke($client, 503));
+        $this->assertFalse($method->invoke($client, 400));
         $this->assertFalse($method->invoke($client, null));
+    }
+
+    public function testExtractUserSearchCandidatesPreservesInputResultPriority(): void
+    {
+        $client = new NativePlayStationApiClient();
+        $method = new ReflectionMethod(NativePlayStationApiClient::class, 'extractUserSearchCandidates');
+        $method->setAccessible(true);
+
+        $payload = [
+            'domainResponses' => [[
+                'results' => [
+                    [
+                        'socialMetadata' => [
+                            'accountId' => '100',
+                            'onlineId' => 'SameName',
+                        ],
+                    ],
+                    [
+                        'socialMetadata' => [
+                            'accountId' => '200',
+                            'onlineId' => 'SameName',
+                        ],
+                    ],
+                ],
+            ]],
+        ];
+
+        $result = $method->invoke($client, $payload);
+
+        $this->assertSame('100', $result[0]['accountId']);
+        $this->assertSame('200', $result[1]['accountId']);
     }
 
     public function testMergeAccountLookupPayloadWithTrophySummaryUsesNestedProfileWhenPresent(): void

--- a/tests/PlayStationAccountLookupUserTest.php
+++ b/tests/PlayStationAccountLookupUserTest.php
@@ -37,6 +37,8 @@ final class PlayStationAccountLookupUserTest extends TestCase
         $this->assertSame(2, $user->trophySummary()->gold());
         $this->assertSame(3, $user->trophySummary()->silver());
         $this->assertSame(4, $user->trophySummary()->bronze());
+        $this->assertFalse($user->hasPlus());
+        $this->assertSame([], $user->avatarUrls());
     }
 
     public function testFromPayloadDefaultsMissingTrophySummaryValuesToZero(): void
@@ -54,5 +56,31 @@ final class PlayStationAccountLookupUserTest extends TestCase
         $this->assertSame(0, $user->trophySummary()->gold());
         $this->assertSame(0, $user->trophySummary()->silver());
         $this->assertSame(0, $user->trophySummary()->bronze());
+    }
+
+    public function testFromPayloadUsesFallbackAccountIdAndMapsAvatarUrls(): void
+    {
+        $user = PlayStationAccountLookupUser::fromPayload(
+            [
+                'onlineId' => 'Ragowit',
+                'isPlus' => true,
+                'avatars' => [
+                    ['size' => 's', 'url' => 'https://example.com/s.png'],
+                    ['size' => 'xl', 'url' => 'https://example.com/xl.png'],
+                ],
+            ],
+            '1882371903386905898'
+        );
+
+        $this->assertSame('1882371903386905898', $user->accountId());
+        $this->assertSame('Ragowit', $user->onlineId());
+        $this->assertTrue($user->hasPlus());
+        $this->assertSame(
+            [
+                's' => 'https://example.com/s.png',
+                'xl' => 'https://example.com/xl.png',
+            ],
+            $user->avatarUrls()
+        );
     }
 }

--- a/wwwroot/classes/PlayStation/Http/PlayStationAccountLookupUser.php
+++ b/wwwroot/classes/PlayStation/Http/PlayStationAccountLookupUser.php
@@ -11,6 +11,9 @@ final readonly class PlayStationAccountLookupUser
         private string $onlineId,
         private ?string $aboutMe,
         private ?string $country,
+        private bool $isPlus,
+        /** @var array<string, string> */
+        private array $avatarUrls,
         private PsnTrophySummaryDto $trophySummary,
     ) {
     }
@@ -40,10 +43,23 @@ final readonly class PlayStationAccountLookupUser
         return $this->trophySummary;
     }
 
+    public function hasPlus(): bool
+    {
+        return $this->isPlus;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function avatarUrls(): array
+    {
+        return $this->avatarUrls;
+    }
+
     /**
      * @param array<string, mixed> $payload
      */
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload, ?string $fallbackAccountId = null): self
     {
         $profile = $payload['profile'] ?? null;
         if (!is_array($profile)) {
@@ -51,6 +67,9 @@ final readonly class PlayStationAccountLookupUser
         }
 
         $accountId = $profile['accountId'] ?? null;
+        if (!is_string($accountId) || trim($accountId) === '') {
+            $accountId = $fallbackAccountId;
+        }
         if (!is_string($accountId) || trim($accountId) === '') {
             throw new UnexpectedValueException('Missing or invalid accountId in PlayStation payload.');
         }
@@ -70,6 +89,29 @@ final readonly class PlayStationAccountLookupUser
             throw new UnexpectedValueException('Invalid country field in PlayStation payload.');
         }
 
+        $isPlus = $profile['isPlus'] ?? false;
+        if (!is_bool($isPlus)) {
+            $isPlus = false;
+        }
+
+        $avatarUrls = [];
+        $avatars = $profile['avatars'] ?? [];
+        if (is_array($avatars)) {
+            foreach ($avatars as $avatar) {
+                if (!is_array($avatar)) {
+                    continue;
+                }
+
+                $size = $avatar['size'] ?? null;
+                $url = $avatar['url'] ?? null;
+                if (!is_string($size) || $size === '' || !is_string($url) || $url === '') {
+                    continue;
+                }
+
+                $avatarUrls[$size] = $url;
+            }
+        }
+
         $trophySummary = $profile['trophySummary'] ?? [];
         if (!is_array($trophySummary)) {
             throw new UnexpectedValueException('Invalid trophySummary in PlayStation payload.');
@@ -80,6 +122,8 @@ final readonly class PlayStationAccountLookupUser
             onlineId: $onlineId,
             aboutMe: $aboutMe,
             country: $country,
+            isPlus: $isPlus,
+            avatarUrls: $avatarUrls,
             trophySummary: new PsnTrophySummaryDto(
                 self::toInt($trophySummary['level'] ?? 0),
                 self::toInt($trophySummary['progress'] ?? 0),

--- a/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
+++ b/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
@@ -114,7 +114,38 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
             []
         );
 
-        return PlayStationAccountLookupUser::fromPayload($payload, $accountId);
+        $trophySummaryPayload = $this->requestJson(
+            'GET',
+            sprintf(
+                'https://m.np.playstation.com/api/trophy/v1/users/%s/trophySummary',
+                rawurlencode($accountId)
+            ),
+            [],
+            []
+        );
+
+        return PlayStationAccountLookupUser::fromPayload(
+            $this->mergeAccountLookupPayloadWithTrophySummary($payload, $trophySummaryPayload),
+            $accountId
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $trophySummaryPayload
+     * @return array<string, mixed>
+     */
+    private function mergeAccountLookupPayloadWithTrophySummary(array $payload, array $trophySummaryPayload): array
+    {
+        if (isset($payload['profile']) && is_array($payload['profile'])) {
+            $payload['profile']['trophySummary'] = $trophySummaryPayload;
+
+            return $payload;
+        }
+
+        $payload['trophySummary'] = $trophySummaryPayload;
+
+        return $payload;
     }
 
     /**

--- a/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
+++ b/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
@@ -114,20 +114,35 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
             []
         );
 
-        $trophySummaryPayload = $this->requestJson(
-            'GET',
-            sprintf(
-                'https://m.np.playstation.com/api/trophy/v1/users/%s/trophySummary',
-                rawurlencode($accountId)
-            ),
-            [],
-            []
-        );
+        $trophySummaryPayload = $this->requestTrophySummaryForAccountId($accountId);
+        if (is_array($trophySummaryPayload)) {
+            $payload = $this->mergeAccountLookupPayloadWithTrophySummary($payload, $trophySummaryPayload);
+        }
 
         return PlayStationAccountLookupUser::fromPayload(
-            $this->mergeAccountLookupPayloadWithTrophySummary($payload, $trophySummaryPayload),
+            $payload,
             $accountId
         );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function requestTrophySummaryForAccountId(string $accountId): ?array
+    {
+        try {
+            return $this->requestJson(
+                'GET',
+                sprintf(
+                    'https://m.np.playstation.com/api/trophy/v1/users/%s/trophySummary',
+                    rawurlencode($accountId)
+                ),
+                [],
+                []
+            );
+        } catch (Throwable) {
+            return null;
+        }
     }
 
     /**
@@ -196,8 +211,10 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
     private function mapUserSearchResults(array $payload): iterable
     {
         foreach ($this->extractUserSearchCandidates($payload) as $candidate) {
+            $preferredOnlineId = $candidate['currentOnlineId'] ?? $candidate['onlineId'];
+
             yield [
-                'onlineId' => $candidate['onlineId'],
+                'onlineId' => $preferredOnlineId,
                 'country' => $candidate['country'],
                 'aboutMe' => $candidate['aboutMe'],
             ];

--- a/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
+++ b/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
@@ -173,7 +173,8 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
     private function executeUserSearch(string $onlineId): iterable
     {
         return $this->mapUserSearchResults(
-            $this->requestUserSearchPayload($onlineId)
+            $this->requestUserSearchPayload($onlineId),
+            $onlineId
         );
     }
 
@@ -212,10 +213,21 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
      * @param array<string, mixed> $payload
      * @return iterable<array{onlineId: string, country: string|null, aboutMe: string|null}>
      */
-    private function mapUserSearchResults(array $payload): iterable
+    private function mapUserSearchResults(array $payload, ?string $queriedOnlineId = null): iterable
     {
+        $normalizedQueriedOnlineId = is_string($queriedOnlineId) ? trim($queriedOnlineId) : '';
+
         foreach ($this->extractUserSearchCandidates($payload) as $candidate) {
             $preferredOnlineId = $candidate['currentOnlineId'] ?? $candidate['onlineId'];
+
+            if ($normalizedQueriedOnlineId !== ''
+                && strcasecmp($candidate['onlineId'], $normalizedQueriedOnlineId) === 0) {
+                $preferredOnlineId = $candidate['onlineId'];
+            } elseif ($normalizedQueriedOnlineId !== ''
+                && is_string($candidate['currentOnlineId'])
+                && strcasecmp($candidate['currentOnlineId'], $normalizedQueriedOnlineId) === 0) {
+                $preferredOnlineId = $candidate['currentOnlineId'];
+            }
 
             yield [
                 'onlineId' => $preferredOnlineId,

--- a/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
+++ b/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
@@ -84,7 +84,7 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
             );
         }
 
-        return $this->transport->lookupUserProfile($searchCandidate['onlineId']);
+        return $this->transport->lookupUserProfile($searchCandidate['accountId']);
     }
 
     public function findUserByAccountId(string $accountId): object
@@ -174,7 +174,7 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
     }
 
     /**
-     * @return array{accountId: string, onlineId: string, country: string|null, aboutMe: string|null}|null
+     * @return array{accountId: string, onlineId: string, currentOnlineId: string|null, country: string|null, aboutMe: string|null}|null
      */
     private function findSearchCandidateByOnlineId(string $onlineId): ?array
     {
@@ -186,7 +186,11 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
         $payload = $this->requestUserSearchPayload($normalizedOnlineId);
 
         foreach ($this->extractUserSearchCandidates($payload) as $candidate) {
-            if (strcasecmp($candidate['onlineId'], $normalizedOnlineId) !== 0) {
+            $matchesOnlineId = strcasecmp($candidate['onlineId'], $normalizedOnlineId) === 0;
+            $matchesCurrentOnlineId = is_string($candidate['currentOnlineId'])
+                && strcasecmp($candidate['currentOnlineId'], $normalizedOnlineId) === 0;
+
+            if (!$matchesOnlineId && !$matchesCurrentOnlineId) {
                 continue;
             }
 
@@ -198,7 +202,7 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
 
     /**
      * @param array<string, mixed> $payload
-     * @return list<array{accountId: string, onlineId: string, country: string|null, aboutMe: string|null}>
+     * @return list<array{accountId: string, onlineId: string, currentOnlineId: string|null, country: string|null, aboutMe: string|null}>
      */
     private function extractUserSearchCandidates(array $payload): array
     {
@@ -212,12 +216,19 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
             }
 
             $accountId = $node['accountId'] ?? null;
-            $onlineId = $node['onlineId'] ?? $node['currentOnlineId'] ?? null;
+            $onlineId = $node['onlineId'] ?? null;
+            $currentOnlineId = $node['currentOnlineId'] ?? null;
 
-            if (is_string($accountId) && trim($accountId) !== '' && is_string($onlineId) && trim($onlineId) !== '') {
+            $normalizedOnlineId = is_string($onlineId) && trim($onlineId) !== '' ? trim($onlineId) : null;
+            $normalizedCurrentOnlineId = is_string($currentOnlineId) && trim($currentOnlineId) !== ''
+                ? trim($currentOnlineId)
+                : null;
+
+            if (is_string($accountId) && trim($accountId) !== '' && ($normalizedOnlineId !== null || $normalizedCurrentOnlineId !== null)) {
                 $results[] = [
                     'accountId' => trim($accountId),
-                    'onlineId' => trim($onlineId),
+                    'onlineId' => $normalizedOnlineId ?? $normalizedCurrentOnlineId,
+                    'currentOnlineId' => $normalizedCurrentOnlineId,
                     'country' => isset($node['country']) && is_string($node['country']) ? $node['country'] : null,
                     'aboutMe' => isset($node['aboutMe']) && is_string($node['aboutMe']) ? $node['aboutMe'] : null,
                 ];

--- a/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
+++ b/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
@@ -141,12 +141,18 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
                 []
             );
         } catch (Throwable $exception) {
-            if ($this->determineThrowableStatusCode($exception) !== 404) {
+            if (!$this->isRecoverableTrophySummaryStatusCode($this->determineThrowableStatusCode($exception))) {
                 throw $exception;
             }
 
             return null;
         }
+    }
+
+
+    private function isRecoverableTrophySummaryStatusCode(?int $statusCode): bool
+    {
+        return in_array($statusCode, [401, 403, 404], true);
     }
 
     /**

--- a/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
+++ b/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
@@ -68,7 +68,23 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
 
     public function lookupProfileByOnlineId(string $onlineId): mixed
     {
-        return $this->transport->lookupUserProfile($onlineId);
+        try {
+            return $this->transport->lookupUserProfile($onlineId);
+        } catch (Throwable $exception) {
+            if ($this->determineThrowableStatusCode($exception) !== 404) {
+                throw $exception;
+            }
+        }
+
+        $searchCandidate = $this->findSearchCandidateByOnlineId($onlineId);
+        if ($searchCandidate === null) {
+            throw new RuntimeException(
+                sprintf('Unable to resolve accountId for online ID "%s".', $onlineId),
+                404
+            );
+        }
+
+        return $this->transport->lookupUserProfile($searchCandidate['onlineId']);
     }
 
     public function findUserByAccountId(string $accountId): object
@@ -90,12 +106,15 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
     {
         $payload = $this->requestJson(
             'GET',
-            sprintf('https://us-prof.np.community.playstation.net/userProfile/v1/users/%s/profile2', rawurlencode($accountId)),
-            ['fields' => 'accountId,onlineId,currentOnlineId,npId,aboutMe,country,trophySummary'],
+            sprintf(
+                'https://m.np.playstation.com/api/userProfile/v1/internal/users/%s/profiles',
+                rawurlencode($accountId)
+            ),
+            [],
             []
         );
 
-        return PlayStationAccountLookupUser::fromPayload($payload);
+        return PlayStationAccountLookupUser::fromPayload($payload, $accountId);
     }
 
     /**
@@ -103,36 +122,130 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
      */
     private function executeUserSearch(string $onlineId): iterable
     {
+        return $this->mapUserSearchResults(
+            $this->requestUserSearchPayload($onlineId)
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function requestUserSearchPayload(string $onlineId): array
+    {
         $normalizedOnlineId = trim($onlineId);
         if ($normalizedOnlineId === '') {
             return [];
         }
 
-        $payload = $this->requestJson(
-            'GET',
-            sprintf('https://us-prof.np.community.playstation.net/userProfile/v1/users/%s/profile2', rawurlencode($normalizedOnlineId)),
-            ['fields' => 'accountId,onlineId,currentOnlineId,npId,aboutMe,country'],
-            []
+        return $this->requestJson(
+            'POST',
+            'https://m.np.playstation.com/api/search/v1/universalSearch',
+            [],
+            ['content-type' => 'application/json'],
+            json_encode([
+                'age' => '69',
+                'countryCode' => 'us',
+                'domainRequests' => [[
+                    'domain' => 'SocialAllAccounts',
+                    'pagination' => [
+                        'cursor' => '',
+                        'pageSize' => '50',
+                    ],
+                ]],
+                'languageCode' => 'en',
+                'searchTerm' => $normalizedOnlineId,
+            ], JSON_THROW_ON_ERROR)
         );
+    }
 
-        $profile = $payload['profile'] ?? null;
-        if (!is_array($profile)) {
-            return [];
+    /**
+     * @param array<string, mixed> $payload
+     * @return iterable<array{onlineId: string, country: string|null, aboutMe: string|null}>
+     */
+    private function mapUserSearchResults(array $payload): iterable
+    {
+        foreach ($this->extractUserSearchCandidates($payload) as $candidate) {
+            yield [
+                'onlineId' => $candidate['onlineId'],
+                'country' => $candidate['country'],
+                'aboutMe' => $candidate['aboutMe'],
+            ];
+        }
+    }
+
+    /**
+     * @return array{accountId: string, onlineId: string, country: string|null, aboutMe: string|null}|null
+     */
+    private function findSearchCandidateByOnlineId(string $onlineId): ?array
+    {
+        $normalizedOnlineId = trim($onlineId);
+        if ($normalizedOnlineId === '') {
+            return null;
         }
 
-        $resolvedOnlineId = $profile['onlineId'] ?? $profile['currentOnlineId'] ?? null;
-        if (!is_string($resolvedOnlineId) || trim($resolvedOnlineId) === '') {
-            return [];
+        $payload = $this->requestUserSearchPayload($normalizedOnlineId);
+
+        foreach ($this->extractUserSearchCandidates($payload) as $candidate) {
+            if (strcasecmp($candidate['onlineId'], $normalizedOnlineId) !== 0) {
+                continue;
+            }
+
+            return $candidate;
         }
 
-        $country = $profile['country'] ?? null;
-        $aboutMe = $profile['aboutMe'] ?? null;
+        return null;
+    }
 
-        return [[
-            'onlineId' => $resolvedOnlineId,
-            'country' => is_string($country) ? $country : null,
-            'aboutMe' => is_string($aboutMe) ? $aboutMe : null,
-        ]];
+    /**
+     * @param array<string, mixed> $payload
+     * @return list<array{accountId: string, onlineId: string, country: string|null, aboutMe: string|null}>
+     */
+    private function extractUserSearchCandidates(array $payload): array
+    {
+        $results = [];
+        $nodes = [$payload];
+
+        while ($nodes !== []) {
+            $node = array_pop($nodes);
+            if (!is_array($node)) {
+                continue;
+            }
+
+            $accountId = $node['accountId'] ?? null;
+            $onlineId = $node['onlineId'] ?? $node['currentOnlineId'] ?? null;
+
+            if (is_string($accountId) && trim($accountId) !== '' && is_string($onlineId) && trim($onlineId) !== '') {
+                $results[] = [
+                    'accountId' => trim($accountId),
+                    'onlineId' => trim($onlineId),
+                    'country' => isset($node['country']) && is_string($node['country']) ? $node['country'] : null,
+                    'aboutMe' => isset($node['aboutMe']) && is_string($node['aboutMe']) ? $node['aboutMe'] : null,
+                ];
+            }
+
+            foreach ($node as $value) {
+                if (is_array($value)) {
+                    $nodes[] = $value;
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    private function determineThrowableStatusCode(Throwable $exception): ?int
+    {
+        $statusCode = $exception->getCode();
+        if (is_int($statusCode) && $statusCode > 0) {
+            return $statusCode;
+        }
+
+        $previous = $exception->getPrevious();
+        if ($previous instanceof Throwable) {
+            return $this->determineThrowableStatusCode($previous);
+        }
+
+        return null;
     }
 
     private function exchangeNpssoForAuthorizationCode(string $npsso): string

--- a/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
+++ b/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
@@ -152,7 +152,15 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
 
     private function isRecoverableTrophySummaryStatusCode(?int $statusCode): bool
     {
-        return in_array($statusCode, [401, 403, 404], true);
+        if ($statusCode === null) {
+            return false;
+        }
+
+        if (in_array($statusCode, [401, 403, 404, 429], true)) {
+            return true;
+        }
+
+        return $statusCode >= 500 && $statusCode <= 599;
     }
 
     /**
@@ -304,10 +312,15 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
                 ];
             }
 
+            $nestedValues = [];
             foreach ($node as $value) {
                 if (is_array($value)) {
-                    $nodes[] = $value;
+                    $nestedValues[] = $value;
                 }
+            }
+
+            for ($index = count($nestedValues) - 1; $index >= 0; $index--) {
+                $nodes[] = $nestedValues[$index];
             }
         }
 

--- a/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
+++ b/wwwroot/classes/PlayStation/NativePlayStationApiClient.php
@@ -140,7 +140,11 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
                 [],
                 []
             );
-        } catch (Throwable) {
+        } catch (Throwable $exception) {
+            if ($this->determineThrowableStatusCode($exception) !== 404) {
+                throw $exception;
+            }
+
             return null;
         }
     }
@@ -263,7 +267,7 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
                 continue;
             }
 
-            $accountId = $node['accountId'] ?? null;
+            $accountId = $this->normalizeAccountId($node['accountId'] ?? null);
             $onlineId = $node['onlineId'] ?? null;
             $currentOnlineId = $node['currentOnlineId'] ?? null;
 
@@ -272,9 +276,9 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
                 ? trim($currentOnlineId)
                 : null;
 
-            if (is_string($accountId) && trim($accountId) !== '' && ($normalizedOnlineId !== null || $normalizedCurrentOnlineId !== null)) {
+            if ($accountId !== null && ($normalizedOnlineId !== null || $normalizedCurrentOnlineId !== null)) {
                 $results[] = [
-                    'accountId' => trim($accountId),
+                    'accountId' => $accountId,
                     'onlineId' => $normalizedOnlineId ?? $normalizedCurrentOnlineId,
                     'currentOnlineId' => $normalizedCurrentOnlineId,
                     'country' => isset($node['country']) && is_string($node['country']) ? $node['country'] : null,
@@ -290,6 +294,25 @@ final class NativePlayStationApiClient implements PlayStationApiClientInterface
         }
 
         return $results;
+    }
+
+    private function normalizeAccountId(mixed $accountId): ?string
+    {
+        if (is_string($accountId)) {
+            $normalizedAccountId = trim($accountId);
+
+            return $normalizedAccountId !== '' ? $normalizedAccountId : null;
+        }
+
+        if (is_int($accountId)) {
+            return (string) $accountId;
+        }
+
+        if (is_float($accountId) && is_finite($accountId) && floor($accountId) === $accountId) {
+            return sprintf('%.0F', $accountId);
+        }
+
+        return null;
     }
 
     private function determineThrowableStatusCode(Throwable $exception): ?int


### PR DESCRIPTION
### Motivation

- Improve resilience of profile lookups by falling back to the universal search when direct profile lookup returns a 404 and provide more complete user data mapping from PlayStation search/profile payloads.

### Description

- Make `lookupProfileByOnlineId` catch 404-like errors and resolve accountIds by searching via `findSearchCandidateByOnlineId` before retrying profile lookup. 
- Replace legacy account lookup/search endpoints with `m.np.playstation.com` internal APIs and add `requestUserSearchPayload`, `mapUserSearchResults`, `findSearchCandidateByOnlineId`, `extractUserSearchCandidates`, and `determineThrowableStatusCode` helpers to parse nested search payloads. 
- Update `PlayStationAccountLookupUser` to include `isPlus` and normalized `avatarUrls`, add `hasPlus()` and `avatarUrls()` accessors, and accept a `fallbackAccountId` in `fromPayload` so accountId can be inferred when missing. 
- Adjust `executeAccountLookup` to call `PlayStationAccountLookupUser::fromPayload` with the fallback account id and wire the new search/map flow into `searchUsers`/`executeUserSearch`.

### Testing

- Added unit tests `NativePlayStationApiClientTest::testExtractUserSearchCandidatesFindsNestedAccountEntries` and `NativePlayStationApiClientTest::testExtractUserSearchCandidatesAcceptsCurrentOnlineIdFallback` and `PlayStationAccountLookupUserTest::testFromPayloadUsesFallbackAccountIdAndMapsAvatarUrls`, and updated existing tests to assert `hasPlus()` and `avatarUrls()` behavior. 
- Ran `phpunit` (unit tests) and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c6df330c832fae3bc8de48924e59)