### PR TITLE
Add deterministic fingerprints for PSN trophy title comparisons and update admin UI/tests

### DIFF
--- a/tests/PsnTrophyTitleComparisonServiceTest.php
+++ b/tests/PsnTrophyTitleComparisonServiceTest.php
@@ -102,9 +102,12 @@ final class PsnTrophyTitleComparisonServiceTest extends TestCase
         $this->assertSame(3, $result['direct']['count']);
         $this->assertSame(2, $result['direct']['pagesFetched']);
         $this->assertSame(1250.0, $result['direct']['durationMs']);
+        $this->assertSame(hash('sha256', 'npCommunicationId:NPWR1|npCommunicationId:NPWR2|npCommunicationId:NPWR3'), $result['direct']['fingerprint']);
         $this->assertSame(3, $result['tustin']['count']);
         $this->assertSame(500.0, $result['tustin']['durationMs']);
+        $this->assertSame(hash('sha256', 'npCommunicationId:NPWR1|npCommunicationId:NPWR2|npCommunicationId:NPWR3'), $result['tustin']['fingerprint']);
         $this->assertSame(true, $result['countsMatch']);
+        $this->assertSame(true, $result['fingerprintsMatch']);
     }
 
     public function testCompareByAccountIdRejectsInvalidInput(): void

--- a/tests/PsnTrophyTitleComparisonServiceTest.php
+++ b/tests/PsnTrophyTitleComparisonServiceTest.php
@@ -110,6 +110,84 @@ final class PsnTrophyTitleComparisonServiceTest extends TestCase
         $this->assertSame(true, $result['fingerprintsMatch']);
     }
 
+
+    public function testCompareByAccountIdUsesMethodBasedTustinTitleKeys(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $client = new class {
+            public function loginWithNpsso(string $npsso): void
+            {
+            }
+
+            /**
+             * @param array<string, mixed> $query
+             * @param array<string, string> $headers
+             */
+            public function get(string $path, array $query = [], array $headers = []): array
+            {
+                return [
+                    'totalItemCount' => 2,
+                    'trophyTitles' => [
+                        ['npCommunicationId' => 'NPWR10'],
+                        ['npCommunicationId' => 'NPWR20'],
+                    ],
+                ];
+            }
+
+            public function users(): object
+            {
+                return new class {
+                    public function find(string $accountId): object
+                    {
+                        return new class {
+                            public function trophyTitles(): object
+                            {
+                                return new class implements IteratorAggregate {
+                                    public function getIterator(): Traversable
+                                    {
+                                        return new ArrayIterator([
+                                            new class {
+                                                public function npCommunicationId(): string
+                                                {
+                                                    return 'NPWR10';
+                                                }
+                                            },
+                                            new class {
+                                                public function npCommunicationId(): string
+                                                {
+                                                    return 'NPWR20';
+                                                }
+                                            },
+                                        ]);
+                                    }
+                                };
+                            }
+                        };
+                    }
+                };
+            }
+        };
+
+        $times = [1.0, 1.0, 2.0, 2.0];
+
+        $service = new PsnTrophyTitleComparisonService(
+            static fn (): array => [$worker],
+            static fn () => $client,
+            static function () use (&$times): float {
+                return (float) array_shift($times);
+            }
+        );
+
+        $result = $service->compareByAccountId('123456');
+
+        $expectedFingerprint = hash('sha256', 'npCommunicationId:NPWR10|npCommunicationId:NPWR20');
+
+        $this->assertSame($expectedFingerprint, $result['direct']['fingerprint']);
+        $this->assertSame($expectedFingerprint, $result['tustin']['fingerprint']);
+        $this->assertSame(true, $result['fingerprintsMatch']);
+    }
+
     public function testCompareByAccountIdRejectsInvalidInput(): void
     {
         $service = new PsnTrophyTitleComparisonService(

--- a/wwwroot/admin/psn-trophy-title-compare.php
+++ b/wwwroot/admin/psn-trophy-title-compare.php
@@ -16,67 +16,6 @@ $handledRequest = PsnTrophyTitleComparisonRequestHandler::handle($service, $acco
 $normalizedAccountId = $handledRequest->getNormalizedAccountId();
 $result = $handledRequest->getResult();
 $errorMessage = $handledRequest->getErrorMessage();
-
-/**
- * @return mixed
- */
-function normalizeForJsonPayload(mixed $value): mixed
-{
-    if (is_null($value) || is_scalar($value)) {
-        return $value;
-    }
-
-    if (is_array($value)) {
-        $normalized = [];
-        foreach ($value as $key => $item) {
-            $normalized[$key] = normalizeForJsonPayload($item);
-        }
-
-        return $normalized;
-    }
-
-    if ($value instanceof JsonSerializable) {
-        return normalizeForJsonPayload($value->jsonSerialize());
-    }
-
-    if (is_object($value)) {
-        if (method_exists($value, 'toArray')) {
-            /** @var mixed $toArrayValue */
-            $toArrayValue = $value->toArray();
-            return normalizeForJsonPayload($toArrayValue);
-        }
-
-        $normalized = ['__class' => get_class($value)];
-        $reflection = new ReflectionObject($value);
-
-        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            if ($method->isStatic() || $method->getNumberOfRequiredParameters() > 0) {
-                continue;
-            }
-
-            $methodName = $method->getName();
-            if (str_starts_with($methodName, '__')) {
-                continue;
-            }
-
-            try {
-                $methodValue = $method->invoke($value);
-            } catch (Throwable) {
-                continue;
-            }
-
-            if (!is_scalar($methodValue) && !is_array($methodValue) && !is_null($methodValue)) {
-                continue;
-            }
-
-            $normalized[$methodName] = normalizeForJsonPayload($methodValue);
-        }
-
-        return $normalized;
-    }
-
-    return (string) $value;
-}
 ?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">
@@ -124,6 +63,8 @@ function normalizeForJsonPayload(mixed $value): mixed
                                     <dd class="col-sm-7"><?= htmlentities((string) ($result['direct']['totalItemCount'] ?? 'n/a'), ENT_QUOTES, 'UTF-8'); ?></dd>
                                     <dt class="col-sm-5">Duration (ms)</dt>
                                     <dd class="col-sm-7"><?= htmlentities((string) ($result['direct']['durationMs'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <dt class="col-sm-5">Fingerprint</dt>
+                                    <dd class="col-sm-7"><code><?= htmlentities((string) ($result['direct']['fingerprint'] ?? ''), ENT_QUOTES, 'UTF-8'); ?></code></dd>
                                 </dl>
                             </div>
                         </div>
@@ -139,28 +80,18 @@ function normalizeForJsonPayload(mixed $value): mixed
                                     <dd class="col-sm-7"><?= htmlentities((string) ($result['tustin']['durationMs'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
                                     <dt class="col-sm-5">Count match</dt>
                                     <dd class="col-sm-7"><?= htmlentities(($result['countsMatch'] ?? false) ? 'Yes' : 'No', ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <dt class="col-sm-5">Fingerprint</dt>
+                                    <dd class="col-sm-7"><code><?= htmlentities((string) ($result['tustin']['fingerprint'] ?? ''), ENT_QUOTES, 'UTF-8'); ?></code></dd>
+                                    <dt class="col-sm-5">Fingerprint match</dt>
+                                    <dd class="col-sm-7"><?= htmlentities(($result['fingerprintsMatch'] ?? false) ? 'Yes' : 'No', ENT_QUOTES, 'UTF-8'); ?></dd>
                                 </dl>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div class="card mb-3">
-                    <div class="card-body">
-                        <h2 class="h5">Direct endpoint payload</h2>
-                        <pre class="mb-0 text-white-50"><?php
-                            $json = json_encode($result['direct']['titles'] ?? [], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-                            echo htmlentities($json === false ? 'Unable to encode response.' : $json, ENT_QUOTES, 'UTF-8');
-                        ?></pre>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card-body">
-                        <h2 class="h5">tustin/psn-php payload</h2>
-                        <pre class="mb-0 text-white-50"><?php
-                            $json = json_encode(normalizeForJsonPayload($result['tustin']['titles'] ?? []), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-                            echo htmlentities($json === false ? 'Unable to encode response.' : $json, ENT_QUOTES, 'UTF-8');
-                        ?></pre>
-                    </div>
+                <div class="alert alert-secondary" role="alert">
+                    Full payload rendering is intentionally disabled on this page to avoid response-size timeouts.
+                    The comparison still fetches <strong>all titles</strong> from both sources and verifies them using count + fingerprint.
                 </div>
             <?php } ?>
         </div>

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -68,6 +68,7 @@ final class PsnTrophyTitleComparisonService
             'direct' => $directFetch,
             'tustin' => $tustinFetch,
             'countsMatch' => ($directFetch['count'] ?? -1) === ($tustinFetch['count'] ?? -1),
+            'fingerprintsMatch' => ($directFetch['fingerprint'] ?? '') === ($tustinFetch['fingerprint'] ?? ''),
         ];
     }
 
@@ -104,7 +105,7 @@ final class PsnTrophyTitleComparisonService
     }
 
     /**
-     * @return array{count: int, durationMs: float, pagesFetched: int, totalItemCount: int|null, titles: array<int, array<string, mixed>>}
+     * @return array{count: int, durationMs: float, pagesFetched: int, totalItemCount: int|null, fingerprint: string}
      */
     private function fetchTitlesViaEndpoint(object $client, string $accountId): array
     {
@@ -115,7 +116,8 @@ final class PsnTrophyTitleComparisonService
         $limit = 800;
         $offset = 0;
         $totalItemCount = null;
-        $titles = [];
+        $titleKeys = [];
+        $count = 0;
         $pagesFetched = 0;
         $startTime = ($this->timeProvider)();
 
@@ -151,7 +153,14 @@ final class PsnTrophyTitleComparisonService
 
             foreach ($batchTitles as $batchTitle) {
                 if (is_array($batchTitle)) {
-                    $titles[] = $batchTitle;
+                    $count++;
+
+                    $titleKey = $this->createTitleKey($batchTitle);
+
+                    if ($titleKey !== '') {
+                        $titleKeys[] = $titleKey;
+                    }
+
                 }
             }
 
@@ -182,18 +191,19 @@ final class PsnTrophyTitleComparisonService
         }
 
         $endTime = ($this->timeProvider)();
+        sort($titleKeys);
 
         return [
-            'count' => count($titles),
+            'count' => $count,
             'durationMs' => round(($endTime - $startTime) * 1000, 2),
             'pagesFetched' => $pagesFetched,
             'totalItemCount' => $totalItemCount,
-            'titles' => $titles,
+            'fingerprint' => hash('sha256', implode('|', $titleKeys)),
         ];
     }
 
     /**
-     * @return array{count: int, durationMs: float, titles: array<int, mixed>}
+     * @return array{count: int, durationMs: float, fingerprint: string}
      */
     private function fetchTitlesViaTustin(object $client, string $accountId): array
     {
@@ -211,7 +221,17 @@ final class PsnTrophyTitleComparisonService
             $user = $users->find($accountId);
             $startTime = ($this->timeProvider)();
             $trophyTitleCollection = $user->trophyTitles();
-            $trophyTitles = iterator_to_array($trophyTitleCollection->getIterator());
+            $titleKeys = [];
+            $count = 0;
+
+            foreach ($trophyTitleCollection->getIterator() as $trophyTitle) {
+                $count++;
+
+                $titleKey = $this->createTitleKey($this->normalizeResponse($trophyTitle));
+                if ($titleKey !== '') {
+                    $titleKeys[] = $titleKey;
+                }
+            }
         } catch (Throwable $exception) {
             throw new PsnTrophyTitleComparisonException(
                 'Failed to retrieve trophy titles via tustin/psn-php.',
@@ -221,12 +241,45 @@ final class PsnTrophyTitleComparisonService
         }
 
         $endTime = ($this->timeProvider)();
+        sort($titleKeys);
 
         return [
-            'count' => count($trophyTitles),
+            'count' => $count,
             'durationMs' => round(($endTime - $startTime) * 1000, 2),
-            'titles' => $trophyTitles,
+            'fingerprint' => hash('sha256', implode('|', $titleKeys)),
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $title
+     */
+    private function createTitleKey(array $title): string
+    {
+        $preferredKeys = [
+            'npCommunicationId',
+            'trophyTitleId',
+            'titleId',
+            'titleName',
+            'trophyTitleName',
+        ];
+
+        foreach ($preferredKeys as $key) {
+            if (!array_key_exists($key, $title)) {
+                continue;
+            }
+
+            $value = $title[$key];
+            if (is_scalar($value) || $value === null) {
+                return $key . ':' . (string) $value;
+            }
+        }
+
+        $encoded = json_encode($title, JSON_UNESCAPED_SLASHES);
+        if ($encoded === false) {
+            return '';
+        }
+
+        return 'json:' . hash('sha256', $encoded);
     }
 
     private function determineStatusCode(Throwable $exception): ?int

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -227,7 +227,7 @@ final class PsnTrophyTitleComparisonService
             foreach ($trophyTitleCollection->getIterator() as $trophyTitle) {
                 $count++;
 
-                $titleKey = $this->createTitleKey($this->normalizeResponse($trophyTitle));
+                $titleKey = $this->createTustinTitleKey($trophyTitle);
                 if ($titleKey !== '') {
                     $titleKeys[] = $titleKey;
                 }
@@ -248,6 +248,38 @@ final class PsnTrophyTitleComparisonService
             'durationMs' => round(($endTime - $startTime) * 1000, 2),
             'fingerprint' => hash('sha256', implode('|', $titleKeys)),
         ];
+    }
+
+
+    private function createTustinTitleKey(mixed $trophyTitle): string
+    {
+        if (is_object($trophyTitle)) {
+            $preferredMethods = [
+                'npCommunicationId',
+                'trophyTitleId',
+                'titleId',
+                'titleName',
+                'trophyTitleName',
+            ];
+
+            foreach ($preferredMethods as $method) {
+                if (!method_exists($trophyTitle, $method)) {
+                    continue;
+                }
+
+                try {
+                    $value = $trophyTitle->{$method}();
+                } catch (Throwable) {
+                    continue;
+                }
+
+                if (is_scalar($value) || $value === null) {
+                    return $method . ':' . (string) $value;
+                }
+            }
+        }
+
+        return $this->createTitleKey($this->normalizeResponse($trophyTitle));
     }
 
     /**


### PR DESCRIPTION
### Motivation

- Improve comparison robustness by generating a deterministic fingerprint of fetched trophy titles so mismatches can be detected beyond simple counts. 
- Avoid rendering full payloads in the admin page to prevent response-size timeouts while still performing full comparisons.

### Description

- Compute a per-source fingerprint by creating stable title keys (preferring `npCommunicationId`, `trophyTitleId`, `titleId`, `titleName`, `trophyTitleName`) and returning `sha256` of the sorted keys via a new `createTitleKey()` helper and changes to `fetchTitlesViaEndpoint()` and `fetchTitlesViaTustin()` to produce `fingerprint` instead of full payloads. 
- Add `fingerprintsMatch` to the result returned by `compareByAccountId()` and update related phpdoc return shapes accordingly. 
- Update the admin UI (`psn-trophy-title-compare.php`) to display fingerprints and a fingerprint-match indicator and to remove full payload rendering with a notice explaining that full rendering is disabled. 
- Update unit tests in `PsnTrophyTitleComparisonServiceTest.php` to assert expected fingerprint values and match behavior.

### Testing

- Ran the updated unit test suite targeting `PsnTrophyTitleComparisonServiceTest` with `phpunit`, and the modified tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9195cb9d0832fbcb7a2a24be36248)