### PR TITLE
Wrap merge operations in atomic database transactions

### DIFF
--- a/tests/TrophyMergeServiceTransactionTest.php
+++ b/tests/TrophyMergeServiceTransactionTest.php
@@ -64,6 +64,27 @@ final class TrophyMergeServiceTransactionTest extends TestCase
         $this->assertSame(1, $database->rollBackCount, 'Expected mergeGames to roll back on failure.');
         $this->assertTrue($database->mappingInserted, 'Expected mapping step to run before the failure.');
     }
+
+    public function testExecuteTransactionRollsBackWhenCommitFails(): void
+    {
+        $database = new CommitFailingTransactionPDO();
+        $service = new TrophyMergeService($database);
+        $executeTransaction = new ReflectionMethod(TrophyMergeService::class, 'executeTransaction');
+        $executeTransaction->setAccessible(true);
+
+        try {
+            $executeTransaction->invoke($service, static function (): void {
+            });
+            $this->fail('Expected commit failure to bubble up.');
+        } catch (PDOException $exception) {
+            $this->assertSame('Commit failed.', $exception->getMessage());
+        }
+
+        $this->assertSame(1, $database->beginCount, 'Expected one database transaction to start.');
+        $this->assertSame(0, $database->commitCount, 'Expected failed commit to avoid counting as success.');
+        $this->assertSame(1, $database->rollBackCount, 'Expected failed commit to roll back open transaction.');
+        $this->assertFalse($database->inTransaction(), 'Expected rollback to clear transaction state.');
+    }
 }
 
 final class TransactionDepthTrackingPDO extends PDO
@@ -72,6 +93,10 @@ final class TransactionDepthTrackingPDO extends PDO
     public int $commitCount = 0;
     public int $rollBackCount = 0;
     private bool $inTransaction = false;
+
+    public function __construct()
+    {
+    }
 
     public function beginTransaction(): bool
     {
@@ -108,6 +133,14 @@ final class TransactionDepthTrackingPDO extends PDO
     }
 }
 
+final class CommitFailingTransactionPDO extends TransactionDepthTrackingPDO
+{
+    public function commit(): bool
+    {
+        throw new PDOException('Commit failed.');
+    }
+}
+
 final class MergeGamesTransactionPDO extends PDO
 {
     public int $beginCount = 0;
@@ -115,6 +148,10 @@ final class MergeGamesTransactionPDO extends PDO
     public int $rollBackCount = 0;
     public bool $mappingInserted = false;
     private bool $inTransaction = false;
+
+    public function __construct()
+    {
+    }
 
     public function beginTransaction(): bool
     {

--- a/tests/TrophyMergeServiceTransactionTest.php
+++ b/tests/TrophyMergeServiceTransactionTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMergeService.php';
+
+final class TrophyMergeServiceTransactionTest extends TestCase
+{
+    public function testNestedExecuteTransactionCommitsDatabaseOnlyOnce(): void
+    {
+        $database = new TransactionDepthTrackingPDO();
+        $service = new TrophyMergeService($database);
+        $executeTransaction = new ReflectionMethod(TrophyMergeService::class, 'executeTransaction');
+        $executeTransaction->setAccessible(true);
+
+        $executeTransaction->invoke($service, function () use ($executeTransaction, $service): void {
+            $executeTransaction->invoke($service, static function (): void {
+            });
+        });
+
+        $this->assertSame(1, $database->beginCount, 'Expected one database transaction to start.');
+        $this->assertSame(1, $database->commitCount, 'Expected one database transaction to commit.');
+        $this->assertSame(0, $database->rollBackCount, 'Expected no rollback for successful nested transactions.');
+    }
+
+    public function testNestedExecuteTransactionRollsBackDatabaseOnInnerFailure(): void
+    {
+        $database = new TransactionDepthTrackingPDO();
+        $service = new TrophyMergeService($database);
+        $executeTransaction = new ReflectionMethod(TrophyMergeService::class, 'executeTransaction');
+        $executeTransaction->setAccessible(true);
+
+        try {
+            $executeTransaction->invoke($service, function () use ($executeTransaction, $service): void {
+                $executeTransaction->invoke($service, static function (): void {
+                    throw new RuntimeException('Inner failure.');
+                });
+            });
+            $this->fail('Expected inner transaction failure to bubble up.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Inner failure.', $exception->getMessage());
+        }
+
+        $this->assertSame(1, $database->beginCount, 'Expected one database transaction to start.');
+        $this->assertSame(0, $database->commitCount, 'Expected failed nested transactions to avoid commit.');
+        $this->assertSame(1, $database->rollBackCount, 'Expected failed nested transactions to roll back.');
+    }
+
+    public function testMergeGamesRollsBackWhenPostMappingStepFails(): void
+    {
+        $database = new MergeGamesTransactionPDO();
+        $service = new TrophyMergeService($database);
+
+        try {
+            $service->mergeGames(10, 20, 'order');
+            $this->fail('Expected mergeGames to fail when marking the child game as merged.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Failed while marking child game as merged.', $exception->getMessage());
+        }
+
+        $this->assertSame(1, $database->beginCount, 'Expected mergeGames to open one database transaction.');
+        $this->assertSame(0, $database->commitCount, 'Expected mergeGames to avoid commit when a later step fails.');
+        $this->assertSame(1, $database->rollBackCount, 'Expected mergeGames to roll back on failure.');
+        $this->assertTrue($database->mappingInserted, 'Expected mapping step to run before the failure.');
+    }
+}
+
+final class TransactionDepthTrackingPDO extends PDO
+{
+    public int $beginCount = 0;
+    public int $commitCount = 0;
+    public int $rollBackCount = 0;
+    private bool $inTransaction = false;
+
+    public function beginTransaction(): bool
+    {
+        $this->beginCount++;
+        $this->inTransaction = true;
+
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        $this->commitCount++;
+        $this->inTransaction = false;
+
+        return true;
+    }
+
+    public function rollBack(): bool
+    {
+        $this->rollBackCount++;
+        $this->inTransaction = false;
+
+        return true;
+    }
+
+    public function inTransaction(): bool
+    {
+        return $this->inTransaction;
+    }
+
+    public function prepare(string $statement, array $options = []): PDOStatement
+    {
+        throw new RuntimeException('Unexpected SQL in transaction depth test: ' . $statement);
+    }
+}
+
+final class MergeGamesTransactionPDO extends PDO
+{
+    public int $beginCount = 0;
+    public int $commitCount = 0;
+    public int $rollBackCount = 0;
+    public bool $mappingInserted = false;
+    private bool $inTransaction = false;
+
+    public function beginTransaction(): bool
+    {
+        $this->beginCount++;
+        $this->inTransaction = true;
+
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        $this->commitCount++;
+        $this->inTransaction = false;
+
+        return true;
+    }
+
+    public function rollBack(): bool
+    {
+        $this->rollBackCount++;
+        $this->inTransaction = false;
+
+        return true;
+    }
+
+    public function inTransaction(): bool
+    {
+        return $this->inTransaction;
+    }
+
+    public function prepare(string $statement, array $options = []): PDOStatement
+    {
+        $normalized = preg_replace('/\s+/', ' ', trim($statement)) ?? '';
+
+        if (str_starts_with($normalized, 'SELECT np_communication_id FROM trophy_title WHERE id = :game_id')) {
+            return new MergeGamesNpCommunicationIdStatement();
+        }
+
+        if (str_contains($normalized, 'INSERT IGNORE into trophy_merge') && str_contains($normalized, 'USING (group_id, order_id)')) {
+            return new MergeGamesMappingStatement($this);
+        }
+
+        if (str_starts_with($normalized, 'UPDATE trophy_title_meta SET status = 2 WHERE np_communication_id = :np_communication_id')) {
+            throw new RuntimeException('Failed while marking child game as merged.');
+        }
+
+        throw new RuntimeException('Unexpected SQL in mergeGames transaction test: ' . $statement);
+    }
+
+    public function recordMappingInsert(): void
+    {
+        $this->mappingInserted = true;
+    }
+}
+
+final class MergeGamesNpCommunicationIdStatement extends PDOStatement
+{
+    private ?int $gameId = null;
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        if ((string) $param === ':game_id') {
+            $this->gameId = (int) $value;
+        }
+
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchColumn(int $column = 0): string
+    {
+        return $this->gameId === 20 ? 'MERGE_000020' : 'NP_CHILD';
+    }
+}
+
+final class MergeGamesMappingStatement extends PDOStatement
+{
+    public function __construct(private readonly MergeGamesTransactionPDO $database)
+    {
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        $this->database->recordMappingInsert();
+
+        return true;
+    }
+}

--- a/tests/TrophyMergeServiceTransactionTest.php
+++ b/tests/TrophyMergeServiceTransactionTest.php
@@ -67,7 +67,7 @@ final class TrophyMergeServiceTransactionTest extends TestCase
 
     public function testExecuteTransactionRollsBackWhenCommitFails(): void
     {
-        $database = new CommitFailingTransactionPDO();
+        $database = new TransactionDepthTrackingPDO(failOnCommit: true);
         $service = new TrophyMergeService($database);
         $executeTransaction = new ReflectionMethod(TrophyMergeService::class, 'executeTransaction');
         $executeTransaction->setAccessible(true);
@@ -94,7 +94,7 @@ final class TransactionDepthTrackingPDO extends PDO
     public int $rollBackCount = 0;
     private bool $inTransaction = false;
 
-    public function __construct()
+    public function __construct(private bool $failOnCommit = false)
     {
     }
 
@@ -108,6 +108,10 @@ final class TransactionDepthTrackingPDO extends PDO
 
     public function commit(): bool
     {
+        if ($this->failOnCommit) {
+            throw new PDOException('Commit failed.');
+        }
+
         $this->commitCount++;
         $this->inTransaction = false;
 
@@ -130,14 +134,6 @@ final class TransactionDepthTrackingPDO extends PDO
     public function prepare(string $statement, array $options = []): PDOStatement
     {
         throw new RuntimeException('Unexpected SQL in transaction depth test: ' . $statement);
-    }
-}
-
-final class CommitFailingTransactionPDO extends TransactionDepthTrackingPDO
-{
-    public function commit(): bool
-    {
-        throw new PDOException('Commit failed.');
     }
 }
 

--- a/tests/TrophyMergeServiceTransactionTest.php
+++ b/tests/TrophyMergeServiceTransactionTest.php
@@ -182,7 +182,11 @@ final class MergeGamesTransactionPDO extends PDO
     {
         $normalized = preg_replace('/\s+/', ' ', trim($statement)) ?? '';
 
-        if (str_starts_with($normalized, 'SELECT np_communication_id FROM trophy_title WHERE id = :game_id')) {
+        if (
+            str_contains($normalized, 'SELECT np_communication_id')
+            && str_contains($normalized, 'FROM trophy_title')
+            && str_contains($normalized, 'WHERE id =')
+        ) {
             return new MergeGamesNpCommunicationIdStatement();
         }
 
@@ -209,7 +213,7 @@ final class MergeGamesNpCommunicationIdStatement extends PDOStatement
 
     public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
     {
-        if ((string) $param === ':game_id') {
+        if ((string) $param === ':game_id' || (string) $param === ':id') {
             $this->gameId = (int) $value;
         }
 

--- a/tests/TrophyMergeServiceTransactionTest.php
+++ b/tests/TrophyMergeServiceTransactionTest.php
@@ -182,16 +182,12 @@ final class MergeGamesTransactionPDO extends PDO
     {
         $normalized = preg_replace('/\s+/', ' ', trim($statement)) ?? '';
 
-        if (
-            str_contains($normalized, 'SELECT np_communication_id')
-            && str_contains($normalized, 'FROM trophy_title')
-            && str_contains($normalized, 'WHERE id =')
-        ) {
-            return new MergeGamesNpCommunicationIdStatement();
-        }
-
         if (str_contains($normalized, 'INSERT IGNORE into trophy_merge') && str_contains($normalized, 'USING (group_id, order_id)')) {
             return new MergeGamesMappingStatement($this);
+        }
+
+        if (str_starts_with($normalized, 'SELECT np_communication_id FROM trophy_title WHERE id =')) {
+            return new MergeGamesNpCommunicationIdStatement();
         }
 
         if (str_starts_with($normalized, 'UPDATE trophy_title_meta SET status = 2 WHERE np_communication_id = :np_communication_id')) {

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -11,6 +11,8 @@ class TrophyMergeService
 
     private PDO $database;
 
+    private int $transactionDepth = 0;
+
     public function __construct(PDO $database)
     {
         $this->database = $database;
@@ -28,6 +30,8 @@ class TrophyMergeService
             throw new InvalidArgumentException('Parent must be a merge title.');
         }
 
+        $childTrophies = [];
+
         foreach ($childTrophyIds as $childTrophyId) {
             $childTrophyId = (int) $childTrophyId;
             $childTrophy = $this->getTrophyById($childTrophyId);
@@ -36,23 +40,35 @@ class TrophyMergeService
                 throw new InvalidArgumentException("Child can't be a merge title.");
             }
 
-            $this->insertTrophyMergeMappingFromIds($childTrophyId, $parentTrophyId);
-            $this->markGameAsMergedByNpId($childTrophy['np_communication_id']);
-
-            $childGameId = $this->getGameIdByTrophyId($childTrophyId);
-
-            $this->copyTrophyEarned(
-                $childTrophy['np_communication_id'],
-                $childTrophy['group_id'],
-                (int) $childTrophy['order_id'],
-                $parentTrophy['np_communication_id'],
-                $parentTrophy['group_id'],
-                (int) $parentTrophy['order_id']
-            );
-
-            $this->updateTrophyGroupPlayer($childGameId);
-            $this->updateTrophyTitlePlayer($childGameId);
+            $childTrophies[] = [
+                'id' => $childTrophyId,
+                'trophy' => $childTrophy,
+            ];
         }
+
+        $this->executeTransaction(function () use ($parentTrophy, $parentTrophyId, $childTrophies): void {
+            foreach ($childTrophies as $childData) {
+                $childTrophyId = $childData['id'];
+                $childTrophy = $childData['trophy'];
+
+                $this->insertTrophyMergeMappingFromIds($childTrophyId, $parentTrophyId);
+                $this->markGameAsMergedByNpId($childTrophy['np_communication_id']);
+
+                $childGameId = $this->getGameIdByTrophyId($childTrophyId);
+
+                $this->copyTrophyEarned(
+                    $childTrophy['np_communication_id'],
+                    $childTrophy['group_id'],
+                    (int) $childTrophy['order_id'],
+                    $parentTrophy['np_communication_id'],
+                    $parentTrophy['group_id'],
+                    (int) $parentTrophy['order_id']
+                );
+
+                $this->updateTrophyGroupPlayer($childGameId);
+                $this->updateTrophyTitlePlayer($childGameId);
+            }
+        });
 
         return 'The trophies have been merged.';
     }
@@ -80,9 +96,15 @@ class TrophyMergeService
 
         $message = '';
 
-        $this->beginTransaction();
-
-        try {
+        $this->executeTransaction(function () use (
+            $childGameId,
+            $childNpCommunicationId,
+            $parentGameId,
+            $parentNpCommunicationId,
+            $method,
+            $progressListener,
+            &$message
+        ): void {
             switch ($method) {
                 case 'name':
                     $this->notifyProgress($progressListener, 30, 'Matching trophies by name…');
@@ -100,33 +122,28 @@ class TrophyMergeService
                     throw new InvalidArgumentException('Wrong input');
             }
 
-            $this->commitTransaction();
-        } catch (Throwable $exception) {
-            $this->rollBackTransaction();
-            throw $exception;
-        }
-
-        $this->notifyProgress($progressListener, 55, 'Trophy mappings saved.');
-        $this->notifyProgress($progressListener, 60, 'Preparing to mark child game as merged…');
-        $this->notifyProgress($progressListener, 62, 'Marking child game as merged…');
-        $this->markGameAsMergedById($childGameId);
-        $this->notifyProgress($progressListener, 65, 'Child game marked as merged.');
-        $this->notifyProgress($progressListener, 70, 'Preparing to copy merged trophies…');
-        $this->notifyProgress($progressListener, 72, 'Copying merged trophies…');
-        $this->copyMergedTrophies($childNpCommunicationId, $progressListener);
-        $this->notifyProgress($progressListener, 75, 'Merged trophies copied.');
-        $this->notifyProgress($progressListener, 80, 'Updating player trophy groups…');
-        $this->updateTrophyGroupPlayer($childGameId);
-        $this->notifyProgress($progressListener, 85, 'Player trophy groups updated.');
-        $this->notifyProgress($progressListener, 88, 'Updating player trophy titles…');
-        $this->updateTrophyTitlePlayer($childGameId);
-        $this->notifyProgress($progressListener, 92, 'Player trophy titles updated.');
-        $this->notifyProgress($progressListener, 94, 'Updating parent relationship…');
-        $this->updateParentRelationship($childNpCommunicationId, $parentNpCommunicationId);
-        $this->notifyProgress($progressListener, 96, 'Parent relationship updated.');
-        $this->notifyProgress($progressListener, 98, 'Logging merge activity…');
-        $this->logChange('GAME_MERGE', $childGameId, $parentGameId);
-        $this->notifyProgress($progressListener, 100, 'Merge process complete.');
+            $this->notifyProgress($progressListener, 55, 'Trophy mappings saved.');
+            $this->notifyProgress($progressListener, 60, 'Preparing to mark child game as merged…');
+            $this->notifyProgress($progressListener, 62, 'Marking child game as merged…');
+            $this->markGameAsMergedById($childGameId);
+            $this->notifyProgress($progressListener, 65, 'Child game marked as merged.');
+            $this->notifyProgress($progressListener, 70, 'Preparing to copy merged trophies…');
+            $this->notifyProgress($progressListener, 72, 'Copying merged trophies…');
+            $this->copyMergedTrophies($childNpCommunicationId, $progressListener);
+            $this->notifyProgress($progressListener, 75, 'Merged trophies copied.');
+            $this->notifyProgress($progressListener, 80, 'Updating player trophy groups…');
+            $this->updateTrophyGroupPlayer($childGameId);
+            $this->notifyProgress($progressListener, 85, 'Player trophy groups updated.');
+            $this->notifyProgress($progressListener, 88, 'Updating player trophy titles…');
+            $this->updateTrophyTitlePlayer($childGameId);
+            $this->notifyProgress($progressListener, 92, 'Player trophy titles updated.');
+            $this->notifyProgress($progressListener, 94, 'Updating parent relationship…');
+            $this->updateParentRelationship($childNpCommunicationId, $parentNpCommunicationId);
+            $this->notifyProgress($progressListener, 96, 'Parent relationship updated.');
+            $this->notifyProgress($progressListener, 98, 'Logging merge activity…');
+            $this->logChange('GAME_MERGE', $childGameId, $parentGameId);
+            $this->notifyProgress($progressListener, 100, 'Merge process complete.');
+        });
 
         return $message . 'The games have been merged.';
     }
@@ -1723,20 +1740,34 @@ SQL
 
     private function beginTransaction(): void
     {
-        if (!$this->database->inTransaction()) {
+        if ($this->transactionDepth === 0) {
             $this->database->beginTransaction();
         }
+
+        $this->transactionDepth++;
     }
 
     private function commitTransaction(): void
     {
-        if ($this->database->inTransaction()) {
+        if ($this->transactionDepth === 0) {
+            return;
+        }
+
+        $this->transactionDepth--;
+
+        if ($this->transactionDepth === 0 && $this->database->inTransaction()) {
             $this->database->commit();
         }
     }
 
     private function rollBackTransaction(): void
     {
+        if ($this->transactionDepth === 0) {
+            return;
+        }
+
+        $this->transactionDepth = 0;
+
         if ($this->database->inTransaction()) {
             $this->database->rollBack();
         }

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -1753,19 +1753,21 @@ SQL
             return;
         }
 
-        $this->transactionDepth--;
+        if ($this->transactionDepth === 1) {
+            if ($this->database->inTransaction()) {
+                $this->database->commit();
+            }
 
-        if ($this->transactionDepth === 0 && $this->database->inTransaction()) {
-            $this->database->commit();
+            $this->transactionDepth = 0;
+
+            return;
         }
+
+        $this->transactionDepth--;
     }
 
     private function rollBackTransaction(): void
     {
-        if ($this->transactionDepth === 0) {
-            return;
-        }
-
         $this->transactionDepth = 0;
 
         if ($this->database->inTransaction()) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Phase 2 data-integrity fixes for trophy/game merge operations. Queue re-submission behavior is intentionally unchanged per product requirements.

## Changes

### Nested transaction support
`TrophyMergeService` now tracks transaction depth so helper methods that call `executeTransaction()` internally (e.g. `insertTrophyMergeMappingFromIds`, `markGameAsMergedById`) no longer commit the database transaction early when invoked from a larger merge operation.

### `mergeSpecificTrophies()`
- Validates all child trophies before any writes
- Runs the full per-child merge loop inside a single outer transaction
- Rolls back all children if any step fails

### `mergeGames()`
- Extends the transaction to cover the entire pipeline: mappings, mark-as-merged, copy merged trophies, player recalculations, parent relationship update, and changelog logging
- Previously only the mapping step was transactional; later failures could leave partially merged state

## Tests

Added `tests/TrophyMergeServiceTransactionTest.php`:
- Nested `executeTransaction()` commits the database only once
- Inner failure rolls back the outer transaction
- `mergeGames()` rolls back when a post-mapping step fails

## Test plan

- [ ] `php tests/run.php`
- [ ] Manually verify admin game merge and specific trophy merge still complete successfully

## Out of scope

- Queue re-submission / `request_time` / IP updates (explicitly excluded)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e92d8bf-6d00-4bf8-846a-f8b0eb114a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e92d8bf-6d00-4bf8-846a-f8b0eb114a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

