### PR TITLE
Optimize PSN Trophy Title Compare for large player libraries

### DIFF
--- a/tests/PsnTrophyTitleComparisonServiceTest.php
+++ b/tests/PsnTrophyTitleComparisonServiceTest.php
@@ -102,16 +102,13 @@ final class PsnTrophyTitleComparisonServiceTest extends TestCase
         $this->assertSame(3, $result['direct']['count']);
         $this->assertSame(2, $result['direct']['pagesFetched']);
         $this->assertSame(1250.0, $result['direct']['durationMs']);
-        $this->assertSame(hash('sha256', 'npCommunicationId:NPWR1|npCommunicationId:NPWR2|npCommunicationId:NPWR3'), $result['direct']['fingerprint']);
         $this->assertSame(3, $result['tustin']['count']);
         $this->assertSame(500.0, $result['tustin']['durationMs']);
-        $this->assertSame(hash('sha256', 'npCommunicationId:NPWR1|npCommunicationId:NPWR2|npCommunicationId:NPWR3'), $result['tustin']['fingerprint']);
         $this->assertSame(true, $result['countsMatch']);
-        $this->assertSame(true, $result['fingerprintsMatch']);
     }
 
 
-    public function testCompareByAccountIdUsesMethodBasedTustinTitleKeys(): void
+    public function testCompareByAccountIdCountsObjectBasedTustinTitles(): void
     {
         $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
 
@@ -181,11 +178,9 @@ final class PsnTrophyTitleComparisonServiceTest extends TestCase
 
         $result = $service->compareByAccountId('123456');
 
-        $expectedFingerprint = hash('sha256', 'npCommunicationId:NPWR10|npCommunicationId:NPWR20');
-
-        $this->assertSame($expectedFingerprint, $result['direct']['fingerprint']);
-        $this->assertSame($expectedFingerprint, $result['tustin']['fingerprint']);
-        $this->assertSame(true, $result['fingerprintsMatch']);
+        $this->assertSame(2, $result['direct']['count']);
+        $this->assertSame(2, $result['tustin']['count']);
+        $this->assertSame(true, $result['countsMatch']);
     }
 
     public function testCompareByAccountIdRejectsInvalidInput(): void

--- a/wwwroot/admin/psn-trophy-title-compare.php
+++ b/wwwroot/admin/psn-trophy-title-compare.php
@@ -63,8 +63,6 @@ $errorMessage = $handledRequest->getErrorMessage();
                                     <dd class="col-sm-7"><?= htmlentities((string) ($result['direct']['totalItemCount'] ?? 'n/a'), ENT_QUOTES, 'UTF-8'); ?></dd>
                                     <dt class="col-sm-5">Duration (ms)</dt>
                                     <dd class="col-sm-7"><?= htmlentities((string) ($result['direct']['durationMs'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
-                                    <dt class="col-sm-5">Fingerprint</dt>
-                                    <dd class="col-sm-7"><code><?= htmlentities((string) ($result['direct']['fingerprint'] ?? ''), ENT_QUOTES, 'UTF-8'); ?></code></dd>
                                 </dl>
                             </div>
                         </div>
@@ -80,10 +78,6 @@ $errorMessage = $handledRequest->getErrorMessage();
                                     <dd class="col-sm-7"><?= htmlentities((string) ($result['tustin']['durationMs'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
                                     <dt class="col-sm-5">Count match</dt>
                                     <dd class="col-sm-7"><?= htmlentities(($result['countsMatch'] ?? false) ? 'Yes' : 'No', ENT_QUOTES, 'UTF-8'); ?></dd>
-                                    <dt class="col-sm-5">Fingerprint</dt>
-                                    <dd class="col-sm-7"><code><?= htmlentities((string) ($result['tustin']['fingerprint'] ?? ''), ENT_QUOTES, 'UTF-8'); ?></code></dd>
-                                    <dt class="col-sm-5">Fingerprint match</dt>
-                                    <dd class="col-sm-7"><?= htmlentities(($result['fingerprintsMatch'] ?? false) ? 'Yes' : 'No', ENT_QUOTES, 'UTF-8'); ?></dd>
                                 </dl>
                             </div>
                         </div>
@@ -91,7 +85,7 @@ $errorMessage = $handledRequest->getErrorMessage();
                 </div>
                 <div class="alert alert-secondary" role="alert">
                     Full payload rendering is intentionally disabled on this page to avoid response-size timeouts.
-                    The comparison still fetches <strong>all titles</strong> from both sources and verifies them using count + fingerprint.
+                    The comparison still fetches <strong>all titles</strong> from both sources and compares the title counts.
                 </div>
             <?php } ?>
         </div>

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -68,7 +68,6 @@ final class PsnTrophyTitleComparisonService
             'direct' => $directFetch,
             'tustin' => $tustinFetch,
             'countsMatch' => ($directFetch['count'] ?? -1) === ($tustinFetch['count'] ?? -1),
-            'fingerprintsMatch' => ($directFetch['fingerprint'] ?? '') === ($tustinFetch['fingerprint'] ?? ''),
         ];
     }
 
@@ -105,7 +104,7 @@ final class PsnTrophyTitleComparisonService
     }
 
     /**
-     * @return array{count: int, durationMs: float, pagesFetched: int, totalItemCount: int|null, fingerprint: string}
+     * @return array{count: int, durationMs: float, pagesFetched: int, totalItemCount: int|null}
      */
     private function fetchTitlesViaEndpoint(object $client, string $accountId): array
     {
@@ -116,7 +115,6 @@ final class PsnTrophyTitleComparisonService
         $limit = 800;
         $offset = 0;
         $totalItemCount = null;
-        $titleKeys = [];
         $count = 0;
         $pagesFetched = 0;
         $startTime = ($this->timeProvider)();
@@ -154,13 +152,6 @@ final class PsnTrophyTitleComparisonService
             foreach ($batchTitles as $batchTitle) {
                 if (is_array($batchTitle)) {
                     $count++;
-
-                    $titleKey = $this->createTitleKey($batchTitle);
-
-                    if ($titleKey !== '') {
-                        $titleKeys[] = $titleKey;
-                    }
-
                 }
             }
 
@@ -191,19 +182,16 @@ final class PsnTrophyTitleComparisonService
         }
 
         $endTime = ($this->timeProvider)();
-        sort($titleKeys);
-
         return [
             'count' => $count,
             'durationMs' => round(($endTime - $startTime) * 1000, 2),
             'pagesFetched' => $pagesFetched,
             'totalItemCount' => $totalItemCount,
-            'fingerprint' => hash('sha256', implode('|', $titleKeys)),
         ];
     }
 
     /**
-     * @return array{count: int, durationMs: float, fingerprint: string}
+     * @return array{count: int, durationMs: float}
      */
     private function fetchTitlesViaTustin(object $client, string $accountId): array
     {
@@ -221,16 +209,10 @@ final class PsnTrophyTitleComparisonService
             $user = $users->find($accountId);
             $startTime = ($this->timeProvider)();
             $trophyTitleCollection = $user->trophyTitles();
-            $titleKeys = [];
             $count = 0;
 
             foreach ($trophyTitleCollection->getIterator() as $trophyTitle) {
                 $count++;
-
-                $titleKey = $this->createTustinTitleKey($trophyTitle);
-                if ($titleKey !== '') {
-                    $titleKeys[] = $titleKey;
-                }
             }
         } catch (Throwable $exception) {
             throw new PsnTrophyTitleComparisonException(
@@ -241,77 +223,10 @@ final class PsnTrophyTitleComparisonService
         }
 
         $endTime = ($this->timeProvider)();
-        sort($titleKeys);
-
         return [
             'count' => $count,
             'durationMs' => round(($endTime - $startTime) * 1000, 2),
-            'fingerprint' => hash('sha256', implode('|', $titleKeys)),
         ];
-    }
-
-
-    private function createTustinTitleKey(mixed $trophyTitle): string
-    {
-        if (is_object($trophyTitle)) {
-            $preferredMethods = [
-                'npCommunicationId',
-                'trophyTitleId',
-                'titleId',
-                'titleName',
-                'trophyTitleName',
-            ];
-
-            foreach ($preferredMethods as $method) {
-                if (!method_exists($trophyTitle, $method)) {
-                    continue;
-                }
-
-                try {
-                    $value = $trophyTitle->{$method}();
-                } catch (Throwable) {
-                    continue;
-                }
-
-                if (is_scalar($value) || $value === null) {
-                    return $method . ':' . (string) $value;
-                }
-            }
-        }
-
-        return $this->createTitleKey($this->normalizeResponse($trophyTitle));
-    }
-
-    /**
-     * @param array<string, mixed> $title
-     */
-    private function createTitleKey(array $title): string
-    {
-        $preferredKeys = [
-            'npCommunicationId',
-            'trophyTitleId',
-            'titleId',
-            'titleName',
-            'trophyTitleName',
-        ];
-
-        foreach ($preferredKeys as $key) {
-            if (!array_key_exists($key, $title)) {
-                continue;
-            }
-
-            $value = $title[$key];
-            if (is_scalar($value) || $value === null) {
-                return $key . ':' . (string) $value;
-            }
-        }
-
-        $encoded = json_encode($title, JSON_UNESCAPED_SLASHES);
-        if ($encoded === false) {
-            return '';
-        }
-
-        return 'json:' . hash('sha256', $encoded);
     }
 
     private function determineStatusCode(Throwable $exception): ?int


### PR DESCRIPTION
### Motivation
- The admin page could time out (Error 524) for players with very large numbers of games because per-title fingerprinting, sorting and payload processing consumed excessive CPU/memory and added latency. 
- The goal is to still fetch all titles but make the comparison lightweight and robust for large libraries by only comparing counts and timing.

### Description
- Changed `PsnTrophyTitleComparisonService` to keep full pagination and iterate every title but stop generating per-title keys, sorting and computing fingerprints, returning only counts/timing/pages/total count where applicable. 
- Removed the title-key/fingerprint logic and related helper code paths to reduce CPU and memory usage during comparison. 
- Updated the admin UI `wwwroot/admin/psn-trophy-title-compare.php` to display counts and duration only and adjusted the explanatory text to reflect count-based comparison. 
- Updated `tests/PsnTrophyTitleComparisonServiceTest.php` to validate the new count-based behavior (including object-based title iteration) and adjusted assertions accordingly.

### Testing
- Ran PHP syntax checks with `php -l` on `wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php`, `wwwroot/admin/psn-trophy-title-compare.php` and `tests/PsnTrophyTitleComparisonServiceTest.php`, all of which reported no syntax errors. 
- Ran the package test runner `php tests/run.php` and the focused test `php tests/run.php PsnTrophyTitleComparisonServiceTest`; the trophy comparison tests passed. 
- The full test suite run produced 2 failures and 1 error unrelated to this change (`PlayerQueueResponseFactoryTest::testCreateQueuedForScanResponseUsesActionVerbsForProgressTitle`, `PsnGameLookupServiceTest::testFetchTrophyDataForNpCommunicationIdPreservesGroupedPayloadWhenFlatTrophiesMissing`, and `TrophyMergeServiceCopyMergedTrophiesTest::testCopyMergedTrophiesBulkCopiesEarnedProgressWithDerivedTables`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92b7758b4832f8b0346f47c535b5e)