### PR TITLE
Add PSN trophy title comparison service, request handler and admin UI

### DIFF
--- a/tests/PsnTrophyTitleComparisonServiceTest.php
+++ b/tests/PsnTrophyTitleComparisonServiceTest.php
@@ -61,19 +61,24 @@ final class PsnTrophyTitleComparisonServiceTest extends TestCase
                 ];
             }
 
-            public function user(string $accountId): object
+            public function users(): object
             {
                 return new class {
-                    public function trophyTitles(): object
+                    public function find(string $accountId): object
                     {
-                        return new class implements IteratorAggregate {
-                            public function getIterator(): Traversable
+                        return new class {
+                            public function trophyTitles(): object
                             {
-                                return new ArrayIterator([
-                                    ['npCommunicationId' => 'NPWR1'],
-                                    ['npCommunicationId' => 'NPWR2'],
-                                    ['npCommunicationId' => 'NPWR3'],
-                                ]);
+                                return new class implements IteratorAggregate {
+                                    public function getIterator(): Traversable
+                                    {
+                                        return new ArrayIterator([
+                                            ['npCommunicationId' => 'NPWR1'],
+                                            ['npCommunicationId' => 'NPWR2'],
+                                            ['npCommunicationId' => 'NPWR3'],
+                                        ]);
+                                    }
+                                };
                             }
                         };
                     }

--- a/tests/PsnTrophyTitleComparisonServiceTest.php
+++ b/tests/PsnTrophyTitleComparisonServiceTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestHandler.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PsnTrophyTitleComparisonException.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/Worker.php';
+
+final class PsnTrophyTitleComparisonServiceTest extends TestCase
+{
+    public function testCompareByAccountIdFetchesAllPagesAndMeasuresTime(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $capturedCalls = [];
+
+        $client = new class($capturedCalls) {
+            /**
+             * @var array<int, array<string, mixed>>
+             */
+            public array $capturedCalls;
+
+            public function __construct(array $capturedCalls)
+            {
+                $this->capturedCalls = $capturedCalls;
+            }
+
+            public function loginWithNpsso(string $npsso): void
+            {
+            }
+
+            /**
+             * @param array<string, mixed> $query
+             * @param array<string, string> $headers
+             */
+            public function get(string $path, array $query = [], array $headers = []): array
+            {
+                $this->capturedCalls[] = [
+                    'path' => $path,
+                    'query' => $query,
+                    'headers' => $headers,
+                ];
+
+                if (($query['offset'] ?? null) === 0) {
+                    return [
+                        'totalItemCount' => 3,
+                        'trophyTitles' => [
+                            ['npCommunicationId' => 'NPWR1'],
+                            ['npCommunicationId' => 'NPWR2'],
+                        ],
+                    ];
+                }
+
+                return [
+                    'totalItemCount' => 3,
+                    'trophyTitles' => [
+                        ['npCommunicationId' => 'NPWR3'],
+                    ],
+                ];
+            }
+
+            public function user(string $accountId): object
+            {
+                return new class {
+                    public function trophyTitles(): object
+                    {
+                        return new class implements IteratorAggregate {
+                            public function getIterator(): Traversable
+                            {
+                                return new ArrayIterator([
+                                    ['npCommunicationId' => 'NPWR1'],
+                                    ['npCommunicationId' => 'NPWR2'],
+                                    ['npCommunicationId' => 'NPWR3'],
+                                ]);
+                            }
+                        };
+                    }
+                };
+            }
+        };
+
+        $times = [10.0, 11.25, 20.0, 20.5];
+
+        $service = new PsnTrophyTitleComparisonService(
+            static fn (): array => [$worker],
+            static fn () => $client,
+            static function () use (&$times): float {
+                return (float) array_shift($times);
+            }
+        );
+
+        $result = $service->compareByAccountId('123456');
+
+        $this->assertSame('123456', $result['accountId']);
+        $this->assertSame(3, $result['direct']['count']);
+        $this->assertSame(2, $result['direct']['pagesFetched']);
+        $this->assertSame(1250.0, $result['direct']['durationMs']);
+        $this->assertSame(3, $result['tustin']['count']);
+        $this->assertSame(500.0, $result['tustin']['durationMs']);
+        $this->assertSame(true, $result['countsMatch']);
+    }
+
+    public function testCompareByAccountIdRejectsInvalidInput(): void
+    {
+        $service = new PsnTrophyTitleComparisonService(
+            static fn (): array => [],
+            static fn (): object => new stdClass()
+        );
+
+        try {
+            $service->compareByAccountId('invalid');
+            $this->fail('Expected InvalidArgumentException to be thrown for non numeric account IDs.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('Account ID must be a numeric value.', $exception->getMessage());
+        }
+    }
+
+    public function testRequestHandlerReturnsErrorMessageFromServiceException(): void
+    {
+        $worker = new Worker(1, 'npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $service = new PsnTrophyTitleComparisonService(
+            static fn (): array => [$worker],
+            static fn (): object => new class {
+                public function loginWithNpsso(string $npsso): void
+                {
+                }
+            }
+        );
+
+        $handled = PsnTrophyTitleComparisonRequestHandler::handle($service, '123');
+
+        $this->assertSame('123', $handled->getNormalizedAccountId());
+        $this->assertSame(null, $handled->getResult());
+        $this->assertSame('The PlayStation client does not support endpoint requests.', $handled->getErrorMessage());
+    }
+
+}

--- a/wwwroot/admin/psn-trophy-title-compare.php
+++ b/wwwroot/admin/psn-trophy-title-compare.php
@@ -16,6 +16,67 @@ $handledRequest = PsnTrophyTitleComparisonRequestHandler::handle($service, $acco
 $normalizedAccountId = $handledRequest->getNormalizedAccountId();
 $result = $handledRequest->getResult();
 $errorMessage = $handledRequest->getErrorMessage();
+
+/**
+ * @return mixed
+ */
+function normalizeForJsonPayload(mixed $value): mixed
+{
+    if (is_null($value) || is_scalar($value)) {
+        return $value;
+    }
+
+    if (is_array($value)) {
+        $normalized = [];
+        foreach ($value as $key => $item) {
+            $normalized[$key] = normalizeForJsonPayload($item);
+        }
+
+        return $normalized;
+    }
+
+    if ($value instanceof JsonSerializable) {
+        return normalizeForJsonPayload($value->jsonSerialize());
+    }
+
+    if (is_object($value)) {
+        if (method_exists($value, 'toArray')) {
+            /** @var mixed $toArrayValue */
+            $toArrayValue = $value->toArray();
+            return normalizeForJsonPayload($toArrayValue);
+        }
+
+        $normalized = ['__class' => get_class($value)];
+        $reflection = new ReflectionObject($value);
+
+        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->isStatic() || $method->getNumberOfRequiredParameters() > 0) {
+                continue;
+            }
+
+            $methodName = $method->getName();
+            if (str_starts_with($methodName, '__')) {
+                continue;
+            }
+
+            try {
+                $methodValue = $method->invoke($value);
+            } catch (Throwable) {
+                continue;
+            }
+
+            if (!is_scalar($methodValue) && !is_array($methodValue) && !is_null($methodValue)) {
+                continue;
+            }
+
+            $normalized[$methodName] = normalizeForJsonPayload($methodValue);
+        }
+
+        return $normalized;
+    }
+
+    return (string) $value;
+}
 ?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">
@@ -96,7 +157,7 @@ $errorMessage = $handledRequest->getErrorMessage();
                     <div class="card-body">
                         <h2 class="h5">tustin/psn-php payload</h2>
                         <pre class="mb-0 text-white-50"><?php
-                            $json = json_encode($result['tustin']['titles'] ?? [], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+                            $json = json_encode(normalizeForJsonPayload($result['tustin']['titles'] ?? []), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
                             echo htmlentities($json === false ? 'Unable to encode response.' : $json, ENT_QUOTES, 'UTF-8');
                         ?></pre>
                     </div>

--- a/wwwroot/admin/psn-trophy-title-compare.php
+++ b/wwwroot/admin/psn-trophy-title-compare.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+require_once '../init.php';
+require_once '../vendor/autoload.php';
+require_once '../classes/Admin/PsnTrophyTitleComparisonException.php';
+require_once '../classes/Admin/PsnTrophyTitleComparisonRequestHandler.php';
+require_once '../classes/Admin/PsnTrophyTitleComparisonRequestResult.php';
+require_once '../classes/Admin/PsnTrophyTitleComparisonService.php';
+
+$accountId = isset($_GET['accountId']) ? (string) $_GET['accountId'] : '';
+$service = PsnTrophyTitleComparisonService::fromDatabase($database);
+$handledRequest = PsnTrophyTitleComparisonRequestHandler::handle($service, $accountId);
+
+$normalizedAccountId = $handledRequest->getNormalizedAccountId();
+$result = $handledRequest->getResult();
+$errorMessage = $handledRequest->getErrorMessage();
+?>
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+        <title>Admin ~ Trophy Title Compare</title>
+    </head>
+    <body>
+        <div class="p-4">
+            <a href="/admin/">Back</a><br><br>
+            <h1 class="h3 mb-3">PSN Trophy Title Compare</h1>
+            <p class="text-body-secondary">Fetch all trophy titles for an account ID using direct endpoint paging and compare it against tustin/psn-php.</p>
+            <form method="get" class="mb-4" action="">
+                <div class="mb-2">
+                    <label for="accountId" class="form-label">Account ID</label>
+                    <div class="input-group">
+                        <input type="text" class="form-control" id="accountId" name="accountId" value="<?= htmlentities($accountId, ENT_QUOTES, 'UTF-8'); ?>" placeholder="e.g. 1234567890123456789" autocomplete="off" inputmode="numeric">
+                        <button class="btn btn-primary" type="submit">Fetch</button>
+                    </div>
+                </div>
+            </form>
+            <?php if ($errorMessage !== null) { ?>
+                <div class="alert alert-warning" role="alert">
+                    <?= htmlentities($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
+                </div>
+            <?php } elseif ($normalizedAccountId !== '' && $result === null) { ?>
+                <div class="alert alert-info" role="alert">
+                    No data was returned for account ID "<?= htmlentities($normalizedAccountId, ENT_QUOTES, 'UTF-8'); ?>".
+                </div>
+            <?php } ?>
+            <?php if (is_array($result)) { ?>
+                <div class="row g-3 mb-3">
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h2 class="h5">Direct endpoint</h2>
+                                <dl class="row mb-0">
+                                    <dt class="col-sm-5">Titles fetched</dt>
+                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['direct']['count'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <dt class="col-sm-5">Pages fetched</dt>
+                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['direct']['pagesFetched'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <dt class="col-sm-5">Total item count</dt>
+                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['direct']['totalItemCount'] ?? 'n/a'), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <dt class="col-sm-5">Duration (ms)</dt>
+                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['direct']['durationMs'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                </dl>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h2 class="h5">tustin/psn-php</h2>
+                                <dl class="row mb-0">
+                                    <dt class="col-sm-5">Titles fetched</dt>
+                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['tustin']['count'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <dt class="col-sm-5">Duration (ms)</dt>
+                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['tustin']['durationMs'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <dt class="col-sm-5">Count match</dt>
+                                    <dd class="col-sm-7"><?= htmlentities(($result['countsMatch'] ?? false) ? 'Yes' : 'No', ENT_QUOTES, 'UTF-8'); ?></dd>
+                                </dl>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h2 class="h5">Direct endpoint payload</h2>
+                        <pre class="mb-0 text-white-50"><?php
+                            $json = json_encode($result['direct']['titles'] ?? [], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+                            echo htmlentities($json === false ? 'Unable to encode response.' : $json, ENT_QUOTES, 'UTF-8');
+                        ?></pre>
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-body">
+                        <h2 class="h5">tustin/psn-php payload</h2>
+                        <pre class="mb-0 text-white-50"><?php
+                            $json = json_encode($result['tustin']['titles'] ?? [], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+                            echo htmlentities($json === false ? 'Unable to encode response.' : $json, ENT_QUOTES, 'UTF-8');
+                        ?></pre>
+                    </div>
+                </div>
+            <?php } ?>
+        </div>
+    </body>
+</html>

--- a/wwwroot/classes/Admin/AdminNavigation.php
+++ b/wwwroot/classes/Admin/AdminNavigation.php
@@ -66,6 +66,7 @@ class AdminNavigation
             new AdminNavigationItem('Possible Cheaters', '/admin/possible.php'),
             new AdminNavigationItem('PSN Game Lookup', '/admin/psn-game-lookup.php'),
             new AdminNavigationItem('PSN Player Lookup', '/admin/psn-player-lookup.php'),
+            new AdminNavigationItem('PSN Trophy Title Compare', '/admin/psn-trophy-title-compare.php'),
             new AdminNavigationItem('PSNP+', '/admin/psnp-plus.php'),
             new AdminNavigationItem('Reported Players', '/admin/report.php'),
             new AdminNavigationItem('Rescan Game', '/admin/rescan.php'),

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonException.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+final class PsnTrophyTitleComparisonException extends RuntimeException
+{
+    public function __construct(string $message, private readonly ?int $statusCode = null, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $statusCode ?? 0, $previous);
+    }
+
+    public function getStatusCode(): ?int
+    {
+        return $this->statusCode;
+    }
+}

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestHandler.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PsnTrophyTitleComparisonException.php';
+require_once __DIR__ . '/PsnTrophyTitleComparisonRequestResult.php';
+require_once __DIR__ . '/PsnTrophyTitleComparisonService.php';
+
+final class PsnTrophyTitleComparisonRequestHandler
+{
+    public static function handle(PsnTrophyTitleComparisonService $service, string $accountId): PsnTrophyTitleComparisonRequestResult
+    {
+        $normalizedAccountId = trim($accountId);
+        $result = null;
+        $errorMessage = null;
+
+        if ($normalizedAccountId !== '') {
+            try {
+                $result = $service->compareByAccountId($normalizedAccountId);
+            } catch (PsnTrophyTitleComparisonException $exception) {
+                $errorMessage = $exception->getMessage();
+            } catch (Throwable $exception) {
+                $message = trim($exception->getMessage());
+                if ($message === '') {
+                    $message = 'An unexpected error occurred while comparing trophy title lookups. Please try again later.';
+                }
+
+                $errorMessage = $message;
+            }
+        }
+
+        return new PsnTrophyTitleComparisonRequestResult($normalizedAccountId, $result, $errorMessage);
+    }
+}

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestResult.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestResult.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+final readonly class PsnTrophyTitleComparisonRequestResult
+{
+    /**
+     * @param array<string, mixed>|null $result
+     */
+    public function __construct(
+        private string $normalizedAccountId,
+        private ?array $result,
+        private ?string $errorMessage,
+    ) {
+    }
+
+    public function getNormalizedAccountId(): string
+    {
+        return $this->normalizedAccountId;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getResult(): ?array
+    {
+        return $this->result;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+}

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -193,16 +193,22 @@ final class PsnTrophyTitleComparisonService
     }
 
     /**
-     * @return array{count: int, durationMs: float, titles: array<int, array<string, mixed>>}
+     * @return array{count: int, durationMs: float, titles: array<int, mixed>}
      */
     private function fetchTitlesViaTustin(object $client, string $accountId): array
     {
-        if (!method_exists($client, 'user')) {
+        if (!method_exists($client, 'users')) {
             throw new PsnTrophyTitleComparisonException('The PlayStation client does not support user requests.');
         }
 
         try {
-            $user = $client->user($accountId);
+            $users = $client->users();
+
+            if (!is_object($users) || !method_exists($users, 'find')) {
+                throw new PsnTrophyTitleComparisonException('The PlayStation client does not support user requests.');
+            }
+
+            $user = $users->find($accountId);
             $startTime = ($this->timeProvider)();
             $trophyTitleCollection = $user->trophyTitles();
             $trophyTitles = iterator_to_array($trophyTitleCollection->getIterator());
@@ -214,22 +220,12 @@ final class PsnTrophyTitleComparisonService
             );
         }
 
-        $normalizedTitles = [];
-
-        foreach ($trophyTitles as $trophyTitle) {
-            $normalizedTitle = $this->normalizeResponse($trophyTitle);
-
-            if ($normalizedTitle !== []) {
-                $normalizedTitles[] = $normalizedTitle;
-            }
-        }
-
         $endTime = ($this->timeProvider)();
 
         return [
-            'count' => count($normalizedTitles),
+            'count' => count($trophyTitles),
             'durationMs' => round(($endTime - $startTime) * 1000, 2),
-            'titles' => $normalizedTitles,
+            'titles' => $trophyTitles,
         ];
     }
 

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Worker.php';
+require_once __DIR__ . '/WorkerService.php';
+require_once __DIR__ . '/PsnTrophyTitleComparisonException.php';
+
+use Tustin\PlayStation\Client;
+
+final class PsnTrophyTitleComparisonService
+{
+    /**
+     * @var \Closure(): iterable<Worker>
+     */
+    private readonly \Closure $workerFetcher;
+
+    /**
+     * @var \Closure(): object
+     */
+    private readonly \Closure $clientFactory;
+
+    /**
+     * @var \Closure(): float
+     */
+    private readonly \Closure $timeProvider;
+
+    /**
+     * @param callable(): iterable<Worker> $workerFetcher
+     * @param callable(): object|null $clientFactory
+     * @param callable(): float|null $timeProvider
+     */
+    public function __construct(
+        callable $workerFetcher,
+        ?callable $clientFactory = null,
+        ?callable $timeProvider = null,
+    ) {
+        $this->workerFetcher = \Closure::fromCallable($workerFetcher);
+        $this->clientFactory = \Closure::fromCallable($clientFactory ?? static fn (): object => new Client());
+        $this->timeProvider = \Closure::fromCallable($timeProvider ?? static fn (): float => microtime(true));
+    }
+
+    public static function fromDatabase(PDO $database): self
+    {
+        $workerService = new WorkerService($database);
+
+        return new self(static fn (): array => $workerService->fetchWorkers());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function compareByAccountId(string $accountId): array
+    {
+        $normalizedAccountId = trim($accountId);
+
+        if ($normalizedAccountId === '' || !ctype_digit($normalizedAccountId)) {
+            throw new InvalidArgumentException('Account ID must be a numeric value.');
+        }
+
+        $client = $this->createAuthenticatedClient();
+
+        $directFetch = $this->fetchTitlesViaEndpoint($client, $normalizedAccountId);
+        $tustinFetch = $this->fetchTitlesViaTustin($client, $normalizedAccountId);
+
+        return [
+            'accountId' => $normalizedAccountId,
+            'direct' => $directFetch,
+            'tustin' => $tustinFetch,
+            'countsMatch' => ($directFetch['count'] ?? -1) === ($tustinFetch['count'] ?? -1),
+        ];
+    }
+
+    private function createAuthenticatedClient(): object
+    {
+        $factory = $this->clientFactory;
+
+        foreach (($this->workerFetcher)() as $worker) {
+            if (!$worker instanceof Worker) {
+                continue;
+            }
+
+            $npsso = $worker->getNpsso();
+            if ($npsso === '') {
+                continue;
+            }
+
+            try {
+                $client = $factory();
+
+                if (!is_object($client) || !method_exists($client, 'loginWithNpsso')) {
+                    throw new RuntimeException('The PlayStation client does not support NPSSO authentication.');
+                }
+
+                $client->loginWithNpsso($npsso);
+
+                return $client;
+            } catch (Throwable) {
+                continue;
+            }
+        }
+
+        throw new RuntimeException('Unable to login to any worker accounts.');
+    }
+
+    /**
+     * @return array{count: int, durationMs: float, pagesFetched: int, totalItemCount: int|null, titles: array<int, array<string, mixed>>}
+     */
+    private function fetchTitlesViaEndpoint(object $client, string $accountId): array
+    {
+        if (!method_exists($client, 'get')) {
+            throw new PsnTrophyTitleComparisonException('The PlayStation client does not support endpoint requests.');
+        }
+
+        $limit = 800;
+        $offset = 0;
+        $totalItemCount = null;
+        $titles = [];
+        $pagesFetched = 0;
+        $startTime = ($this->timeProvider)();
+
+        while (true) {
+            $path = sprintf(
+                'https://m.np.playstation.com/api/trophy/v1/users/%s/trophyTitles',
+                rawurlencode($accountId)
+            );
+
+            try {
+                $payload = $client->get(
+                    $path,
+                    [
+                        'limit' => $limit,
+                        'offset' => $offset,
+                    ],
+                    ['content-type' => 'application/json']
+                );
+            } catch (Throwable $exception) {
+                throw new PsnTrophyTitleComparisonException(
+                    'Failed to retrieve trophy titles from the direct endpoint.',
+                    $this->determineStatusCode($exception),
+                    $exception
+                );
+            }
+
+            $normalizedPayload = $this->normalizeResponse($payload);
+            $batchTitles = $normalizedPayload['trophyTitles'] ?? [];
+
+            if (!is_array($batchTitles)) {
+                $batchTitles = [];
+            }
+
+            foreach ($batchTitles as $batchTitle) {
+                if (is_array($batchTitle)) {
+                    $titles[] = $batchTitle;
+                }
+            }
+
+            $pagesFetched++;
+
+            if (isset($normalizedPayload['totalItemCount']) && is_numeric($normalizedPayload['totalItemCount'])) {
+                $totalItemCount = (int) $normalizedPayload['totalItemCount'];
+            }
+
+            $batchCount = count($batchTitles);
+            if ($batchCount === 0) {
+                break;
+            }
+
+            $offset += $batchCount;
+
+            if ($totalItemCount !== null) {
+                if ($offset >= $totalItemCount) {
+                    break;
+                }
+
+                continue;
+            }
+
+            if ($batchCount < $limit) {
+                break;
+            }
+        }
+
+        $endTime = ($this->timeProvider)();
+
+        return [
+            'count' => count($titles),
+            'durationMs' => round(($endTime - $startTime) * 1000, 2),
+            'pagesFetched' => $pagesFetched,
+            'totalItemCount' => $totalItemCount,
+            'titles' => $titles,
+        ];
+    }
+
+    /**
+     * @return array{count: int, durationMs: float, titles: array<int, array<string, mixed>>}
+     */
+    private function fetchTitlesViaTustin(object $client, string $accountId): array
+    {
+        if (!method_exists($client, 'user')) {
+            throw new PsnTrophyTitleComparisonException('The PlayStation client does not support user requests.');
+        }
+
+        try {
+            $user = $client->user($accountId);
+            $startTime = ($this->timeProvider)();
+            $trophyTitleCollection = $user->trophyTitles();
+            $trophyTitles = iterator_to_array($trophyTitleCollection->getIterator());
+        } catch (Throwable $exception) {
+            throw new PsnTrophyTitleComparisonException(
+                'Failed to retrieve trophy titles via tustin/psn-php.',
+                $this->determineStatusCode($exception),
+                $exception
+            );
+        }
+
+        $normalizedTitles = [];
+
+        foreach ($trophyTitles as $trophyTitle) {
+            $normalizedTitle = $this->normalizeResponse($trophyTitle);
+
+            if ($normalizedTitle !== []) {
+                $normalizedTitles[] = $normalizedTitle;
+            }
+        }
+
+        $endTime = ($this->timeProvider)();
+
+        return [
+            'count' => count($normalizedTitles),
+            'durationMs' => round(($endTime - $startTime) * 1000, 2),
+            'titles' => $normalizedTitles,
+        ];
+    }
+
+    private function determineStatusCode(Throwable $exception): ?int
+    {
+        $code = $exception->getCode();
+
+        if (is_int($code) && $code > 0) {
+            return $code;
+        }
+
+        $previous = $exception->getPrevious();
+
+        if ($previous instanceof Throwable) {
+            return $this->determineStatusCode($previous);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeResponse(mixed $payload): array
+    {
+        if (is_array($payload)) {
+            return $payload;
+        }
+
+        if (is_object($payload)) {
+            try {
+                $encoded = json_encode($payload, JSON_THROW_ON_ERROR);
+                $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
+
+                if (is_array($decoded)) {
+                    return $decoded;
+                }
+            } catch (JsonException) {
+            }
+
+            return get_object_vars($payload);
+        }
+
+        return [];
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a way to fetch all PSN trophy titles via the direct endpoint and compare results against `tustin/psn-php` to validate parity and timing.

### Description

- Add `PsnTrophyTitleComparisonService` to authenticate with worker NPSSO credentials, page a direct trophy titles endpoint, collect/timestamp results, and fetch the same data via `tustin/psn-php` for comparison.
- Add `PsnTrophyTitleComparisonRequestHandler`, `PsnTrophyTitleComparisonRequestResult`, and `PsnTrophyTitleComparisonException` to normalize request/response handling and surface user-friendly error messages.
- Add admin UI page `wwwroot/admin/psn-trophy-title-compare.php` to expose the comparison results and raw payloads, and register the page in the admin navigation via `AdminNavigation.php`.
- Add unit tests in `tests/PsnTrophyTitleComparisonServiceTest.php` covering pagination/time measurement, input validation, and request handler error mapping.

### Testing

- Ran `vendor/bin/phpunit --filter PsnTrophyTitleComparisonServiceTest` which executed `testCompareByAccountIdFetchesAllPagesAndMeasuresTime`, `testCompareByAccountIdRejectsInvalidInput`, and `testRequestHandlerReturnsErrorMessageFromServiceException`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90a0b300c832fb27ebd1c08a55c5a)