### PR TITLE
Harden admin actions and public output against XSS/CSRF

### DIFF
--- a/tests/AdminPlayerReportPageTest.php
+++ b/tests/AdminPlayerReportPageTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PlayerReportAdminService.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PlayerReportAdminPage.php';
+
+final class AdminPlayerReportPageTest extends TestCase
+{
+    public function testHandleDeletesReportViaPost(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE player (account_id INTEGER PRIMARY KEY, online_id TEXT)');
+        $database->exec('CREATE TABLE player_report (report_id INTEGER PRIMARY KEY, account_id INTEGER, explanation TEXT)');
+        $database->exec("INSERT INTO player (account_id, online_id) VALUES (1, 'ExampleUser')");
+        $database->exec("INSERT INTO player_report (report_id, account_id, explanation) VALUES (5, 1, 'Cheating')");
+
+        $service = new PlayerReportAdminService($database);
+        $page = new PlayerReportAdminPage($service);
+
+        $result = $page->handle([], ['delete_id' => '5'], 'POST');
+
+        $this->assertSame('Report 5 deleted successfully.', $result->getSuccessMessage());
+        $this->assertSame(null, $result->getErrorMessage());
+        $this->assertSame([], $result->getReportedPlayers());
+    }
+
+    public function testHandleIgnoresGetDeleteRequests(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE player (account_id INTEGER PRIMARY KEY, online_id TEXT)');
+        $database->exec('CREATE TABLE player_report (report_id INTEGER PRIMARY KEY, account_id INTEGER, explanation TEXT)');
+        $database->exec("INSERT INTO player (account_id, online_id) VALUES (1, 'ExampleUser')");
+        $database->exec("INSERT INTO player_report (report_id, account_id, explanation) VALUES (5, 1, 'Cheating')");
+
+        $service = new PlayerReportAdminService($database);
+        $page = new PlayerReportAdminPage($service);
+
+        $result = $page->handle(['delete' => '5'], [], 'GET');
+
+        $this->assertSame(null, $result->getSuccessMessage());
+        $this->assertSame(null, $result->getErrorMessage());
+        $this->assertCount(1, $result->getReportedPlayers());
+    }
+}

--- a/tests/GameMessageSanitizerTest.php
+++ b/tests/GameMessageSanitizerTest.php
@@ -27,6 +27,36 @@ final class GameMessageSanitizerTest extends TestCase
         );
     }
 
+    public function testSanitizeAllowsLineBreakTags(): void
+    {
+        $message = 'First line<br>Second line<br />Third line<br/>Fourth line';
+
+        $this->assertSame(
+            'First line<br>Second line<br>Third line<br>Fourth line',
+            GameMessageSanitizer::sanitize($message)
+        );
+    }
+
+    public function testSanitizeAllowsLineBreaksWithAnchorTags(): void
+    {
+        $message = 'Read more:<br><a href="https://example.com">the guide</a><br>Then continue.';
+
+        $this->assertSame(
+            'Read more:<br><a href="https://example.com">the guide</a><br>Then continue.',
+            GameMessageSanitizer::sanitize($message)
+        );
+    }
+
+    public function testSanitizeEscapesBrTagsWithAttributes(): void
+    {
+        $message = 'Line one<br onclick="alert(1)">Line two';
+
+        $this->assertSame(
+            'Line one&lt;br onclick=&quot;alert(1)&quot;&gt;Line two',
+            GameMessageSanitizer::sanitize($message)
+        );
+    }
+
     public function testSanitizeEscapesPlainText(): void
     {
         $message = 'Use caution &amp; avoid <script>alert(1)</script>.';

--- a/tests/GameMessageSanitizerTest.php
+++ b/tests/GameMessageSanitizerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/GameMessageSanitizer.php';
+
+final class GameMessageSanitizerTest extends TestCase
+{
+    public function testSanitizeAllowsSafeAnchorTags(): void
+    {
+        $message = 'See <a href="https://example.com/path">the guide</a> for details.';
+
+        $this->assertSame(
+            'See <a href="https://example.com/path">the guide</a> for details.',
+            GameMessageSanitizer::sanitize($message)
+        );
+    }
+
+    public function testSanitizePreservesTargetBlankOnSafeLinks(): void
+    {
+        $message = '<a href="https://example.com" target="_blank">External link</a>';
+
+        $this->assertSame(
+            '<a href="https://example.com" target="_blank" rel="noopener noreferrer">External link</a>',
+            GameMessageSanitizer::sanitize($message)
+        );
+    }
+
+    public function testSanitizeEscapesPlainText(): void
+    {
+        $message = 'Use caution &amp; avoid <script>alert(1)</script>.';
+
+        $this->assertSame(
+            'Use caution &amp;amp; avoid &lt;script&gt;alert(1)&lt;/script&gt;.',
+            GameMessageSanitizer::sanitize($message)
+        );
+    }
+
+    public function testSanitizeRejectsUnsafeHrefSchemes(): void
+    {
+        $message = '<a href="javascript:alert(1)">Click me</a>';
+
+        $this->assertSame(
+            '&lt;a href=&quot;javascript:alert(1)&quot;&gt;Click me&lt;/a&gt;',
+            GameMessageSanitizer::sanitize($message)
+        );
+    }
+
+    public function testSanitizeStripsNestedMarkupInsideAnchorText(): void
+    {
+        $message = '<a href="https://example.com"><img src=x onerror=alert(1)>Guide</a>';
+
+        $this->assertSame(
+            '<a href="https://example.com">Guide</a>',
+            GameMessageSanitizer::sanitize($message)
+        );
+    }
+
+    public function testEscapeTextareaContentPreventsBreakout(): void
+    {
+        $message = 'Hello</textarea><script>alert(1)</script>';
+
+        $this->assertSame(
+            'Hello&lt;/textarea><script>alert(1)</script>',
+            GameMessageSanitizer::escapeTextareaContent($message)
+        );
+    }
+}

--- a/tests/GameMessageSanitizerTest.php
+++ b/tests/GameMessageSanitizerTest.php
@@ -27,6 +27,26 @@ final class GameMessageSanitizerTest extends TestCase
         );
     }
 
+    public function testSanitizePreservesEntityEncodedUrlsInHref(): void
+    {
+        $message = '<a href="https://example.com/?a=1&amp;b=2">Link</a>';
+
+        $this->assertSame(
+            '<a href="https://example.com/?a=1&amp;b=2">Link</a>',
+            GameMessageSanitizer::sanitize($message)
+        );
+    }
+
+    public function testSanitizePreservesEntityEncodedAmpersandsInLinkText(): void
+    {
+        $message = '<a href="https://example.com">Tom &amp; Jerry</a>';
+
+        $this->assertSame(
+            '<a href="https://example.com">Tom &amp; Jerry</a>',
+            GameMessageSanitizer::sanitize($message)
+        );
+    }
+
     public function testSanitizeAllowsLineBreakTags(): void
     {
         $message = 'First line<br>Second line<br />Third line<br/>Fourth line';

--- a/tests/PlayerQueueEndpointTest.php
+++ b/tests/PlayerQueueEndpointTest.php
@@ -77,7 +77,7 @@ final class PlayerQueueEndpointTest extends TestCase
         $controller = new PlayerQueueControllerSpy($response);
         $endpoint = PlayerQueueEndpoint::create($controller, new JsonResponseEmitter());
 
-        $requestData = ['player' => 'ExampleUser'];
+        $requestData = ['q' => 'ExampleUser'];
         $serverData = ['REMOTE_ADDR' => '192.0.2.1'];
 
         header_remove();
@@ -103,7 +103,7 @@ final class PlayerQueueEndpointTest extends TestCase
         $controller = new PlayerQueueControllerSpy($response);
         $endpoint = PlayerQueueEndpoint::create($controller, new JsonResponseEmitter());
 
-        $requestData = ['player' => 'QueueUser'];
+        $requestData = ['q' => 'QueueUser'];
         $serverData = ['REMOTE_ADDR' => '198.51.100.23'];
 
         header_remove();

--- a/tests/PlayerReportDeletionRequestTest.php
+++ b/tests/PlayerReportDeletionRequestTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PlayerReportDeletionRequest.php';
+
+final class PlayerReportDeletionRequestTest extends TestCase
+{
+    public function testFromPostDataParsesDeleteId(): void
+    {
+        $request = PlayerReportDeletionRequest::fromPostData(['delete_id' => '7']);
+
+        $this->assertTrue($request->isValidDeletion());
+        $this->assertSame(7, $request->getDeleteId());
+        $this->assertFalse($request->hasError());
+    }
+
+    public function testFromPostDataReturnsErrorWhenDeleteIdInvalid(): void
+    {
+        $request = PlayerReportDeletionRequest::fromPostData(['delete_id' => 'abc']);
+
+        $this->assertTrue($request->hasError());
+        $this->assertSame('Please provide a valid report ID to delete.', $request->getErrorMessage());
+        $this->assertFalse($request->isValidDeletion());
+    }
+
+    public function testFromPostDataReturnsNoDeletionWhenKeyMissing(): void
+    {
+        $request = PlayerReportDeletionRequest::fromPostData([]);
+
+        $this->assertFalse($request->hasDeletionRequest());
+        $this->assertFalse($request->isValidDeletion());
+    }
+}

--- a/wwwroot/.htaccess
+++ b/wwwroot/.htaccess
@@ -12,6 +12,9 @@ FallbackResource /index.php
     AddOutputFilterByType DEFLATE text/xml
 </IfModule>
 #Cache
+<IfModule mod_headers.c>
+    Header always set Strict-Transport-Security "max-age=31536000" env=HTTPS
+</IfModule>
 <FilesMatch "\.(ico|pdf|jpg|jpeg|png|webp|gif|html|htm|xml|txt|xsl|css|svg|avif|js)$">
     Header set Cache-Control "max-age=31536050"
 </FilesMatch>

--- a/wwwroot/about.php
+++ b/wwwroot/about.php
@@ -158,7 +158,7 @@ require_once("header.php");
                                                     </div>
 
                                                     <div class="ms-auto">
-                                                        <img src="/img/country/<?= $countryCode; ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
+                                                        <img src="/img/country/<?= htmlspecialchars($countryCode, ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
                                                     </div>
                                                 </div>
                                             </td>

--- a/wwwroot/admin/detail.php
+++ b/wwwroot/admin/detail.php
@@ -7,6 +7,7 @@ require_once '../classes/Admin/GameDetailService.php';
 require_once '../classes/Admin/GameDetailPage.php';
 require_once '../classes/Admin/GameDetailPageResult.php';
 require_once '../classes/GameStatusService.php';
+require_once '../classes/GameMessageSanitizer.php';
 
 $gameDetailService = new GameDetailService($database);
 $gameStatusService = new GameStatusService($database);
@@ -108,7 +109,7 @@ $requestedNpCommunicationId = isset($_GET['np_communication_id']) ? (string) $_G
                     <input type="text" name="obsolete_ids" style="width: 859px;" value="<?= htmlentities((string) ($gameDetail->getObsoleteIds() ?? ''), ENT_QUOTES, 'UTF-8'); ?>"><br>
                     <small>Comma separated trophy_title.id values.</small><br>
                     Message:<br>
-                    <textarea name="message" rows="6" cols="120"><?= $gameDetail->getMessage(); ?></textarea><br><br>
+                    <textarea name="message" rows="6" cols="120"><?= GameMessageSanitizer::escapeTextareaContent($gameDetail->getMessage()); ?></textarea><br><br>
                     <label for="status">Status:</label><br>
                     <select id="status" name="status" class="form-select" style="max-width: 300px;">
                         <?php foreach ($statusOptions as $value => $label) { ?>

--- a/wwwroot/admin/report.php
+++ b/wwwroot/admin/report.php
@@ -7,7 +7,7 @@ require_once '../classes/Admin/PlayerReportAdminPage.php';
 
 $playerReportAdminService = new PlayerReportAdminService($database);
 $playerReportAdminPage = new PlayerReportAdminPage($playerReportAdminService);
-$pageResult = $playerReportAdminPage->handle($_GET ?? []);
+$pageResult = $playerReportAdminPage->handle($_GET ?? [], $_POST ?? [], $_SERVER['REQUEST_METHOD'] ?? 'GET');
 
 $reportedPlayers = $pageResult->getReportedPlayers();
 $successMessage = $pageResult->getSuccessMessage();
@@ -44,11 +44,24 @@ $errorMessage = $pageResult->getErrorMessage();
                         <?= nl2br(htmlentities($reportedPlayer->getExplanation(), ENT_QUOTES, 'UTF-8')); ?>
                     </div>
                     <div class="mt-2">
-                        <a href="?delete=<?= $reportedPlayer->getReportId(); ?>">Delete</a>
+                        <form method="post" class="d-inline js-report-delete-form">
+                            <?php AdminBootstrap::renderCsrfField(); ?>
+                            <input type="hidden" name="delete_id" value="<?= (int) $reportedPlayer->getReportId(); ?>">
+                            <button type="submit" class="btn btn-link p-0">Delete</button>
+                        </form>
                     </div>
                 </div>
                 <hr>
             <?php } ?>
         </div>
+        <script>
+            document.querySelectorAll('.js-report-delete-form').forEach((form) => {
+                form.addEventListener('submit', (event) => {
+                    if (!window.confirm('Are you sure you want to delete this report?')) {
+                        event.preventDefault();
+                    }
+                });
+            });
+        </script>
     </body>
 </html>

--- a/wwwroot/avatars.php
+++ b/wwwroot/avatars.php
@@ -25,8 +25,8 @@ require_once("header.php");
             ?>
             <div class="col">
                 <div class="bg-body-tertiary p-3 rounded mb-3 text-center vstack gap-1">
-                    <a href="/leaderboard/trophy?avatar=<?= $avatar->getUrl(); ?>">
-                        <img src="/img/avatar/<?= $avatar->getUrl(); ?>" class="mx-auto" alt="" width="100" />
+                    <a href="/leaderboard/trophy?avatar=<?= htmlspecialchars($avatar->getUrl(), ENT_QUOTES, 'UTF-8'); ?>">
+                        <img src="/img/avatar/<?= htmlspecialchars($avatar->getUrl(), ENT_QUOTES, 'UTF-8'); ?>" class="mx-auto" alt="" width="100" />
                     </a>
                     <?= $avatar->getCount(); ?> <?= $avatar->getPlayerLabel(); ?>
                 </div>

--- a/wwwroot/classes/Admin/PlayerReportAdminPage.php
+++ b/wwwroot/classes/Admin/PlayerReportAdminPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerReportAdminService.php';
 require_once __DIR__ . '/PlayerReportAdminPageResult.php';
+require_once __DIR__ . '/PlayerReportDeletionRequest.php';
 
 class PlayerReportAdminPage
 {
@@ -16,49 +17,30 @@ class PlayerReportAdminPage
 
     /**
      * @param array<string, mixed> $queryParameters
+     * @param array<string, mixed> $postData
      */
-    public function handle(array $queryParameters): PlayerReportAdminPageResult
+    public function handle(array $queryParameters, array $postData, string $method): PlayerReportAdminPageResult
     {
         $successMessage = null;
         $errorMessage = null;
 
-        if (array_key_exists('delete', $queryParameters)) {
-            $deleteId = $this->parseDeleteId($queryParameters['delete']);
+        if (strtoupper($method) === 'POST') {
+            $deletionRequest = PlayerReportDeletionRequest::fromPostData($postData);
 
-            if ($deleteId === null) {
-                $errorMessage = 'Please provide a valid report ID to delete.';
-            } else {
-                $this->playerReportAdminService->deleteReportById($deleteId);
-                $successMessage = sprintf('Report %d deleted successfully.', $deleteId);
+            if ($deletionRequest->hasError()) {
+                $errorMessage = $deletionRequest->getErrorMessage();
+            } elseif ($deletionRequest->isValidDeletion()) {
+                $deleteId = $deletionRequest->getDeleteId();
+
+                if ($deleteId !== null) {
+                    $this->playerReportAdminService->deleteReportById($deleteId);
+                    $successMessage = sprintf('Report %d deleted successfully.', $deleteId);
+                }
             }
         }
 
         $reportedPlayers = $this->playerReportAdminService->getReportedPlayers();
 
         return new PlayerReportAdminPageResult($reportedPlayers, $successMessage, $errorMessage);
-    }
-
-    private function parseDeleteId(mixed $value): ?int
-    {
-        if (is_int($value)) {
-            return $value > 0 ? $value : null;
-        }
-
-        if (!is_string($value)) {
-            return null;
-        }
-
-        $trimmedValue = trim($value);
-        if ($trimmedValue === '') {
-            return null;
-        }
-
-        if (!ctype_digit($trimmedValue)) {
-            return null;
-        }
-
-        $deleteId = (int) $trimmedValue;
-
-        return $deleteId > 0 ? $deleteId : null;
     }
 }

--- a/wwwroot/classes/Admin/PlayerReportDeletionRequest.php
+++ b/wwwroot/classes/Admin/PlayerReportDeletionRequest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+final readonly class PlayerReportDeletionRequest
+{
+    private function __construct(
+        private ?int $deleteId,
+        private ?string $errorMessage
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $postData
+     */
+    public static function fromPostData(array $postData): self
+    {
+        if (!array_key_exists('delete_id', $postData)) {
+            return new self(null, null);
+        }
+
+        $deleteId = self::parsePositiveInt($postData['delete_id'] ?? null);
+
+        if ($deleteId === null) {
+            return new self(null, 'Please provide a valid report ID to delete.');
+        }
+
+        return new self($deleteId, null);
+    }
+
+    public function hasError(): bool
+    {
+        return $this->errorMessage !== null;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+
+    public function hasDeletionRequest(): bool
+    {
+        return $this->deleteId !== null || $this->errorMessage !== null;
+    }
+
+    public function isValidDeletion(): bool
+    {
+        return $this->deleteId !== null && !$this->hasError();
+    }
+
+    public function getDeleteId(): ?int
+    {
+        return $this->deleteId;
+    }
+
+    private static function parsePositiveInt(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value > 0 ? $value : null;
+        }
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '' || !ctype_digit($trimmed)) {
+            return null;
+        }
+
+        $intValue = (int) $trimmed;
+
+        return $intValue > 0 ? $intValue : null;
+    }
+}

--- a/wwwroot/classes/GameMessageSanitizer.php
+++ b/wwwroot/classes/GameMessageSanitizer.php
@@ -85,7 +85,11 @@ final class GameMessageSanitizer
 
         $href = trim($matches[2]);
 
-        return $href === '' ? null : $href;
+        if ($href === '') {
+            return null;
+        }
+
+        return self::decodeHtmlEntities($href);
     }
 
     private static function hasTargetBlank(string $attributes): bool
@@ -95,6 +99,11 @@ final class GameMessageSanitizer
 
     private static function sanitizeLinkText(string $content): string
     {
-        return htmlentities(strip_tags($content), ENT_QUOTES, 'UTF-8');
+        return htmlentities(self::decodeHtmlEntities(strip_tags($content)), ENT_QUOTES, 'UTF-8');
+    }
+
+    private static function decodeHtmlEntities(string $value): string
+    {
+        return html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
     }
 }

--- a/wwwroot/classes/GameMessageSanitizer.php
+++ b/wwwroot/classes/GameMessageSanitizer.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+final class GameMessageSanitizer
+{
+    public static function sanitize(string $message): string
+    {
+        if ($message === '') {
+            return '';
+        }
+
+        $pattern = '/<a\b([^>]*)>(.*?)<\/a>/is';
+        $offset = 0;
+        $sanitized = '';
+
+        while (preg_match($pattern, $message, $matches, PREG_OFFSET_CAPTURE, $offset) === 1) {
+            $matchText = $matches[0][0];
+            $matchPosition = $matches[0][1];
+
+            $sanitized .= htmlentities(substr($message, $offset, $matchPosition - $offset), ENT_QUOTES, 'UTF-8');
+
+            $attributes = $matches[1][0];
+            $linkContent = $matches[2][0];
+            $href = self::extractHref($attributes);
+            $validatedUrl = $href !== null ? filter_var($href, FILTER_VALIDATE_URL) : false;
+
+            if ($validatedUrl !== false && preg_match('/^https?:\/\//i', (string) $validatedUrl) === 1) {
+                $targetAttributes = self::hasTargetBlank($attributes)
+                    ? ' target="_blank" rel="noopener noreferrer"'
+                    : '';
+
+                $sanitized .= sprintf(
+                    '<a href="%s"%s>%s</a>',
+                    htmlentities((string) $validatedUrl, ENT_QUOTES, 'UTF-8'),
+                    $targetAttributes,
+                    self::sanitizeLinkText($linkContent)
+                );
+            } else {
+                $sanitized .= htmlentities($matchText, ENT_QUOTES, 'UTF-8');
+            }
+
+            $offset = $matchPosition + strlen($matchText);
+        }
+
+        $sanitized .= htmlentities(substr($message, $offset), ENT_QUOTES, 'UTF-8');
+
+        return $sanitized;
+    }
+
+    private static function extractHref(string $attributes): ?string
+    {
+        if (preg_match('/\bhref\s*=\s*(["\'])(.*?)\1/is', $attributes, $matches) !== 1) {
+            return null;
+        }
+
+        $href = trim($matches[2]);
+
+        return $href === '' ? null : $href;
+    }
+
+    private static function hasTargetBlank(string $attributes): bool
+    {
+        return preg_match('/\btarget\s*=\s*(["\'])?_blank\1/i', $attributes) === 1;
+    }
+
+    private static function sanitizeLinkText(string $content): string
+    {
+        return htmlentities(strip_tags($content), ENT_QUOTES, 'UTF-8');
+    }
+
+    public static function escapeTextareaContent(string $message): string
+    {
+        return preg_replace('/<\/textarea/i', '&lt;/textarea', $message) ?? $message;
+    }
+}

--- a/wwwroot/classes/GameMessageSanitizer.php
+++ b/wwwroot/classes/GameMessageSanitizer.php
@@ -18,7 +18,7 @@ final class GameMessageSanitizer
             $matchText = $matches[0][0];
             $matchPosition = $matches[0][1];
 
-            $sanitized .= htmlentities(substr($message, $offset, $matchPosition - $offset), ENT_QUOTES, 'UTF-8');
+            $sanitized .= self::sanitizePlainText(substr($message, $offset, $matchPosition - $offset));
 
             $attributes = $matches[1][0];
             $linkContent = $matches[2][0];
@@ -43,7 +43,36 @@ final class GameMessageSanitizer
             $offset = $matchPosition + strlen($matchText);
         }
 
-        $sanitized .= htmlentities(substr($message, $offset), ENT_QUOTES, 'UTF-8');
+        $sanitized .= self::sanitizePlainText(substr($message, $offset));
+
+        return $sanitized;
+    }
+
+    public static function escapeTextareaContent(string $message): string
+    {
+        return preg_replace('/<\/textarea/i', '&lt;/textarea', $message) ?? $message;
+    }
+
+    private static function sanitizePlainText(string $text): string
+    {
+        if ($text === '') {
+            return '';
+        }
+
+        $pattern = '/<br\s*\/?>/i';
+        $offset = 0;
+        $sanitized = '';
+
+        while (preg_match($pattern, $text, $matches, PREG_OFFSET_CAPTURE, $offset) === 1) {
+            $matchText = $matches[0][0];
+            $matchPosition = $matches[0][1];
+
+            $sanitized .= htmlentities(substr($text, $offset, $matchPosition - $offset), ENT_QUOTES, 'UTF-8');
+            $sanitized .= '<br>';
+            $offset = $matchPosition + strlen($matchText);
+        }
+
+        $sanitized .= htmlentities(substr($text, $offset), ENT_QUOTES, 'UTF-8');
 
         return $sanitized;
     }
@@ -67,10 +96,5 @@ final class GameMessageSanitizer
     private static function sanitizeLinkText(string $content): string
     {
         return htmlentities(strip_tags($content), ENT_QUOTES, 'UTF-8');
-    }
-
-    public static function escapeTextareaContent(string $message): string
-    {
-        return preg_replace('/<\/textarea/i', '&lt;/textarea', $message) ?? $message;
     }
 }

--- a/wwwroot/classes/SessionManager.php
+++ b/wwwroot/classes/SessionManager.php
@@ -14,6 +14,19 @@ final class SessionManager
             return;
         }
 
+        $isSecure = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+            || (($_SERVER['SERVER_PORT'] ?? '') === '443');
+
+        session_set_cookie_params([
+            'lifetime' => 0,
+            'path' => '/',
+            'secure' => $isSecure,
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ]);
+
+        ini_set('session.use_strict_mode', '1');
+
         session_start();
     }
 

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/classes/Game/GamePlayerProgress.php';
+require_once __DIR__ . '/classes/GameMessageSanitizer.php';
 
 /** @var GameDetails $game */
 /** @var GameHeaderData $gameHeaderData */
@@ -115,7 +116,7 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
         ?>
         <div class="col-12">
             <div class="alert alert-warning" role="alert">
-                <?= $game->getMessage(); ?>
+                <?= GameMessageSanitizer::sanitize($game->getMessage()); ?>
             </div>
         </div>
         <?php
@@ -135,7 +136,7 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
                     : '../missing-ps4-game.png')
                 : $gameIconUrl;
             ?>
-            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= $iconPath; ?>" alt="<?= htmlentities($game->getName()); ?>">
+            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= htmlspecialchars($iconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($game->getName()); ?>">
         </div>
 
         <div class="col-12 col-lg-6">

--- a/wwwroot/games.php
+++ b/wwwroot/games.php
@@ -152,7 +152,7 @@ require_once("header.php");
                             <div class="card">
                                 <div class="d-flex justify-content-center align-items-center" style="min-height: 11.5rem;">
                                     <a href="/game/<?= $gameLink; ?>">
-                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= $iconPath; ?>" alt="<?= htmlentities($game->getName()); ?>">
+                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= htmlspecialchars($iconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($game->getName()); ?>">
                                         <div class="card-img-overlay d-flex align-items-end p-2">
                                             <?php
                                             foreach ($platforms as $platform) {

--- a/wwwroot/header.php
+++ b/wwwroot/header.php
@@ -163,7 +163,7 @@ if (isset($metaData) && $metaData instanceof PageMetaData) {
 
         <script src="/js/localized-date-formatter.js" defer></script>
 
-        <title><?= $title; ?></title>
+        <title><?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?></title>
     </head>
     <body>
         <?php require_once("nav.php"); ?>

--- a/wwwroot/init.php
+++ b/wwwroot/init.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
 header("Expires: 0");
+header('X-Content-Type-Options: nosniff');
+header('Referrer-Policy: strict-origin-when-cross-origin');
+header('X-Frame-Options: SAMEORIGIN');
 
 require_once __DIR__ . '/classes/ApplicationBootstrapper.php';
 

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -143,7 +143,7 @@ require_once("header.php");
                                     <tr<?= $rowAttributes; ?>>
                                         <td scope="row">
                                             <div class="hstack gap-3">
-                                                <img src="/img/title/<?= $playerGame->getIconFileName(); ?>" alt="<?= htmlentities($playerGame->getName()); ?>" width="100" />
+                                                <img src="/img/title/<?= htmlspecialchars($playerGame->getIconFileName(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($playerGame->getName()); ?>" width="100" />
 
                                                 <div class="vstack">
                                                     <span>

--- a/wwwroot/player_header.php
+++ b/wwwroot/player_header.php
@@ -51,7 +51,7 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
             <!-- Country -->
             <div class="ms-auto">
                 <?php $countryName = htmlentities($playerHeaderViewModel->getCountryName(), ENT_QUOTES, 'UTF-8'); ?>
-                <img src="/img/country/<?= $playerHeaderViewModel->getCountryCode(); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
+                <img src="/img/country/<?= htmlspecialchars($playerHeaderViewModel->getCountryCode(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
             </div>
         </div>
     </div>

--- a/wwwroot/player_random.php
+++ b/wwwroot/player_random.php
@@ -79,7 +79,7 @@ require_once("header.php");
                                 <div class="card">
                                     <div class="d-flex justify-content-center align-items-center" style="min-height: 11.5rem;">
                                         <a href="/game/<?= htmlspecialchars($gameLink, ENT_QUOTES, 'UTF-8'); ?>">
-                                            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= $game->getIconUrl(); ?>" alt="<?= htmlentities($game->getName()); ?>">
+                                            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= htmlspecialchars($game->getIconUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($game->getName()); ?>">
                                             <div class="card-img-overlay d-flex align-items-end p-2">
                                                 <?php
                                                 foreach ($game->getPlatforms() as $platform) {

--- a/wwwroot/trophies.php
+++ b/wwwroot/trophies.php
@@ -48,14 +48,14 @@ require_once('header.php');
                                 <tr>
                                     <td scope="row" class="text-center align-middle">
                                         <a href="<?= $gameUrl; ?>">
-                                            <img src="/img/title/<?= $trophy->getGameIconPath(); ?>" alt="<?= htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 10rem;" />
+                                            <img src="/img/title/<?= htmlspecialchars($trophy->getGameIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 10rem;" />
                                         </a>
                                     </td>
                                     <td class="align-middle">
                                         <div class="hstack gap-3">
                                             <div class="d-flex align-items-center justify-content-center">
                                                 <a href="<?= $trophyUrl; ?>">
-                                                    <img src="/img/trophy/<?= $trophy->getTrophyIconPath(); ?>" alt="<?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 5rem;" />
+                                                    <img src="/img/trophy/<?= htmlspecialchars($trophy->getTrophyIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 5rem;" />
                                                 </a>
                                             </div>
 
@@ -108,7 +108,7 @@ require_once('header.php');
                                         <div><?= $inGameRarity->renderSpan(); ?></div>
                                     </td>
                                     <td class="text-center align-middle">
-                                        <img src="/img/trophy-<?= $trophy->getTrophyType(); ?>.svg" alt="<?= ucfirst($trophy->getTrophyType()); ?>" title="<?= ucfirst($trophy->getTrophyType()); ?>" height="50" />
+                                        <img src="/img/trophy-<?= htmlspecialchars($trophy->getTrophyType(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= ucfirst($trophy->getTrophyType()); ?>" title="<?= ucfirst($trophy->getTrophyType()); ?>" height="50" />
                                     </td>
                                 </tr>
                                 <?php


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Third batch from the code audit: security hardening for admin actions, stored HTML game messages, and baseline HTTP/session protections.

## Changes

### CSRF-protected admin report deletion

Player report delete previously used a GET link (`?delete=<id>`), which was vulnerable to cross-site request forgery. It now follows the same POST + CSRF pattern as admin log deletion, with a confirmation prompt.

### Game message XSS (preserving `<a>` and `<br>` HTML)

Admin game messages may intentionally contain `<a>` links and `<br>` line breaks. `GameMessageSanitizer` allows only:
- http(s) anchor tags with validated URLs and escaped link text
- bare `<br>`, `<br/>`, and `<br />` tags (normalized to `<br>`)

All other markup is entity-encoded on the public game page. The admin textarea uses a breakout-only escape so admins can still edit raw HTML without `</textarea>` injection.

### Output escaping

- Page `<title>` values are escaped centrally in `header.php`
- Dynamic image path segments (`src`, query params) are escaped on pages that were still missing `htmlspecialchars` (games, player, trophies, avatars, etc.)

### Session and HTTP hardening

- Explicit session cookie params: `HttpOnly`, `Secure` (when on HTTPS), `SameSite=Lax`, strict mode
- Baseline security headers in `init.php`: `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`
- HSTS header in `.htaccess` for HTTPS deployments

### Test hygiene

- `PlayerQueueEndpointTest` now uses the production `q` parameter instead of `player`

## Tests

All **578 tests pass** (`php tests/run.php`), including coverage for `<a>`, `<br>`, and combined game message sanitization.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b802e74-fa75-4ec6-bc64-eb1887fafe9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b802e74-fa75-4ec6-bc64-eb1887fafe9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

