### PR TITLE
Randomize fallback game selection in PlayerRandomGamesService

### DIFF
--- a/tests/PlayerRandomGamesServiceTest.php
+++ b/tests/PlayerRandomGamesServiceTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/Utility.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerRandomGame.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerRandomGamesFilter.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerRandomGamesService.php';
+
+use Random\Engine\Mt19937;
+use Random\Randomizer;
+
+final class PlayerRandomGamesServiceTest extends TestCase
+{
+    private PDO $database;
+
+    private PlayerRandomGamesService $service;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->database->exec(
+            <<<SQL
+            CREATE TABLE trophy_title (
+                id INTEGER PRIMARY KEY,
+                np_communication_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                icon_url TEXT,
+                platform TEXT,
+                platinum INTEGER NOT NULL DEFAULT 0,
+                gold INTEGER NOT NULL DEFAULT 0,
+                silver INTEGER NOT NULL DEFAULT 0,
+                bronze INTEGER NOT NULL DEFAULT 0
+            )
+            SQL
+        );
+
+        $this->database->exec(
+            <<<SQL
+            CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                status INTEGER NOT NULL,
+                owners INTEGER NOT NULL DEFAULT 0,
+                difficulty TEXT,
+                rarity_points INTEGER NOT NULL DEFAULT 0,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0
+            )
+            SQL
+        );
+
+        $this->database->exec(
+            <<<SQL
+            CREATE TABLE trophy_title_player (
+                account_id INTEGER NOT NULL,
+                np_communication_id TEXT NOT NULL,
+                progress INTEGER
+            )
+            SQL
+        );
+
+        $this->service = new PlayerRandomGamesService(
+            $this->database,
+            new Utility(),
+            new Randomizer(new Mt19937(1234))
+        );
+    }
+
+    public function testFallbackExcludesAlreadySeenIds(): void
+    {
+        $this->insertEligibleGames(total: 40, platform: 'PS4');
+
+        $rows = $this->invokeFetchFallbackGames(
+            accountId: 55,
+            filter: PlayerRandomGamesFilter::fromArray([]),
+            limit: 8,
+            seenIds: [1, 2, 3, 4, 5, 6]
+        );
+
+        $this->assertCount(8, $rows);
+        foreach ($rows as $row) {
+            $this->assertNotContains((int) $row['id'], [1, 2, 3, 4, 5, 6]);
+        }
+    }
+
+    public function testFallbackSelectionVariesAcrossRepeatedRunsWithLargePool(): void
+    {
+        $this->insertEligibleGames(total: 80, platform: 'PS5');
+
+        $selectedIds = [];
+        for ($i = 0; $i < 25; $i++) {
+            $rows = $this->invokeFetchFallbackGames(
+                accountId: 88,
+                filter: PlayerRandomGamesFilter::fromArray([]),
+                limit: 1,
+                seenIds: [1, 2, 3, 4, 5]
+            );
+
+            $this->assertCount(1, $rows);
+            $selectedIds[] = (int) $rows[0]['id'];
+        }
+
+        $this->assertGreaterThan(
+            1,
+            count(array_unique($selectedIds)),
+            'Expected fallback selection to vary across repeated runs when many eligible rows exist.'
+        );
+    }
+
+    public function testPs3FallbackCanStillReturnEligibleRowsWhenRandomIdSamplingUnderfills(): void
+    {
+        $this->insertEligibleGames(total: 12, platform: 'PS3');
+        $this->insertEligibleGames(total: 50, platform: 'PS5', startingId: 1000);
+
+        $rows = $this->invokeFetchFallbackGames(
+            accountId: 77,
+            filter: PlayerRandomGamesFilter::fromArray([PlayerRandomGamesFilter::PLATFORM_PS3 => '1']),
+            limit: 30,
+            seenIds: [1, 2]
+        );
+
+        $this->assertCount(10, $rows);
+        foreach ($rows as $row) {
+            $this->assertStringContainsString('PS3', (string) $row['platform']);
+            $this->assertNotContains((int) $row['id'], [1, 2]);
+        }
+    }
+
+    private function insertEligibleGames(int $total, string $platform, int $startingId = 1): void
+    {
+        $titleStatement = $this->database->prepare(
+            'INSERT INTO trophy_title (id, np_communication_id, name, icon_url, platform, platinum, gold, silver, bronze) '
+            . 'VALUES (:id, :np, :name, :icon_url, :platform, 1, 2, 3, 4)'
+        );
+
+        $metaStatement = $this->database->prepare(
+            'INSERT INTO trophy_title_meta (np_communication_id, status, owners, difficulty, rarity_points, in_game_rarity_points) '
+            . 'VALUES (:np, 0, 100, "3.50", 77, 33)'
+        );
+
+        for ($offset = 0; $offset < $total; $offset++) {
+            $id = $startingId + $offset;
+            $npCommunicationId = sprintf('NPWR%05d', $id);
+
+            $titleStatement->bindValue(':id', $id, PDO::PARAM_INT);
+            $titleStatement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
+            $titleStatement->bindValue(':name', 'Game ' . $id, PDO::PARAM_STR);
+            $titleStatement->bindValue(':icon_url', 'icon.png', PDO::PARAM_STR);
+            $titleStatement->bindValue(':platform', $platform, PDO::PARAM_STR);
+            $titleStatement->execute();
+
+            $metaStatement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
+            $metaStatement->execute();
+        }
+    }
+
+    /**
+     * @param list<int> $seenIds
+     * @return array<int, array<string, mixed>>
+     */
+    private function invokeFetchFallbackGames(int $accountId, PlayerRandomGamesFilter $filter, int $limit, array $seenIds): array
+    {
+        $reflectionMethod = new ReflectionMethod(PlayerRandomGamesService::class, 'fetchFallbackGames');
+        $reflectionMethod->setAccessible(true);
+
+        $result = $reflectionMethod->invoke($this->service, $accountId, $filter, $limit, $seenIds);
+
+        $this->assertIsArray($result);
+
+        return $result;
+    }
+}

--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -84,7 +84,7 @@ class PlayerRandomGamesService
         }
 
         if (count($games) < $limit) {
-            $fallbackRows = $this->fetchFallbackGames($accountId, $filter, $limit - count($games));
+            $fallbackRows = $this->fetchFallbackGames($accountId, $filter, $limit - count($games), array_keys($seenIds));
 
             foreach ($fallbackRows as $gameData) {
                 $id = isset($gameData['id']) ? (int) $gameData['id'] : 0;
@@ -228,7 +228,12 @@ class PlayerRandomGamesService
      * @param list<int> $ids
      * @return array<int, array<string, mixed>>
      */
-    private function fetchSampledGames(int $accountId, PlayerRandomGamesFilter $filter, array $ids): array
+    private function fetchSampledGames(
+        int $accountId,
+        PlayerRandomGamesFilter $filter,
+        array $ids,
+        array $excludeIds = []
+    ): array
     {
         if ($ids === []) {
             return [];
@@ -240,7 +245,8 @@ class PlayerRandomGamesService
         }
 
         $sql = $this->buildSelectableQuery($filter)
-            . sprintf(' AND tt.id IN (%s)', implode(', ', $placeholders));
+            . sprintf(' AND tt.id IN (%s)', implode(', ', $placeholders))
+            . $this->buildExcludeSeenIdsClause($excludeIds);
 
         $statement = $this->database->prepare($sql);
         $statement->bindValue(':account_id', $accountId, PDO::PARAM_INT);
@@ -248,6 +254,7 @@ class PlayerRandomGamesService
         foreach ($ids as $index => $id) {
             $statement->bindValue(':id_' . $index, $id, PDO::PARAM_INT);
         }
+        $this->bindSeenIdParameters($statement, $excludeIds);
 
         $statement->execute();
 
@@ -267,16 +274,51 @@ class PlayerRandomGamesService
     /**
      * @return array<int, array<string, mixed>>
      */
-    private function fetchFallbackGames(int $accountId, PlayerRandomGamesFilter $filter, int $limit): array
+    private function fetchFallbackGames(int $accountId, PlayerRandomGamesFilter $filter, int $limit, array $seenIds = []): array
     {
         if ($limit <= 0) {
             return [];
         }
 
-        $sql = $this->buildSelectableQuery($filter) . ' ORDER BY tt.id LIMIT :limit';
+        $seenIds = array_values(array_unique(array_map('intval', $seenIds)));
+
+        if ($limit <= 25) {
+            return $this->fetchFallbackRowsWithRandomOrder($accountId, $filter, $limit, $seenIds);
+        }
+
+        $rows = $this->fetchFallbackRowsByRandomIdSampling($accountId, $filter, $limit, $seenIds);
+
+        if (count($rows) >= $limit) {
+            return $rows;
+        }
+
+        $additionalRows = $this->fetchFallbackRowsWithRandomOrder(
+            $accountId,
+            $filter,
+            $limit - count($rows),
+            [...$seenIds, ...array_map(static fn(array $row): int => (int) ($row['id'] ?? 0), $rows)]
+        );
+
+        if ($additionalRows === []) {
+            return $rows;
+        }
+
+        return [...$rows, ...$additionalRows];
+    }
+
+    /**
+     * @param list<int> $seenIds
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchFallbackRowsWithRandomOrder(int $accountId, PlayerRandomGamesFilter $filter, int $limit, array $seenIds): array
+    {
+        $sql = $this->buildSelectableQuery($filter)
+            . $this->buildExcludeSeenIdsClause($seenIds)
+            . ' ORDER BY ' . $this->resolveRandomOrderExpression() . ' LIMIT :limit';
 
         $statement = $this->database->prepare($sql);
         $statement->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $this->bindSeenIdParameters($statement, $seenIds);
         $statement->bindValue(':limit', $limit, PDO::PARAM_INT);
         $statement->execute();
 
@@ -287,5 +329,100 @@ class PlayerRandomGamesService
         }
 
         return array_values(array_filter($rows, 'is_array'));
+    }
+
+    /**
+     * @param list<int> $seenIds
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchFallbackRowsByRandomIdSampling(int $accountId, PlayerRandomGamesFilter $filter, int $limit, array $seenIds): array
+    {
+        $bounds = $this->fetchIdBoundsWithExclusions($accountId, $filter, $seenIds);
+
+        if ($bounds === null) {
+            return [];
+        }
+
+        [$minId, $maxId] = $bounds;
+        $rangeSize = $maxId - $minId + 1;
+
+        if ($rangeSize <= 0) {
+            return [];
+        }
+
+        $sampleSize = (int) min(max($limit * 6, 60), $rangeSize);
+        $sampleIds = $this->generateRandomIds($minId, $maxId, $sampleSize);
+        if ($sampleIds === []) {
+            return [];
+        }
+
+        $rows = $this->fetchSampledGames($accountId, $filter, $sampleIds, $seenIds);
+
+        return array_slice($rows, 0, $limit);
+    }
+
+    /**
+     * @param list<int> $seenIds
+     * @return array{0: int, 1: int}|null
+     */
+    private function fetchIdBoundsWithExclusions(int $accountId, PlayerRandomGamesFilter $filter, array $seenIds): ?array
+    {
+        $sql = 'SELECT MIN(tt.id) AS min_id, MAX(tt.id) AS max_id'
+            . $this->buildBaseQuery($filter)
+            . $this->buildExcludeSeenIdsClause($seenIds);
+
+        $statement = $this->database->prepare($sql);
+        $statement->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $this->bindSeenIdParameters($statement, $seenIds);
+        $statement->execute();
+
+        $result = $statement->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($result)) {
+            return null;
+        }
+
+        $minId = isset($result['min_id']) ? (int) $result['min_id'] : null;
+        $maxId = isset($result['max_id']) ? (int) $result['max_id'] : null;
+
+        if ($minId === null || $maxId === null) {
+            return null;
+        }
+
+        return [$minId, $maxId];
+    }
+
+    /**
+     * @param list<int> $seenIds
+     */
+    private function buildExcludeSeenIdsClause(array $seenIds): string
+    {
+        if ($seenIds === []) {
+            return '';
+        }
+
+        $placeholders = [];
+        foreach ($seenIds as $index => $_) {
+            $placeholders[] = ':seen_id_' . $index;
+        }
+
+        return ' AND tt.id NOT IN (' . implode(', ', $placeholders) . ')';
+    }
+
+    /**
+     * @param list<int> $seenIds
+     */
+    private function bindSeenIdParameters(PDOStatement $statement, array $seenIds): void
+    {
+        foreach ($seenIds as $index => $seenId) {
+            $statement->bindValue(':seen_id_' . $index, $seenId, PDO::PARAM_INT);
+        }
+    }
+
+    private function resolveRandomOrderExpression(): string
+    {
+        $driverName = strtolower((string) $this->database->getAttribute(PDO::ATTR_DRIVER_NAME));
+
+        return $driverName === 'mysql' ? 'RAND()' : 'RANDOM()';
     }
 }


### PR DESCRIPTION
### Motivation
- Avoid deterministic fallback selection caused by `ORDER BY tt.id LIMIT :limit` so repeated runs can return varied titles when the eligible pool is large.
- Ensure fallback results can exclude already-selected IDs at the SQL level to avoid unnecessary post-query filtering and duplicate returns.
- Provide a robust fallback strategy that remains effective for sparse platform filters (e.g. `ps3`) where simple sampling may under-fill.

### Description
- Thread `seenIds` from `getRandomGames()` into `fetchFallbackGames()` and add a `NOT IN (...)` exclusion clause to fallback queries using helper methods `buildExcludeSeenIdsClause()` and `bindSeenIdParameters()`.
- Replace deterministic `ORDER BY tt.id LIMIT :limit` with a hybrid strategy: small limits use SQL-level random ordering (`RAND()` for MySQL, `RANDOM()` otherwise) via `fetchFallbackRowsWithRandomOrder()`, while larger limits use randomized-ID sampling via `fetchFallbackRowsByRandomIdSampling()` with a random-order top-up if sampling under-fills.
- Extend `fetchSampledGames()` to accept an exclusion list and added `fetchIdBoundsWithExclusions()` to compute sampling bounds while respecting exclusions.
- Added `resolveRandomOrderExpression()` to pick the proper DB random function, and kept result shuffling for sampled rows using the injected `Randomizer`.

### Testing
- Added `tests/PlayerRandomGamesServiceTest.php` with three tests: exclusion of seen IDs, variation across repeated runs with a large eligible pool, and sparse-`ps3` under-fill handling; the test file was run locally and included deterministic RNG seeding.
- Ran syntax checks with `php -l` on the modified service and test files which reported no syntax errors.
- Ran targeted PHPUnit tests using a temporary bootstrap alias and PHPUnit 9 which executed `tests/PlayerRandomGamesFilterTest.php` and `tests/PlayerRandomGamesServiceTest.php`; all tests passed (total: 3 tests in the new service test suite passed with 83 assertions, and the filter test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e938fb8128832f9b2ef5666b8c9510)