### PR TITLE
Rename Rarity (Meta) → Rarity (Leaderboard) and Rarity (In-Game) → Rarity (Game)

### DIFF
--- a/wwwroot/about.php
+++ b/wwwroot/about.php
@@ -630,7 +630,7 @@ require_once("header.php");
                     Thanks to <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/player/dmland12">dmland12</a> for bringing this formula to our attention (<a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="https://forum.psnprofiles.com/topic/46506-rarity-leaderboard/?page=8#comment-1852921" target="_blank">source</a>).
                 </p>
                 <p>
-                    Our Rarity (Meta) naming uses the following numbers and is calculated from player data within the top 10,000 players:
+                    Our Rarity (Leaderboard) naming uses the following numbers and is calculated from player data within the top 10,000 players:
                 </p>
                 <ul>
                     <li><span class="trophy-legendary">0-0.02% ~ Legendary</span></li>
@@ -640,7 +640,7 @@ require_once("header.php");
                     <li>10.01-100% ~ Common</li>
                 </ul>
                 <p>
-                    For Rarity (In-Game), the percentage comes from the share of trophy owners within its game, again only counting
+                    For Rarity (Game), the percentage comes from the share of trophy owners within its game, again only counting
                     owners within the top 10,000 players. The naming uses these thresholds:
                 </p>
                 <ul>

--- a/wwwroot/classes/Leaderboard/InGameRarityLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/InGameRarityLeaderboardPageContext.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/InGameRarityLeaderboardRow.php';
 
 class InGameRarityLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
-    private const TITLE = 'PSN Rarity (In-Game) Leaderboard ~ PSN 100%';
+    private const TITLE = 'PSN Rarity (Game) Leaderboard ~ PSN 100%';
 
     public function getTitle(): string
     {

--- a/wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/RarityLeaderboardRow.php';
 
 class RarityLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
-    private const TITLE = 'PSN Rarity (Meta) Leaderboard ~ PSN 100%';
+    private const TITLE = 'PSN Rarity (Leaderboard) Leaderboard ~ PSN 100%';
 
     public function getTitle(): string
     {

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -259,8 +259,8 @@ require_once __DIR__ . '/classes/Game/GamePlayerProgress.php';
                     $details = [];
 
                     if ($status === 0) {
-                        $details[] = number_format($game->getRarityPoints()) . ' Rarity (Meta) Points';
-                        $details[] = number_format($game->getInGameRarityPoints()) . ' Rarity (In-Game) Points';
+                        $details[] = number_format($game->getRarityPoints()) . ' Rarity (Leaderboard) Points';
+                        $details[] = number_format($game->getInGameRarityPoints()) . ' Rarity (Game) Points';
                     } elseif ($status === 1) {
                         $details[] = "<span class='badge rounded-pill text-bg-warning' title='This game is delisted, no trophies will be accounted for on any leaderboard.'>Delisted</span>";
                     } elseif ($status === 3) {

--- a/wwwroot/games.php
+++ b/wwwroot/games.php
@@ -122,8 +122,8 @@ require_once("header.php");
                         ?>
                         <option value="completion"<?= ($filter->isSort(GameListFilter::SORT_COMPLETION) ? ' selected' : ''); ?>>Completion Rate</option>
                         <option value="owners"<?= ($filter->isSort(GameListFilter::SORT_OWNERS) ? ' selected' : ''); ?>>Owners</option>
-                        <option value="in-game-rarity"<?= ($filter->isSort(GameListFilter::SORT_IN_GAME_RARITY) ? ' selected' : ''); ?>>Rarity (In-Game) Points</option>
-                        <option value="rarity"<?= ($filter->isSort(GameListFilter::SORT_RARITY) ? ' selected' : ''); ?>>Rarity (Meta) Points</option>
+                        <option value="in-game-rarity"<?= ($filter->isSort(GameListFilter::SORT_IN_GAME_RARITY) ? ' selected' : ''); ?>>Rarity (Game) Points</option>
+                        <option value="rarity"<?= ($filter->isSort(GameListFilter::SORT_RARITY) ? ' selected' : ''); ?>>Rarity (Leaderboard) Points</option>
                     </select>
                 </div>
             </form>
@@ -190,9 +190,9 @@ require_once("header.php");
                         <div>
                             <?php
                             if ($game->shouldShowRarityPoints() && $filter->isSort(GameListFilter::SORT_RARITY)) {
-                                echo number_format($rarityPoints) . ' Rarity (Meta) Points';
+                                echo number_format($rarityPoints) . ' Rarity (Leaderboard) Points';
                             } elseif ($game->shouldShowRarityPoints() && $filter->isSort(GameListFilter::SORT_IN_GAME_RARITY)) {
-                                echo number_format($inGameRarityPoints) . ' Rarity (In-Game) Points';
+                                echo number_format($inGameRarityPoints) . ' Rarity (Game) Points';
                             } elseif ($statusBadge !== null) {
                                 ?>
                                 <span class="<?= $statusBadge->getCssClass(); ?>" title="<?= $statusBadge->getTooltip(); ?>"><?= $statusBadge->getLabel(); ?></span>

--- a/wwwroot/leaderboard_in_game_rarity.php
+++ b/wwwroot/leaderboard_in_game_rarity.php
@@ -17,14 +17,14 @@ $shouldShowCountryRank = $leaderboardPageContext->shouldShowCountryRank();
 <main class="container">
     <div class="row">
         <div class="col-6">
-            <h1>PSN Rarity (In-Game) Leaderboard</h1>
+            <h1>PSN Rarity (Game) Leaderboard</h1>
         </div>
         <div class="col-6 d-flex justify-content-end">
             <div class="bg-body-tertiary p-3 rounded">
                 <div class="btn-group">
                     <a class="btn btn-outline-primary" href="/leaderboard/trophy?<?= http_build_query($filterParameters); ?>">Trophy</a>
-                    <a class="btn btn-outline-primary" href="/leaderboard/rarity?<?= http_build_query($filterParameters); ?>">Rarity (Meta)</a>
-                    <a class="btn btn-primary active" href="/leaderboard/in-game-rarity">Rarity (In-Game)</a>
+                    <a class="btn btn-outline-primary" href="/leaderboard/rarity?<?= http_build_query($filterParameters); ?>">Rarity (Leaderboard)</a>
+                    <a class="btn btn-primary active" href="/leaderboard/in-game-rarity">Rarity (Game)</a>
                 </div>
             </div>
         </div>

--- a/wwwroot/leaderboard_main.php
+++ b/wwwroot/leaderboard_main.php
@@ -22,8 +22,8 @@ $filterParameters = $trophyLeaderboardPageContext->getFilterQueryParameters();
             <div class="bg-body-tertiary p-3 rounded">
                 <div class="btn-group">
                     <a class="btn btn-primary active" href="/leaderboard/trophy">Trophy</a>
-                    <a class="btn btn-outline-primary" href="/leaderboard/rarity?<?= http_build_query($filterParameters); ?>">Rarity (Meta)</a>
-                    <a class="btn btn-outline-primary" href="/leaderboard/in-game-rarity?<?= http_build_query($filterParameters); ?>">Rarity (In-Game)</a>
+                    <a class="btn btn-outline-primary" href="/leaderboard/rarity?<?= http_build_query($filterParameters); ?>">Rarity (Leaderboard)</a>
+                    <a class="btn btn-outline-primary" href="/leaderboard/in-game-rarity?<?= http_build_query($filterParameters); ?>">Rarity (Game)</a>
                 </div>
             </div>
         </div>

--- a/wwwroot/leaderboard_rarity.php
+++ b/wwwroot/leaderboard_rarity.php
@@ -17,14 +17,14 @@ $shouldShowCountryRank = $rarityLeaderboardPageContext->shouldShowCountryRank();
 <main class="container">
     <div class="row">
         <div class="col-6">
-            <h1>PSN Rarity (Meta) Leaderboard</h1>
+            <h1>PSN Rarity (Leaderboard) Leaderboard</h1>
         </div>
         <div class="col-6 d-flex justify-content-end">
             <div class="bg-body-tertiary p-3 rounded">
                 <div class="btn-group">
                     <a class="btn btn-outline-primary" href="/leaderboard/trophy?<?= http_build_query($filterParameters); ?>">Trophy</a>
-                    <a class="btn btn-primary active" href="/leaderboard/rarity">Rarity (Meta)</a>
-                    <a class="btn btn-outline-primary" href="/leaderboard/in-game-rarity?<?= http_build_query($filterParameters); ?>">Rarity (In-Game)</a>
+                    <a class="btn btn-primary active" href="/leaderboard/rarity">Rarity (Leaderboard)</a>
+                    <a class="btn btn-outline-primary" href="/leaderboard/in-game-rarity?<?= http_build_query($filterParameters); ?>">Rarity (Game)</a>
                 </div>
             </div>
         </div>

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -92,11 +92,11 @@ require_once("header.php");
                             <option disabled>Sort by...</option>
                             <option value="search"<?= ($sort == "search" ? " selected" : ""); ?>>Best Match</option>
                             <option value="date"<?= ($sort == "date" ? " selected" : ""); ?>>Date</option>
-                            <option value="max-in-game-rarity"<?= ($sort == "max-in-game-rarity" ? " selected" : ""); ?>>Max Rarity (In-Game)</option>
-                            <option value="max-rarity"<?= ($sort == "max-rarity" ? " selected" : ""); ?>>Max Rarity (Meta)</option>
+                            <option value="max-in-game-rarity"<?= ($sort == "max-in-game-rarity" ? " selected" : ""); ?>>Max Rarity (Game)</option>
+                            <option value="max-rarity"<?= ($sort == "max-rarity" ? " selected" : ""); ?>>Max Rarity (Leaderboard)</option>
                             <option value="name"<?= ($sort == "name" ? " selected" : ""); ?>>Name</option>
-                            <option value="in-game-rarity"<?= ($sort == "in-game-rarity" ? " selected" : ""); ?>>Rarity (In-Game)</option>
-                            <option value="rarity"<?= ($sort == "rarity" ? " selected" : ""); ?>>Rarity (Meta)</option>
+                            <option value="in-game-rarity"<?= ($sort == "in-game-rarity" ? " selected" : ""); ?>>Rarity (Game)</option>
+                            <option value="rarity"<?= ($sort == "rarity" ? " selected" : ""); ?>>Rarity (Leaderboard)</option>
                         </select>
                     </div>
                 </form>

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -33,8 +33,8 @@ $platformFilterRenderer = PlayerPlatformFilterRenderer::createDefault();
 $playerStatusNotice = $playerAdvisorPageContext->getPlayerStatusNotice();
 $playerOnlineId = $playerAdvisorPageContext->getPlayerOnlineId();
 $rarityColumnLabel = $playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_IN_GAME_RARITY
-    ? 'Rarity (In-Game)'
-    : 'Rarity (Meta)';
+    ? 'Rarity (Game)'
+    : 'Rarity (Leaderboard)';
 
 $title = $playerAdvisorPageContext->getTitle();
 require_once("header.php");
@@ -62,8 +62,8 @@ require_once("header.php");
 
                         <select class="form-select" name="sort" onChange="this.form.submit()">
                             <option disabled>Sort by...</option>
-                            <option value="<?= PlayerAdvisorFilter::SORT_IN_GAME_RARITY; ?>"<?php if ($playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_IN_GAME_RARITY) { echo ' selected'; } ?>>Rarity (In-Game)</option>
-                            <option value="<?= PlayerAdvisorFilter::SORT_RARITY; ?>"<?php if ($playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_RARITY) { echo ' selected'; } ?>>Rarity (Meta)</option>
+                            <option value="<?= PlayerAdvisorFilter::SORT_IN_GAME_RARITY; ?>"<?php if ($playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_IN_GAME_RARITY) { echo ' selected'; } ?>>Rarity (Game)</option>
+                            <option value="<?= PlayerAdvisorFilter::SORT_RARITY; ?>"<?php if ($playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_RARITY) { echo ' selected'; } ?>>Rarity (Leaderboard)</option>
                         </select>
                     </div>
                 </form>

--- a/wwwroot/player_header.php
+++ b/wwwroot/player_header.php
@@ -241,7 +241,7 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
             <div class="bg-body-tertiary p-3 rounded w-100 h-100">
                 <div class="vstack">
                     <div>
-                        Rarity (Meta) Leaderboard
+                        Rarity (Leaderboard) Leaderboard
                     </div>
 
                     <div class="text-center bg-dark-subtle p1 rounded">
@@ -302,11 +302,11 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
 
     <div class="col-12 col-lg-4 mb-3">
         <div class="vstack gap-3 text-center h-100">
-            <!-- Rarity (In-Game) Leaderboard -->
+            <!-- Rarity (Game) Leaderboard -->
             <div class="bg-body-tertiary p-3 rounded w-100 h-100">
                 <div class="vstack">
                     <div>
-                        Rarity (In-Game) Leaderboard
+                        Rarity (Game) Leaderboard
                     </div>
 
                     <div class="text-center bg-dark-subtle p-1 rounded">

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -62,8 +62,8 @@ require_once("header.php");
                         <select class="form-select" name="sort" onChange="this.form.submit()">
                             <option disabled>Sort by...</option>
                             <option value="date"<?= $playerLogFilter->isSort(PlayerLogFilter::SORT_DATE) ? ' selected' : ''; ?>>Date</option>
-                            <option value="in-game-rarity"<?= $playerLogFilter->isSort(PlayerLogFilter::SORT_IN_GAME_RARITY) ? ' selected' : ''; ?>>Rarity (In-Game)</option>
-                            <option value="rarity"<?= $playerLogFilter->isSort(PlayerLogFilter::SORT_RARITY) ? ' selected' : ''; ?>>Rarity (Meta)</option>
+                            <option value="in-game-rarity"<?= $playerLogFilter->isSort(PlayerLogFilter::SORT_IN_GAME_RARITY) ? ' selected' : ''; ?>>Rarity (Game)</option>
+                            <option value="rarity"<?= $playerLogFilter->isSort(PlayerLogFilter::SORT_RARITY) ? ' selected' : ''; ?>>Rarity (Leaderboard)</option>
                         </select>
                     </div>
                 </form>
@@ -81,8 +81,8 @@ require_once("header.php");
                                 <th scope="col" class="text-center">Game</th>
                                 <th scope="col">Trophy</th>
                                 <th scope="col" class="text-center">Platform</th>
-                                <th scope="col" class="text-center">Rarity (Meta)</th>
-                                <th scope="col" class="text-center">Rarity (In-Game)</th>
+                                <th scope="col" class="text-center">Rarity (Leaderboard)</th>
+                                <th scope="col" class="text-center">Rarity (Game)</th>
                                 <th scope="col" class="text-center">Type</th>
                             </tr>
                         </thead>

--- a/wwwroot/player_random.php
+++ b/wwwroot/player_random.php
@@ -116,14 +116,14 @@ require_once("header.php");
                             <!-- rarity (meta) points -->
                             <div>
                                 <?php
-                                echo number_format($game->getRarityPoints()) . " Rarity (Meta) Points";
+                                echo number_format($game->getRarityPoints()) . " Rarity (Leaderboard) Points";
                                 ?>
                             </div>
 
                             <!-- rarity (in-game) points -->
                             <div>
                                 <?php
-                                echo number_format($game->getInGameRarityPoints()) . " Rarity (In-Game) Points";
+                                echo number_format($game->getInGameRarityPoints()) . " Rarity (Game) Points";
                                 ?>
                             </div>
                         </div>

--- a/wwwroot/trophies.php
+++ b/wwwroot/trophies.php
@@ -33,8 +33,8 @@ require_once('header.php');
                                 <th scope="col" class="text-center">Game</th>
                                 <th scope="col">Trophy</th>
                                 <th scope="col" class="text-center">Platform</th>
-                                <th scope="col" class="text-center">Rarity (Meta)</th>
-                                <th scope="col" class="text-center">Rarity (In-Game)</th>
+                                <th scope="col" class="text-center">Rarity (Leaderboard)</th>
+                                <th scope="col" class="text-center">Rarity (Game)</th>
                                 <th scope="col" class="text-center">Type</th>
                             </tr>
                         </thead>

--- a/wwwroot/trophy.php
+++ b/wwwroot/trophy.php
@@ -136,7 +136,7 @@ require_once("header.php");
                                 </div>
 
                                 <div class="col-2 text-center align-self-center">
-                                    <div class="small text-uppercase text-secondary">Rarity (Meta)</div>
+                                    <div class="small text-uppercase text-secondary">Rarity (Leaderboard)</div>
                                     <div>
                                         <?php if ($metaRarity->isUnobtainable()) { ?>
                                             <?= $metaRarity->getLabel(); ?>
@@ -147,7 +147,7 @@ require_once("header.php");
                                 </div>
 
                                 <div class="col-2 text-center align-self-center">
-                                    <div class="small text-uppercase text-secondary">Rarity (In-Game)</div>
+                                    <div class="small text-uppercase text-secondary">Rarity (Game)</div>
                                     <div>
                                         <?php if ($inGameRarity->isUnobtainable()) { ?>
                                             <?= $inGameRarity->getLabel(); ?>


### PR DESCRIPTION
### Motivation
- Improve clarity and consistency of rarity terminology in the UI by renaming ambiguous labels to more descriptive names.
- Ensure leaderboard and in-game rarity labels match the intended meaning in page titles, filters, headers and point descriptions.

### Description
- Replaced user-facing occurrences of `Rarity (Meta)` with `Rarity (Leaderboard)` across view templates and helper copy. 
- Replaced user-facing occurrences of `Rarity (In-Game)` with `Rarity (Game)` across view templates and helper copy. 
- Updated leaderboard page context titles in `wwwroot/classes/Leaderboard/*` and adjusted buttons, table headers, select options and point descriptions in multiple `wwwroot/*.php` view files to use the new terminology.
- Changes are limited to UI strings and page metadata; no logic or database schema modifications were made.

### Testing
- Ran the full automated test suite with `php tests/run.php` and all tests passed (`All 482 tests passed`).
- Ran PHP syntax checks on modified PHP files with `php -l` and found no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f70a0a7660832fa113295829f26f36)