### PR TITLE
Guard game page dates and make admin game copy atomic

### DIFF
--- a/tests/TrophyHistorySnapshotTest.php
+++ b/tests/TrophyHistorySnapshotTest.php
@@ -64,6 +64,34 @@ final class TrophyHistorySnapshotTest extends TestCase
         $this->assertSame('Updated trophy detail', $trophyHistoryQuery->fetchColumn());
     }
 
+    public function testRecordByTitleIdSwallowsErrorsWhenManagingItsOwnTransaction(): void
+    {
+        $this->seedInitialData();
+        $this->database->exec('DROP TABLE trophy_group_history');
+
+        $this->historyRecorder->recordByTitleId(1);
+
+        $this->assertSame(0, (int) $this->database->query('SELECT COUNT(*) FROM trophy_title_history')->fetchColumn());
+    }
+
+    public function testRecordByTitleIdRethrowsWhenParticipatingInOuterTransaction(): void
+    {
+        $this->seedInitialData();
+        $this->database->beginTransaction();
+
+        try {
+            $this->database->exec('DROP TABLE trophy_group_history');
+            $this->historyRecorder->recordByTitleId(1);
+            $this->fail('Expected history recording to abort the outer transaction.');
+        } catch (Throwable $exception) {
+            $this->assertTrue($this->database->inTransaction());
+            $this->database->rollBack();
+        }
+
+        $this->assertSame(0, (int) $this->database->query('SELECT COUNT(*) FROM trophy_title_history')->fetchColumn());
+        $this->assertSame(0, (int) $this->database->query('SELECT COUNT(*) FROM psn100_change')->fetchColumn());
+    }
+
     private function createSchema(): void
     {
         $this->database->exec('CREATE TABLE log (id INTEGER PRIMARY KEY AUTOINCREMENT, message TEXT)');

--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -199,46 +199,55 @@ class GameCopyService
         bool $copyIconUrl = true,
         bool $copySetVersion = true
     ): void {
-        $childNpCommunicationId = $this->getNpCommunicationId($childId);
-        $parentNpCommunicationId = $this->getNpCommunicationId($parentId);
+        $this->database->beginTransaction();
 
-        $this->ensureChildIsNotMergeTitle($childNpCommunicationId);
-        $this->ensureParentIsMergeTitle($parentNpCommunicationId);
+        try {
+            $childNpCommunicationId = $this->getNpCommunicationId($childId);
+            $parentNpCommunicationId = $this->getNpCommunicationId($parentId);
 
-        $this->copyTrophyTitle(
-            $childNpCommunicationId,
-            $parentNpCommunicationId,
-            $copyIconUrl,
-            $copySetVersion
-        );
+            $this->ensureChildIsNotMergeTitle($childNpCommunicationId);
+            $this->ensureParentIsMergeTitle($parentNpCommunicationId);
 
-        if ($this->isBaseList($childNpCommunicationId)) {
-            $this->copyNewTrophyGroups($childNpCommunicationId, $parentNpCommunicationId);
-            $groupIdMapping = $this->copyConflictingTrophyGroups(
+            $this->copyTrophyTitle(
                 $childNpCommunicationId,
                 $parentNpCommunicationId,
-                [],
-                true
+                $copyIconUrl,
+                $copySetVersion
             );
-            $this->copyTrophyGroups($childNpCommunicationId, $parentNpCommunicationId);
-            $this->copyNewTrophies($childNpCommunicationId, $parentNpCommunicationId);
-            $this->copyConflictingTrophies($childNpCommunicationId, $parentNpCommunicationId, $groupIdMapping);
-            $this->copyTrophies($childNpCommunicationId, $parentNpCommunicationId);
-        } else {
-            $numericGroupIds = $this->getNumericGroupIds($childNpCommunicationId);
-            $groupIdMapping = $this->copyConflictingTrophyGroups(
-                $childNpCommunicationId,
-                $parentNpCommunicationId,
-                $numericGroupIds
-            );
-            $this->copyConflictingTrophies($childNpCommunicationId, $parentNpCommunicationId, $groupIdMapping);
+
+            if ($this->isBaseList($childNpCommunicationId)) {
+                $this->copyNewTrophyGroups($childNpCommunicationId, $parentNpCommunicationId);
+                $groupIdMapping = $this->copyConflictingTrophyGroups(
+                    $childNpCommunicationId,
+                    $parentNpCommunicationId,
+                    [],
+                    true
+                );
+                $this->copyTrophyGroups($childNpCommunicationId, $parentNpCommunicationId);
+                $this->copyNewTrophies($childNpCommunicationId, $parentNpCommunicationId);
+                $this->copyConflictingTrophies($childNpCommunicationId, $parentNpCommunicationId, $groupIdMapping);
+                $this->copyTrophies($childNpCommunicationId, $parentNpCommunicationId);
+            } else {
+                $numericGroupIds = $this->getNumericGroupIds($childNpCommunicationId);
+                $groupIdMapping = $this->copyConflictingTrophyGroups(
+                    $childNpCommunicationId,
+                    $parentNpCommunicationId,
+                    $numericGroupIds
+                );
+                $this->copyConflictingTrophies($childNpCommunicationId, $parentNpCommunicationId, $groupIdMapping);
+            }
+
+            $this->updateTrophyTitleCounts($parentNpCommunicationId);
+
+            $this->recordCopyAction($childId, $parentId);
+
+            $this->historyRecorder->recordByTitleId($parentId);
+
+            $this->database->commit();
+        } catch (Throwable $exception) {
+            $this->database->rollBack();
+            throw $exception;
         }
-
-        $this->updateTrophyTitleCounts($parentNpCommunicationId);
-
-        $this->recordCopyAction($childId, $parentId);
-
-        $this->historyRecorder->recordByTitleId($parentId);
     }
 
     private function getNpCommunicationId(int $gameId): string

--- a/wwwroot/classes/GameHistoryService.php
+++ b/wwwroot/classes/GameHistoryService.php
@@ -40,6 +40,8 @@ final class GameHistoryService
                 SQL
             );
         } catch (PDOException $exception) {
+            $this->logDatabaseError($exception, 'prepare history query');
+
             return [];
         }
 
@@ -48,6 +50,8 @@ final class GameHistoryService
         try {
             $query->execute();
         } catch (PDOException $exception) {
+            $this->logDatabaseError($exception, 'execute history query');
+
             return [];
         }
 
@@ -200,6 +204,8 @@ final class GameHistoryService
         try {
             $query = $this->database->prepare($sql);
         } catch (PDOException $exception) {
+            $this->logDatabaseError($exception, 'prepare related history query');
+
             return [];
         }
 
@@ -210,12 +216,19 @@ final class GameHistoryService
         try {
             $query->execute();
         } catch (PDOException $exception) {
+            $this->logDatabaseError($exception, 'execute related history query');
+
             return [];
         }
 
         $rows = $query->fetchAll(PDO::FETCH_ASSOC);
 
         return is_array($rows) ? $rows : [];
+    }
+
+    private function logDatabaseError(PDOException $exception, string $context): void
+    {
+        error_log(sprintf('GameHistoryService %s failed: %s', $context, $exception->getMessage()));
     }
 
     private function createDateTime(string $value): DateTimeImmutable

--- a/wwwroot/classes/TrophyHistoryRecorder.php
+++ b/wwwroot/classes/TrophyHistoryRecorder.php
@@ -124,6 +124,10 @@ class TrophyHistoryRecorder
                     $exception->getMessage()
                 ));
             }
+
+            if (!$startedTransaction) {
+                throw $exception;
+            }
         }
     }
 

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -277,28 +277,31 @@ require_once("header.php");
                                                     && $previousTimeStamp !== null
                                                     && $trophyRow->hasRecordedEarnedDate()
                                                 ) {
-                                                    echo "<br>";
                                                     $datetime1 = date_create($previousTimeStamp);
                                                     $datetime2 = date_create($trophyRow->getEarnedDate());
-                                                    $completionTimes = explode(", ", date_diff($datetime1, $datetime2)->format("%y years, %m months, %d days, %h hours, %i minutes, %s seconds"));
-                                                    $first = -1;
-                                                    $second = -1;
-                                                    for ($i = 0; $i < count($completionTimes); $i++) {
-                                                        if ($completionTimes[$i][0] == "0") {
-                                                            continue;
+
+                                                    if ($datetime1 !== false && $datetime2 !== false) {
+                                                        echo "<br>";
+                                                        $completionTimes = explode(", ", date_diff($datetime1, $datetime2)->format("%y years, %m months, %d days, %h hours, %i minutes, %s seconds"));
+                                                        $first = -1;
+                                                        $second = -1;
+                                                        for ($i = 0; $i < count($completionTimes); $i++) {
+                                                            if ($completionTimes[$i][0] == "0") {
+                                                                continue;
+                                                            }
+
+                                                            if ($first == -1) {
+                                                                $first = $i;
+                                                            } elseif ($second == -1) {
+                                                                $second = $i;
+                                                            }
                                                         }
 
-                                                        if ($first == -1) {
-                                                            $first = $i;
-                                                        } elseif ($second == -1) {
-                                                            $second = $i;
+                                                        if ($first >= 0 && $second >= 0) {
+                                                            echo "(+". $completionTimes[$first] .", ". $completionTimes[$second] .")";
+                                                        } elseif ($first >= 0 && $second == -1) {
+                                                            echo "(+". $completionTimes[$first] .")";
                                                         }
-                                                    }
-
-                                                    if ($first >= 0 && $second >= 0) {
-                                                        echo "(+". $completionTimes[$first] .", ". $completionTimes[$second] .")";
-                                                    } elseif ($first >= 0 && $second == -1) {
-                                                        echo "(+". $completionTimes[$first] .")";
                                                     }
                                                 }
                                                 if ($sort == "date") {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Second batch of reliability fixes from the code audit (PR 1 covered cron date safety).

## Changes

### Guard `game.php` date diff on malformed earned dates

When sorting trophies by date, the completion-time display called `date_diff()` on the result of `date_create()` without checking for parse failures. Malformed earned dates caused a fatal error on the public game page.

**Fix:** Only render the completion-time block when both timestamps parse successfully.

### Transaction-wrap `GameCopyService::copyChildToParent()`

Copying a child game into a parent runs 10+ sequential SQL steps with no transaction. Failure mid-copy could leave a partially merged parent game.

**Fix:** Wrap the entire copy operation in `beginTransaction()` / `commit()` with `rollBack()` on any exception, matching the pattern used in `GameDetailService`.

### Rethrow `TrophyHistoryRecorder` errors in outer transactions

`recordByTitleId()` is called from `copyChildToParent()` inside the new outer transaction. When it catches `Throwable` without rethrowing, partial history inserts could commit alongside the game copy on failure.

**Fix:** Rethrow after logging when participating in a caller-managed transaction; standalone callers still swallow errors and roll back their own transaction.

### Log `GameHistoryService` database errors

Transient database failures were caught and returned as an empty history array with no diagnostic output, indistinguishable from "no history."

**Fix:** Log `PDOException` messages via `error_log()` before returning `[]`.

## Tests

All **564 tests pass** (`php tests/run.php`), including two new cases for outer-transaction rethrow behavior in `TrophyHistoryRecorder`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b802e74-fa75-4ec6-bc64-eb1887fafe9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b802e74-fa75-4ec6-bc64-eb1887fafe9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

