### PR TITLE
Refactor random game selection to sample eligible IDs directly

### DIFF
--- a/tests/PlayerRandomGamesServiceTest.php
+++ b/tests/PlayerRandomGamesServiceTest.php
@@ -80,7 +80,7 @@ final class PlayerRandomGamesServiceTest extends TestCase
 
         $this->assertCount(8, $rows);
         foreach ($rows as $row) {
-            $this->assertNotContains((int) $row['id'], [1, 2, 3, 4, 5, 6]);
+            $this->assertTrue(!in_array((int) $row['id'], [1, 2, 3, 4, 5, 6], true));
         }
     }
 
@@ -101,9 +101,8 @@ final class PlayerRandomGamesServiceTest extends TestCase
             $selectedIds[] = (int) $rows[0]['id'];
         }
 
-        $this->assertGreaterThan(
-            1,
-            count(array_unique($selectedIds)),
+        $this->assertTrue(
+            count(array_unique($selectedIds)) > 1,
             'Expected fallback selection to vary across repeated runs when many eligible rows exist.'
         );
     }
@@ -123,8 +122,64 @@ final class PlayerRandomGamesServiceTest extends TestCase
         $this->assertCount(10, $rows);
         foreach ($rows as $row) {
             $this->assertStringContainsString('PS3', (string) $row['platform']);
-            $this->assertNotContains((int) $row['id'], [1, 2]);
+            $this->assertTrue(!in_array((int) $row['id'], [1, 2], true));
         }
+    }
+
+    public function testGetRandomGamesSamplesFromSparsePs3EligibleSet(): void
+    {
+        $this->insertEligibleGames(total: 7, platform: 'PS3', startingId: 10);
+        $this->insertEligibleGames(total: 120, platform: 'PS5', startingId: 1000);
+
+        $games = $this->service->getRandomGames(
+            accountId: 222,
+            filter: PlayerRandomGamesFilter::fromArray([PlayerRandomGamesFilter::PLATFORM_PS3 => '1']),
+            limit: 5
+        );
+
+        $this->assertCount(5, $games);
+        foreach ($games as $game) {
+            $this->assertTrue(in_array('PS3', $game->getPlatforms(), true));
+        }
+    }
+
+    public function testGetRandomGamesPsvrFilterExcludesPsvr2Rows(): void
+    {
+        $this->insertEligibleGames(total: 8, platform: 'PSVR', startingId: 200);
+        $this->insertEligibleGames(total: 12, platform: 'PSVR2', startingId: 400);
+
+        $games = $this->service->getRandomGames(
+            accountId: 333,
+            filter: PlayerRandomGamesFilter::fromArray([PlayerRandomGamesFilter::PLATFORM_PSVR => '1']),
+            limit: 6
+        );
+
+        $this->assertCount(6, $games);
+        foreach ($games as $game) {
+            $this->assertSame(['PSVR'], $game->getPlatforms());
+        }
+    }
+
+    public function testGetRandomGamesHasNearUniformVariabilityAcrossRepeatedSampling(): void
+    {
+        $this->insertEligibleGames(total: 10, platform: 'PS5');
+
+        $selectionCounts = [];
+        for ($seed = 1; $seed <= 1000; $seed++) {
+            $service = $this->createServiceWithSeed($seed);
+            $games = $service->getRandomGames(
+                accountId: 444,
+                filter: PlayerRandomGamesFilter::fromArray([]),
+                limit: 1
+            );
+
+            $this->assertCount(1, $games);
+            $id = $games[0]->getId();
+            $selectionCounts[$id] = ($selectionCounts[$id] ?? 0) + 1;
+        }
+
+        $this->assertCount(10, $selectionCounts);
+        $this->assertTrue((max($selectionCounts) - min($selectionCounts)) <= 80);
     }
 
     private function insertEligibleGames(int $total, string $platform, int $startingId = 1): void
@@ -155,6 +210,15 @@ final class PlayerRandomGamesServiceTest extends TestCase
         }
     }
 
+    private function createServiceWithSeed(int $seed): PlayerRandomGamesService
+    {
+        return new PlayerRandomGamesService(
+            $this->database,
+            new Utility(),
+            new Randomizer(new Mt19937($seed))
+        );
+    }
+
     /**
      * @param list<int> $seenIds
      * @return array<int, array<string, mixed>>
@@ -166,7 +230,7 @@ final class PlayerRandomGamesServiceTest extends TestCase
 
         $result = $reflectionMethod->invoke($this->service, $accountId, $filter, $limit, $seenIds);
 
-        $this->assertIsArray($result);
+        $this->assertTrue(is_array($result));
 
         return $result;
     }

--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -36,72 +36,22 @@ class PlayerRandomGamesService
     {
         $limit = max(1, $limit);
 
-        $bounds = $this->fetchIdBounds($accountId, $filter);
-
-        if ($bounds === null) {
+        $eligibleIds = $this->fetchEligibleIds($accountId, $filter);
+        if ($eligibleIds === []) {
             return [];
         }
 
-        [$minId, $maxId] = $bounds;
-        $rangeSize = $maxId - $minId + 1;
-
-        if ($rangeSize <= 0) {
+        $sampledIds = $this->sampleEligibleIds($eligibleIds, $limit);
+        if ($sampledIds === []) {
             return [];
         }
 
-        $sampleSize = (int) min(max($limit * 4, 20), $rangeSize);
-        $sampleSize = max($sampleSize, $limit);
-        $maxAttempts = max(1, min(5, (int) ceil($rangeSize / $sampleSize)));
+        $rows = $this->fetchSampledGames($accountId, $filter, $sampledIds);
 
-        $games = [];
-        $seenIds = [];
-
-        for ($attempt = 0; $attempt < $maxAttempts && count($games) < $limit; $attempt++) {
-            $sampleIds = $this->generateRandomIds($minId, $maxId, $sampleSize);
-            if ($sampleIds === []) {
-                break;
-            }
-
-            $rows = $this->fetchSampledGames($accountId, $filter, $sampleIds);
-
-            if ($rows === []) {
-                continue;
-            }
-
-            foreach ($rows as $gameData) {
-                $id = isset($gameData['id']) ? (int) $gameData['id'] : 0;
-                if ($id === 0 || isset($seenIds[$id])) {
-                    continue;
-                }
-
-                $seenIds[$id] = true;
-                $games[] = PlayerRandomGame::fromArray($gameData, $this->utility);
-
-                if (count($games) >= $limit) {
-                    break;
-                }
-            }
-        }
-
-        if (count($games) < $limit) {
-            $fallbackRows = $this->fetchFallbackGames($accountId, $filter, $limit - count($games), array_keys($seenIds));
-
-            foreach ($fallbackRows as $gameData) {
-                $id = isset($gameData['id']) ? (int) $gameData['id'] : 0;
-                if ($id === 0 || isset($seenIds[$id])) {
-                    continue;
-                }
-
-                $seenIds[$id] = true;
-                $games[] = PlayerRandomGame::fromArray($gameData, $this->utility);
-
-                if (count($games) >= $limit) {
-                    break;
-                }
-            }
-        }
-
-        return $games;
+        return array_map(
+            fn(array $gameData): PlayerRandomGame => PlayerRandomGame::fromArray($gameData, $this->utility),
+            $rows
+        );
     }
 
     private function buildSelectableQuery(PlayerRandomGamesFilter $filter): string
@@ -161,30 +111,39 @@ class PlayerRandomGamesService
     }
 
     /**
-     * @return array{0: int, 1: int}|null
+     * @return list<int>
      */
-    private function fetchIdBounds(int $accountId, PlayerRandomGamesFilter $filter): ?array
+    private function fetchEligibleIds(int $accountId, PlayerRandomGamesFilter $filter): array
     {
-        $sql = 'SELECT MIN(tt.id) AS min_id, MAX(tt.id) AS max_id' . $this->buildBaseQuery($filter);
+        $sql = 'SELECT tt.id' . $this->buildBaseQuery($filter);
 
         $statement = $this->database->prepare($sql);
         $statement->bindValue(':account_id', $accountId, PDO::PARAM_INT);
         $statement->execute();
 
-        $result = $statement->fetch(PDO::FETCH_ASSOC);
-
-        if (!is_array($result)) {
-            return null;
+        $results = $statement->fetchAll(PDO::FETCH_COLUMN);
+        if (!is_array($results) || $results === []) {
+            return [];
         }
 
-        $minId = isset($result['min_id']) ? (int) $result['min_id'] : null;
-        $maxId = isset($result['max_id']) ? (int) $result['max_id'] : null;
+        return array_values(array_map('intval', $results));
+    }
 
-        if ($minId === null || $maxId === null) {
-            return null;
+    /**
+     * @param list<int> $eligibleIds
+     * @return list<int>
+     */
+    private function sampleEligibleIds(array $eligibleIds, int $limit): array
+    {
+        if ($eligibleIds === []) {
+            return [];
         }
 
-        return [$minId, $maxId];
+        if (count($eligibleIds) <= $limit) {
+            return $this->randomizer->shuffleArray($eligibleIds);
+        }
+
+        return array_slice($this->randomizer->shuffleArray($eligibleIds), 0, $limit);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Improve correctness and efficiency by sampling directly from the filtered set of eligible `tt.id` rows instead of drawing random IDs from the full min/max id range and post-filtering.
- Reduce complexity and remove the multi-attempt random-id probing flow in the primary `getRandomGames()` path.

### Description
- Rewrote `PlayerRandomGamesService::getRandomGames()` to fetch the eligible id pool via `fetchEligibleIds()`, sample up to `limit` ids with `sampleEligibleIds()`, then fetch and map full rows to `PlayerRandomGame` objects.
- Added `fetchEligibleIds()` and `sampleEligibleIds()` helpers and removed the main-path dependency on range-based `generateRandomIds()` sampling.
- Kept fallback/random-order helpers intact for other codepaths and preserved existing `fetchSampledGames()` behavior to fetch details for a given id list.
- Added/updated unit tests in `tests/PlayerRandomGamesServiceTest.php` to cover sparse `ps3` pools, `psvr` vs `psvr2` filtering, and repeated-sampling variability, and adjusted assertions to this repository's `TestCase` API.

### Testing
- Ran syntax checks with `php -l wwwroot/classes/PlayerRandomGamesService.php` and `php -l tests/PlayerRandomGamesServiceTest.php`, which reported no syntax errors.
- Executed the test runner with `php tests/run.php` and confirmed the updated `PlayerRandomGamesService` tests pass locally (new and existing assertions in `tests/PlayerRandomGamesServiceTest.php` passed).
- Ran the full test suite with `php tests/run.php`, which completed but still reports pre-existing unrelated failures/errors in other tests (suite result: 469 tests run with remaining unrelated failures/errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93b861a44832fb0beec7658014744)