### PR TITLE
Treat invalid PSN API responses as transient retryable failures

### DIFF
--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -140,6 +140,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
      */
     private function handleInvalidApiResponse(array $player, int $workerId, Throwable $exception): void
     {
+        // Middleware/type mismatches from the PSN client are treated as temporary API failures, not permanent "player not found" states.
         $this->logger->log(
             sprintf(
                 'Failed to scan %s because the PlayStation API returned an invalid response: %s',
@@ -162,7 +163,10 @@ final class ThirtyMinuteCronJob implements CronJobInterface
 
         if ($accountId !== false) {
             $query = $this->database->prepare('UPDATE player
-                SET `status` = 5, last_updated_date = NOW()
+                SET last_updated_date = CASE
+                    WHEN last_updated_date IS NULL THEN NOW()
+                    ELSE DATE_ADD(last_updated_date, INTERVAL 1 HOUR)
+                END
                 WHERE  account_id = :account_id ');
             $query->bindValue(':account_id', (int) $accountId, PDO::PARAM_INT);
             $query->execute();


### PR DESCRIPTION
### Motivation
- Avoid marking players as permanently missing (`status = 5`) when the PSN client returns transient/middleware/type errors so scans will be retried soon instead of requiring manual admin intervention.

### Description
- Replace the `UPDATE player SET status = 5, last_updated_date = NOW()` in `handleInvalidApiResponse` with a retry-friendly `UPDATE player SET last_updated_date = CASE WHEN last_updated_date IS NULL THEN NOW() ELSE DATE_ADD(last_updated_date, INTERVAL 1 HOUR) END WHERE account_id = :account_id`, keep the existing `DELETE FROM player_queue` and worker-release behavior, and add an inline comment clarifying these errors are temporary API/middleware failures rather than "player not found." 

### Testing
- Ran a repository search for `status = 5` and `handleInvalidApiResponse` to verify transient exception paths route through the retry-friendly update and that the explicit NotFound branch still sets `status = 5`, which succeeded. 
- Ran `php -l wwwroot/classes/Cron/ThirtyMinuteCronJob.php` to verify no syntax errors, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100b6039f0832f9843f0a0b4688bbf)