### PR TITLE
Prevent set_version downgrades; normalize and compare versions with tests

### DIFF
--- a/tests/GameRescanServiceSetVersionTest.php
+++ b/tests/GameRescanServiceSetVersionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/TrophyCalculator.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanDifferenceTracker.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanService.php';
+
+final class GameRescanServiceSetVersionTest extends TestCase
+{
+    public function testIsSetVersionAtLeastCurrentReturnsFalseForLowerVersion(): void
+    {
+        $method = new ReflectionMethod(GameRescanService::class, 'isSetVersionAtLeastCurrent');
+        $method->setAccessible(true);
+
+        $result = $method->invoke(null, '01.09', '01.10');
+
+        $this->assertFalse($result);
+    }
+
+    public function testIsSetVersionAtLeastCurrentAllowsEqualOrGreaterVersions(): void
+    {
+        $method = new ReflectionMethod(GameRescanService::class, 'isSetVersionAtLeastCurrent');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke(null, '01.10', '01.10'));
+        $this->assertTrue($method->invoke(null, '01.11', '01.10'));
+    }
+
+    public function testUpdateTrophySetVersionSkipsDowngrade(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE trophy_title (np_communication_id TEXT PRIMARY KEY, set_version TEXT)');
+        $database->exec("INSERT INTO trophy_title (np_communication_id, set_version) VALUES ('NPWR00001_00', '01.10')");
+
+        $service = new GameRescanService($database, new TrophyCalculator($database));
+        $differenceTracker = new GameRescanDifferenceTracker();
+
+        $method = new ReflectionMethod(GameRescanService::class, 'updateTrophySetVersion');
+        $method->setAccessible(true);
+        $method->invoke($service, 'NPWR00001_00', '01.09', $differenceTracker);
+
+        $updatedVersion = $database->query(
+            "SELECT set_version FROM trophy_title WHERE np_communication_id = 'NPWR00001_00'"
+        )->fetchColumn();
+
+        $this->assertSame('01.10', $updatedVersion);
+        $this->assertSame([], $differenceTracker->getDifferences());
+    }
+}

--- a/tests/ThirtyMinuteCronJobSetVersionTest.php
+++ b/tests/ThirtyMinuteCronJobSetVersionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Psn100Logger.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyCalculator.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyHistoryRecorder.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/ThirtyMinuteCronJob.php';
+
+final class ThirtyMinuteCronJobSetVersionTest extends TestCase
+{
+    private ThirtyMinuteCronJob $cronJob;
+
+    protected function setUp(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE log (message TEXT NOT NULL)');
+
+        $logger = new Psn100Logger($database);
+        $this->cronJob = new ThirtyMinuteCronJob(
+            $database,
+            new TrophyCalculator($database),
+            $logger,
+            new TrophyHistoryRecorder($database, $logger),
+            1
+        );
+    }
+
+    public function testResolveSetVersionForUpdateKeepsCurrentWhenNewVersionIsLower(): void
+    {
+        $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'resolveSetVersionForUpdate');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->cronJob, '01.09', '01.10');
+
+        $this->assertSame('01.10', $result);
+    }
+
+    public function testResolveSetVersionForUpdateAllowsEqualOrHigherVersion(): void
+    {
+        $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'resolveSetVersionForUpdate');
+        $method->setAccessible(true);
+
+        $this->assertSame('01.10', $method->invoke($this->cronJob, '01.10', '01.10'));
+        $this->assertSame('01.11', $method->invoke($this->cronJob, '01.11', '01.10'));
+    }
+
+    public function testResolveSetVersionForUpdateUsesNewVersionWhenCurrentMissing(): void
+    {
+        $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'resolveSetVersionForUpdate');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->cronJob, '01.05', null);
+
+        $this->assertSame('01.05', $result);
+    }
+}

--- a/tests/ThirtyMinuteCronJobSetVersionTest.php
+++ b/tests/ThirtyMinuteCronJobSetVersionTest.php
@@ -56,4 +56,24 @@ final class ThirtyMinuteCronJobSetVersionTest extends TestCase
 
         $this->assertSame('01.05', $result);
     }
+
+
+    public function testIsIncomingSetVersionOlderThanStoredReturnsTrueForLowerVersion(): void
+    {
+        $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'isIncomingSetVersionOlderThanStored');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->cronJob, '01.09', '01.10');
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsIncomingSetVersionOlderThanStoredReturnsFalseForEqualOrHigherVersion(): void
+    {
+        $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'isIncomingSetVersionOlderThanStored');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($this->cronJob, '01.10', '01.10'));
+        $this->assertFalse($method->invoke($this->cronJob, '01.11', '01.10'));
+    }
 }

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -390,6 +390,13 @@ class GameRescanService
         GameRescanDifferenceTracker $differenceTracker
     ): array {
         $existingTitleInfo = $this->fetchExistingTrophyTitleInfo($npCommunicationId);
+
+        if (!self::isSetVersionAtLeastCurrent((string) $trophyTitle->trophySetVersion(), $existingTitleInfo['set_version'])) {
+            $this->notifyProgress($progressListener, 70, 'Skipping trophy refresh because incoming set version is lower.');
+
+            return [];
+        }
+
         $existingGroupData = $this->fetchExistingTrophyGroupData($npCommunicationId);
         $existingTrophyData = $this->fetchExistingTrophyData($npCommunicationId);
 
@@ -1003,6 +1010,10 @@ class GameRescanService
     ): void {
         $previousVersion = $this->fetchCurrentTrophySetVersion($npCommunicationId);
 
+        if (!self::isSetVersionAtLeastCurrent($setVersion, $previousVersion)) {
+            return;
+        }
+
         $query = $this->database->prepare(
             'UPDATE trophy_title
             SET set_version = :set_version
@@ -1013,6 +1024,17 @@ class GameRescanService
         $query->execute();
 
         $differenceTracker->recordTitleChange('Set Version', $previousVersion, $setVersion);
+    }
+
+    private static function isSetVersionAtLeastCurrent(string $newVersion, ?string $currentVersion): bool
+    {
+        $normalizedCurrentVersion = $currentVersion === null ? null : trim($currentVersion);
+
+        if ($normalizedCurrentVersion === null || $normalizedCurrentVersion === '') {
+            return true;
+        }
+
+        return version_compare(trim($newVersion), $normalizedCurrentVersion, '>=');
     }
 
     private function recordRescan(int $gameId): void

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1003,6 +1003,11 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                             $existingTitleQuery->execute();
                             $existingTitle = $existingTitleQuery->fetch(PDO::FETCH_ASSOC) ?: null;
                             $isNewTitle = $existingTitle === null;
+                            $incomingSetVersion = $trophyTitle->trophySetVersion();
+                            $setVersionForUpdate = $this->resolveSetVersionForUpdate(
+                                $incomingSetVersion,
+                                is_array($existingTitle) ? ($existingTitle['set_version'] ?? null) : null
+                            );
 
                             $previousTitleIconFilename = $existingTitle['icon_url'] ?? null;
                             $titleIconFilename = $previousTitleIconFilename;
@@ -1011,7 +1016,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
 
                             $titleNeedsUpdate = $existingTitle === null
                                 || $existingTitle['detail'] !== $trophyTitle->detail()
-                                || $existingTitle['set_version'] !== $trophyTitle->trophySetVersion();
+                                || $existingTitle['set_version'] !== $setVersionForUpdate;
 
                             if ($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) {
                                 $titleIconFilename = $this->downloadMandatoryImage(
@@ -1049,7 +1054,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 $query->bindValue(":detail", $trophyTitle->detail(), PDO::PARAM_STR);
                                 $query->bindValue(":icon_url", $titleIconFilename, PDO::PARAM_STR);
                                 $query->bindValue(":platform", $platforms, PDO::PARAM_STR);
-                                $query->bindValue(":set_version", $trophyTitle->trophySetVersion(), PDO::PARAM_STR);
+                                $query->bindValue(":set_version", $setVersionForUpdate, PDO::PARAM_STR);
                                 // Don't insert platinum/gold/silver/bronze here since our site recalculate this.
                                 $query->execute();
 
@@ -2767,5 +2772,35 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         }
 
         return false;
+    }
+
+    private function resolveSetVersionForUpdate(string $newVersion, mixed $currentVersion): string
+    {
+        $normalizedCurrentVersion = $this->normalizeSetVersion($currentVersion);
+
+        if ($normalizedCurrentVersion === null) {
+            return trim($newVersion);
+        }
+
+        if (version_compare(trim($newVersion), $normalizedCurrentVersion, '<')) {
+            return $normalizedCurrentVersion;
+        }
+
+        return trim($newVersion);
+    }
+
+    private function normalizeSetVersion(mixed $version): ?string
+    {
+        if (!is_string($version)) {
+            return null;
+        }
+
+        $trimmedVersion = trim($version);
+
+        if ($trimmedVersion === '') {
+            return null;
+        }
+
+        return $trimmedVersion;
     }
 }

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1008,6 +1008,10 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 $incomingSetVersion,
                                 is_array($existingTitle) ? ($existingTitle['set_version'] ?? null) : null
                             );
+                            $incomingVersionIsOlderThanStored = $this->isIncomingSetVersionOlderThanStored(
+                                $incomingSetVersion,
+                                is_array($existingTitle) ? ($existingTitle['set_version'] ?? null) : null
+                            );
 
                             $previousTitleIconFilename = $existingTitle['icon_url'] ?? null;
                             $titleIconFilename = $previousTitleIconFilename;
@@ -1015,10 +1019,15 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 || !file_exists(self::TITLE_ICON_DIRECTORY . $titleIconFilename);
 
                             $titleNeedsUpdate = $existingTitle === null
-                                || $existingTitle['detail'] !== $trophyTitle->detail()
-                                || $existingTitle['set_version'] !== $setVersionForUpdate;
+                                || (
+                                    !$incomingVersionIsOlderThanStored
+                                    && (
+                                        $existingTitle['detail'] !== $trophyTitle->detail()
+                                        || $existingTitle['set_version'] !== $setVersionForUpdate
+                                    )
+                                );
 
-                            if ($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) {
+                            if (($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) && !$incomingVersionIsOlderThanStored) {
                                 $titleIconFilename = $this->downloadMandatoryImage(
                                     $trophyTitle->iconUrl(),
                                     self::TITLE_ICON_DIRECTORY,
@@ -1027,7 +1036,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 );
                             }
 
-                            if ($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) {
+                            if (($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) && !$incomingVersionIsOlderThanStored) {
                                 $query = $this->database->prepare("INSERT INTO trophy_title(
                                         np_communication_id,
                                         name,
@@ -2781,6 +2790,18 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         }
 
         return false;
+    }
+
+
+    private function isIncomingSetVersionOlderThanStored(string $newVersion, mixed $currentVersion): bool
+    {
+        $normalizedCurrentVersion = $this->normalizeSetVersion($currentVersion);
+
+        if ($normalizedCurrentVersion === null) {
+            return false;
+        }
+
+        return version_compare(trim($newVersion), $normalizedCurrentVersion, '<');
     }
 
     private function resolveSetVersionForUpdate(string $newVersion, mixed $currentVersion): string

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1027,7 +1027,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                     )
                                 );
 
-                            if (($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) && !$incomingVersionIsOlderThanStored) {
+                            if ($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) {
                                 $titleIconFilename = $this->downloadMandatoryImage(
                                     $trophyTitle->iconUrl(),
                                     self::TITLE_ICON_DIRECTORY,
@@ -1036,7 +1036,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 );
                             }
 
-                            if (($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) && !$incomingVersionIsOlderThanStored) {
+                            if ($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) {
                                 $query = $this->database->prepare("INSERT INTO trophy_title(
                                         np_communication_id,
                                         name,
@@ -1055,7 +1055,10 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                     ) AS new
                                     ON DUPLICATE KEY
                                     UPDATE
-                                        detail = new.detail,
+                                        detail = CASE
+                                            WHEN :incoming_version_is_older = 1 THEN trophy_title.detail
+                                            ELSE new.detail
+                                        END,
                                         icon_url = new.icon_url,
                                         set_version = CASE
                                             WHEN trophy_title.set_version IS NULL OR TRIM(trophy_title.set_version) = '' THEN new.set_version
@@ -1073,6 +1076,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 $query->bindValue(":icon_url", $titleIconFilename, PDO::PARAM_STR);
                                 $query->bindValue(":platform", $platforms, PDO::PARAM_STR);
                                 $query->bindValue(":set_version", $setVersionForUpdate, PDO::PARAM_STR);
+                                $query->bindValue(":incoming_version_is_older", $incomingVersionIsOlderThanStored ? 1 : 0, PDO::PARAM_INT);
                                 // Don't insert platinum/gold/silver/bronze here since our site recalculate this.
                                 $query->execute();
 

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1048,7 +1048,16 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                     UPDATE
                                         detail = new.detail,
                                         icon_url = new.icon_url,
-                                        set_version = new.set_version");
+                                        set_version = CASE
+                                            WHEN trophy_title.set_version IS NULL OR TRIM(trophy_title.set_version) = '' THEN new.set_version
+                                            WHEN CAST(SUBSTRING_INDEX(TRIM(new.set_version), '.', 1) AS UNSIGNED)
+                                                > CAST(SUBSTRING_INDEX(TRIM(trophy_title.set_version), '.', 1) AS UNSIGNED) THEN new.set_version
+                                            WHEN CAST(SUBSTRING_INDEX(TRIM(new.set_version), '.', 1) AS UNSIGNED)
+                                                = CAST(SUBSTRING_INDEX(TRIM(trophy_title.set_version), '.', 1) AS UNSIGNED)
+                                                AND CAST(SUBSTRING_INDEX(TRIM(new.set_version), '.', -1) AS UNSIGNED)
+                                                    >= CAST(SUBSTRING_INDEX(TRIM(trophy_title.set_version), '.', -1) AS UNSIGNED) THEN new.set_version
+                                            ELSE trophy_title.set_version
+                                        END");
                                 $query->bindValue(":np_communication_id", $npid, PDO::PARAM_STR);
                                 $query->bindValue(":name", $sanitizedTitleName, PDO::PARAM_STR);
                                 $query->bindValue(":detail", $trophyTitle->detail(), PDO::PARAM_STR);


### PR DESCRIPTION
### Motivation

- Prevent incoming older `set_version` values from overwriting newer values during rescan and cron updates by introducing normalized comparison logic.
- Centralize version normalization and comparison to avoid inconsistent behavior between the rescan service and the cron job.

### Description

- Added `GameRescanService::isSetVersionAtLeastCurrent` and used it in `updateTrophyTitle` to skip refreshing a title when the incoming `trophySetVersion` is lower, and in `updateTrophySetVersion` to avoid applying downgrades.
- In `ThirtyMinuteCronJob` introduced `resolveSetVersionForUpdate` and `normalizeSetVersion`, computed `$setVersionForUpdate` from the incoming and existing values, used that normalized value for title change detection and when binding `:set_version` for DB inserts.
- Added unit tests `tests/GameRescanServiceSetVersionTest.php` and `tests/ThirtyMinuteCronJobSetVersionTest.php` to cover the version comparison logic and the prevention of downgrades, plus small helpers included to instantiate required classes.

### Testing

- Ran `phpunit` tests covering `GameRescanServiceSetVersionTest`, which verified `isSetVersionAtLeastCurrent` behavior and that `updateTrophySetVersion` does not downgrade; tests passed.
- Ran `phpunit` tests covering `ThirtyMinuteCronJobSetVersionTest`, which verified `resolveSetVersionForUpdate` behavior when current version is missing, lower, equal, or higher; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef18948b28832f947107ef529dc641)