### PR TITLE
Add trophy summary to PSN Player Lookup admin page

### DIFF
--- a/tests/PsnPlayerLookupServiceTest.php
+++ b/tests/PsnPlayerLookupServiceTest.php
@@ -16,12 +16,19 @@ final class PsnPlayerLookupServiceTest extends TestCase
         $capturedPath = null;
         $capturedQuery = null;
         $capturedHeaders = null;
+        $capturedSummaryPath = null;
+        $capturedSummaryQuery = null;
+        $capturedSummaryHeaders = null;
 
         $service = new PsnPlayerLookupService(
             static fn (): array => [$worker],
-            function () use (&$capturedPath, &$capturedQuery, &$capturedHeaders): object {
+            function () use (&$capturedPath, &$capturedQuery, &$capturedHeaders, &$capturedSummaryPath, &$capturedSummaryQuery, &$capturedSummaryHeaders): object {
                 return new StubClient(
                     profileHandler: function (string $path, array $query, array $headers) use (&$capturedPath, &$capturedQuery, &$capturedHeaders): object {
+                        if (str_contains($path, '/trophySummary')) {
+                            throw new RuntimeException('Unexpected trophy summary request in profile handler.');
+                        }
+
                         $capturedPath = $path;
                         $capturedQuery = $query;
                         $capturedHeaders = $headers;
@@ -32,6 +39,21 @@ final class PsnPlayerLookupServiceTest extends TestCase
                                 'accountId' => '1234567890',
                                 'currentOnlineId' => 'ExampleNew',
                                 'npId' => base64_encode('example@a6.us'),
+                            ],
+                        ];
+                    },
+                    summaryHandler: function (string $path, array $query, array $headers) use (&$capturedSummaryPath, &$capturedSummaryQuery, &$capturedSummaryHeaders): object {
+                        $capturedSummaryPath = $path;
+                        $capturedSummaryQuery = $query;
+                        $capturedSummaryHeaders = $headers;
+
+                        return (object) [
+                            'accountId' => '1234567890',
+                            'earnedTrophies' => (object) [
+                                'bronze' => 1,
+                                'silver' => 2,
+                                'gold' => 3,
+                                'platinum' => 4,
                             ],
                         ];
                     }
@@ -47,9 +69,16 @@ final class PsnPlayerLookupServiceTest extends TestCase
         );
         $this->assertSame(['fields' => 'accountId,onlineId,currentOnlineId,npId'], $capturedQuery);
         $this->assertSame(['content-type' => 'application/json'], $capturedHeaders);
+        $this->assertSame(
+            'https://m.np.playstation.com/api/trophy/v1/users/1234567890/trophySummary',
+            $capturedSummaryPath
+        );
+        $this->assertSame([], $capturedSummaryQuery);
+        $this->assertSame(['content-type' => 'application/json'], $capturedSummaryHeaders);
         $this->assertSame('Example', $result['profile']['onlineId']);
         $this->assertSame('1234567890', $result['profile']['accountId']);
         $this->assertSame('ExampleNew', $result['profile']['currentOnlineId']);
+        $this->assertSame(4, $result['trophySummary']['earnedTrophies']['platinum']);
     }
 
     public function testLookupThrowsNotFoundException(): void
@@ -232,12 +261,18 @@ final class StubClient
     /** @var callable(string, array, array): object */
     private $profileHandler;
 
+    /** @var callable(string, array, array): object */
+    private $summaryHandler;
+
     /** @var callable(string): void */
     private $loginHandler;
 
-    public function __construct(?callable $profileHandler = null, ?callable $loginHandler = null)
+    public function __construct(?callable $profileHandler = null, ?callable $summaryHandler = null, ?callable $loginHandler = null)
     {
         $this->profileHandler = $profileHandler ?? static function (): object {
+            return (object) [];
+        };
+        $this->summaryHandler = $summaryHandler ?? static function (): object {
             return (object) [];
         };
 
@@ -252,6 +287,10 @@ final class StubClient
 
     public function get(string $path = '', array $query = [], array $headers = []): object
     {
+        if (str_contains($path, '/trophySummary')) {
+            return ($this->summaryHandler)($path, $query, $headers);
+        }
+
         return ($this->profileHandler)($path, $query, $headers);
     }
 }

--- a/tests/PsnPlayerLookupServiceTest.php
+++ b/tests/PsnPlayerLookupServiceTest.php
@@ -105,6 +105,36 @@ final class PsnPlayerLookupServiceTest extends TestCase
         }
     }
 
+    public function testLookupReturnsProfileWhenTrophySummaryRequestFails(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $service = new PsnPlayerLookupService(
+            static fn (): array => [$worker],
+            static fn (): object => new StubClient(
+                profileHandler: static function (string $path = '', array $query = [], array $headers = []): object {
+                    return (object) [
+                        'profile' => (object) [
+                            'onlineId' => 'Example',
+                            'accountId' => '1234567890',
+                        ],
+                    ];
+                },
+                summaryHandler: static function (string $path = '', array $query = [], array $headers = []): object {
+                    $response = new StubResponse(503);
+
+                    throw new StubHttpException('Service Unavailable', $response);
+                }
+            )
+        );
+
+        $result = $service->lookup('Example');
+
+        $this->assertSame('Example', $result['profile']['onlineId']);
+        $this->assertSame('1234567890', $result['profile']['accountId']);
+        $this->assertFalse(array_key_exists('trophySummary', $result));
+    }
+
     public function testLookupSkipsWorkersThatFailToAuthenticate(): void
     {
         $workers = [

--- a/wwwroot/admin/psn-player-lookup.php
+++ b/wwwroot/admin/psn-player-lookup.php
@@ -15,6 +15,21 @@ $result = $handledRequest->getResult();
 $errorMessage = $handledRequest->getErrorMessage();
 $decodedNpId = $handledRequest->getDecodedNpId();
 $npCountry = $handledRequest->getNpCountry();
+$trophySummary = is_array($result) && isset($result['trophySummary']) && is_array($result['trophySummary'])
+    ? $result['trophySummary']
+    : null;
+$earnedTrophies = is_array($trophySummary) && isset($trophySummary['earnedTrophies']) && is_array($trophySummary['earnedTrophies'])
+    ? $trophySummary['earnedTrophies']
+    : null;
+$totalTrophies = null;
+
+if (is_array($earnedTrophies)) {
+    $bronze = isset($earnedTrophies['bronze']) && is_numeric($earnedTrophies['bronze']) ? (int) $earnedTrophies['bronze'] : 0;
+    $silver = isset($earnedTrophies['silver']) && is_numeric($earnedTrophies['silver']) ? (int) $earnedTrophies['silver'] : 0;
+    $gold = isset($earnedTrophies['gold']) && is_numeric($earnedTrophies['gold']) ? (int) $earnedTrophies['gold'] : 0;
+    $platinum = isset($earnedTrophies['platinum']) && is_numeric($earnedTrophies['platinum']) ? (int) $earnedTrophies['platinum'] : 0;
+    $totalTrophies = $bronze + $silver + $gold + $platinum;
+}
 ?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">
@@ -59,6 +74,27 @@ $npCountry = $handledRequest->getNpCountry();
                             <?php if ($npCountry !== null) { ?>
                                 <dt class="col-sm-3">Country</dt>
                                 <dd class="col-sm-9"><?= htmlentities($npCountry, ENT_QUOTES, 'UTF-8'); ?></dd>
+                            <?php } ?>
+                        </dl>
+                    </div>
+                </div>
+            <?php } ?>
+            <?php if ($trophySummary !== null) { ?>
+                <div class="card mb-4">
+                    <div class="card-body">
+                        <h2 class="h5">Trophy Summary</h2>
+                        <dl class="row mb-0">
+                            <?php if ($totalTrophies !== null) { ?>
+                                <dt class="col-sm-3">Total Trophies</dt>
+                                <dd class="col-sm-9"><?= number_format($totalTrophies); ?></dd>
+                            <?php } ?>
+                            <?php if (isset($trophySummary['trophyLevel']) && is_numeric($trophySummary['trophyLevel'])) { ?>
+                                <dt class="col-sm-3">Trophy Level</dt>
+                                <dd class="col-sm-9"><?= number_format((int) $trophySummary['trophyLevel']); ?></dd>
+                            <?php } ?>
+                            <?php if (isset($trophySummary['progress']) && is_numeric($trophySummary['progress'])) { ?>
+                                <dt class="col-sm-3">Progress</dt>
+                                <dd class="col-sm-9"><?= number_format((int) $trophySummary['progress']); ?>%</dd>
                             <?php } ?>
                         </dl>
                     </div>

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -57,7 +57,6 @@ final class PsnPlayerLookupService
         try {
             $profile = $this->executeUserProfileRequest($client, $normalizedOnlineId);
             $normalizedProfile = $this->normalizeProfileResponse($profile);
-            $trophySummary = $this->fetchTrophySummary($client, $normalizedProfile);
         } catch (Throwable $exception) {
             $statusCode = $this->determineStatusCode($exception);
 
@@ -74,6 +73,14 @@ final class PsnPlayerLookupService
                 $statusCode,
                 $exception
             );
+        }
+
+        $trophySummary = null;
+
+        try {
+            $trophySummary = $this->fetchTrophySummary($client, $normalizedProfile);
+        } catch (Throwable) {
+            $trophySummary = null;
         }
 
         if ($trophySummary !== null) {

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -56,6 +56,8 @@ final class PsnPlayerLookupService
 
         try {
             $profile = $this->executeUserProfileRequest($client, $normalizedOnlineId);
+            $normalizedProfile = $this->normalizeProfileResponse($profile);
+            $trophySummary = $this->fetchTrophySummary($client, $normalizedProfile);
         } catch (Throwable $exception) {
             $statusCode = $this->determineStatusCode($exception);
 
@@ -74,7 +76,11 @@ final class PsnPlayerLookupService
             );
         }
 
-        return $this->normalizeProfileResponse($profile);
+        if ($trophySummary !== null) {
+            $normalizedProfile['trophySummary'] = $trophySummary;
+        }
+
+        return $normalizedProfile;
     }
 
     private function createAuthenticatedClient(): object
@@ -130,6 +136,33 @@ final class PsnPlayerLookupService
         ];
 
         return $client->get($path, $query, ['content-type' => 'application/json']);
+    }
+
+    /**
+     * @param array<string, mixed> $profile
+     * @return array<string, mixed>|null
+     */
+    private function fetchTrophySummary(object $client, array $profile): ?array
+    {
+        if (!method_exists($client, 'get')) {
+            return null;
+        }
+
+        $accountId = $profile['profile']['accountId'] ?? null;
+
+        if (!is_string($accountId) || $accountId === '') {
+            return null;
+        }
+
+        $path = sprintf(
+            'https://m.np.playstation.com/api/trophy/v1/users/%s/trophySummary',
+            rawurlencode($accountId)
+        );
+
+        $summary = $client->get($path, [], ['content-type' => 'application/json']);
+        $normalizedSummary = $this->normalizeProfileResponse($summary);
+
+        return $normalizedSummary === [] ? null : $normalizedSummary;
     }
 
     private function determineStatusCode(Throwable $exception): ?int


### PR DESCRIPTION
### Motivation
- Surface a player's trophy summary from Sony's trophy API alongside the existing PSN profile lookup so admins can see level, progress and aggregated trophy counts. 
- Compute and display the total trophy count (bronze + silver + gold + platinum) for convenience.

### Description
- Updated `PsnPlayerLookupService::lookup()` to normalize the profile response and fetch the trophy summary from `https://m.np.playstation.com/api/trophy/v1/users/{accountId}/trophySummary`, attaching it to the lookup result as `trophySummary` via a new private method `fetchTrophySummary()`.
- Updated the admin UI in `wwwroot/admin/psn-player-lookup.php` to read `trophySummary`, compute `totalTrophies` (bronze + silver + gold + platinum), and render a new "Trophy Summary" card showing total trophies, trophy level and progress.
- Expanded `tests/PsnPlayerLookupServiceTest.php` with a `summaryHandler` in the `StubClient` and assertions verifying the trophy summary request URL, headers, and that the `trophySummary` payload is merged into the lookup result.

### Testing
- Linted modified PHP files with `php -l` for `wwwroot/classes/Admin/PsnPlayerLookupService.php`, `wwwroot/admin/psn-player-lookup.php`, and `tests/PsnPlayerLookupServiceTest.php`, and all reported no syntax errors.
- Executed the PSN player lookup service unit tests via `php tests/run.php PsnPlayerLookupServiceTest` and the `PsnPlayerLookupServiceTest` cases (including the new trophy summary assertions) passed.
- Ran the repository test runner which executes the full suite; the full run completed but there are unrelated pre-existing failures/errors in other tests (`PlayerQueueResponseFactoryTest`, `PsnGameLookupServiceTest`, and `TrophyMergeServiceCopyMergedTrophiesTest`) that are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee8ccdb654832f9957605674200b01)