### PR TITLE
Scroll to popular games after filter change on mobile

### DIFF
--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -142,14 +142,14 @@ require_once("header.php");
         </div>
 
         <!-- Popular Games -->
-        <div class="col-12 col-lg-4">
+        <div class="col-12 col-lg-4" id="popular-games" style="scroll-margin-top: 0.5rem;">
             <div class="bg-body-tertiary p-3 rounded">
                 <h1>Popular Games</h1>
-                <form method="get" class="mb-3">
+                <form method="get" class="mb-3" id="popular-games-filter">
                     <div class="row">
                         <div class="col-8">
                             <div class="form-floating">
-                                <select class="form-select form-select-sm" name="platform" id="popular-platform" onchange="this.form.submit()">
+                                <select class="form-select form-select-sm" name="platform" id="popular-platform" onchange="this.form.requestSubmit()">
                                     <?php
                                     foreach (HomepagePopularGamesFilter::getPlatformOptions() as $platformValue => $platformLabel) {
                                         ?>
@@ -165,7 +165,7 @@ require_once("header.php");
                         </div>
                         <div class="col-4 d-flex align-items-center">
                             <div class="form-check form-switch">
-                                <input class="form-check-input" type="checkbox" role="switch" name="exclusive" value="true" id="popular-exclusive"<?= ($popularGamesFilter->isExclusiveOnly() ? ' checked' : ''); ?> onchange="this.form.submit()">
+                                <input class="form-check-input" type="checkbox" role="switch" name="exclusive" value="true" id="popular-exclusive"<?= ($popularGamesFilter->isExclusiveOnly() ? ' checked' : ''); ?> onchange="this.form.requestSubmit()">
                                 <label class="form-check-label" for="popular-exclusive">Exclusive</label>
                             </div>
                         </div>
@@ -399,6 +399,23 @@ class PlayerQueueManager {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    const popularGamesFilterForm = document.getElementById('popular-games-filter');
+    if (popularGamesFilterForm) {
+        popularGamesFilterForm.addEventListener('submit', () => {
+            sessionStorage.setItem('home-scroll-popular-games', '1');
+        });
+    }
+
+    if (sessionStorage.getItem('home-scroll-popular-games') === '1') {
+        sessionStorage.removeItem('home-scroll-popular-games');
+        const popularGames = document.getElementById('popular-games');
+        if (popularGames) {
+            requestAnimationFrame(() => {
+                popularGames.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            });
+        }
+    }
+
     const queueManager = new PlayerQueueManager({
         playerInputId: 'player',
         buttonId: 'player-button',

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -149,7 +149,7 @@ require_once("header.php");
                     <div class="row">
                         <div class="col-8">
                             <div class="form-floating">
-                                <select class="form-select form-select-sm" name="platform" id="popular-platform" onchange="this.form.requestSubmit()">
+                                <select class="form-select form-select-sm" name="platform" id="popular-platform" onchange="submitPopularGamesFilter(this.form)">
                                     <?php
                                     foreach (HomepagePopularGamesFilter::getPlatformOptions() as $platformValue => $platformLabel) {
                                         ?>
@@ -165,7 +165,7 @@ require_once("header.php");
                         </div>
                         <div class="col-4 d-flex align-items-center">
                             <div class="form-check form-switch">
-                                <input class="form-check-input" type="checkbox" role="switch" name="exclusive" value="true" id="popular-exclusive"<?= ($popularGamesFilter->isExclusiveOnly() ? ' checked' : ''); ?> onchange="this.form.requestSubmit()">
+                                <input class="form-check-input" type="checkbox" role="switch" name="exclusive" value="true" id="popular-exclusive"<?= ($popularGamesFilter->isExclusiveOnly() ? ' checked' : ''); ?> onchange="submitPopularGamesFilter(this.form)">
                                 <label class="form-check-label" for="popular-exclusive">Exclusive</label>
                             </div>
                         </div>
@@ -398,23 +398,69 @@ class PlayerQueueManager {
     }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-    const popularGamesFilterForm = document.getElementById('popular-games-filter');
-    if (popularGamesFilterForm) {
-        popularGamesFilterForm.addEventListener('submit', () => {
-            sessionStorage.setItem('home-scroll-popular-games', '1');
-        });
+const POPULAR_GAMES_SCROLL_KEY = 'home-scroll-popular-games';
+
+function isSessionStorageAvailable() {
+    try {
+        const testKey = '__storage_test__';
+        sessionStorage.setItem(testKey, '1');
+        sessionStorage.removeItem(testKey);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
+function markPopularGamesScrollOnReload() {
+    if (!isSessionStorageAvailable()) {
+        return;
     }
 
-    if (sessionStorage.getItem('home-scroll-popular-games') === '1') {
-        sessionStorage.removeItem('home-scroll-popular-games');
-        const popularGames = document.getElementById('popular-games');
-        if (popularGames) {
-            requestAnimationFrame(() => {
-                popularGames.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            });
-        }
+    try {
+        sessionStorage.setItem(POPULAR_GAMES_SCROLL_KEY, '1');
+    } catch (error) {
+        // Ignore storage failures.
     }
+}
+
+function submitPopularGamesFilter(form) {
+    markPopularGamesScrollOnReload();
+
+    if (typeof form.requestSubmit === 'function') {
+        form.requestSubmit();
+        return;
+    }
+
+    form.submit();
+}
+
+function scrollToPopularGamesIfRequested() {
+    if (!isSessionStorageAvailable()) {
+        return;
+    }
+
+    try {
+        if (sessionStorage.getItem(POPULAR_GAMES_SCROLL_KEY) !== '1') {
+            return;
+        }
+
+        sessionStorage.removeItem(POPULAR_GAMES_SCROLL_KEY);
+    } catch (error) {
+        return;
+    }
+
+    const popularGames = document.getElementById('popular-games');
+    if (!popularGames) {
+        return;
+    }
+
+    requestAnimationFrame(() => {
+        popularGames.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    scrollToPopularGamesIfRequested();
 
     const queueManager = new PlayerQueueManager({
         playerInputId: 'player',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After changing the Popular Games platform or exclusive filter on mobile, the page reloads at the top and users have to scroll back down. This PR restores scroll position by smoothly scrolling to the Popular Games section after a filter change.

## Changes

- Add `id="popular-games"` anchor with `scroll-margin-top` on the Popular Games column
- Add `submitPopularGamesFilter()` helper that records scroll intent and uses `requestSubmit()` with `form.submit()` fallback
- Guard all `sessionStorage` access so queue initialization is unaffected when storage is unavailable
- Smooth-scroll to Popular Games on the next page load when a filter change was submitted

Built on top of the responsive filter layout already merged in #16037.

## Test plan

- [ ] On mobile (or narrow viewport), change platform or exclusive filter and confirm the page scrolls back to Popular Games
- [ ] On desktop, confirm filter behavior is unchanged
- [ ] Confirm homepage Update field still works when storage is disabled
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6346e3b4-156f-4bcc-869c-0fe59dd5d207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6346e3b4-156f-4bcc-869c-0fe59dd5d207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

