### PR TITLE
Add platform and exclusive filters to homepage popular games

### DIFF
--- a/tests/HomepageContentServiceTest.php
+++ b/tests/HomepageContentServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/HomepageContentService.php';
+require_once __DIR__ . '/../wwwroot/classes/HomepagePopularGamesFilter.php';
 require_once __DIR__ . '/../wwwroot/classes/Homepage/HomepageNewGame.php';
 require_once __DIR__ . '/../wwwroot/classes/Homepage/HomepageDlc.php';
 require_once __DIR__ . '/../wwwroot/classes/Homepage/HomepagePopularGame.php';
@@ -168,5 +169,102 @@ final class HomepageContentServiceTest extends TestCase
         $this->assertSame(1500, $popularGames[0]->getRecentPlayers());
         $this->assertSame('Moderate Game', $popularGames[1]->getName());
         $this->assertSame(500, $popularGames[1]->getRecentPlayers());
+    }
+
+    public function testGetPopularGamesFiltersByPlatform(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO trophy_title " .
+            "(id, np_communication_id, name, icon_url, platform, platinum, gold, silver, bronze) VALUES" .
+            " (1, 'NPWR600', 'PS4 Game', 'ps4.png', 'PS4', 0, 0, 0, 0)," .
+            " (2, 'NPWR601', 'PS5 Game', 'ps5.png', 'PS5', 0, 0, 0, 0)," .
+            " (3, 'NPWR602', 'Cross Gen', 'cross.png', 'PS4,PS5', 0, 0, 0, 0)"
+        );
+
+        $this->pdo->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status, recent_players) VALUES" .
+            " ('NPWR600', 0, 100)," .
+            " ('NPWR601', 0, 300)," .
+            " ('NPWR602', 0, 200)"
+        );
+
+        $filter = HomepagePopularGamesFilter::fromArray(['platform' => 'ps5']);
+        $popularGames = $this->service->getPopularGames(10, $filter);
+
+        $this->assertSame(['PS5 Game', 'Cross Gen'], array_map(
+            static fn(HomepagePopularGame $game): string => $game->getName(),
+            $popularGames
+        ));
+    }
+
+    public function testGetPopularGamesPsvrFilterExcludesPsvr2OnlyTitles(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO trophy_title " .
+            "(id, np_communication_id, name, icon_url, platform, platinum, gold, silver, bronze) VALUES" .
+            " (1, 'NPWR700', 'PSVR Game', 'psvr.png', 'PSVR', 0, 0, 0, 0)," .
+            " (2, 'NPWR701', 'PSVR2 Game', 'psvr2.png', 'PSVR2', 0, 0, 0, 0)"
+        );
+
+        $this->pdo->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status, recent_players) VALUES" .
+            " ('NPWR700', 0, 100)," .
+            " ('NPWR701', 0, 200)"
+        );
+
+        $filter = HomepagePopularGamesFilter::fromArray(['platform' => 'psvr']);
+        $popularGames = $this->service->getPopularGames(10, $filter);
+
+        $this->assertCount(1, $popularGames);
+        $this->assertSame('PSVR Game', $popularGames[0]->getName());
+    }
+
+    public function testGetPopularGamesExclusiveFilterReturnsSinglePlatformTitlesOnly(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO trophy_title " .
+            "(id, np_communication_id, name, icon_url, platform, platinum, gold, silver, bronze) VALUES" .
+            " (1, 'NPWR800', 'PS5 Only', 'ps5-only.png', 'PS5', 0, 0, 0, 0)," .
+            " (2, 'NPWR801', 'Cross Gen', 'cross.png', 'PS4,PS5', 0, 0, 0, 0)"
+        );
+
+        $this->pdo->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status, recent_players) VALUES" .
+            " ('NPWR800', 0, 50)," .
+            " ('NPWR801', 0, 500)"
+        );
+
+        $filter = HomepagePopularGamesFilter::fromArray(['exclusive' => 'true']);
+        $popularGames = $this->service->getPopularGames(10, $filter);
+
+        $this->assertCount(1, $popularGames);
+        $this->assertSame('PS5 Only', $popularGames[0]->getName());
+    }
+
+    public function testGetPopularGamesExclusivePlatformFilterMatchesExactPlatform(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO trophy_title " .
+            "(id, np_communication_id, name, icon_url, platform, platinum, gold, silver, bronze) VALUES" .
+            " (1, 'NPWR900', 'PS5 Only', 'ps5-only.png', 'PS5', 0, 0, 0, 0)," .
+            " (2, 'NPWR901', 'Cross Gen', 'cross.png', 'PS4,PS5', 0, 0, 0, 0)," .
+            " (3, 'NPWR902', 'PS4 Only', 'ps4-only.png', 'PS4', 0, 0, 0, 0)"
+        );
+
+        $this->pdo->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status, recent_players) VALUES" .
+            " ('NPWR900', 0, 100)," .
+            " ('NPWR901', 0, 500)," .
+            " ('NPWR902', 0, 200)"
+        );
+
+        $filter = HomepagePopularGamesFilter::fromArray([
+            'platform' => 'ps5',
+            'exclusive' => 'true',
+        ]);
+        $popularGames = $this->service->getPopularGames(10, $filter);
+
+        $this->assertCount(1, $popularGames);
+        $this->assertSame('PS5 Only', $popularGames[0]->getName());
     }
 }

--- a/tests/HomepageContentServiceTest.php
+++ b/tests/HomepageContentServiceTest.php
@@ -267,4 +267,26 @@ final class HomepageContentServiceTest extends TestCase
         $this->assertCount(1, $popularGames);
         $this->assertSame('PS5 Only', $popularGames[0]->getName());
     }
+
+    public function testGetPopularGamesFiltersByPcPlatform(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO trophy_title " .
+            "(id, np_communication_id, name, icon_url, platform, platinum, gold, silver, bronze) VALUES" .
+            " (1, 'NPWR950', 'PC Game', 'pc.png', 'PC', 0, 0, 0, 0)," .
+            " (2, 'NPWR951', 'PS5 Game', 'ps5.png', 'PS5', 0, 0, 0, 0)"
+        );
+
+        $this->pdo->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status, recent_players) VALUES" .
+            " ('NPWR950', 0, 100)," .
+            " ('NPWR951', 0, 200)"
+        );
+
+        $filter = HomepagePopularGamesFilter::fromArray(['platform' => 'pc']);
+        $popularGames = $this->service->getPopularGames(10, $filter);
+
+        $this->assertCount(1, $popularGames);
+        $this->assertSame('PC Game', $popularGames[0]->getName());
+    }
 }

--- a/tests/HomepagePopularGamesFilterTest.php
+++ b/tests/HomepagePopularGamesFilterTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/HomepagePopularGamesFilter.php';
+
+final class HomepagePopularGamesFilterTest extends TestCase
+{
+    public function testFromArrayDefaultsToAllPlatformsWithoutExclusiveFilter(): void
+    {
+        $filter = HomepagePopularGamesFilter::fromArray([]);
+
+        $this->assertSame(HomepagePopularGamesFilter::PLATFORM_ALL, $filter->getPlatform());
+        $this->assertFalse($filter->hasPlatformFilter());
+        $this->assertFalse($filter->isExclusiveOnly());
+        $this->assertSame([], $filter->getQueryParameters());
+    }
+
+    public function testFromArrayParsesPlatformAndExclusiveParameters(): void
+    {
+        $filter = HomepagePopularGamesFilter::fromArray([
+            'platform' => 'ps5',
+            'exclusive' => 'true',
+        ]);
+
+        $this->assertTrue($filter->isPlatformSelected(HomepagePopularGamesFilter::PLATFORM_PS5));
+        $this->assertTrue($filter->isExclusiveOnly());
+        $this->assertSame(
+            [
+                'platform' => 'ps5',
+                'exclusive' => 'true',
+            ],
+            $filter->getQueryParameters()
+        );
+        $this->assertSame('PS5', $filter->getPlatformDatabaseValue());
+    }
+
+    public function testFromArrayRejectsUnknownPlatformValues(): void
+    {
+        $filter = HomepagePopularGamesFilter::fromArray([
+            'platform' => 'dreamcast',
+            'exclusive' => '1',
+        ]);
+
+        $this->assertFalse($filter->hasPlatformFilter());
+        $this->assertTrue($filter->isExclusiveOnly());
+        $this->assertSame(['exclusive' => 'true'], $filter->getQueryParameters());
+    }
+}

--- a/tests/HomepagePopularGamesFilterTest.php
+++ b/tests/HomepagePopularGamesFilterTest.php
@@ -46,4 +46,16 @@ final class HomepagePopularGamesFilterTest extends TestCase
         $this->assertTrue($filter->isExclusiveOnly());
         $this->assertSame(['exclusive' => 'true'], $filter->getQueryParameters());
     }
+
+    public function testGetPlatformOptionsListsAllFirstThenAlphabeticalPlatforms(): void
+    {
+        $this->assertSame(
+            ['', 'pc', 'ps3', 'ps4', 'ps5', 'psvita', 'psvr', 'psvr2'],
+            array_keys(HomepagePopularGamesFilter::getPlatformOptions())
+        );
+        $this->assertSame(
+            ['All', 'PC', 'PS3', 'PS4', 'PS5', 'PSVITA', 'PSVR', 'PSVR2'],
+            array_values(HomepagePopularGamesFilter::getPlatformOptions())
+        );
+    }
 }

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -16,11 +16,12 @@ class HomepageContentService
     private const DEFAULT_POPULAR_GAME_LIMIT = 10;
 
     private const PLATFORM_CONDITIONS = [
+        HomepagePopularGamesFilter::PLATFORM_PC => "tt.platform LIKE '%PC%'",
         HomepagePopularGamesFilter::PLATFORM_PS3 => "tt.platform LIKE '%PS3%'",
-        HomepagePopularGamesFilter::PLATFORM_PSVITA => "tt.platform LIKE '%PSVITA%'",
         HomepagePopularGamesFilter::PLATFORM_PS4 => "tt.platform LIKE '%PS4%'",
-        HomepagePopularGamesFilter::PLATFORM_PSVR => "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'",
         HomepagePopularGamesFilter::PLATFORM_PS5 => "tt.platform LIKE '%PS5%'",
+        HomepagePopularGamesFilter::PLATFORM_PSVITA => "tt.platform LIKE '%PSVITA%'",
+        HomepagePopularGamesFilter::PLATFORM_PSVR => "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'",
         HomepagePopularGamesFilter::PLATFORM_PSVR2 => "tt.platform LIKE '%PSVR2%'",
     ];
 

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -7,12 +7,22 @@ require_once __DIR__ . '/Homepage/HomepageTitle.php';
 require_once __DIR__ . '/Homepage/HomepageNewGame.php';
 require_once __DIR__ . '/Homepage/HomepageDlc.php';
 require_once __DIR__ . '/Homepage/HomepagePopularGame.php';
+require_once __DIR__ . '/HomepagePopularGamesFilter.php';
 
 class HomepageContentService
 {
     private const DEFAULT_NEW_GAME_LIMIT = 8;
     private const DEFAULT_NEW_DLCS_LIMIT = 8;
     private const DEFAULT_POPULAR_GAME_LIMIT = 10;
+
+    private const PLATFORM_CONDITIONS = [
+        HomepagePopularGamesFilter::PLATFORM_PS3 => "tt.platform LIKE '%PS3%'",
+        HomepagePopularGamesFilter::PLATFORM_PSVITA => "tt.platform LIKE '%PSVITA%'",
+        HomepagePopularGamesFilter::PLATFORM_PS4 => "tt.platform LIKE '%PS4%'",
+        HomepagePopularGamesFilter::PLATFORM_PSVR => "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'",
+        HomepagePopularGamesFilter::PLATFORM_PS5 => "tt.platform LIKE '%PS5%'",
+        HomepagePopularGamesFilter::PLATFORM_PSVR2 => "tt.platform LIKE '%PSVR2%'",
+    ];
 
     public function __construct(private readonly PDO $database)
     {
@@ -100,10 +110,15 @@ class HomepageContentService
     /**
      * @return HomepagePopularGame[]
      */
-    public function getPopularGames(int $limit = self::DEFAULT_POPULAR_GAME_LIMIT): array
-    {
+    public function getPopularGames(
+        int $limit = self::DEFAULT_POPULAR_GAME_LIMIT,
+        ?HomepagePopularGamesFilter $filter = null
+    ): array {
+        $filter ??= HomepagePopularGamesFilter::fromArray([]);
+        $whereClause = implode(' AND ', $this->buildPopularGamesWhereClauses($filter));
+
         $query = $this->database->prepare(
-            <<<'SQL'
+            <<<SQL
             SELECT
                 tt.id,
                 tt.icon_url,
@@ -114,7 +129,7 @@ class HomepageContentService
                 trophy_title tt
                 JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             WHERE
-                ttm.status <> 2
+                {$whereClause}
             ORDER BY
                 ttm.recent_players DESC
             LIMIT
@@ -130,5 +145,26 @@ class HomepageContentService
             static fn(array $row): HomepagePopularGame => HomepagePopularGame::fromArray($row),
             $rows
         );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildPopularGamesWhereClauses(HomepagePopularGamesFilter $filter): array
+    {
+        $conditions = ['ttm.status <> 2'];
+
+        if ($filter->isExclusiveOnly() && $filter->hasPlatformFilter()) {
+            $conditions[] = 'tt.platform = ' . $this->database->quote($filter->getPlatformDatabaseValue());
+        } elseif ($filter->isExclusiveOnly()) {
+            $conditions[] = "tt.platform NOT LIKE '%,%'";
+        } elseif ($filter->hasPlatformFilter()) {
+            $platformCondition = self::PLATFORM_CONDITIONS[$filter->getPlatform()] ?? null;
+            if ($platformCondition !== null) {
+                $conditions[] = $platformCondition;
+            }
+        }
+
+        return $conditions;
     }
 }

--- a/wwwroot/classes/HomepageController.php
+++ b/wwwroot/classes/HomepageController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/HomepageContentService.php';
 require_once __DIR__ . '/HomepagePage.php';
 require_once __DIR__ . '/HomepageViewModel.php';
+require_once __DIR__ . '/HomepagePopularGamesFilter.php';
 
 final class HomepageController
 {
@@ -47,6 +48,13 @@ final class HomepageController
     public function withPopularGamesLimit(int $limit): self
     {
         $this->homepagePage->setPopularGamesLimit($limit);
+
+        return $this;
+    }
+
+    public function withPopularGamesFilter(HomepagePopularGamesFilter $filter): self
+    {
+        $this->homepagePage->setPopularGamesFilter($filter);
 
         return $this;
     }

--- a/wwwroot/classes/HomepagePage.php
+++ b/wwwroot/classes/HomepagePage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/HomepageContentService.php';
 require_once __DIR__ . '/HomepageViewModel.php';
+require_once __DIR__ . '/HomepagePopularGamesFilter.php';
 
 class HomepagePage
 {
@@ -15,6 +16,7 @@ class HomepagePage
         private ?int $newGamesLimit = null,
         private ?int $newDlcsLimit = null,
         private ?int $popularGamesLimit = null,
+        private ?HomepagePopularGamesFilter $popularGamesFilter = null,
     ) {
     }
 
@@ -49,6 +51,13 @@ class HomepagePage
         return $this;
     }
 
+    public function setPopularGamesFilter(HomepagePopularGamesFilter $filter): self
+    {
+        $this->popularGamesFilter = $filter;
+
+        return $this;
+    }
+
     public function buildViewModel(): HomepageViewModel
     {
         $newGames = $this->newGamesLimit === null
@@ -59,11 +68,13 @@ class HomepagePage
             ? $this->contentService->getNewDlcs()
             : $this->contentService->getNewDlcs($this->newDlcsLimit);
 
-        $popularGames = $this->popularGamesLimit === null
-            ? $this->contentService->getPopularGames()
-            : $this->contentService->getPopularGames($this->popularGamesLimit);
+        $popularGamesFilter = $this->popularGamesFilter ?? HomepagePopularGamesFilter::fromArray([]);
 
-        return new HomepageViewModel($this->title, $newGames, $newDlcs, $popularGames);
+        $popularGames = $this->popularGamesLimit === null
+            ? $this->contentService->getPopularGames(filter: $popularGamesFilter)
+            : $this->contentService->getPopularGames($this->popularGamesLimit, $popularGamesFilter);
+
+        return new HomepageViewModel($this->title, $newGames, $newDlcs, $popularGames, $popularGamesFilter);
     }
 
     private function assertPositiveLimit(int $limit): void

--- a/wwwroot/classes/HomepagePopularGamesFilter.php
+++ b/wwwroot/classes/HomepagePopularGamesFilter.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+final class HomepagePopularGamesFilter
+{
+    public const PLATFORM_ALL = '';
+    public const PLATFORM_PS3 = 'ps3';
+    public const PLATFORM_PSVITA = 'psvita';
+    public const PLATFORM_PS4 = 'ps4';
+    public const PLATFORM_PSVR = 'psvr';
+    public const PLATFORM_PS5 = 'ps5';
+    public const PLATFORM_PSVR2 = 'psvr2';
+
+    /**
+     * @var list<string>
+     */
+    private const PLATFORM_KEYS = [
+        self::PLATFORM_PS3,
+        self::PLATFORM_PSVITA,
+        self::PLATFORM_PS4,
+        self::PLATFORM_PSVR,
+        self::PLATFORM_PS5,
+        self::PLATFORM_PSVR2,
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const PLATFORM_LABELS = [
+        self::PLATFORM_ALL => 'All',
+        self::PLATFORM_PS3 => 'PS3',
+        self::PLATFORM_PSVITA => 'PSVITA',
+        self::PLATFORM_PS4 => 'PS4',
+        self::PLATFORM_PSVR => 'PSVR',
+        self::PLATFORM_PS5 => 'PS5',
+        self::PLATFORM_PSVR2 => 'PSVR2',
+    ];
+
+    private function __construct(
+        private readonly string $platform,
+        private readonly bool $exclusiveOnly,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $queryParameters
+     */
+    public static function fromArray(array $queryParameters): self
+    {
+        $platform = self::normalizePlatform($queryParameters['platform'] ?? null);
+        $exclusiveOnly = self::toBool($queryParameters['exclusive'] ?? null);
+
+        return new self($platform, $exclusiveOnly);
+    }
+
+    public function getPlatform(): string
+    {
+        return $this->platform;
+    }
+
+    public function hasPlatformFilter(): bool
+    {
+        return $this->platform !== self::PLATFORM_ALL;
+    }
+
+    public function isExclusiveOnly(): bool
+    {
+        return $this->exclusiveOnly;
+    }
+
+    public function isPlatformSelected(string $platform): bool
+    {
+        return $this->platform === $platform;
+    }
+
+    public function getPlatformDatabaseValue(): string
+    {
+        return self::PLATFORM_LABELS[$this->platform] ?? '';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getQueryParameters(): array
+    {
+        $parameters = [];
+
+        if ($this->hasPlatformFilter()) {
+            $parameters['platform'] = $this->platform;
+        }
+
+        if ($this->exclusiveOnly) {
+            $parameters['exclusive'] = 'true';
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getPlatformOptions(): array
+    {
+        return self::PLATFORM_LABELS;
+    }
+
+    private static function normalizePlatform(mixed $value): string
+    {
+        if (!is_string($value) && !is_numeric($value)) {
+            return self::PLATFORM_ALL;
+        }
+
+        $platform = strtolower(trim((string) $value));
+
+        if ($platform === '' || !in_array($platform, self::PLATFORM_KEYS, true)) {
+            return self::PLATFORM_ALL;
+        }
+
+        return $platform;
+    }
+
+    private static function toBool(mixed $value): bool
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value !== 0;
+        }
+
+        if (is_string($value)) {
+            $value = strtolower(trim($value));
+
+            if ($value === '' || $value === 'false' || $value === '0') {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/wwwroot/classes/HomepagePopularGamesFilter.php
+++ b/wwwroot/classes/HomepagePopularGamesFilter.php
@@ -5,22 +5,24 @@ declare(strict_types=1);
 final class HomepagePopularGamesFilter
 {
     public const PLATFORM_ALL = '';
+    public const PLATFORM_PC = 'pc';
     public const PLATFORM_PS3 = 'ps3';
-    public const PLATFORM_PSVITA = 'psvita';
     public const PLATFORM_PS4 = 'ps4';
-    public const PLATFORM_PSVR = 'psvr';
     public const PLATFORM_PS5 = 'ps5';
+    public const PLATFORM_PSVITA = 'psvita';
+    public const PLATFORM_PSVR = 'psvr';
     public const PLATFORM_PSVR2 = 'psvr2';
 
     /**
      * @var list<string>
      */
     private const PLATFORM_KEYS = [
+        self::PLATFORM_PC,
         self::PLATFORM_PS3,
-        self::PLATFORM_PSVITA,
         self::PLATFORM_PS4,
-        self::PLATFORM_PSVR,
         self::PLATFORM_PS5,
+        self::PLATFORM_PSVITA,
+        self::PLATFORM_PSVR,
         self::PLATFORM_PSVR2,
     ];
 
@@ -29,11 +31,12 @@ final class HomepagePopularGamesFilter
      */
     private const PLATFORM_LABELS = [
         self::PLATFORM_ALL => 'All',
+        self::PLATFORM_PC => 'PC',
         self::PLATFORM_PS3 => 'PS3',
-        self::PLATFORM_PSVITA => 'PSVITA',
         self::PLATFORM_PS4 => 'PS4',
-        self::PLATFORM_PSVR => 'PSVR',
         self::PLATFORM_PS5 => 'PS5',
+        self::PLATFORM_PSVITA => 'PSVITA',
+        self::PLATFORM_PSVR => 'PSVR',
         self::PLATFORM_PSVR2 => 'PSVR2',
     ];
 

--- a/wwwroot/classes/HomepageViewModel.php
+++ b/wwwroot/classes/HomepageViewModel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/Homepage/HomepageNewGame.php';
 require_once __DIR__ . '/Homepage/HomepageDlc.php';
 require_once __DIR__ . '/Homepage/HomepagePopularGame.php';
+require_once __DIR__ . '/HomepagePopularGamesFilter.php';
 
 class HomepageViewModel
 {
@@ -25,17 +26,25 @@ class HomepageViewModel
      */
     private array $popularGames;
 
+    private HomepagePopularGamesFilter $popularGamesFilter;
+
     /**
      * @param HomepageNewGame[] $newGames
      * @param HomepageDlc[] $newDlcs
      * @param HomepagePopularGame[] $popularGames
      */
-    public function __construct(string $title, array $newGames, array $newDlcs, array $popularGames)
-    {
+    public function __construct(
+        string $title,
+        array $newGames,
+        array $newDlcs,
+        array $popularGames,
+        ?HomepagePopularGamesFilter $popularGamesFilter = null
+    ) {
         $this->title = $title;
         $this->newGames = $newGames;
         $this->newDlcs = $newDlcs;
         $this->popularGames = $popularGames;
+        $this->popularGamesFilter = $popularGamesFilter ?? HomepagePopularGamesFilter::fromArray([]);
     }
 
     public function getTitle(): string
@@ -65,5 +74,10 @@ class HomepageViewModel
     public function getPopularGames(): array
     {
         return $this->popularGames;
+    }
+
+    public function getPopularGamesFilter(): HomepagePopularGamesFilter
+    {
+        return $this->popularGamesFilter;
     }
 }

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -3,14 +3,18 @@
 declare(strict_types=1);
 
 require_once 'classes/HomepageController.php';
+require_once 'classes/HomepagePopularGamesFilter.php';
 
-$homepageController = HomepageController::fromDatabase($database);
+$popularGamesFilter = HomepagePopularGamesFilter::fromArray($_GET ?? []);
+$homepageController = HomepageController::fromDatabase($database)
+    ->withPopularGamesFilter($popularGamesFilter);
 $homepageViewModel = $homepageController->getViewModel();
 
 $title = $homepageViewModel->getTitle();
 $newGames = $homepageViewModel->getNewGames();
 $newDlcs = $homepageViewModel->getNewDlcs();
 $popularGames = $homepageViewModel->getPopularGames();
+$popularGamesFilter = $homepageViewModel->getPopularGamesFilter();
 require_once("header.php");
 ?>
 
@@ -141,6 +145,26 @@ require_once("header.php");
         <div class="col-12 col-lg-4">
             <div class="bg-body-tertiary p-3 rounded">
                 <h1>Popular Games</h1>
+                <form method="get" class="mb-3">
+                    <div class="mb-2">
+                        <label for="popular-platform" class="form-label mb-1">Platform</label>
+                        <select class="form-select form-select-sm" name="platform" id="popular-platform" onchange="this.form.submit()">
+                            <?php
+                            foreach (HomepagePopularGamesFilter::getPlatformOptions() as $platformValue => $platformLabel) {
+                                ?>
+                                <option value="<?= htmlentities($platformValue, ENT_QUOTES, 'UTF-8'); ?>"<?= ($popularGamesFilter->isPlatformSelected($platformValue) ? ' selected' : ''); ?>>
+                                    <?= htmlentities($platformLabel); ?>
+                                </option>
+                                <?php
+                            }
+                            ?>
+                        </select>
+                    </div>
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" role="switch" name="exclusive" value="true" id="popular-exclusive"<?= ($popularGamesFilter->isExclusiveOnly() ? ' checked' : ''); ?> onchange="this.form.submit()">
+                        <label class="form-check-label" for="popular-exclusive">Exclusive</label>
+                    </div>
+                </form>
                 <?php
                 foreach ($popularGames as $game) {
                     $gameUrl = $game->getRelativeUrl($utility);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds platform selection and an exclusive-only toggle to the **Popular Games** section on the home page.

- **Platform filter:** All, PC, PS3, PS4, PS5, PSVITA, PSVR, PSVR2 (All first, then alphabetical)
- **Exclusive toggle:** when enabled, limits results to single-platform titles (exact match when a platform is selected)

## Changes

- New `HomepagePopularGamesFilter` parses `platform` and `exclusive` query parameters
- `HomepageContentService::getPopularGames()` applies platform and exclusivity SQL conditions (PSVR uses comma-boundary matching to avoid matching PSVR2)
- Home page sidebar renders a platform dropdown and exclusive switch that auto-submit on change
- Added unit tests for filter parsing and filtered query behavior

## Test plan

- [x] `php tests/run.php` — all 538 tests pass
- [ ] Manually verify home page filters at `/?platform=pc&exclusive=true`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6346e3b4-156f-4bcc-869c-0fe59dd5d207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6346e3b4-156f-4bcc-869c-0fe59dd5d207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

