### PR TITLE
Fix Phase 2 bugs: report message, Bootstrap SRI, route validation, IP resolver

### DIFF
--- a/tests/IpAddressResolverTest.php
+++ b/tests/IpAddressResolverTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/IpAddressResolver.php';
+
+final class IpAddressResolverTest extends TestCase
+{
+    public function testResolveReturnsValidatedIpv4Address(): void
+    {
+        $this->assertSame('127.0.0.1', IpAddressResolver::resolve('  127.0.0.1  '));
+    }
+
+    public function testResolveReturnsValidatedIpv6Address(): void
+    {
+        $this->assertSame('::1', IpAddressResolver::resolve('::1'));
+    }
+
+    public function testResolveReturnsEmptyStringForInvalidAddress(): void
+    {
+        $this->assertSame('', IpAddressResolver::resolve('not-an-ip'));
+    }
+
+    public function testResolveUsesFirstArrayValue(): void
+    {
+        $this->assertSame('8.8.8.8', IpAddressResolver::resolve([' 8.8.8.8 ', '9.9.9.9 ']));
+    }
+
+    public function testResolveSupportsStringableObjects(): void
+    {
+        $stringable = new class {
+            public function __toString(): string
+            {
+                return '203.0.113.12';
+            }
+        };
+
+        $this->assertSame('203.0.113.12', IpAddressResolver::resolve($stringable));
+    }
+
+    public function testResolveReturnsEmptyStringForUnsupportedValues(): void
+    {
+        $resource = fopen('php://temp', 'r');
+
+        $this->assertSame('', IpAddressResolver::resolve($resource));
+
+        if (is_resource($resource)) {
+            fclose($resource);
+        }
+
+        $this->assertSame('', IpAddressResolver::resolve(new stdClass()));
+        $this->assertSame('', IpAddressResolver::resolve(null));
+        $this->assertSame('', IpAddressResolver::resolve(''));
+    }
+}

--- a/tests/MaintenancePageTest.php
+++ b/tests/MaintenancePageTest.php
@@ -70,9 +70,19 @@ final class MaintenancePageTest extends TestCase
         );
         $this->assertSame('stylesheet', $bootstrap->getRel());
         $this->assertSame(
-            'sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB',
+            'sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM',
             $bootstrap->getIntegrity()
         );
         $this->assertSame('anonymous', $bootstrap->getCrossorigin());
+    }
+
+    public function testBootstrapCdnThrowsForUnsupportedVersion(): void
+    {
+        try {
+            MaintenancePageStylesheet::bootstrapCdn('4.6.2');
+            $this->fail('Expected InvalidArgumentException for unsupported Bootstrap version.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('Unsupported Bootstrap CDN version: 4.6.2', $exception->getMessage());
+        }
     }
 }

--- a/tests/PlayerQueueRequestTest.php
+++ b/tests/PlayerQueueRequestTest.php
@@ -62,4 +62,15 @@ final class PlayerQueueRequestTest extends TestCase
         $this->assertSame('', $emptyRequest->getIpAddress());
         $this->assertTrue($emptyRequest->isPlayerNameEmpty());
     }
+
+    public function testFromArraysRejectsInvalidIpAddress(): void
+    {
+        $request = PlayerQueueRequest::fromArrays(
+            ['q' => 'ValidPlayer'],
+            ['REMOTE_ADDR' => 'not-an-ip']
+        );
+
+        $this->assertSame('ValidPlayer', $request->getPlayerName());
+        $this->assertSame('', $request->getIpAddress());
+    }
 }

--- a/tests/PlayerReportServiceTest.php
+++ b/tests/PlayerReportServiceTest.php
@@ -85,7 +85,7 @@ final class PlayerReportServiceTest extends TestCase
 
         $this->assertFalse($result->isSuccess());
         $this->assertSame(
-            "You've already 10 players reported waiting to be processed. Please try again later.",
+            'You already have 10 reports waiting to be processed. Please try again later.',
             $result->getMessage()
         );
 

--- a/tests/TrophyRouteHandlerTest.php
+++ b/tests/TrophyRouteHandlerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/Routing/TrophyRouteHandler.php';
+
+final class TrophyRouteHandlerTest extends TestCase
+{
+    private TrophyRepository $trophyRepository;
+
+    private TrophyRouteHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->trophyRepository = new class extends TrophyRepository {
+            /** @var array<string, int> */
+            public array $idsBySegment = [];
+
+            public function __construct()
+            {
+            }
+
+            public function findIdFromSegment(?string $segment): ?int
+            {
+                if ($segment === null) {
+                    return null;
+                }
+
+                return $this->idsBySegment[$segment] ?? null;
+            }
+        };
+
+        $this->handler = new TrophyRouteHandler($this->trophyRepository);
+    }
+
+    public function testHandleIncludesValidPlayerSegment(): void
+    {
+        $this->trophyRepository->idsBySegment['42-example-trophy'] = 42;
+
+        $result = $this->handler->handle(['42-example-trophy', 'player42']);
+
+        $this->assertTrue($result->shouldInclude());
+        $this->assertSame('trophy.php', $result->getInclude());
+        $this->assertSame(
+            [
+                'trophyId' => 42,
+                'player' => 'player42',
+            ],
+            $result->getVariables()
+        );
+    }
+
+    public function testHandleIgnoresInvalidPlayerSegment(): void
+    {
+        $this->trophyRepository->idsBySegment['42-example-trophy'] = 42;
+
+        $result = $this->handler->handle(['42-example-trophy', '<script>alert(1)</script>']);
+
+        $this->assertTrue($result->shouldInclude());
+        $this->assertSame(
+            [
+                'trophyId' => 42,
+                'player' => null,
+            ],
+            $result->getVariables()
+        );
+    }
+
+    public function testHandleRedirectsWhenTrophySegmentIsUnknown(): void
+    {
+        $result = $this->handler->handle(['missing-trophy', 'player42']);
+
+        $this->assertTrue($result->shouldRedirect());
+        $this->assertSame('/trophy/', $result->getRedirect());
+    }
+}

--- a/wwwroot/classes/IpAddressResolver.php
+++ b/wwwroot/classes/IpAddressResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+final class IpAddressResolver
+{
+    public static function resolve(mixed $remoteAddr): string
+    {
+        if (is_array($remoteAddr)) {
+            $remoteAddr = reset($remoteAddr);
+        }
+
+        if (is_object($remoteAddr) && method_exists($remoteAddr, '__toString')) {
+            $remoteAddr = (string) $remoteAddr;
+        } elseif (!is_scalar($remoteAddr) && $remoteAddr !== null) {
+            return '';
+        }
+
+        $ipAddress = trim((string) ($remoteAddr ?? ''));
+        if ($ipAddress === '') {
+            return '';
+        }
+
+        $validatedAddress = filter_var($ipAddress, FILTER_VALIDATE_IP);
+
+        return is_string($validatedAddress) ? $validatedAddress : '';
+    }
+}

--- a/wwwroot/classes/MaintenancePageStylesheet.php
+++ b/wwwroot/classes/MaintenancePageStylesheet.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 final class MaintenancePageStylesheet
 {
+    /** @var array<string, string> */
+    private const array BOOTSTRAP_INTEGRITY_HASHES = [
+        '5.3.0' => 'sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM',
+        '5.3.8' => 'sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB',
+    ];
+
     private string $href;
 
     private string $rel;
@@ -27,8 +33,12 @@ final class MaintenancePageStylesheet
 
     public static function bootstrapCdn(string $version = '5.3.8'): self
     {
+        $integrity = self::BOOTSTRAP_INTEGRITY_HASHES[$version] ?? null;
+        if ($integrity === null) {
+            throw new InvalidArgumentException(sprintf('Unsupported Bootstrap CDN version: %s', $version));
+        }
+
         $href = sprintf('https://cdn.jsdelivr.net/npm/bootstrap@%s/dist/css/bootstrap.min.css', $version);
-        $integrity = 'sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB';
         $crossorigin = 'anonymous';
 
         return new self($href, 'stylesheet', $integrity, $crossorigin);

--- a/wwwroot/classes/PlayerQueueRequest.php
+++ b/wwwroot/classes/PlayerQueueRequest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/IpAddressResolver.php';
+
 readonly class PlayerQueueRequest
 {
     private function __construct(
@@ -12,7 +14,7 @@ readonly class PlayerQueueRequest
     public static function fromArrays(array $requestData, array $serverData): self
     {
         $playerName = self::sanitizeValue($requestData['q'] ?? '');
-        $ipAddress = self::sanitizeValue($serverData['REMOTE_ADDR'] ?? '');
+        $ipAddress = IpAddressResolver::resolve($serverData['REMOTE_ADDR'] ?? '');
 
         return new self($playerName, $ipAddress);
     }

--- a/wwwroot/classes/PlayerReportRequest.php
+++ b/wwwroot/classes/PlayerReportRequest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/IpAddressResolver.php';
+
 final readonly class PlayerReportRequest
 {
     private function __construct(
@@ -18,7 +20,7 @@ final readonly class PlayerReportRequest
     {
         $explanationSubmitted = array_key_exists('explanation', $postParameters);
         $explanation = self::sanitizeExplanation($postParameters['explanation'] ?? null);
-        $ipAddress = self::resolveIpAddress($serverParameters);
+        $ipAddress = IpAddressResolver::resolve($serverParameters['REMOTE_ADDR'] ?? '');
 
         return new self($explanation, $explanationSubmitted, $ipAddress);
     }
@@ -47,18 +49,4 @@ final readonly class PlayerReportRequest
         return trim((string) $explanation);
     }
 
-    /**
-     * @param array<string, mixed> $serverParameters
-     */
-    private static function resolveIpAddress(array $serverParameters): string
-    {
-        $ipAddress = (string) ($serverParameters['REMOTE_ADDR'] ?? '');
-        if ($ipAddress === '') {
-            return '';
-        }
-
-        $validatedAddress = filter_var($ipAddress, FILTER_VALIDATE_IP);
-
-        return is_string($validatedAddress) ? $validatedAddress : '';
-    }
 }

--- a/wwwroot/classes/PlayerReportService.php
+++ b/wwwroot/classes/PlayerReportService.php
@@ -19,7 +19,7 @@ class PlayerReportService
         }
 
         if ($this->getReportCountForIp($ipAddress) >= self::MAX_PENDING_REPORTS_PER_IP) {
-            return PlayerReportResult::error("You've already 10 players reported waiting to be processed. Please try again later.");
+            return PlayerReportResult::error('You already have 10 reports waiting to be processed. Please try again later.');
         }
 
         $this->insertReport($accountId, $ipAddress, $explanation);

--- a/wwwroot/classes/Routing/TrophyRouteHandler.php
+++ b/wwwroot/classes/Routing/TrophyRouteHandler.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../PlayerQueueService.php';
 require_once __DIR__ . '/../TrophyRepository.php';
 require_once __DIR__ . '/RouteHandlerInterface.php';
 
@@ -28,7 +29,10 @@ final readonly class TrophyRouteHandler implements RouteHandlerInterface
             return RouteResult::redirect('/trophy/');
         }
 
-        $player = $segments[0] ?? null;
+        $playerSegment = $segments[0] ?? null;
+        $player = is_string($playerSegment) && PlayerQueueService::isValidOnlineId($playerSegment)
+            ? $playerSegment
+            : null;
 
         return RouteResult::include(
             'trophy.php',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Phase 2 bug fixes from the code review, excluding re-queue `request_time` behavior (intentional).

## Changes

### 2.2 Player report error message
- Fixed grammar in the IP-limit error returned by `PlayerReportService`
- New message: "You already have 10 reports waiting to be processed. Please try again later."

### 2.3 Bootstrap SRI hashes
- `MaintenancePageStylesheet::bootstrapCdn()` now maps each supported Bootstrap version to its correct SRI hash (5.3.0 and 5.3.8)
- Unsupported versions throw `InvalidArgumentException` instead of using a mismatched hash

### 2.4 Trophy route player validation
- `TrophyRouteHandler` now validates player URL segments with `PlayerQueueService::isValidOnlineId()`, matching `GameRouteHandler` behavior
- Invalid segments are treated as `null` instead of being passed through to the page layer

### 2.5 Shared IP address validation
- Added `IpAddressResolver` used by both `PlayerQueueRequest` and `PlayerReportRequest`
- Invalid `REMOTE_ADDR` values are rejected consistently via `FILTER_VALIDATE_IP`

## Tests

- Added `IpAddressResolverTest` (6 cases)
- Added `TrophyRouteHandlerTest` (3 cases)
- Updated `PlayerReportServiceTest`, `MaintenancePageTest`, and `PlayerQueueRequestTest`
- All **502** tests pass (`php tests/run.php`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-accb207f-5558-4125-92a3-240c2112cfaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-accb207f-5558-4125-92a3-240c2112cfaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

