### PR TITLE
Add source toggle for PSN Trophy Title Compare admin page

### DIFF
--- a/tests/PsnTrophyTitleComparisonServiceTest.php
+++ b/tests/PsnTrophyTitleComparisonServiceTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/../wwwroot/classes/Admin/Worker.php';
 
 final class PsnTrophyTitleComparisonServiceTest extends TestCase
 {
-    public function testCompareByAccountIdFetchesAllPagesAndMeasuresTime(): void
+    public function testCompareByAccountIdFetchesAllPagesAndMeasuresTimeForDirectSource(): void
     {
         $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
 
@@ -86,7 +86,7 @@ final class PsnTrophyTitleComparisonServiceTest extends TestCase
             }
         };
 
-        $times = [10.0, 11.25, 20.0, 20.5];
+        $times = [10.0, 11.25];
 
         $service = new PsnTrophyTitleComparisonService(
             static fn (): array => [$worker],
@@ -96,15 +96,13 @@ final class PsnTrophyTitleComparisonServiceTest extends TestCase
             }
         );
 
-        $result = $service->compareByAccountId('123456');
+        $result = $service->compareByAccountId('123456', PsnTrophyTitleComparisonService::SOURCE_DIRECT);
 
         $this->assertSame('123456', $result['accountId']);
-        $this->assertSame(3, $result['direct']['count']);
-        $this->assertSame(2, $result['direct']['pagesFetched']);
-        $this->assertSame(1250.0, $result['direct']['durationMs']);
-        $this->assertSame(3, $result['tustin']['count']);
-        $this->assertSame(500.0, $result['tustin']['durationMs']);
-        $this->assertSame(true, $result['countsMatch']);
+        $this->assertSame(PsnTrophyTitleComparisonService::SOURCE_DIRECT, $result['source']);
+        $this->assertSame(3, $result['result']['count']);
+        $this->assertSame(2, $result['result']['pagesFetched']);
+        $this->assertSame(1250.0, $result['result']['durationMs']);
     }
 
 
@@ -166,7 +164,7 @@ final class PsnTrophyTitleComparisonServiceTest extends TestCase
             }
         };
 
-        $times = [1.0, 1.0, 2.0, 2.0];
+        $times = [2.0, 2.5];
 
         $service = new PsnTrophyTitleComparisonService(
             static fn (): array => [$worker],
@@ -176,11 +174,11 @@ final class PsnTrophyTitleComparisonServiceTest extends TestCase
             }
         );
 
-        $result = $service->compareByAccountId('123456');
+        $result = $service->compareByAccountId('123456', PsnTrophyTitleComparisonService::SOURCE_TUSTIN);
 
-        $this->assertSame(2, $result['direct']['count']);
-        $this->assertSame(2, $result['tustin']['count']);
-        $this->assertSame(true, $result['countsMatch']);
+        $this->assertSame(PsnTrophyTitleComparisonService::SOURCE_TUSTIN, $result['source']);
+        $this->assertSame(2, $result['result']['count']);
+        $this->assertSame(500.0, $result['result']['durationMs']);
     }
 
     public function testCompareByAccountIdRejectsInvalidInput(): void
@@ -191,10 +189,25 @@ final class PsnTrophyTitleComparisonServiceTest extends TestCase
         );
 
         try {
-            $service->compareByAccountId('invalid');
+            $service->compareByAccountId('invalid', PsnTrophyTitleComparisonService::SOURCE_DIRECT);
             $this->fail('Expected InvalidArgumentException to be thrown for non numeric account IDs.');
         } catch (InvalidArgumentException $exception) {
             $this->assertSame('Account ID must be a numeric value.', $exception->getMessage());
+        }
+    }
+
+    public function testCompareByAccountIdRejectsInvalidSource(): void
+    {
+        $service = new PsnTrophyTitleComparisonService(
+            static fn (): array => [],
+            static fn (): object => new stdClass()
+        );
+
+        try {
+            $service->compareByAccountId('1234', 'invalid');
+            $this->fail('Expected InvalidArgumentException to be thrown for invalid source.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('Source must be either "direct" or "tustin".', $exception->getMessage());
         }
     }
 
@@ -211,9 +224,10 @@ final class PsnTrophyTitleComparisonServiceTest extends TestCase
             }
         );
 
-        $handled = PsnTrophyTitleComparisonRequestHandler::handle($service, '123');
+        $handled = PsnTrophyTitleComparisonRequestHandler::handle($service, '123', PsnTrophyTitleComparisonService::SOURCE_DIRECT);
 
         $this->assertSame('123', $handled->getNormalizedAccountId());
+        $this->assertSame(PsnTrophyTitleComparisonService::SOURCE_DIRECT, $handled->getNormalizedSource());
         $this->assertSame(null, $handled->getResult());
         $this->assertSame('The PlayStation client does not support endpoint requests.', $handled->getErrorMessage());
     }

--- a/wwwroot/admin/psn-trophy-title-compare.php
+++ b/wwwroot/admin/psn-trophy-title-compare.php
@@ -10,10 +10,12 @@ require_once '../classes/Admin/PsnTrophyTitleComparisonRequestResult.php';
 require_once '../classes/Admin/PsnTrophyTitleComparisonService.php';
 
 $accountId = isset($_GET['accountId']) ? (string) $_GET['accountId'] : '';
+$source = isset($_GET['source']) ? (string) $_GET['source'] : PsnTrophyTitleComparisonService::SOURCE_DIRECT;
 $service = PsnTrophyTitleComparisonService::fromDatabase($database);
-$handledRequest = PsnTrophyTitleComparisonRequestHandler::handle($service, $accountId);
+$handledRequest = PsnTrophyTitleComparisonRequestHandler::handle($service, $accountId, $source);
 
 $normalizedAccountId = $handledRequest->getNormalizedAccountId();
+$normalizedSource = $handledRequest->getNormalizedSource();
 $result = $handledRequest->getResult();
 $errorMessage = $handledRequest->getErrorMessage();
 ?>
@@ -29,13 +31,23 @@ $errorMessage = $handledRequest->getErrorMessage();
         <div class="p-4">
             <a href="/admin/">Back</a><br><br>
             <h1 class="h3 mb-3">PSN Trophy Title Compare</h1>
-            <p class="text-body-secondary">Fetch all trophy titles for an account ID using direct endpoint paging and compare it against tustin/psn-php.</p>
+            <p class="text-body-secondary">Fetch all trophy titles for an account ID using a selectable source.</p>
             <form method="get" class="mb-4" action="">
                 <div class="mb-2">
                     <label for="accountId" class="form-label">Account ID</label>
                     <div class="input-group">
                         <input type="text" class="form-control" id="accountId" name="accountId" value="<?= htmlentities($accountId, ENT_QUOTES, 'UTF-8'); ?>" placeholder="e.g. 1234567890123456789" autocomplete="off" inputmode="numeric">
                         <button class="btn btn-primary" type="submit">Fetch</button>
+                    </div>
+                </div>
+                <div class="mb-2">
+                    <span class="form-label d-block">Source</span>
+                    <div class="btn-group" role="group" aria-label="Source toggle">
+                        <input type="radio" class="btn-check" name="source" id="source-direct" value="direct" autocomplete="off" <?= $normalizedSource === PsnTrophyTitleComparisonService::SOURCE_DIRECT ? 'checked' : ''; ?>>
+                        <label class="btn btn-outline-secondary" for="source-direct">Direct endpoint</label>
+
+                        <input type="radio" class="btn-check" name="source" id="source-tustin" value="tustin" autocomplete="off" <?= $normalizedSource === PsnTrophyTitleComparisonService::SOURCE_TUSTIN ? 'checked' : ''; ?>>
+                        <label class="btn btn-outline-secondary" for="source-tustin">tustin/psn-php</label>
                     </div>
                 </div>
             </form>
@@ -53,31 +65,18 @@ $errorMessage = $handledRequest->getErrorMessage();
                     <div class="col-md-6">
                         <div class="card h-100">
                             <div class="card-body">
-                                <h2 class="h5">Direct endpoint</h2>
+                                <h2 class="h5"><?= $normalizedSource === PsnTrophyTitleComparisonService::SOURCE_DIRECT ? 'Direct endpoint' : 'tustin/psn-php'; ?></h2>
                                 <dl class="row mb-0">
                                     <dt class="col-sm-5">Titles fetched</dt>
-                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['direct']['count'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
-                                    <dt class="col-sm-5">Pages fetched</dt>
-                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['direct']['pagesFetched'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
-                                    <dt class="col-sm-5">Total item count</dt>
-                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['direct']['totalItemCount'] ?? 'n/a'), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['result']['count'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <?php if ($normalizedSource === PsnTrophyTitleComparisonService::SOURCE_DIRECT) { ?>
+                                        <dt class="col-sm-5">Pages fetched</dt>
+                                        <dd class="col-sm-7"><?= htmlentities((string) ($result['result']['pagesFetched'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                        <dt class="col-sm-5">Total item count</dt>
+                                        <dd class="col-sm-7"><?= htmlentities((string) ($result['result']['totalItemCount'] ?? 'n/a'), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <?php } ?>
                                     <dt class="col-sm-5">Duration (ms)</dt>
-                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['direct']['durationMs'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
-                                </dl>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-md-6">
-                        <div class="card h-100">
-                            <div class="card-body">
-                                <h2 class="h5">tustin/psn-php</h2>
-                                <dl class="row mb-0">
-                                    <dt class="col-sm-5">Titles fetched</dt>
-                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['tustin']['count'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
-                                    <dt class="col-sm-5">Duration (ms)</dt>
-                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['tustin']['durationMs'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
-                                    <dt class="col-sm-5">Count match</dt>
-                                    <dd class="col-sm-7"><?= htmlentities(($result['countsMatch'] ?? false) ? 'Yes' : 'No', ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['result']['durationMs'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
                                 </dl>
                             </div>
                         </div>
@@ -85,7 +84,7 @@ $errorMessage = $handledRequest->getErrorMessage();
                 </div>
                 <div class="alert alert-secondary" role="alert">
                     Full payload rendering is intentionally disabled on this page to avoid response-size timeouts.
-                    The comparison still fetches <strong>all titles</strong> from both sources and compares the title counts.
+                    This lookup still fetches <strong>all titles</strong> from the selected source.
                 </div>
             <?php } ?>
         </div>

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestHandler.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestHandler.php
@@ -8,15 +8,17 @@ require_once __DIR__ . '/PsnTrophyTitleComparisonService.php';
 
 final class PsnTrophyTitleComparisonRequestHandler
 {
-    public static function handle(PsnTrophyTitleComparisonService $service, string $accountId): PsnTrophyTitleComparisonRequestResult
+    public static function handle(PsnTrophyTitleComparisonService $service, string $accountId, string $source): PsnTrophyTitleComparisonRequestResult
     {
         $normalizedAccountId = trim($accountId);
+        $normalizedSource = PsnTrophyTitleComparisonService::normalizeSource($source)
+            ?? PsnTrophyTitleComparisonService::SOURCE_DIRECT;
         $result = null;
         $errorMessage = null;
 
         if ($normalizedAccountId !== '') {
             try {
-                $result = $service->compareByAccountId($normalizedAccountId);
+                $result = $service->compareByAccountId($normalizedAccountId, $normalizedSource);
             } catch (PsnTrophyTitleComparisonException $exception) {
                 $errorMessage = $exception->getMessage();
             } catch (Throwable $exception) {
@@ -29,6 +31,6 @@ final class PsnTrophyTitleComparisonRequestHandler
             }
         }
 
-        return new PsnTrophyTitleComparisonRequestResult($normalizedAccountId, $result, $errorMessage);
+        return new PsnTrophyTitleComparisonRequestResult($normalizedAccountId, $normalizedSource, $result, $errorMessage);
     }
 }

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestResult.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestResult.php
@@ -9,6 +9,7 @@ final readonly class PsnTrophyTitleComparisonRequestResult
      */
     public function __construct(
         private string $normalizedAccountId,
+        private string $normalizedSource,
         private ?array $result,
         private ?string $errorMessage,
     ) {
@@ -17,6 +18,11 @@ final readonly class PsnTrophyTitleComparisonRequestResult
     public function getNormalizedAccountId(): string
     {
         return $this->normalizedAccountId;
+    }
+
+    public function getNormalizedSource(): string
+    {
+        return $this->normalizedSource;
     }
 
     /**

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -10,6 +10,9 @@ use Tustin\PlayStation\Client;
 
 final class PsnTrophyTitleComparisonService
 {
+    public const SOURCE_DIRECT = 'direct';
+    public const SOURCE_TUSTIN = 'tustin';
+
     /**
      * @var \Closure(): iterable<Worker>
      */
@@ -50,25 +53,40 @@ final class PsnTrophyTitleComparisonService
     /**
      * @return array<string, mixed>
      */
-    public function compareByAccountId(string $accountId): array
+    public function compareByAccountId(string $accountId, string $source): array
     {
         $normalizedAccountId = trim($accountId);
+        $normalizedSource = self::normalizeSource($source);
 
         if ($normalizedAccountId === '' || !ctype_digit($normalizedAccountId)) {
             throw new InvalidArgumentException('Account ID must be a numeric value.');
         }
 
-        $client = $this->createAuthenticatedClient();
+        if ($normalizedSource === null) {
+            throw new InvalidArgumentException('Source must be either "direct" or "tustin".');
+        }
 
-        $directFetch = $this->fetchTitlesViaEndpoint($client, $normalizedAccountId);
-        $tustinFetch = $this->fetchTitlesViaTustin($client, $normalizedAccountId);
+        $client = $this->createAuthenticatedClient();
+        $fetchResult = $normalizedSource === self::SOURCE_DIRECT
+            ? $this->fetchTitlesViaEndpoint($client, $normalizedAccountId)
+            : $this->fetchTitlesViaTustin($client, $normalizedAccountId);
 
         return [
             'accountId' => $normalizedAccountId,
-            'direct' => $directFetch,
-            'tustin' => $tustinFetch,
-            'countsMatch' => ($directFetch['count'] ?? -1) === ($tustinFetch['count'] ?? -1),
+            'source' => $normalizedSource,
+            'result' => $fetchResult,
         ];
+    }
+
+    public static function normalizeSource(string $source): ?string
+    {
+        $normalizedSource = strtolower(trim($source));
+
+        if ($normalizedSource === self::SOURCE_DIRECT || $normalizedSource === self::SOURCE_TUSTIN) {
+            return $normalizedSource;
+        }
+
+        return null;
     }
 
     private function createAuthenticatedClient(): object


### PR DESCRIPTION
### Motivation
- Avoid fetching both the direct endpoint and tustin/psn-php on every lookup by letting the admin choose a single source, reducing work and improving predictability.

### Description
- Add `SOURCE_DIRECT` and `SOURCE_TUSTIN` constants and a `normalizeSource()` helper to `PsnTrophyTitleComparisonService`, change `compareByAccountId()` to accept a `source` and return a source-scoped payload (`accountId`, `source`, `result`) while fetching only the selected source.
- Update `PsnTrophyTitleComparisonRequestHandler` to accept and normalize a `source` (defaulting to `direct`) and pass it to the service, and update `PsnTrophyTitleComparisonRequestResult` to carry the normalized source with a getter.
- Update the admin page `wwwroot/admin/psn-trophy-title-compare.php` to render a radio toggle for the source, submit the selected `source` parameter, and display metrics for only the selected source (including pages/totalItemCount when `direct` is selected).
- Update `tests/PsnTrophyTitleComparisonServiceTest.php` to exercise the new `source`-based behavior, add an invalid-source validation test, and adjust expectations to the new response shape.

### Testing
- Ran syntax checks with `php -l` for the changed files and the updated test file, which reported no syntax errors.
- Ran the full test suite with `php tests/run.php`; the modified tests and the new/updated `PsnTrophyTitleComparisonService` tests passed, while the overall suite completed with unrelated failures and an error (examples: `PlayerQueueResponseFactoryTest::testCreateQueuedForScanResponseUsesActionVerbsForProgressTitle` failure, `PsnGameLookupServiceTest` error about `assertArrayNotHasKey()`, and `TrophyMergeServiceCopyMergedTrophiesTest` failure) that are outside the scope of these changes.
- The admin page now submits `source` and the UI renders only the selected-source metrics as intended (manual UI verification not performed in CI environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e930735d20832fb80b51d4f63f9b26)