### PR TITLE
Persist worker refresh_token to setting.refresh_token after successful PSN login

### DIFF
--- a/tests/AdminWorkerServiceTest.php
+++ b/tests/AdminWorkerServiceTest.php
@@ -77,6 +77,32 @@ SQL
         $this->assertFalse($service->updateWorkerNpsso(42, 'does-not-exist'));
     }
 
+    public function testUpdateWorkerRefreshTokenReturnsTrueWhenRowUpdated(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY AUTOINCREMENT, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_start TEXT, scan_progress TEXT)');
+        $database->exec("INSERT INTO setting (refresh_token, npsso, scanning, scan_start) VALUES ('old-token', 'npsso-1', 'player-one', '2024-01-01 09:00:00')");
+
+        $service = new WorkerService($database);
+        $this->assertTrue($service->updateWorkerRefreshToken(1, 'new-token'));
+
+        $statement = $database->query('SELECT refresh_token FROM setting WHERE id = 1');
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertSame('new-token', $row['refresh_token']);
+    }
+
+    public function testUpdateWorkerRefreshTokenReturnsFalseWhenRowMissing(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY AUTOINCREMENT, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_start TEXT, scan_progress TEXT)');
+
+        $service = new WorkerService($database);
+        $this->assertFalse($service->updateWorkerRefreshToken(42, 'does-not-exist'));
+    }
+
     public function testFetchWorkersHandlesInvalidScanProgress(): void
     {
         $database = new PDO('sqlite::memory:');

--- a/tests/PsnPlayerLookupServiceTest.php
+++ b/tests/PsnPlayerLookupServiceTest.php
@@ -180,6 +180,48 @@ final class PsnPlayerLookupServiceTest extends TestCase
         $this->assertSame('42', $result['profile']['accountId']);
     }
 
+    public function testLookupSucceedsWhenRefreshTokenPersistenceFails(): void
+    {
+        $worker = new Worker(1, 'valid-npsso', '', new DateTimeImmutable('2024-01-01T00:00:00+00:00'), null);
+
+        $service = new PsnPlayerLookupService(
+            static fn (): array => [$worker],
+            static fn (): object => new class {
+                public function loginWithNpsso(string $npsso): void
+                {
+                }
+
+                public function getRefreshToken(): object
+                {
+                    return new class {
+                        public function getToken(): string
+                        {
+                            return 'refresh-token';
+                        }
+                    };
+                }
+
+                public function get(string $path = '', array $query = [], array $headers = []): object
+                {
+                    return (object) [
+                        'profile' => (object) [
+                            'onlineId' => 'Hunter',
+                            'accountId' => '42',
+                        ],
+                    ];
+                }
+            },
+            static function (): bool {
+                throw new RuntimeException('Failed to persist refresh token.');
+            }
+        );
+
+        $result = $service->lookup('Hunter');
+
+        $this->assertSame('Hunter', $result['profile']['onlineId']);
+        $this->assertSame('42', $result['profile']['accountId']);
+    }
+
     public function testLookupThrowsWhenNoWorkerCanAuthenticate(): void
     {
         $service = new PsnPlayerLookupService(

--- a/tests/ThirtyMinuteCronJobWorkerValidationTest.php
+++ b/tests/ThirtyMinuteCronJobWorkerValidationTest.php
@@ -50,4 +50,39 @@ final class ThirtyMinuteCronJobWorkerValidationTest extends TestCase
             $this->assertSame('Worker ID must be greater than zero. Received: 0', $exception->getMessage());
         }
     }
+
+    public function testSaveWorkerRefreshTokenBestEffortLogsAndDoesNotThrowOnFailure(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY, npsso TEXT, scanning TEXT, scan_progress TEXT, refresh_token TEXT)');
+        $database->exec('CREATE TABLE log (message TEXT NOT NULL)');
+        $database->exec("INSERT INTO setting (id, npsso, scanning, scan_progress, refresh_token) VALUES (1, 'token', NULL, NULL, NULL)");
+
+        $logger = new Psn100Logger($database);
+        $cronJob = new ThirtyMinuteCronJob(
+            $database,
+            new TrophyCalculator($database),
+            $logger,
+            new TrophyHistoryRecorder($database, $logger),
+            1
+        );
+
+        $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'saveWorkerRefreshTokenBestEffort');
+        $method->setAccessible(true);
+
+        $method->invoke($cronJob, 1, new class {
+            public function getRefreshToken(): object
+            {
+                throw new RuntimeException('db unavailable');
+            }
+        });
+
+        $statement = $database->query('SELECT message FROM log ORDER BY rowid DESC LIMIT 1');
+        $message = $statement !== false ? $statement->fetchColumn() : false;
+        $this->assertSame(
+            'Failed to persist refresh token for worker 1: db unavailable',
+            $message !== false ? (string) $message : ''
+        );
+    }
 }

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -159,6 +159,7 @@ class GameRescanService
                 try {
                     $client = new Client();
                     $client->loginWithNpsso($worker['npsso']);
+                    $this->saveWorkerRefreshToken((int) $worker['id'], $client);
 
                     return $client;
                 } catch (TypeError $exception) {
@@ -178,6 +179,28 @@ class GameRescanService
         $query->execute();
 
         return $query->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    private function saveWorkerRefreshToken(int $workerId, object $client): void
+    {
+        if (!method_exists($client, 'getRefreshToken')) {
+            return;
+        }
+
+        $refreshToken = $client->getRefreshToken();
+        if (!is_object($refreshToken) || !method_exists($refreshToken, 'getToken')) {
+            return;
+        }
+
+        $tokenValue = $refreshToken->getToken();
+        if (!is_string($tokenValue) || $tokenValue === '') {
+            return;
+        }
+
+        $query = $this->database->prepare('UPDATE setting SET refresh_token = :refresh_token WHERE id = :id');
+        $query->bindValue(':refresh_token', $tokenValue, PDO::PARAM_STR);
+        $query->bindValue(':id', $workerId, PDO::PARAM_INT);
+        $query->execute();
     }
 
     private function logMessage(string $message): void

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -159,7 +159,7 @@ class GameRescanService
                 try {
                     $client = new Client();
                     $client->loginWithNpsso($worker['npsso']);
-                    $this->saveWorkerRefreshToken((int) $worker['id'], $client);
+                    $this->saveWorkerRefreshTokenBestEffort((int) $worker['id'], $client);
 
                     return $client;
                 } catch (TypeError $exception) {
@@ -179,6 +179,15 @@ class GameRescanService
         $query->execute();
 
         return $query->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    private function saveWorkerRefreshTokenBestEffort(int $workerId, object $client): void
+    {
+        try {
+            $this->saveWorkerRefreshToken($workerId, $client);
+        } catch (Throwable) {
+            // Refresh-token persistence is best-effort and must not fail authentication.
+        }
     }
 
     private function saveWorkerRefreshToken(int $workerId, object $client): void

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -19,23 +19,35 @@ final class PsnGameLookupService
      * @var \Closure(): object
      */
     private readonly \Closure $clientFactory;
+    /**
+     * @var \Closure(int, string): void
+     */
+    private readonly \Closure $refreshTokenSaver;
 
     public function __construct(
         private readonly PDO $database,
         callable $workerFetcher,
-        ?callable $clientFactory = null
+        ?callable $clientFactory = null,
+        ?callable $refreshTokenSaver = null
     ) {
         $this->workerFetcher = \Closure::fromCallable($workerFetcher);
         $this->clientFactory = \Closure::fromCallable(
             $clientFactory ?? static fn (): object => new Client()
         );
+        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? static function (int $workerId, string $refreshToken): void {
+        });
     }
 
     public static function fromDatabase(PDO $database): self
     {
         $workerService = new WorkerService($database);
 
-        return new self($database, static fn (): array => $workerService->fetchWorkers());
+        return new self(
+            $database,
+            static fn (): array => $workerService->fetchWorkers(),
+            null,
+            static fn (int $workerId, string $refreshToken): bool => $workerService->updateWorkerRefreshToken($workerId, $refreshToken)
+        );
     }
 
     /**
@@ -343,6 +355,7 @@ final class PsnGameLookupService
                 }
 
                 $client->loginWithNpsso($npsso);
+                $this->saveRefreshToken($worker->getId(), $client);
 
                 return $client;
             } catch (Throwable) {
@@ -351,6 +364,25 @@ final class PsnGameLookupService
         }
 
         throw new RuntimeException('Unable to login to any worker accounts.');
+    }
+
+    private function saveRefreshToken(int $workerId, object $client): void
+    {
+        if (!method_exists($client, 'getRefreshToken')) {
+            return;
+        }
+
+        $refreshToken = $client->getRefreshToken();
+        if (!is_object($refreshToken) || !method_exists($refreshToken, 'getToken')) {
+            return;
+        }
+
+        $tokenValue = $refreshToken->getToken();
+        if (!is_string($tokenValue) || $tokenValue === '') {
+            return;
+        }
+
+        ($this->refreshTokenSaver)($workerId, $tokenValue);
     }
 
     /**

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -355,7 +355,7 @@ final class PsnGameLookupService
                 }
 
                 $client->loginWithNpsso($npsso);
-                $this->saveRefreshToken($worker->getId(), $client);
+                $this->persistRefreshTokenBestEffort($worker->getId(), $client);
 
                 return $client;
             } catch (Throwable) {
@@ -364,6 +364,15 @@ final class PsnGameLookupService
         }
 
         throw new RuntimeException('Unable to login to any worker accounts.');
+    }
+
+    private function persistRefreshTokenBestEffort(int $workerId, object $client): void
+    {
+        try {
+            $this->saveRefreshToken($workerId, $client);
+        } catch (Throwable) {
+            // Refresh-token persistence is best-effort and must not fail authentication.
+        }
     }
 
     private function saveRefreshToken(int $workerId, object $client): void

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -19,12 +19,16 @@ final class PsnPlayerLookupService
      * @var \Closure(): object
      */
     private readonly \Closure $clientFactory;
+    /**
+     * @var \Closure(int, string): void
+     */
+    private readonly \Closure $refreshTokenSaver;
 
     /**
      * @param callable(): iterable<Worker> $workerFetcher
      * @param callable(): object|null $clientFactory
      */
-    public function __construct(callable $workerFetcher, ?callable $clientFactory = null)
+    public function __construct(callable $workerFetcher, ?callable $clientFactory = null, ?callable $refreshTokenSaver = null)
     {
         $this->workerFetcher = \Closure::fromCallable($workerFetcher);
         $this->clientFactory = \Closure::fromCallable(
@@ -32,13 +36,19 @@ final class PsnPlayerLookupService
                 return new Client();
             }
         );
+        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? static function (int $workerId, string $refreshToken): void {
+        });
     }
 
     public static function fromDatabase(PDO $database): self
     {
         $workerService = new WorkerService($database);
 
-        return new self(static fn (): array => $workerService->fetchWorkers());
+        return new self(
+            static fn (): array => $workerService->fetchWorkers(),
+            null,
+            static fn (int $workerId, string $refreshToken): bool => $workerService->updateWorkerRefreshToken($workerId, $refreshToken)
+        );
     }
 
     /**
@@ -117,6 +127,7 @@ final class PsnPlayerLookupService
                 }
 
                 $client->loginWithNpsso($npsso);
+                $this->saveRefreshToken($worker->getId(), $client);
 
                 return $client;
             } catch (Throwable) {
@@ -125,6 +136,25 @@ final class PsnPlayerLookupService
         }
 
         throw new RuntimeException('Unable to login to any worker accounts.');
+    }
+
+    private function saveRefreshToken(int $workerId, object $client): void
+    {
+        if (!method_exists($client, 'getRefreshToken')) {
+            return;
+        }
+
+        $refreshToken = $client->getRefreshToken();
+        if (!is_object($refreshToken) || !method_exists($refreshToken, 'getToken')) {
+            return;
+        }
+
+        $tokenValue = $refreshToken->getToken();
+        if (!is_string($tokenValue) || $tokenValue === '') {
+            return;
+        }
+
+        ($this->refreshTokenSaver)($workerId, $tokenValue);
     }
 
     private function executeUserProfileRequest(object $client, string $onlineId): mixed

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -127,7 +127,7 @@ final class PsnPlayerLookupService
                 }
 
                 $client->loginWithNpsso($npsso);
-                $this->saveRefreshToken($worker->getId(), $client);
+                $this->persistRefreshTokenBestEffort($worker->getId(), $client);
 
                 return $client;
             } catch (Throwable) {
@@ -136,6 +136,15 @@ final class PsnPlayerLookupService
         }
 
         throw new RuntimeException('Unable to login to any worker accounts.');
+    }
+
+    private function persistRefreshTokenBestEffort(int $workerId, object $client): void
+    {
+        try {
+            $this->saveRefreshToken($workerId, $client);
+        } catch (Throwable) {
+            // Refresh-token persistence is best-effort and must not fail authentication.
+        }
     }
 
     private function saveRefreshToken(int $workerId, object $client): void

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -123,7 +123,7 @@ final class PsnTrophyTitleComparisonService
                 }
 
                 $client->loginWithNpsso($npsso);
-                $this->saveRefreshToken($worker->getId(), $client);
+                $this->persistRefreshTokenBestEffort($worker->getId(), $client);
 
                 return $client;
             } catch (Throwable) {
@@ -132,6 +132,15 @@ final class PsnTrophyTitleComparisonService
         }
 
         throw new RuntimeException('Unable to login to any worker accounts.');
+    }
+
+    private function persistRefreshTokenBestEffort(int $workerId, object $client): void
+    {
+        try {
+            $this->saveRefreshToken($workerId, $client);
+        } catch (Throwable) {
+            // Refresh-token persistence is best-effort and must not fail authentication.
+        }
     }
 
     private function saveRefreshToken(int $workerId, object $client): void

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -22,6 +22,10 @@ final class PsnTrophyTitleComparisonService
      * @var \Closure(): object
      */
     private readonly \Closure $clientFactory;
+    /**
+     * @var \Closure(int, string): void
+     */
+    private readonly \Closure $refreshTokenSaver;
 
     /**
      * @var \Closure(): float
@@ -37,17 +41,25 @@ final class PsnTrophyTitleComparisonService
         callable $workerFetcher,
         ?callable $clientFactory = null,
         ?callable $timeProvider = null,
+        ?callable $refreshTokenSaver = null,
     ) {
         $this->workerFetcher = \Closure::fromCallable($workerFetcher);
         $this->clientFactory = \Closure::fromCallable($clientFactory ?? static fn (): object => new Client());
         $this->timeProvider = \Closure::fromCallable($timeProvider ?? static fn (): float => microtime(true));
+        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? static function (int $workerId, string $refreshToken): void {
+        });
     }
 
     public static function fromDatabase(PDO $database): self
     {
         $workerService = new WorkerService($database);
 
-        return new self(static fn (): array => $workerService->fetchWorkers());
+        return new self(
+            static fn (): array => $workerService->fetchWorkers(),
+            null,
+            null,
+            static fn (int $workerId, string $refreshToken): bool => $workerService->updateWorkerRefreshToken($workerId, $refreshToken)
+        );
     }
 
     /**
@@ -111,6 +123,7 @@ final class PsnTrophyTitleComparisonService
                 }
 
                 $client->loginWithNpsso($npsso);
+                $this->saveRefreshToken($worker->getId(), $client);
 
                 return $client;
             } catch (Throwable) {
@@ -119,6 +132,25 @@ final class PsnTrophyTitleComparisonService
         }
 
         throw new RuntimeException('Unable to login to any worker accounts.');
+    }
+
+    private function saveRefreshToken(int $workerId, object $client): void
+    {
+        if (!method_exists($client, 'getRefreshToken')) {
+            return;
+        }
+
+        $refreshToken = $client->getRefreshToken();
+        if (!is_object($refreshToken) || !method_exists($refreshToken, 'getToken')) {
+            return;
+        }
+
+        $tokenValue = $refreshToken->getToken();
+        if (!is_string($tokenValue) || $tokenValue === '') {
+            return;
+        }
+
+        ($this->refreshTokenSaver)($workerId, $tokenValue);
     }
 
     /**

--- a/wwwroot/classes/Admin/WorkerService.php
+++ b/wwwroot/classes/Admin/WorkerService.php
@@ -88,6 +88,22 @@ final class WorkerService
         return $statement->rowCount() > 0;
     }
 
+    public function updateWorkerRefreshToken(int $workerId, string $refreshToken): bool
+    {
+        $statement = $this->database->prepare('UPDATE setting SET refresh_token = :refresh_token WHERE id = :id');
+
+        if ($statement === false) {
+            return false;
+        }
+
+        $statement->bindValue(':refresh_token', $refreshToken, PDO::PARAM_STR);
+        $statement->bindValue(':id', $workerId, PDO::PARAM_INT);
+
+        $statement->execute();
+
+        return $statement->rowCount() > 0;
+    }
+
     public function restartWorker(int $workerId): CommandExecutionResult
     {
         return $this->commandExecutor->run([

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -327,6 +327,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                     $client = new Client();
                     $npsso = $worker["npsso"];
                     $client->loginWithNpsso($npsso);
+                    $this->saveWorkerRefreshToken((int) $worker['id'], $client);
 
                     $loggedIn = true;
                 } catch (TypeError $e) {
@@ -2003,6 +2004,28 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                 $this->setWorkerScanProgress((int) $worker['id'], null);
             }
         }
+    }
+
+    private function saveWorkerRefreshToken(int $workerId, object $client): void
+    {
+        if (!method_exists($client, 'getRefreshToken')) {
+            return;
+        }
+
+        $refreshToken = $client->getRefreshToken();
+        if (!is_object($refreshToken) || !method_exists($refreshToken, 'getToken')) {
+            return;
+        }
+
+        $tokenValue = $refreshToken->getToken();
+        if (!is_string($tokenValue) || $tokenValue === '') {
+            return;
+        }
+
+        $query = $this->database->prepare('UPDATE setting SET refresh_token = :refresh_token WHERE id = :id');
+        $query->bindValue(':refresh_token', $tokenValue, PDO::PARAM_STR);
+        $query->bindValue(':id', $workerId, PDO::PARAM_INT);
+        $query->execute();
     }
 
     /**

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -327,9 +327,8 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                     $client = new Client();
                     $npsso = $worker["npsso"];
                     $client->loginWithNpsso($npsso);
-                    $this->saveWorkerRefreshToken((int) $worker['id'], $client);
-
                     $loggedIn = true;
+                    $this->saveWorkerRefreshTokenBestEffort((int) $worker['id'], $client);
                 } catch (TypeError $e) {
                     // Something odd, let's wait a minute
                     $this->setWaitingScanProgress(
@@ -2003,6 +2002,17 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             } finally {
                 $this->setWorkerScanProgress((int) $worker['id'], null);
             }
+        }
+    }
+
+    private function saveWorkerRefreshTokenBestEffort(int $workerId, object $client): void
+    {
+        try {
+            $this->saveWorkerRefreshToken($workerId, $client);
+        } catch (Throwable $exception) {
+            $this->logger->log(
+                sprintf('Failed to persist refresh token for worker %d: %s', $workerId, $exception->getMessage())
+            );
         }
     }
 


### PR DESCRIPTION
### Motivation
- Save the PSN `refresh_token` after a successful NPSSO login so workers can reuse it for future authentication without exposing or reusing the NPSSO cookie flow.
- The upstream `tustin/psn-php` client exposes the refresh token via `getRefreshToken()` so persist it when available for reliability and reduced login friction.

### Description
- Add `WorkerService::updateWorkerRefreshToken(int, string): bool` to centrally update `setting.refresh_token`.
- Persist refresh tokens immediately after successful `Client::loginWithNpsso(...)` in all worker-login code paths by calling a saver callback or directly updating the DB: `PsnPlayerLookupService`, `PsnGameLookupService`, `PsnTrophyTitleComparisonService`, `GameRescanService`, and `ThirtyMinuteCronJob`.
- Each admin lookup service now accepts an optional refresh-token saver closure and its `fromDatabase()` factory wires it to `WorkerService::updateWorkerRefreshToken()`.
- Add helper `saveRefreshToken` / `saveWorkerRefreshToken` implementations that validate the presence of `getRefreshToken()` and `getToken()` on the client before persisting.
- Add tests in `tests/AdminWorkerServiceTest.php` to cover `updateWorkerRefreshToken` success and missing-row cases.

### Testing
- Ran PHP lint on changed files with `php -l` for all modified PHP sources and `tests/AdminWorkerServiceTest.php`, all reported no syntax errors.
- Ran the test suite with `php tests/run.php`; the suite executed but the repository already contains unrelated failures/errors: `PlayerQueueResponseFactoryTest::testCreateQueuedForScanResponseUsesActionVerbsForProgressTitle` (failure), `TrophyMergeServiceCopyMergedTrophiesTest::testCopyMergedTrophiesBulkCopiesEarnedProgressWithDerivedTables` (failure), and an error in `PsnGameLookupServiceTest::testFetchTrophyDataForNpCommunicationIdPreservesGroupedPayloadWhenFlatTrophiesMissing` (undefined assertion method); these pre-existing issues are unrelated to the refresh-token changes.
- The new/updated `AdminWorkerServiceTest` assertions for `updateWorkerRefreshToken` passed in the full run output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee942fd564832f8c4cc839af8dd12e)