### PR TITLE
Fix queue progress formatting and grouped trophy lookup fallback

### DIFF
--- a/tests/PsnGameLookupServiceTest.php
+++ b/tests/PsnGameLookupServiceTest.php
@@ -168,7 +168,7 @@ final class PsnGameLookupServiceTest extends TestCase
 
         $result = $service->fetchTrophyDataForNpCommunicationId('NPWR00000_00', $providedClient);
 
-        $this->assertArrayNotHasKey('trophies', $result);
+        $this->assertFalse(array_key_exists('trophies', $result));
         $this->assertSame('all', $result['trophyGroups'][0]['trophyGroupId']);
         $this->assertSame('Bronze Trophy', $result['trophyGroups'][0]['trophies'][0]['trophyName']);
     }

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -182,6 +182,9 @@ final class PsnGameLookupService
         }
 
         $groupedTrophies = $this->groupTrophiesByGroupId($normalizedResponse['trophies'] ?? null);
+        if ($groupedTrophies === []) {
+            $groupedTrophies = $this->groupNestedTrophiesFromGroups($normalizedResponse['trophyGroups'] ?? null);
+        }
         $normalizedResponse['trophyGroups'] = $this->buildTrophyGroups(
             $normalizedGroupResponse['trophyGroups'] ?? null,
             $groupedTrophies
@@ -274,6 +277,44 @@ final class PsnGameLookupService
         }
 
         return array_values($groups);
+    }
+
+    /**
+     * @return array<int, array{trophyGroupId: string, trophyGroupName: string, trophyGroupDetail: string, trophyGroupIconUrl: string, trophies: array<int, array<string, mixed>>}>
+     */
+    private function groupNestedTrophiesFromGroups(mixed $rawGroups): array
+    {
+        if (!is_array($rawGroups)) {
+            return [];
+        }
+
+        $groups = [];
+
+        foreach ($rawGroups as $rawGroup) {
+            if (!is_array($rawGroup)) {
+                continue;
+            }
+
+            $groupId = (string) ($rawGroup['trophyGroupId'] ?? '');
+            if ($groupId === '') {
+                continue;
+            }
+
+            $trophies = $rawGroup['trophies'] ?? null;
+            if (!is_array($trophies)) {
+                $trophies = [];
+            }
+
+            $groups[] = [
+                'trophyGroupId' => $groupId,
+                'trophyGroupName' => (string) ($rawGroup['trophyGroupName'] ?? ''),
+                'trophyGroupDetail' => (string) ($rawGroup['trophyGroupDetail'] ?? ''),
+                'trophyGroupIconUrl' => (string) ($rawGroup['trophyGroupIconUrl'] ?? ''),
+                'trophies' => $trophies,
+            ];
+        }
+
+        return $groups;
     }
 
     private function resolvePreferredNpServiceName(string $npCommunicationId): ?string

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -151,9 +151,10 @@ final class PlayerQueueResponseFactory
         }
 
         if (preg_match('/^(Updating|Fetching)\b/i', $normalizedTitle) === 1) {
-            $actionText = ucfirst($normalizedTitle);
+            $actionText = strtolower($normalizedTitle);
+            $escapedActionText = $this->service->escapeHtml($actionText);
 
-            return $this->service->escapeHtml($actionText);
+            return ucfirst($escapedActionText);
         }
 
         if ($this->isErrorProgressTitle($normalizedTitle)) {


### PR DESCRIPTION
### Motivation
- Two unit tests were failing: one for queue scan progress formatting and one for PSN trophy lookup grouping when API payload omitted flat `trophies` data. The intent is to keep user-facing messages correct while ensuring grouped trophy data is preserved when only nested `trophyGroups[].trophies` is present. 
- Make the test expectations compatible with the in-repo test helper API.

### Description
- Adjusted `formatProgressTitle` in `wwwroot/classes/PlayerQueueResponseFactory.php` to normalize action-verb titles to lowercase, escape them, then return sentence-case with `ucfirst` so escaped text preserves lowercasing while rendered text matches expected sentence case. (`formatProgressTitle`) 
- Added a fallback in `wwwroot/classes/Admin/PsnGameLookupService.php` to derive grouped trophies from `trophyGroups[].trophies` when flat `trophies` is missing by introducing `groupNestedTrophiesFromGroups()` and using it when `groupTrophiesByGroupId()` returns empty. 
- Updated the failing test in `tests/PsnGameLookupServiceTest.php` to use the project test helper-compatible assertion `assertFalse(array_key_exists(...))` instead of `assertArrayNotHasKey()`. 
- No external skills were used for these changes.

### Testing
- Linted modified files with `php -l` for `wwwroot/classes/Admin/PsnGameLookupService.php`, `wwwroot/classes/PlayerQueueResponseFactory.php`, and `tests/PsnGameLookupServiceTest.php` with no syntax errors. 
- Ran full test suite with `php tests/run.php` and confirmed all tests passed: 474/474.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef14b43fbc832f884a81eac01c07c8)