### PR TITLE
Optimize hourly trophy stats update query

### DIFF
--- a/tests/HourlyCronJobTest.php
+++ b/tests/HourlyCronJobTest.php
@@ -7,50 +7,53 @@ require_once __DIR__ . '/../wwwroot/classes/Cron/HourlyCronJob.php';
 
 final class HourlyCronJobTest extends TestCase
 {
-    public function testUsesBatchAndStatsTemporaryTablesForNonEmptyBatchUpdates(): void
+    public function testUsesSingleSetBasedUpdateQuery(): void
     {
         $class = new ReflectionClass(HourlyCronJob::class);
-        $createBatchTableQuery = $this->readPrivateConstantValue($class, 'CREATE_BATCH_TEMP_TABLE_QUERY');
-        $createStatsTableQuery = $this->readPrivateConstantValue($class, 'CREATE_STATS_TEMP_TABLE_QUERY');
-        $insertStatsQuery = $this->readPrivateConstantValue($class, 'INSERT_STATS_QUERY');
-        $updateMetaQuery = $this->readPrivateConstantValue($class, 'UPDATE_META_QUERY');
+        $updateAllMetaQuery = $this->readPrivateConstantValue($class, 'UPDATE_ALL_META_QUERY');
 
-        $this->assertStringContainsString('COLLATE utf8mb4_unicode_ci', $createBatchTableQuery);
-        $this->assertStringContainsString('COLLATE utf8mb4_unicode_ci', $createStatsTableQuery);
-        $this->assertStringContainsString('INSERT INTO tmp_hourly_stats', $insertStatsQuery);
-        $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id', $insertStatsQuery);
-        $this->assertStringContainsString('COUNT(*) AS owners', $insertStatsQuery);
-        $this->assertStringContainsString('SUM(ttp.progress = 100) AS owners_completed', $insertStatsQuery);
-        $this->assertStringContainsString('SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players', $insertStatsQuery);
+        $this->assertStringContainsString('UPDATE trophy_title_meta ttm', $updateAllMetaQuery);
+        $this->assertStringContainsString('LEFT JOIN (', $updateAllMetaQuery);
+        $this->assertStringContainsString('FROM trophy_title_player ttp', $updateAllMetaQuery);
+        $this->assertStringContainsString('JOIN player_ranking pr ON pr.account_id = ttp.account_id', $updateAllMetaQuery);
+        $this->assertStringContainsString('WHERE pr.ranking <= 10000', $updateAllMetaQuery);
+        $this->assertStringContainsString('GROUP BY ttp.np_communication_id', $updateAllMetaQuery);
+        $this->assertStringContainsString('COUNT(*) AS owners', $updateAllMetaQuery);
+        $this->assertStringContainsString('SUM(ttp.progress = 100) AS owners_completed', $updateAllMetaQuery);
+        $this->assertStringContainsString('SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players', $updateAllMetaQuery);
 
-        $this->assertStringContainsString('UPDATE trophy_title_meta ttm', $updateMetaQuery);
-        $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttm.np_communication_id', $updateMetaQuery);
+        $this->assertFalse(str_contains($updateAllMetaQuery, 'tmp_hourly_batch'));
+        $this->assertFalse(str_contains($updateAllMetaQuery, 'tmp_hourly_stats'));
     }
 
-    public function testResetsBatchTitlesWithoutQualifyingPlayersToZeroValues(): void
+    public function testResetsTitlesWithoutQualifyingPlayersToZeroValues(): void
     {
         $class = new ReflectionClass(HourlyCronJob::class);
-        $updateMetaQuery = $this->readPrivateConstantValue($class, 'UPDATE_META_QUERY');
+        $updateAllMetaQuery = $this->readPrivateConstantValue($class, 'UPDATE_ALL_META_QUERY');
 
-        $this->assertStringContainsString('LEFT JOIN tmp_hourly_stats s ON s.np_communication_id = ttm.np_communication_id', $updateMetaQuery);
-        $this->assertStringContainsString('ttm.owners = COALESCE(s.owners, 0)', $updateMetaQuery);
-        $this->assertStringContainsString('ttm.owners_completed = COALESCE(s.owners_completed, 0)', $updateMetaQuery);
-        $this->assertStringContainsString('ttm.recent_players = COALESCE(s.recent_players, 0)', $updateMetaQuery);
-        $this->assertStringContainsString('COALESCE(s.owners, 0) = 0', $updateMetaQuery);
-        $this->assertStringContainsString('(COALESCE(s.owners_completed, 0) / COALESCE(s.owners, 0)) * 100', $updateMetaQuery);
+        $this->assertStringContainsString('LEFT JOIN (', $updateAllMetaQuery);
+        $this->assertStringContainsString(') s ON s.np_communication_id = ttm.np_communication_id', $updateAllMetaQuery);
+        $this->assertStringContainsString('ttm.owners = COALESCE(s.owners, 0)', $updateAllMetaQuery);
+        $this->assertStringContainsString('ttm.owners_completed = COALESCE(s.owners_completed, 0)', $updateAllMetaQuery);
+        $this->assertStringContainsString('ttm.recent_players = COALESCE(s.recent_players, 0)', $updateAllMetaQuery);
+        $this->assertStringContainsString('COALESCE(s.owners, 0) = 0', $updateAllMetaQuery);
+        $this->assertStringContainsString('(COALESCE(s.owners_completed, 0) / COALESCE(s.owners, 0)) * 100', $updateAllMetaQuery);
     }
 
 
-    public function testUsesDeleteInsteadOfTruncateInBatchUpdateFlow(): void
+    public function testDoesNotUseTempTableBatchFlow(): void
     {
         $class = new ReflectionClass(HourlyCronJob::class);
         $source = file_get_contents((string) $class->getFileName());
         $this->assertTrue(is_string($source));
 
-        $this->assertStringContainsString("DELETE FROM tmp_hourly_batch", $source);
-        $this->assertStringContainsString("DELETE FROM tmp_hourly_stats", $source);
-        $this->assertFalse(str_contains($source, 'TRUNCATE TABLE tmp_hourly_batch'));
-        $this->assertFalse(str_contains($source, 'TRUNCATE TABLE tmp_hourly_stats'));
+        $this->assertFalse(str_contains($source, 'tmp_hourly_batch'));
+        $this->assertFalse(str_contains($source, 'tmp_hourly_stats'));
+        $this->assertFalse(str_contains($source, 'TRUNCATE TABLE'));
+        $this->assertFalse($class->hasConstant('CREATE_BATCH_TEMP_TABLE_QUERY'));
+        $this->assertFalse($class->hasConstant('CREATE_STATS_TEMP_TABLE_QUERY'));
+        $this->assertFalse($class->hasConstant('INSERT_STATS_QUERY'));
+        $this->assertFalse($class->hasConstant('UPDATE_META_QUERY'));
     }
 
     public function testNoDynamicUnionAllSelectBatchPathExists(): void

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -6,40 +6,19 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final readonly class HourlyCronJob implements CronJobInterface
 {
-    private const BATCH_SIZE = 500;
-
-    private const CREATE_BATCH_TEMP_TABLE_QUERY = <<<'SQL'
-        CREATE TEMPORARY TABLE IF NOT EXISTS tmp_hourly_batch (
-            np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci PRIMARY KEY
-        )
-        SQL;
-
-    private const CREATE_STATS_TEMP_TABLE_QUERY = <<<'SQL'
-        CREATE TEMPORARY TABLE IF NOT EXISTS tmp_hourly_stats (
-            np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci PRIMARY KEY,
-            owners INT NOT NULL,
-            owners_completed INT NOT NULL,
-            recent_players INT NOT NULL
-        )
-        SQL;
-
-    private const INSERT_STATS_QUERY = <<<'SQL'
-        INSERT INTO tmp_hourly_stats (np_communication_id, owners, owners_completed, recent_players)
-        SELECT
-            ttp.np_communication_id,
-            COUNT(*) AS owners,
-            SUM(ttp.progress = 100) AS owners_completed,
-            SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players
-        FROM trophy_title_player ttp
-        JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id
-        JOIN player_ranking pr ON pr.account_id = ttp.account_id AND pr.ranking <= 10000
-        GROUP BY ttp.np_communication_id
-        SQL;
-
-    private const UPDATE_META_QUERY = <<<'SQL'
+    private const UPDATE_ALL_META_QUERY = <<<'SQL'
         UPDATE trophy_title_meta ttm
-        JOIN tmp_hourly_batch b ON b.np_communication_id = ttm.np_communication_id
-        LEFT JOIN tmp_hourly_stats s ON s.np_communication_id = ttm.np_communication_id
+        LEFT JOIN (
+            SELECT
+                ttp.np_communication_id,
+                COUNT(*) AS owners,
+                SUM(ttp.progress = 100) AS owners_completed,
+                SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players
+            FROM trophy_title_player ttp
+            JOIN player_ranking pr ON pr.account_id = ttp.account_id
+            WHERE pr.ranking <= 10000
+            GROUP BY ttp.np_communication_id
+        ) s ON s.np_communication_id = ttm.np_communication_id
         SET
             ttm.owners = COALESCE(s.owners, 0),
             ttm.owners_completed = COALESCE(s.owners_completed, 0),
@@ -58,93 +37,10 @@ final readonly class HourlyCronJob implements CronJobInterface
     #[\Override]
     public function run(): void
     {
-        $this->executeWithRetry([$this, 'updateTrophyTitleStatistics']);
-    }
-
-    private function updateTrophyTitleStatistics(): void
-    {
-        $lastId = null;
-
-        $this->initializeTemporaryTables();
-
-        try {
-            while (true) {
-                $batchIds = $this->getBatchNpCommunicationIds($lastId, self::BATCH_SIZE);
-
-                if ($batchIds === []) {
-                    break;
-                }
-
-                $this->database->beginTransaction();
-
-                try {
-                    $this->updateStatisticsForBatch($batchIds);
-                    $this->database->commit();
-                } catch (Exception $exception) {
-                    $this->database->rollBack();
-
-                    throw $exception;
-                }
-
-                $lastId = end($batchIds);
-            }
-        } finally {
-            $this->dropTemporaryTables();
-        }
-    }
-
-    private function getBatchNpCommunicationIds(?string $lastId, int $limit): array
-    {
-        $baseQuery = 'SELECT np_communication_id FROM trophy_title_meta %s ORDER BY np_communication_id LIMIT :limit';
-
-        if ($lastId === null) {
-            $query = $this->database->prepare(sprintf($baseQuery, ''));
-        } else {
-            $query = $this->database->prepare(sprintf($baseQuery, 'WHERE np_communication_id > :last_id'));
-            $query->bindValue(':last_id', $lastId, PDO::PARAM_STR);
-        }
-
-        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
-        $query->execute();
-
-        return $query->fetchAll(PDO::FETCH_COLUMN);
-    }
-
-    private function updateStatisticsForBatch(array $batchIds): void
-    {
-        $this->database->exec('DELETE FROM tmp_hourly_batch');
-        $this->insertBatchIdsIntoTemporaryTable($batchIds);
-
-        $this->database->exec('DELETE FROM tmp_hourly_stats');
-        $insertStatsQuery = $this->database->prepare(self::INSERT_STATS_QUERY);
-        $insertStatsQuery->execute();
-
-        $updateMetaQuery = $this->database->prepare(self::UPDATE_META_QUERY);
-        $updateMetaQuery->execute();
-    }
-
-    private function initializeTemporaryTables(): void
-    {
-        $this->database->exec(self::CREATE_BATCH_TEMP_TABLE_QUERY);
-        $this->database->exec(self::CREATE_STATS_TEMP_TABLE_QUERY);
-    }
-
-    private function dropTemporaryTables(): void
-    {
-        $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_hourly_stats');
-        $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_hourly_batch');
-    }
-
-    private function insertBatchIdsIntoTemporaryTable(array $batchIds): void
-    {
-        $placeholders = implode(', ', array_fill(0, count($batchIds), '(?)'));
-        $query = $this->database->prepare(
-            sprintf(
-                'INSERT INTO tmp_hourly_batch (np_communication_id) VALUES %s',
-                $placeholders
-            )
-        );
-        $query->execute(array_values($batchIds));
+        $this->executeWithRetry(function (): void {
+            $query = $this->database->prepare(self::UPDATE_ALL_META_QUERY);
+            $query->execute();
+        });
     }
 
     private function executeWithRetry(callable $operation): void


### PR DESCRIPTION
## Summary
- replaced the hourly batch/temp-table loop in `HourlyCronJob` with one set-based `UPDATE ... LEFT JOIN (aggregated subquery)` statement
- removed temporary-table setup/teardown and per-batch data movement logic
- preserved the existing retry behavior around the database operation

## Why
The previous implementation recalculated stats in many batches using temporary tables, which adds significant overhead when there are many `np_communication_id` rows. This change delegates the work to a single grouped query so MySQL can optimize the full operation directly.

## Validation
- `php -l wwwroot/classes/Cron/HourlyCronJob.php`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a497ebe0832fac8e16e0c198e13a)