### PR TITLE
Fix Phase 1 security issues: XSS, date injection, and report POST

### DIFF
--- a/tests/PlayerReportRequestTest.php
+++ b/tests/PlayerReportRequestTest.php
@@ -9,10 +9,10 @@ final class PlayerReportRequestTest extends TestCase
 {
     public function testFromArraysTrimsExplanationAndCapturesIpAddress(): void
     {
-        $queryParameters = ['explanation' => '  Needs review  '];
+        $postParameters = ['explanation' => '  Needs review  '];
         $serverParameters = ['REMOTE_ADDR' => '198.51.100.24'];
 
-        $request = PlayerReportRequest::fromArrays($queryParameters, $serverParameters);
+        $request = PlayerReportRequest::fromArrays($postParameters, $serverParameters);
 
         $this->assertSame('Needs review', $request->getExplanation());
         $this->assertTrue($request->wasExplanationSubmitted());
@@ -30,7 +30,7 @@ final class PlayerReportRequestTest extends TestCase
 
     public function testFromArraysSanitizesNonScalarExplanationValues(): void
     {
-        $queryParameters = ['explanation' => ['value', 'other']];
+        $postParameters = ['explanation' => ['value', 'other']];
         $serverParameters = ['REMOTE_ADDR' => new class {
             public function __toString(): string
             {
@@ -38,10 +38,21 @@ final class PlayerReportRequestTest extends TestCase
             }
         }];
 
-        $request = PlayerReportRequest::fromArrays($queryParameters, $serverParameters);
+        $request = PlayerReportRequest::fromArrays($postParameters, $serverParameters);
 
         $this->assertSame('', $request->getExplanation());
         $this->assertTrue($request->wasExplanationSubmitted());
         $this->assertSame('203.0.113.12', $request->getIpAddress());
+    }
+
+    public function testFromArraysIgnoresExplanationInQueryParameters(): void
+    {
+        $request = PlayerReportRequest::fromArrays(
+            [],
+            ['REMOTE_ADDR' => '198.51.100.24', 'QUERY_STRING' => 'explanation=ignored']
+        );
+
+        $this->assertSame('', $request->getExplanation());
+        $this->assertFalse($request->wasExplanationSubmitted());
     }
 }

--- a/wwwroot/classes/PlayerReportPage.php
+++ b/wwwroot/classes/PlayerReportPage.php
@@ -19,7 +19,7 @@ class PlayerReportPage
     /**
      * @var array<string, mixed>
      */
-    private array $queryParameters;
+    private array $postParameters;
 
     /**
      * @var array<string, mixed>
@@ -35,20 +35,20 @@ class PlayerReportPage
     private PlayerReportResult $reportResult;
 
     /**
-     * @param array<string, mixed> $queryParameters
+     * @param array<string, mixed> $postParameters
      * @param array<string, mixed> $serverParameters
      */
     public function __construct(
         PlayerReportHandler $playerReportHandler,
         PlayerSummaryService $playerSummaryService,
         int $accountId,
-        array $queryParameters,
+        array $postParameters,
         array $serverParameters
     ) {
         $this->playerReportHandler = $playerReportHandler;
         $this->playerSummaryService = $playerSummaryService;
         $this->accountId = $accountId;
-        $this->queryParameters = $queryParameters;
+        $this->postParameters = $postParameters;
         $this->serverParameters = $serverParameters;
 
         $this->initialize();
@@ -57,7 +57,7 @@ class PlayerReportPage
     private function initialize(): void
     {
         $this->playerSummary = $this->playerSummaryService->getSummary($this->accountId);
-        $request = PlayerReportRequest::fromArrays($this->queryParameters, $this->serverParameters);
+        $request = PlayerReportRequest::fromArrays($this->postParameters, $this->serverParameters);
         $this->explanation = $request->getExplanation();
         $this->explanationSubmitted = $request->wasExplanationSubmitted();
         $this->reportResult = $this->playerReportHandler->handleReportRequest(

--- a/wwwroot/classes/PlayerReportRequest.php
+++ b/wwwroot/classes/PlayerReportRequest.php
@@ -11,13 +11,13 @@ final readonly class PlayerReportRequest
     ) {}
 
     /**
-     * @param array<string, mixed> $queryParameters
+     * @param array<string, mixed> $postParameters
      * @param array<string, mixed> $serverParameters
      */
-    public static function fromArrays(array $queryParameters, array $serverParameters): self
+    public static function fromArrays(array $postParameters, array $serverParameters): self
     {
-        $explanationSubmitted = array_key_exists('explanation', $queryParameters);
-        $explanation = self::sanitizeExplanation($queryParameters['explanation'] ?? null);
+        $explanationSubmitted = array_key_exists('explanation', $postParameters);
+        $explanation = self::sanitizeExplanation($postParameters['explanation'] ?? null);
         $ipAddress = self::resolveIpAddress($serverParameters);
 
         return new self($explanation, $explanationSubmitted, $ipAddress);

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -154,7 +154,7 @@ require_once("header.php");
 
                                                     <span id="<?= $playerGame->getId(); ?>"></span>
                                                     <script>
-                                                        document.getElementById("<?= $playerGame->getId(); ?>").innerHTML = new Date('<?= $playerGame->getLastUpdatedDate(); ?> UTC').toLocaleString('sv-SE');
+                                                        document.getElementById(<?= json_encode((string) $playerGame->getId()); ?>).innerHTML = new Date(<?= json_encode($playerGame->getLastUpdatedDate() . ' UTC'); ?>).toLocaleString('sv-SE');
                                                     </script>
 
                                                     <?php

--- a/wwwroot/player_header.php
+++ b/wwwroot/player_header.php
@@ -95,7 +95,7 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
                     $lastUpdatedDate = $playerHeaderViewModel->getLastUpdatedDate();
                     ?>
                     <script>
-                        document.getElementById("lastUpdate").innerHTML = new Date('<?= $lastUpdatedDate; ?> UTC').toLocaleString('sv-SE');
+                        document.getElementById("lastUpdate").innerHTML = new Date(<?= json_encode($lastUpdatedDate . ' UTC'); ?>).toLocaleString('sv-SE');
                     </script>
                     <?php
                 }

--- a/wwwroot/player_report.php
+++ b/wwwroot/player_report.php
@@ -19,7 +19,7 @@ $playerReportPage = new PlayerReportPage(
     $playerReportHandler,
     $playerSummaryService,
     (int) $accountId,
-    $_GET ?? [],
+    $_POST ?? [],
     $_SERVER ?? []
 );
 
@@ -27,8 +27,9 @@ $playerSummary = $playerReportPage->getPlayerSummary();
 $explanation = $playerReportPage->getExplanation();
 $reportResult = $playerReportPage->getReportResult();
 $playerNavigation = PlayerNavigation::forSection((string) $player['online_id']);
+$playerOnlineId = (string) $player['online_id'];
 
-$title = $player["online_id"] . "'s Report ~ PSN 100%";
+$title = htmlspecialchars($playerOnlineId, ENT_QUOTES, 'UTF-8') . "'s Report ~ PSN 100%";
 require_once("header.php");
 ?>
 
@@ -40,7 +41,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="/player/<?= $player["online_id"]; ?>/report">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="/player/<?= htmlspecialchars($playerOnlineId, ENT_QUOTES, 'UTF-8'); ?>/report">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">
@@ -68,7 +69,7 @@ require_once("header.php");
 
         <div class="col-12 mb-3">
             <div class="bg-body-tertiary p-3 rounded">
-                <form>
+                <form method="post">
                     <div class="mb-3">
                         <label for="explanation" class="form-label">What's wrong?</label>
                         <ul>

--- a/wwwroot/trophies.php
+++ b/wwwroot/trophies.php
@@ -70,13 +70,15 @@ require_once('header.php');
                                                     <?php
                                                     $progressTargetValue = $trophy->getProgressTargetValue();
                                                     if ($progressTargetValue !== null) {
-                                                        echo '<br><b>0/' . $progressTargetValue . '</b>';
+                                                        echo '<br><b>0/' . htmlspecialchars((string) $progressTargetValue, ENT_QUOTES, 'UTF-8') . '</b>';
                                                     }
 
                                                     $rewardName = $trophy->getRewardName();
                                                     $rewardImageUrl = $trophy->getRewardImageUrl();
                                                     if ($rewardName !== null && $rewardImageUrl !== null) {
-                                                        echo "<br>Reward: <a href='/img/reward/" . $rewardImageUrl . "'>" . $rewardName . '</a>';
+                                                        echo '<br>Reward: <a href="/img/reward/'
+                                                            . htmlspecialchars($rewardImageUrl, ENT_QUOTES, 'UTF-8') . '">'
+                                                            . htmlspecialchars($rewardName, ENT_QUOTES, 'UTF-8') . '</a>';
                                                     }
                                                     ?>
                                                 </div>
@@ -87,7 +89,8 @@ require_once('header.php');
                                         <div class="vstack gap-1">
                                             <?php
                                             foreach ($trophy->getPlatforms() as $platform) {
-                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2\">" . $platform . '</span> ';
+                                                echo '<span class="badge rounded-pill text-bg-primary p-2">'
+                                                    . htmlentities($platform, ENT_QUOTES, 'UTF-8') . '</span> ';
                                             }
                                             ?>
                                         </div>

--- a/wwwroot/trophy.php
+++ b/wwwroot/trophy.php
@@ -87,7 +87,7 @@ require_once("header.php");
                                                             <span class="badge rounded-pill text-bg-success" id="earnedTrophy"></span>
                                                             <script>
                                                                 <?php if ($earnedDate !== null) { ?>
-                                                                document.getElementById("earnedTrophy").innerHTML = 'Earned ' + new Date('<?= $earnedDate; ?> UTC').toLocaleString('sv-SE');
+                                                                document.getElementById("earnedTrophy").innerHTML = 'Earned ' + new Date(<?= json_encode($earnedDate . ' UTC'); ?>).toLocaleString('sv-SE');
                                                                 <?php } else { ?>
                                                                 document.getElementById("earnedTrophy").innerHTML = 'Earned';
                                                                 <?php } ?>
@@ -214,7 +214,7 @@ require_once("header.php");
                                             </td>
 
                                             <script>
-                                                document.getElementById("faDate<?= $count; ?>").innerHTML = new Date('<?= $result->getEarnedDate(); ?> UTC').toLocaleString('sv-SE').replace(' ', '<br>');
+                                                document.getElementById("faDate<?= $count; ?>").innerHTML = new Date(<?= json_encode($result->getEarnedDate() . ' UTC'); ?>).toLocaleString('sv-SE').replace(' ', '<br>');
                                             </script>
                                         </tr>
                                         <?php
@@ -271,7 +271,7 @@ require_once("header.php");
                                             </td>
 
                                             <script>
-                                                document.getElementById("laDate<?= $count; ?>").innerHTML = new Date('<?= $result->getEarnedDate(); ?> UTC').toLocaleString('sv-SE').replace(' ', '<br>');
+                                                document.getElementById("laDate<?= $count; ?>").innerHTML = new Date(<?= json_encode($result->getEarnedDate() . ' UTC'); ?>).toLocaleString('sv-SE').replace(' ', '<br>');
                                             </script>
                                         </tr>
                                         <?php


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Phase 1 security hotfixes identified in the codebase review:

- **XSS in trophies list:** Escape reward names, image URLs, progress targets, and platform badges in `trophies.php` (matching existing patterns in `trophy.php`).
- **JavaScript injection via dates:** Replace raw PHP date interpolation in inline scripts with `json_encode()` in `trophy.php`, `player.php`, and `player_header.php`.
- **Player report privacy/CSRF:** Submit reports via POST instead of GET so explanations are not stored in URLs, and escape `online_id` in the report page title/link.

## Changes

| Area | File(s) | Fix |
|------|---------|-----|
| XSS | `wwwroot/trophies.php` | `htmlspecialchars` / `htmlentities` on reward and platform output |
| Date injection | `trophy.php`, `player.php`, `player_header.php` | `json_encode(...)` for `new Date(...)` arguments |
| Report POST | `player_report.php`, `PlayerReportPage.php`, `PlayerReportRequest.php` | `method="post"`, read `$_POST` |
| Tests | `tests/PlayerReportRequestTest.php` | Updated for POST body; added test that GET query params are ignored |

## Test plan

- [x] `php tests/run.php`
- [x] Open `/trophies` and confirm reward/platform badges render correctly
- [x] Open a trophy/player page and confirm localized dates still display
- [x] Submit a player report and confirm it works via POST (explanation not in URL)

## Follow-up (not in this PR)

Phase 2+ items from the review: merge transaction boundaries, queue re-submission refresh, CSRF tokens, maintenance gate on standalone endpoints.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e92d8bf-6d00-4bf8-846a-f8b0eb114a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e92d8bf-6d00-4bf8-846a-f8b0eb114a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

