### PR TITLE
Phase 3 hardening: XSS escape, DB env fallback, trusted proxy IPs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,13 @@ the non-obvious steps to actually run the services.
 
 - MySQL does not auto-start. Start it each session with `sudo service mysql start`.
 - The app reads its DB connection from **environment variables**: `DB_HOST`,
-  `DB_NAME`, `DB_USER`, `DB_PASSWORD` (see `wwwroot/database.php` /
-  `ApplicationContainer::create()`). There is no config file fallback.
+ `DB_NAME`, `DB_USER`, `DB_PASSWORD` (see `wwwroot/database.php` /
+ `ApplicationContainer::create()`). There is no config file fallback.
+ `DatabaseConfig::fromEnvironment()` also falls back to `getenv()` when `$_ENV`
+ is empty, but missing values still produce a clear connection error.
+- IP rate limits use `REMOTE_ADDR` unless `TRUSTED_PROXY_IPS` lists the direct
+ client as a trusted proxy, in which case the leftmost valid `X-Forwarded-For`
+ address is used.
 - Dev database/credentials used during setup: db `psn100`, user `psn100`,
   password `psn100`, host `127.0.0.1`.
 - The committed schema is **structure-only** (`database/psn100.sql`, no rows). If the

--- a/README.md
+++ b/README.md
@@ -12,6 +12,53 @@ PSN 100% is not a community for discussion (forum), gaming/boosting sessions or 
 - **PHP:** 8.5
 - **MySQL:** 8.4
 
+## Deployment notes
+
+### Database environment variables
+
+The application reads MySQL credentials from `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASSWORD`.
+Values are read from `$_ENV` when populated, and fall back to `getenv()` when they are not.
+
+When using PHP's built-in development server, either export the variables in your shell or pass
+`-d variables_order=EGPCS` so `$_ENV` is populated:
+
+```bash
+cd wwwroot && DB_HOST=127.0.0.1 DB_NAME=psn100 DB_USER=psn100 DB_PASSWORD=psn100 \
+php -d variables_order=EGPCS -S 0.0.0.0:8000 /tmp/psn100-router.php
+```
+
+If configuration is missing, the app throws a clear `DatabaseConnectionException` instead of
+attempting a connection with empty credentials.
+
+### Reverse proxies and client IP limits
+
+Queue submissions and player reports rate-limit by client IP. By default the app uses
+`REMOTE_ADDR` only.
+
+If the app runs behind a trusted reverse proxy, set `TRUSTED_PROXY_IPS` to a comma-separated
+list of proxy addresses that may append `X-Forwarded-For`. When the direct client is a listed
+proxy, the leftmost valid IP from `X-Forwarded-For` is used for rate limiting.
+
+Example:
+
+```bash
+export TRUSTED_PROXY_IPS=127.0.0.1,10.0.0.1
+```
+
+Only enable this when the proxy strips untrusted `X-Forwarded-For` values from clients.
+
+### Admin access
+
+Admin pages require a row in the `admin_user` table. Create an account with a bcrypt hash:
+
+```bash
+php -r "echo password_hash('your-password', PASSWORD_DEFAULT), PHP_EOL;"
+```
+
+```sql
+INSERT INTO admin_user (username, password_hash) VALUES ('admin', '$2y$10$...');
+```
+
 ## Merge Guideline Priorities
 1. Available > Delisted
 2. English language > Other language

--- a/tests/DatabaseConfigTest.php
+++ b/tests/DatabaseConfigTest.php
@@ -41,16 +41,54 @@ final class DatabaseConfigTest extends TestCase
         }
     }
 
-    public function testIsCompleteRequiresHostDatabaseAndUser(): void
+    public function testIsCompleteRequiresHostDatabaseUserAndPassword(): void
     {
-        $config = DatabaseConfig::fromEnvironment([
+        $missingDatabase = DatabaseConfig::fromEnvironment([
             'DB_HOST' => '127.0.0.1',
             'DB_NAME' => '',
             'DB_USER' => 'psn100',
             'DB_PASSWORD' => 'psn100',
         ]);
 
-        $this->assertFalse($config->isComplete());
+        $this->assertFalse($missingDatabase->isComplete());
+
+        $missingPassword = DatabaseConfig::fromEnvironment([
+            'DB_HOST' => '127.0.0.1',
+            'DB_NAME' => 'psn100',
+            'DB_USER' => 'psn100',
+            'DB_PASSWORD' => '',
+        ]);
+
+        $this->assertFalse($missingPassword->isComplete());
+    }
+
+    public function testFromEnvironmentPreservesExactDbPasswordValue(): void
+    {
+        $config = DatabaseConfig::fromEnvironment([
+            'DB_HOST' => '127.0.0.1',
+            'DB_NAME' => 'psn100',
+            'DB_USER' => 'psn100',
+            'DB_PASSWORD' => '  secret-password  ',
+        ]);
+
+        $this->assertTrue($config->isComplete());
+        $this->assertSame('  secret-password  ', $config->getPassword());
+    }
+
+    public function testDatabaseConstructorThrowsWhenPasswordIsMissing(): void
+    {
+        try {
+            new Database(DatabaseConfig::fromEnvironment([
+                'DB_HOST' => '127.0.0.1',
+                'DB_NAME' => 'psn100',
+                'DB_USER' => 'psn100',
+                'DB_PASSWORD' => '',
+            ]));
+            $this->fail('Expected DatabaseConnectionException for missing DB_PASSWORD.');
+        } catch (DatabaseConnectionException $exception) {
+            $this->assertStringContainsString('Database connection is not configured', $exception->getMessage());
+            $this->assertStringContainsString('DB_PASSWORD', $exception->getMessage());
+        }
     }
 
     public function testDatabaseConstructorThrowsWhenConfigurationIsIncomplete(): void

--- a/tests/DatabaseConfigTest.php
+++ b/tests/DatabaseConfigTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/database.php';
+
+final class DatabaseConfigTest extends TestCase
+{
+    public function testFromEnvironmentReadsValuesFromArray(): void
+    {
+        $config = DatabaseConfig::fromEnvironment([
+            'DB_HOST' => 'db.example.test',
+            'DB_NAME' => 'psn100',
+            'DB_USER' => 'psn100',
+            'DB_PASSWORD' => 'secret',
+        ]);
+
+        $this->assertTrue($config->isComplete());
+        $this->assertSame('mysql:host=db.example.test;dbname=psn100;charset=utf8mb4', $config->getDsn());
+        $this->assertSame('psn100', $config->getUser());
+        $this->assertSame('secret', $config->getPassword());
+    }
+
+    public function testFromEnvironmentFallsBackToGetenvWhenArrayValueMissing(): void
+    {
+        putenv('DB_HOST=127.0.0.1');
+        putenv('DB_NAME=psn100');
+        putenv('DB_USER=psn100');
+        putenv('DB_PASSWORD=psn100');
+
+        try {
+            $config = DatabaseConfig::fromEnvironment([]);
+
+            $this->assertTrue($config->isComplete());
+            $this->assertSame('127.0.0.1', $this->readPrivateProperty($config, 'host'));
+        } finally {
+            putenv('DB_HOST');
+            putenv('DB_NAME');
+            putenv('DB_USER');
+            putenv('DB_PASSWORD');
+        }
+    }
+
+    public function testIsCompleteRequiresHostDatabaseAndUser(): void
+    {
+        $config = DatabaseConfig::fromEnvironment([
+            'DB_HOST' => '127.0.0.1',
+            'DB_NAME' => '',
+            'DB_USER' => 'psn100',
+            'DB_PASSWORD' => 'psn100',
+        ]);
+
+        $this->assertFalse($config->isComplete());
+    }
+
+    public function testDatabaseConstructorThrowsWhenConfigurationIsIncomplete(): void
+    {
+        try {
+            new Database(DatabaseConfig::fromEnvironment([
+                'DB_HOST' => '',
+                'DB_NAME' => '',
+                'DB_USER' => '',
+                'DB_PASSWORD' => '',
+            ]));
+            $this->fail('Expected DatabaseConnectionException for incomplete configuration.');
+        } catch (DatabaseConnectionException $exception) {
+            $this->assertStringContainsString('Database connection is not configured', $exception->getMessage());
+            $this->assertStringContainsString('DB_HOST', $exception->getMessage());
+        }
+    }
+
+    private function readPrivateProperty(DatabaseConfig $config, string $property): string
+    {
+        $reflection = new ReflectionClass($config);
+        $propertyReflection = $reflection->getProperty($property);
+        $propertyReflection->setAccessible(true);
+
+        return (string) $propertyReflection->getValue($config);
+    }
+}

--- a/tests/IpAddressResolverTest.php
+++ b/tests/IpAddressResolverTest.php
@@ -52,4 +52,40 @@ final class IpAddressResolverTest extends TestCase
         $this->assertSame('', IpAddressResolver::resolve(null));
         $this->assertSame('', IpAddressResolver::resolve(''));
     }
+
+    public function testResolveFromServerUsesRemoteAddrByDefault(): void
+    {
+        $ipAddress = IpAddressResolver::resolveFromServerWithTrustedProxies(
+            ['REMOTE_ADDR' => '198.51.100.10'],
+            []
+        );
+
+        $this->assertSame('198.51.100.10', $ipAddress);
+    }
+
+    public function testResolveFromServerUsesForwardedForWhenProxyIsTrusted(): void
+    {
+        $ipAddress = IpAddressResolver::resolveFromServerWithTrustedProxies(
+            [
+                'REMOTE_ADDR' => '10.0.0.1',
+                'HTTP_X_FORWARDED_FOR' => '203.0.113.5, 10.0.0.1',
+            ],
+            ['10.0.0.1']
+        );
+
+        $this->assertSame('203.0.113.5', $ipAddress);
+    }
+
+    public function testResolveFromServerIgnoresForwardedForFromUntrustedProxy(): void
+    {
+        $ipAddress = IpAddressResolver::resolveFromServerWithTrustedProxies(
+            [
+                'REMOTE_ADDR' => '198.51.100.44',
+                'HTTP_X_FORWARDED_FOR' => '203.0.113.5',
+            ],
+            ['10.0.0.1']
+        );
+
+        $this->assertSame('198.51.100.44', $ipAddress);
+    }
 }

--- a/tests/PlayerReportResultTest.php
+++ b/tests/PlayerReportResultTest.php
@@ -31,5 +31,14 @@ final class PlayerReportResultTest extends TestCase
         $this->assertFalse($result->hasMessage());
         $this->assertFalse($result->isSuccess());
         $this->assertSame('', $result->getMessage());
+        $this->assertSame('', $result->getEscapedMessage());
+    }
+
+    public function testGetEscapedMessageEscapesHtmlEntities(): void
+    {
+        $result = PlayerReportResult::error('<script>alert(1)</script>');
+
+        $this->assertSame('<script>alert(1)</script>', $result->getMessage());
+        $this->assertSame('&lt;script&gt;alert(1)&lt;/script&gt;', $result->getEscapedMessage());
     }
 }

--- a/wwwroot/classes/IpAddressResolver.php
+++ b/wwwroot/classes/IpAddressResolver.php
@@ -4,6 +4,39 @@ declare(strict_types=1);
 
 final class IpAddressResolver
 {
+    /**
+     * @param array<string, mixed> $serverParameters
+     */
+    public static function resolveFromServer(array $serverParameters): string
+    {
+        return self::resolveFromServerWithTrustedProxies(
+            $serverParameters,
+            self::readTrustedProxyIpsFromEnvironment()
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $serverParameters
+     * @param list<string> $trustedProxyIps
+     */
+    public static function resolveFromServerWithTrustedProxies(
+        array $serverParameters,
+        array $trustedProxyIps,
+    ): string {
+        $remoteAddress = self::resolve($serverParameters['REMOTE_ADDR'] ?? '');
+
+        if ($remoteAddress === '' || !in_array($remoteAddress, $trustedProxyIps, true)) {
+            return $remoteAddress;
+        }
+
+        $forwardedClientIp = self::resolveForwardedClientIp($serverParameters['HTTP_X_FORWARDED_FOR'] ?? null);
+        if ($forwardedClientIp !== '') {
+            return $forwardedClientIp;
+        }
+
+        return $remoteAddress;
+    }
+
     public static function resolve(mixed $remoteAddr): string
     {
         if (is_array($remoteAddr)) {
@@ -24,5 +57,42 @@ final class IpAddressResolver
         $validatedAddress = filter_var($ipAddress, FILTER_VALIDATE_IP);
 
         return is_string($validatedAddress) ? $validatedAddress : '';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function readTrustedProxyIpsFromEnvironment(): array
+    {
+        $value = getenv('TRUSTED_PROXY_IPS');
+        if (!is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $proxyIps = [];
+        foreach (explode(',', $value) as $proxyIp) {
+            $proxyIp = trim($proxyIp);
+            if ($proxyIp !== '') {
+                $proxyIps[] = $proxyIp;
+            }
+        }
+
+        return $proxyIps;
+    }
+
+    private static function resolveForwardedClientIp(mixed $forwardedFor): string
+    {
+        if (!is_string($forwardedFor) || trim($forwardedFor) === '') {
+            return '';
+        }
+
+        foreach (explode(',', $forwardedFor) as $candidate) {
+            $validatedAddress = self::resolve(trim($candidate));
+            if ($validatedAddress !== '') {
+                return $validatedAddress;
+            }
+        }
+
+        return '';
     }
 }

--- a/wwwroot/classes/PlayerQueueRequest.php
+++ b/wwwroot/classes/PlayerQueueRequest.php
@@ -14,7 +14,7 @@ readonly class PlayerQueueRequest
     public static function fromArrays(array $requestData, array $serverData): self
     {
         $playerName = self::sanitizeValue($requestData['q'] ?? '');
-        $ipAddress = IpAddressResolver::resolve($serverData['REMOTE_ADDR'] ?? '');
+        $ipAddress = IpAddressResolver::resolveFromServer($serverData);
 
         return new self($playerName, $ipAddress);
     }

--- a/wwwroot/classes/PlayerReportRequest.php
+++ b/wwwroot/classes/PlayerReportRequest.php
@@ -22,7 +22,7 @@ final readonly class PlayerReportRequest
     {
         $explanationSubmitted = array_key_exists('explanation', $postParameters);
         $explanation = self::sanitizeExplanation($postParameters['explanation'] ?? null);
-        $ipAddress = IpAddressResolver::resolve($serverParameters['REMOTE_ADDR'] ?? '');
+        $ipAddress = IpAddressResolver::resolveFromServer($serverParameters);
         $csrfToken = self::sanitizeCsrfToken($postParameters['_csrf_token'] ?? null);
 
         return new self($explanation, $explanationSubmitted, $ipAddress, $csrfToken);

--- a/wwwroot/classes/PlayerReportResult.php
+++ b/wwwroot/classes/PlayerReportResult.php
@@ -37,4 +37,9 @@ readonly class PlayerReportResult
     {
         return $this->message;
     }
+
+    public function getEscapedMessage(): string
+    {
+        return htmlspecialchars($this->message, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
 }

--- a/wwwroot/database.php
+++ b/wwwroot/database.php
@@ -45,19 +45,34 @@ final readonly class DatabaseConfig
 
     public function isComplete(): bool
     {
-        return $this->host !== '' && $this->database !== '' && $this->user !== '';
+        return $this->host !== ''
+            && $this->database !== ''
+            && $this->user !== ''
+            && $this->password !== '';
     }
 
     private static function readConfigValue(string $name, array $environment): string
     {
         $value = $environment[$name] ?? false;
-        if (is_string($value) && trim($value) !== '') {
-            return trim($value);
+        if (is_string($value)) {
+            if ($name === 'DB_PASSWORD') {
+                return $value;
+            }
+
+            if (trim($value) !== '') {
+                return trim($value);
+            }
         }
 
         $fallback = getenv($name);
-        if (is_string($fallback) && trim($fallback) !== '') {
-            return trim($fallback);
+        if (is_string($fallback)) {
+            if ($name === 'DB_PASSWORD') {
+                return $fallback;
+            }
+
+            if (trim($fallback) !== '') {
+                return trim($fallback);
+            }
         }
 
         return '';

--- a/wwwroot/database.php
+++ b/wwwroot/database.php
@@ -36,11 +36,31 @@ final readonly class DatabaseConfig
     public static function fromEnvironment(array $environment = []): self
     {
         return new self(
-            (string) ($environment['DB_HOST'] ?? ''),
-            (string) ($environment['DB_NAME'] ?? ''),
-            (string) ($environment['DB_USER'] ?? ''),
-            (string) ($environment['DB_PASSWORD'] ?? '')
+            self::readConfigValue('DB_HOST', $environment),
+            self::readConfigValue('DB_NAME', $environment),
+            self::readConfigValue('DB_USER', $environment),
+            self::readConfigValue('DB_PASSWORD', $environment),
         );
+    }
+
+    public function isComplete(): bool
+    {
+        return $this->host !== '' && $this->database !== '' && $this->user !== '';
+    }
+
+    private static function readConfigValue(string $name, array $environment): string
+    {
+        $value = $environment[$name] ?? false;
+        if (is_string($value) && trim($value) !== '') {
+            return trim($value);
+        }
+
+        $fallback = getenv($name);
+        if (is_string($fallback) && trim($fallback) !== '') {
+            return trim($fallback);
+        }
+
+        return '';
     }
 
     public function getDsn(): string
@@ -80,6 +100,10 @@ class Database extends PDO
     {
         $this->config = $config ?? DatabaseConfig::createDefault();
         $this->options = $this->resolveOptions($options);
+
+        if (!$this->config->isComplete()) {
+            throw new DatabaseConnectionException(self::buildMissingConfigurationMessage());
+        }
 
         try {
             parent::__construct(
@@ -138,5 +162,12 @@ class Database extends PDO
         } catch (PDOException $exception) {
             // The optimizer switch is an optional hint; ignore failures so connections still succeed.
         }
+    }
+
+    private static function buildMissingConfigurationMessage(): string
+    {
+        return 'Database connection is not configured. Set DB_HOST, DB_NAME, DB_USER, and DB_PASSWORD '
+            . 'environment variables. When using the PHP built-in server, pass -d variables_order=EGPCS '
+            . 'or rely on getenv() by exporting the variables in your shell.';
     }
 }

--- a/wwwroot/player_report.php
+++ b/wwwroot/player_report.php
@@ -61,7 +61,7 @@ require_once("header.php");
             ?>
             <div class="col-12 mb-3">
                 <div class="alert alert-<?= $alertClass; ?>" role="alert">
-                    <?= $reportResult->getMessage(); ?>
+                    <?= $reportResult->getEscapedMessage(); ?>
                 </div>
             </div>
             <?php


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Phase 3 hardening from the code review: XSS safety, clearer database configuration, optional trusted-proxy client IP handling, and deployment documentation.

## Changes

### XSS hardening
- Added `PlayerReportResult::getEscapedMessage()` and use it in `player_report.php`
- Report alert text is now escaped even if message sources change in the future

### Database configuration
- `DatabaseConfig::fromEnvironment()` falls back to `getenv()` when `$_ENV` is empty
- Incomplete configuration fails fast with a clear `DatabaseConnectionException` mentioning required variables and `variables_order=EGPCS`
- `isComplete()` now requires `DB_PASSWORD` as well as host, database, and user
- `DB_PASSWORD` is passed through unchanged (no trimming) so credentials with leading/trailing whitespace are preserved

### Trusted reverse proxy support
- `IpAddressResolver::resolveFromServer()` uses `REMOTE_ADDR` by default
- When `TRUSTED_PROXY_IPS` lists the direct client, the leftmost valid `X-Forwarded-For` IP is used for queue/report rate limits
- `PlayerQueueRequest` and `PlayerReportRequest` now use the shared resolver

### Documentation
- Added deployment notes to `README.md` (DB env vars, proxy config, admin setup)
- Updated `AGENTS.md` with getenv fallback and `TRUSTED_PROXY_IPS` behavior

## Tests

- Added `DatabaseConfigTest` (including password completeness and exact-password preservation)
- Extended `IpAddressResolverTest` and `PlayerReportResultTest`
- All **529** tests pass (`php tests/run.php`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-accb207f-5558-4125-92a3-240c2112cfaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-accb207f-5558-4125-92a3-240c2112cfaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

