### PR TITLE
Harden PlayerRankingUpdater: lock, orphan cleanup, infinite retry logging

### DIFF
--- a/tests/PlayerRankingUpdaterIntegrationTest.php
+++ b/tests/PlayerRankingUpdaterIntegrationTest.php
@@ -8,9 +8,19 @@ require_once __DIR__ . '/../wwwroot/classes/Psn100Logger.php';
 
 final class PlayerRankingUpdaterIntegrationTest extends TestCase
 {
+    private const string INTEGRATION_TEST_DB_ENV = 'PSN100_INTEGRATION_TEST_DB';
+
+    private const string DEFAULT_APP_DATABASE = 'psn100';
+
     private ?PDO $database = null;
 
     private ?PDO $lockHolderConnection = null;
+
+    private ?PDO $adminConnection = null;
+
+    private ?string $integrationDatabaseName = null;
+
+    private bool $ownsIntegrationDatabase = false;
 
     protected function tearDown(): void
     {
@@ -21,14 +31,23 @@ final class PlayerRankingUpdaterIntegrationTest extends TestCase
 
         if ($this->database instanceof PDO) {
             $this->releaseRankingLock();
+        }
+
+        if ($this->ownsIntegrationDatabase && $this->integrationDatabaseName !== null && $this->adminConnection instanceof PDO) {
+            $this->adminConnection->exec(
+                sprintf('DROP DATABASE IF EXISTS `%s`', $this->escapeDatabaseIdentifier($this->integrationDatabaseName))
+            );
+        } elseif ($this->database instanceof PDO) {
             $this->database->exec('DROP TABLE IF EXISTS player_ranking_old');
             $this->database->exec('DROP TABLE IF EXISTS player_ranking_new');
             $this->database->exec('DROP TABLE IF EXISTS player_ranking');
             $this->database->exec('DROP TABLE IF EXISTS player');
-            $this->database->exec('DROP TABLE IF EXISTS log');
         }
 
         $this->database = null;
+        $this->adminConnection = null;
+        $this->integrationDatabaseName = null;
+        $this->ownsIntegrationDatabase = false;
     }
 
     public function testRecalculateRebuildsRankingsFromActivePlayers(): void
@@ -123,18 +142,58 @@ final class PlayerRankingUpdaterIntegrationTest extends TestCase
         );
     }
 
+    public function testIntegrationTestsSkipWithoutExplicitDisposableDatabase(): void
+    {
+        $originalValue = getenv(self::INTEGRATION_TEST_DB_ENV);
+        $method = new ReflectionMethod($this, 'resolveIntegrationDatabaseConfiguration');
+        $method->setAccessible(true);
+
+        putenv(self::INTEGRATION_TEST_DB_ENV);
+        try {
+            $this->assertSame(null, $method->invoke($this));
+        } finally {
+            if ($originalValue === false) {
+                putenv(self::INTEGRATION_TEST_DB_ENV);
+            } else {
+                putenv(self::INTEGRATION_TEST_DB_ENV . '=' . $originalValue);
+            }
+        }
+    }
+
+    public function testIntegrationTestsRejectDefaultApplicationDatabaseName(): void
+    {
+        $originalValue = getenv(self::INTEGRATION_TEST_DB_ENV);
+        $method = new ReflectionMethod($this, 'resolveIntegrationDatabaseConfiguration');
+        $method->setAccessible(true);
+
+        putenv(self::INTEGRATION_TEST_DB_ENV . '=' . self::DEFAULT_APP_DATABASE);
+        try {
+            $this->assertSame(null, $method->invoke($this));
+        } finally {
+            if ($originalValue === false) {
+                putenv(self::INTEGRATION_TEST_DB_ENV);
+            } else {
+                putenv(self::INTEGRATION_TEST_DB_ENV . '=' . $originalValue);
+            }
+        }
+    }
+
     private function createMysqlDatabase(): ?PDO
     {
-        $host = getenv('DB_HOST') ?: '127.0.0.1';
-        $name = getenv('DB_NAME') ?: 'psn100';
-        $user = getenv('DB_USER') ?: 'psn100';
-        $password = getenv('DB_PASSWORD') ?: 'psn100';
+        if ($this->database instanceof PDO) {
+            return $this->database;
+        }
+
+        $configuration = $this->resolveIntegrationDatabaseConfiguration();
+        if ($configuration === null) {
+            return null;
+        }
 
         try {
-            $database = new PDO(
-                sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4', $host, $name),
-                $user,
-                $password,
+            $this->adminConnection = new PDO(
+                sprintf('mysql:host=%s;charset=utf8mb4', $configuration['host']),
+                $configuration['user'],
+                $configuration['password'],
                 [
                     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                 ]
@@ -143,38 +202,133 @@ final class PlayerRankingUpdaterIntegrationTest extends TestCase
             return null;
         }
 
-        $this->database = $database;
-        $this->createSchema($database);
+        if ($configuration['ephemeral']) {
+            $this->integrationDatabaseName = sprintf('psn100_it_%s', bin2hex(random_bytes(4)));
+            $this->ownsIntegrationDatabase = true;
 
-        return $database;
+            try {
+                $this->adminConnection->exec(
+                    sprintf(
+                        'CREATE DATABASE `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci',
+                        $this->escapeDatabaseIdentifier($this->integrationDatabaseName)
+                    )
+                );
+            } catch (Throwable) {
+                return null;
+            }
+        } else {
+            $this->integrationDatabaseName = $configuration['database'];
+            $this->ownsIntegrationDatabase = false;
+        }
+
+        try {
+            $this->database = $this->connectToIntegrationDatabase(
+                $configuration['host'],
+                $this->integrationDatabaseName,
+                $configuration['user'],
+                $configuration['password']
+            );
+        } catch (Throwable) {
+            return null;
+        }
+
+        $this->createSchema($this->database);
+
+        return $this->database;
+    }
+
+    /**
+     * @return array{host: string, user: string, password: string, database: ?string, ephemeral: bool}|null
+     */
+    private function resolveIntegrationDatabaseConfiguration(): ?array
+    {
+        $configuredValue = getenv(self::INTEGRATION_TEST_DB_ENV);
+        if (!is_string($configuredValue)) {
+            return null;
+        }
+
+        $configuredValue = trim($configuredValue);
+        if ($configuredValue === '' || $configuredValue === '0') {
+            return null;
+        }
+
+        $ephemeral = in_array(strtolower($configuredValue), ['1', 'true', 'yes', 'auto'], true);
+        $databaseName = $ephemeral ? null : $configuredValue;
+
+        if ($databaseName === self::DEFAULT_APP_DATABASE) {
+            return null;
+        }
+
+        return [
+            'host' => $this->readEnvironmentString('DB_HOST') ?? '127.0.0.1',
+            'user' => $this->readEnvironmentString('DB_USER') ?? 'psn100',
+            'password' => $this->readEnvironmentString('DB_PASSWORD') ?? 'psn100',
+            'database' => $databaseName,
+            'ephemeral' => $ephemeral,
+        ];
+    }
+
+    private function readEnvironmentString(string $name): ?string
+    {
+        $value = getenv($name);
+
+        return is_string($value) && trim($value) !== '' ? trim($value) : null;
     }
 
     private function createAdditionalMysqlConnection(): ?PDO
     {
-        $host = getenv('DB_HOST') ?: '127.0.0.1';
-        $name = getenv('DB_NAME') ?: 'psn100';
-        $user = getenv('DB_USER') ?: 'psn100';
-        $password = getenv('DB_PASSWORD') ?: 'psn100';
+        if ($this->integrationDatabaseName === null) {
+            return null;
+        }
+
+        $configuration = $this->resolveIntegrationDatabaseConfiguration();
+        if ($configuration === null) {
+            return null;
+        }
 
         try {
-            return new PDO(
-                sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4', $host, $name),
-                $user,
-                $password,
-                [
-                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                ]
+            return $this->connectToIntegrationDatabase(
+                $configuration['host'],
+                $this->integrationDatabaseName,
+                $configuration['user'],
+                $configuration['password']
             );
         } catch (Throwable) {
             return null;
         }
     }
 
+    private function connectToIntegrationDatabase(
+        string $host,
+        string $databaseName,
+        string $user,
+        string $password,
+    ): PDO {
+        return new PDO(
+            sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4', $host, $databaseName),
+            $user,
+            $password,
+            [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            ]
+        );
+    }
+
+    private function escapeDatabaseIdentifier(string $databaseName): string
+    {
+        return str_replace('`', '``', $databaseName);
+    }
+
     private function createSchema(PDO $database): void
     {
+        $database->exec('DROP TABLE IF EXISTS player_ranking_old');
+        $database->exec('DROP TABLE IF EXISTS player_ranking_new');
+        $database->exec('DROP TABLE IF EXISTS player_ranking');
+        $database->exec('DROP TABLE IF EXISTS player');
+
         $database->exec(
             <<<SQL
-            CREATE TABLE IF NOT EXISTS player (
+            CREATE TABLE player (
                 account_id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
                 online_id VARCHAR(16) NOT NULL,
                 country VARCHAR(2) NOT NULL,
@@ -216,7 +370,7 @@ final class PlayerRankingUpdaterIntegrationTest extends TestCase
 
         $database->exec(
             <<<SQL
-            CREATE TABLE IF NOT EXISTS player_ranking (
+            CREATE TABLE player_ranking (
                 account_id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
                 ranking MEDIUMINT UNSIGNED NOT NULL,
                 ranking_country MEDIUMINT UNSIGNED NOT NULL,
@@ -227,9 +381,6 @@ final class PlayerRankingUpdaterIntegrationTest extends TestCase
             )
             SQL
         );
-
-        $database->exec('DELETE FROM player_ranking');
-        $database->exec('DELETE FROM player');
     }
 
     private function seedPlayers(PDO $database): void

--- a/tests/PlayerRankingUpdaterIntegrationTest.php
+++ b/tests/PlayerRankingUpdaterIntegrationTest.php
@@ -10,8 +10,15 @@ final class PlayerRankingUpdaterIntegrationTest extends TestCase
 {
     private ?PDO $database = null;
 
+    private ?PDO $lockHolderConnection = null;
+
     protected function tearDown(): void
     {
+        if ($this->lockHolderConnection instanceof PDO) {
+            $this->releaseRankingLock($this->lockHolderConnection);
+            $this->lockHolderConnection = null;
+        }
+
         if ($this->database instanceof PDO) {
             $this->releaseRankingLock();
             $this->database->exec('DROP TABLE IF EXISTS player_ranking_old');
@@ -85,7 +92,14 @@ final class PlayerRankingUpdaterIntegrationTest extends TestCase
         }
 
         $this->seedPlayers($database);
-        $this->assertTrue($this->acquireRankingLock());
+
+        $lockHolder = $this->createAdditionalMysqlConnection();
+        if ($lockHolder === null) {
+            return;
+        }
+
+        $this->lockHolderConnection = $lockHolder;
+        $this->assertTrue($this->acquireRankingLock($lockHolder));
 
         $logDatabase = new PDO('sqlite::memory:');
         $logDatabase->exec('CREATE TABLE log (id INTEGER PRIMARY KEY AUTOINCREMENT, message TEXT NOT NULL)');
@@ -103,6 +117,10 @@ final class PlayerRankingUpdaterIntegrationTest extends TestCase
         $messages = $logDatabase->query('SELECT message FROM log ORDER BY id')->fetchAll(PDO::FETCH_COLUMN);
         $this->assertCount(1, $messages);
         $this->assertStringContainsString('skipped because another run is in progress', $messages[0]);
+        $this->assertSame(
+            0,
+            (int) $database->query('SELECT COUNT(*) FROM player_ranking')->fetchColumn()
+        );
     }
 
     private function createMysqlDatabase(): ?PDO
@@ -129,6 +147,27 @@ final class PlayerRankingUpdaterIntegrationTest extends TestCase
         $this->createSchema($database);
 
         return $database;
+    }
+
+    private function createAdditionalMysqlConnection(): ?PDO
+    {
+        $host = getenv('DB_HOST') ?: '127.0.0.1';
+        $name = getenv('DB_NAME') ?: 'psn100';
+        $user = getenv('DB_USER') ?: 'psn100';
+        $password = getenv('DB_PASSWORD') ?: 'psn100';
+
+        try {
+            return new PDO(
+                sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4', $host, $name),
+                $user,
+                $password,
+                [
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                ]
+            );
+        } catch (Throwable) {
+            return null;
+        }
     }
 
     private function createSchema(PDO $database): void
@@ -271,25 +310,29 @@ final class PlayerRankingUpdaterIntegrationTest extends TestCase
         }
     }
 
-    private function acquireRankingLock(): bool
+    private function acquireRankingLock(?PDO $connection = null): bool
     {
-        if (!$this->database instanceof PDO) {
+        $connection ??= $this->database;
+
+        if (!$connection instanceof PDO) {
             return false;
         }
 
-        $statement = $this->database->prepare("SELECT GET_LOCK('psn100:player_ranking_recalc', 0)");
+        $statement = $connection->prepare("SELECT GET_LOCK('psn100:player_ranking_recalc', 0)");
         $statement->execute();
 
         return (int) ($statement->fetchColumn() ?? 0) === 1;
     }
 
-    private function releaseRankingLock(): void
+    private function releaseRankingLock(?PDO $connection = null): void
     {
-        if (!$this->database instanceof PDO) {
+        $connection ??= $this->database;
+
+        if (!$connection instanceof PDO) {
             return;
         }
 
-        $statement = $this->database->prepare("SELECT RELEASE_LOCK('psn100:player_ranking_recalc')");
+        $statement = $connection->prepare("SELECT RELEASE_LOCK('psn100:player_ranking_recalc')");
         $statement->execute();
     }
 }

--- a/tests/PlayerRankingUpdaterIntegrationTest.php
+++ b/tests/PlayerRankingUpdaterIntegrationTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerRankingUpdater.php';
+require_once __DIR__ . '/../wwwroot/classes/Psn100Logger.php';
+
+final class PlayerRankingUpdaterIntegrationTest extends TestCase
+{
+    private ?PDO $database = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->database instanceof PDO) {
+            $this->releaseRankingLock();
+            $this->database->exec('DROP TABLE IF EXISTS player_ranking_old');
+            $this->database->exec('DROP TABLE IF EXISTS player_ranking_new');
+            $this->database->exec('DROP TABLE IF EXISTS player_ranking');
+            $this->database->exec('DROP TABLE IF EXISTS player');
+            $this->database->exec('DROP TABLE IF EXISTS log');
+        }
+
+        $this->database = null;
+    }
+
+    public function testRecalculateRebuildsRankingsFromActivePlayers(): void
+    {
+        $database = $this->createMysqlDatabase();
+        if ($database === null) {
+            return;
+        }
+
+        $this->seedPlayers($database);
+
+        $updater = new PlayerRankingUpdater(
+            $database,
+            retryDelaySeconds: 1,
+            maxRetryDelaySeconds: 1,
+        );
+        $updater->recalculate();
+
+        $rows = $database->query('SELECT account_id, ranking, ranking_country FROM player_ranking ORDER BY ranking')
+            ->fetchAll(PDO::FETCH_ASSOC);
+
+        $this->assertCount(2, $rows);
+        $this->assertSame('100', (string) $rows[0]['account_id']);
+        $this->assertSame('1', (string) $rows[0]['ranking']);
+        $this->assertSame('1', (string) $rows[0]['ranking_country']);
+        $this->assertSame('200', (string) $rows[1]['account_id']);
+        $this->assertSame('2', (string) $rows[1]['ranking']);
+        $this->assertSame('1', (string) $rows[1]['ranking_country']);
+    }
+
+    public function testRecalculateRecoversFromOrphanedPreviousTable(): void
+    {
+        $database = $this->createMysqlDatabase();
+        if ($database === null) {
+            return;
+        }
+
+        $this->seedPlayers($database);
+        $database->exec('CREATE TABLE player_ranking_old LIKE player_ranking');
+
+        $updater = new PlayerRankingUpdater(
+            $database,
+            retryDelaySeconds: 1,
+            maxRetryDelaySeconds: 1,
+        );
+        $updater->recalculate();
+
+        $oldTableExists = (int) $database->query(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'player_ranking_old'"
+        )->fetchColumn();
+
+        $this->assertSame(0, $oldTableExists);
+        $this->assertSame(2, (int) $database->query('SELECT COUNT(*) FROM player_ranking')->fetchColumn());
+    }
+
+    public function testRecalculateSkipsWhenAnotherRunHoldsLock(): void
+    {
+        $database = $this->createMysqlDatabase();
+        if ($database === null) {
+            return;
+        }
+
+        $this->seedPlayers($database);
+        $this->assertTrue($this->acquireRankingLock());
+
+        $logDatabase = new PDO('sqlite::memory:');
+        $logDatabase->exec('CREATE TABLE log (id INTEGER PRIMARY KEY AUTOINCREMENT, message TEXT NOT NULL)');
+
+        $updater = new PlayerRankingUpdater(
+            $database,
+            logger: new Psn100Logger($logDatabase),
+            sleeper: static function (int $seconds): void {
+                throw new RuntimeException('Should not sleep when lock is unavailable.');
+            },
+        );
+
+        $updater->recalculate();
+
+        $messages = $logDatabase->query('SELECT message FROM log ORDER BY id')->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertCount(1, $messages);
+        $this->assertStringContainsString('skipped because another run is in progress', $messages[0]);
+    }
+
+    private function createMysqlDatabase(): ?PDO
+    {
+        $host = getenv('DB_HOST') ?: '127.0.0.1';
+        $name = getenv('DB_NAME') ?: 'psn100';
+        $user = getenv('DB_USER') ?: 'psn100';
+        $password = getenv('DB_PASSWORD') ?: 'psn100';
+
+        try {
+            $database = new PDO(
+                sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4', $host, $name),
+                $user,
+                $password,
+                [
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                ]
+            );
+        } catch (Throwable) {
+            return null;
+        }
+
+        $this->database = $database;
+        $this->createSchema($database);
+
+        return $database;
+    }
+
+    private function createSchema(PDO $database): void
+    {
+        $database->exec(
+            <<<SQL
+            CREATE TABLE IF NOT EXISTS player (
+                account_id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+                online_id VARCHAR(16) NOT NULL,
+                country VARCHAR(2) NOT NULL,
+                avatar_url VARCHAR(100) DEFAULT NULL,
+                plus TINYINT(1) NOT NULL DEFAULT 0,
+                about_me TEXT NOT NULL,
+                last_updated_date DATETIME DEFAULT NULL,
+                bronze MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                silver MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                gold MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                platinum MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                level SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+                progress TINYINT UNSIGNED NOT NULL DEFAULT 0,
+                points INT UNSIGNED NOT NULL DEFAULT 0,
+                rarity_points INT UNSIGNED NOT NULL DEFAULT 0,
+                rank_last_week MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                rarity_rank_last_week MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                rank_country_last_week MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                rarity_rank_country_last_week MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                common MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                uncommon MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                rare MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                epic MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                legendary MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                status TINYINT UNSIGNED NOT NULL DEFAULT 99,
+                trophy_count_npwr MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                trophy_count_sony MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                in_game_rarity_points INT UNSIGNED NOT NULL DEFAULT 0,
+                in_game_rarity_rank_last_week MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                in_game_rarity_rank_country_last_week MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                in_game_common MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                in_game_uncommon MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                in_game_rare MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                in_game_epic MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+                in_game_legendary MEDIUMINT UNSIGNED NOT NULL DEFAULT 0
+            )
+            SQL
+        );
+
+        $database->exec(
+            <<<SQL
+            CREATE TABLE IF NOT EXISTS player_ranking (
+                account_id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+                ranking MEDIUMINT UNSIGNED NOT NULL,
+                ranking_country MEDIUMINT UNSIGNED NOT NULL,
+                rarity_ranking MEDIUMINT UNSIGNED NOT NULL,
+                rarity_ranking_country MEDIUMINT UNSIGNED NOT NULL,
+                in_game_rarity_ranking MEDIUMINT UNSIGNED NOT NULL,
+                in_game_rarity_ranking_country MEDIUMINT UNSIGNED NOT NULL
+            )
+            SQL
+        );
+
+        $database->exec('DELETE FROM player_ranking');
+        $database->exec('DELETE FROM player');
+    }
+
+    private function seedPlayers(PDO $database): void
+    {
+        $statement = $database->prepare(
+            <<<SQL
+            INSERT INTO player (
+                account_id,
+                online_id,
+                country,
+                plus,
+                about_me,
+                points,
+                platinum,
+                gold,
+                silver,
+                rarity_points,
+                in_game_rarity_points,
+                status
+            ) VALUES (
+                :account_id,
+                :online_id,
+                :country,
+                0,
+                '',
+                :points,
+                :platinum,
+                :gold,
+                :silver,
+                :rarity_points,
+                :in_game_rarity_points,
+                :status
+            )
+            SQL
+        );
+
+        $players = [
+            [
+                'account_id' => 100,
+                'online_id' => 'TopPlayer',
+                'country' => 'US',
+                'points' => 5000,
+                'platinum' => 10,
+                'gold' => 20,
+                'silver' => 30,
+                'rarity_points' => 900,
+                'in_game_rarity_points' => 800,
+                'status' => 0,
+            ],
+            [
+                'account_id' => 200,
+                'online_id' => 'SecondPlayer',
+                'country' => 'US',
+                'points' => 1000,
+                'platinum' => 1,
+                'gold' => 2,
+                'silver' => 3,
+                'rarity_points' => 100,
+                'in_game_rarity_points' => 50,
+                'status' => 0,
+            ],
+            [
+                'account_id' => 300,
+                'online_id' => 'InactivePlayer',
+                'country' => 'US',
+                'points' => 9999,
+                'platinum' => 99,
+                'gold' => 99,
+                'silver' => 99,
+                'rarity_points' => 9999,
+                'in_game_rarity_points' => 9999,
+                'status' => 1,
+            ],
+        ];
+
+        foreach ($players as $player) {
+            $statement->execute($player);
+        }
+    }
+
+    private function acquireRankingLock(): bool
+    {
+        if (!$this->database instanceof PDO) {
+            return false;
+        }
+
+        $statement = $this->database->prepare("SELECT GET_LOCK('psn100:player_ranking_recalc', 0)");
+        $statement->execute();
+
+        return (int) ($statement->fetchColumn() ?? 0) === 1;
+    }
+
+    private function releaseRankingLock(): void
+    {
+        if (!$this->database instanceof PDO) {
+            return;
+        }
+
+        $statement = $this->database->prepare("SELECT RELEASE_LOCK('psn100:player_ranking_recalc')");
+        $statement->execute();
+    }
+}

--- a/tests/PlayerRankingUpdaterTest.php
+++ b/tests/PlayerRankingUpdaterTest.php
@@ -91,7 +91,7 @@ final class PlayerRankingUpdaterTest extends TestCase
 
     public function testAcquireLockReturnsFalseWhenMysqlLockIsUnavailable(): void
     {
-        $database = new PlayerRankingUpdaterLockTestDatabase(false);
+        $database = new PlayerRankingUpdaterLockTestDatabase(0);
         $updater = new PlayerRankingUpdater($database);
         $method = new ReflectionMethod($updater, 'acquireLock');
         $method->setAccessible(true);
@@ -101,12 +101,55 @@ final class PlayerRankingUpdaterTest extends TestCase
 
     public function testAcquireLockReturnsTrueWhenMysqlLockIsAvailable(): void
     {
-        $database = new PlayerRankingUpdaterLockTestDatabase(true);
+        $database = new PlayerRankingUpdaterLockTestDatabase(1);
         $updater = new PlayerRankingUpdater($database);
         $method = new ReflectionMethod($updater, 'acquireLock');
         $method->setAccessible(true);
 
         $this->assertTrue($method->invoke($updater));
+    }
+
+    public function testAcquireLockThrowsWhenGetLockReturnsNull(): void
+    {
+        $database = new PlayerRankingUpdaterLockTestDatabase(null);
+        $updater = new PlayerRankingUpdater($database);
+        $method = new ReflectionMethod($updater, 'acquireLock');
+        $method->setAccessible(true);
+
+        try {
+            $method->invoke($updater);
+            $this->fail('Expected acquireLock to throw when GET_LOCK returns NULL.');
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString('Unable to acquire player ranking recalculation lock', $exception->getMessage());
+        }
+    }
+
+    public function testRecalculateRetriesLockAcquisitionWhenGetLockReturnsNull(): void
+    {
+        $database = new PlayerRankingUpdaterLockTestDatabase(1, 2);
+        $logDatabase = new PDO('sqlite::memory:');
+        $logDatabase->exec('CREATE TABLE log (id INTEGER PRIMARY KEY AUTOINCREMENT, message TEXT NOT NULL)');
+        $logger = new Psn100Logger($logDatabase);
+        $sleepCalls = [];
+
+        $updater = new PlayerRankingUpdater(
+            $database,
+            retryDelaySeconds: 1,
+            maxRetryDelaySeconds: 1,
+            logger: $logger,
+            sleeper: static function (int $seconds) use (&$sleepCalls): void {
+                $sleepCalls[] = $seconds;
+            },
+        );
+
+        $updater->recalculate();
+
+        $this->assertSame([1, 1], $sleepCalls);
+
+        $messages = $logDatabase->query('SELECT message FROM log ORDER BY id')->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertCount(2, $messages);
+        $this->assertStringContainsString('lock acquisition failed (attempt 1)', $messages[0]);
+        $this->assertStringContainsString('lock acquisition failed (attempt 2)', $messages[1]);
     }
 
     public function testRecalculateContinuesRetryingWhenDatabaseLoggingFails(): void
@@ -133,7 +176,7 @@ final class PlayerRankingUpdaterTest extends TestCase
 
     public function testRecalculateSkipsWhenLockIsAlreadyHeld(): void
     {
-        $database = new PlayerRankingUpdaterLockTestDatabase(false);
+        $database = new PlayerRankingUpdaterLockTestDatabase(0);
         $logDatabase = new PDO('sqlite::memory:');
         $logDatabase->exec('CREATE TABLE log (id INTEGER PRIMARY KEY AUTOINCREMENT, message TEXT NOT NULL)');
         $logger = new Psn100Logger($logDatabase);
@@ -206,8 +249,12 @@ final class PlayerRankingUpdaterRetryTestDatabase extends PDO
 
 final class PlayerRankingUpdaterLockTestDatabase extends PDO
 {
-    public function __construct(private readonly bool $lockAvailable)
-    {
+    private int $lockAttempts = 0;
+
+    public function __construct(
+        private readonly mixed $lockResult,
+        private readonly ?int $failuresBeforeSuccess = null,
+    ) {
     }
 
     public function getAttribute($attribute): mixed
@@ -221,22 +268,50 @@ final class PlayerRankingUpdaterLockTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
-        if (!str_contains($query, 'GET_LOCK')) {
-            throw new RuntimeException('Unexpected prepare call: ' . $query);
+        if (str_contains($query, 'GET_LOCK')) {
+            return new PlayerRankingUpdaterLockTestStatement($this->resolveLockResult());
         }
 
-        return new PlayerRankingUpdaterLockTestStatement($this->lockAvailable);
+        if (str_contains($query, 'RELEASE_LOCK')) {
+            return new PlayerRankingUpdaterLockTestStatement(1);
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+
+    private function resolveLockResult(): mixed
+    {
+        $this->lockAttempts++;
+
+        if (
+            $this->failuresBeforeSuccess !== null
+            && $this->lockAttempts <= $this->failuresBeforeSuccess
+        ) {
+            return null;
+        }
+
+        return $this->lockResult;
     }
 
     public function exec(string $statement): int|false
     {
-        throw new RuntimeException('Should not execute ranking SQL when lock is unavailable.');
+        if (
+            str_contains($statement, 'DROP TABLE IF EXISTS')
+            || str_contains($statement, 'CREATE TABLE IF NOT EXISTS')
+            || str_contains($statement, 'TRUNCATE TABLE')
+            || str_contains($statement, 'INSERT INTO player_ranking_new')
+            || str_contains($statement, 'RENAME TABLE')
+        ) {
+            return 0;
+        }
+
+        throw new RuntimeException('Unexpected exec call: ' . $statement);
     }
 }
 
 final class PlayerRankingUpdaterLockTestStatement extends PDOStatement
 {
-    public function __construct(private readonly bool $lockAvailable)
+    public function __construct(private readonly mixed $lockResult)
     {
     }
 
@@ -252,6 +327,6 @@ final class PlayerRankingUpdaterLockTestStatement extends PDOStatement
 
     public function fetchColumn(int $column = 0): mixed
     {
-        return $this->lockAvailable ? 1 : 0;
+        return $this->lockResult;
     }
 }

--- a/tests/PlayerRankingUpdaterTest.php
+++ b/tests/PlayerRankingUpdaterTest.php
@@ -197,6 +197,217 @@ final class PlayerRankingUpdaterTest extends TestCase
         $this->assertCount(1, $messages);
         $this->assertStringContainsString('skipped because another run is in progress', $messages[0]);
     }
+
+    public function testSwapPhaseRetriesSafelyAfterRenameCommittedButClientLostConnection(): void
+    {
+        $database = new PlayerRankingUpdaterSwapTestDatabase();
+        $sleepCalls = [];
+
+        $updater = new PlayerRankingUpdater(
+            $database,
+            retryDelaySeconds: 1,
+            maxRetryDelaySeconds: 1,
+            sleeper: static function (int $seconds) use (&$sleepCalls): void {
+                $sleepCalls[] = $seconds;
+            },
+        );
+
+        $updater->recalculate();
+
+        $this->assertSame([1], $sleepCalls);
+        $this->assertSame(1, $database->getRenameAttempts());
+        $this->assertFalse($database->hasTable('player_ranking_new'));
+        $this->assertFalse($database->hasTable('player_ranking_old'));
+        $this->assertTrue($database->hasTable('player_ranking'));
+    }
+
+    public function testIsRankingSwapAlreadyCompleteDetectsCommittedSwap(): void
+    {
+        $database = new PlayerRankingUpdaterSwapStateTestDatabase([
+            'player_ranking' => true,
+            'player_ranking_old' => true,
+        ]);
+        $updater = new PlayerRankingUpdater($database);
+        $method = new ReflectionMethod($updater, 'isRankingSwapAlreadyComplete');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($updater));
+    }
+
+    public function testIsRankingSwapAlreadyCompleteDetectsCommittedSwapAfterOldTableDropped(): void
+    {
+        $database = new PlayerRankingUpdaterSwapStateTestDatabase([
+            'player_ranking' => true,
+        ]);
+        $updater = new PlayerRankingUpdater($database);
+        $method = new ReflectionMethod($updater, 'isRankingSwapAlreadyComplete');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($updater));
+    }
+
+    public function testIsRankingSwapAlreadyCompleteIsFalseWhenTemporaryTableExists(): void
+    {
+        $database = new PlayerRankingUpdaterSwapStateTestDatabase([
+            'player_ranking' => true,
+            'player_ranking_new' => true,
+        ]);
+        $updater = new PlayerRankingUpdater($database);
+        $method = new ReflectionMethod($updater, 'isRankingSwapAlreadyComplete');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($updater));
+    }
+}
+
+final class PlayerRankingUpdaterSwapStateTestDatabase extends PDO
+{
+    /**
+     * @param array<string, bool> $tables
+     */
+    public function __construct(private array $tables)
+    {
+    }
+
+    public function getAttribute($attribute): mixed
+    {
+        if ($attribute === PDO::ATTR_DRIVER_NAME) {
+            return 'mysql';
+        }
+
+        return parent::getAttribute($attribute);
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'information_schema.tables')) {
+            return new PlayerRankingUpdaterTableExistsStatement($this->tables);
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
+final class PlayerRankingUpdaterTableExistsStatement extends PDOStatement
+{
+    private ?string $tableName = null;
+
+    /**
+     * @param array<string, bool> $tables
+     */
+    public function __construct(private array $tables)
+    {
+    }
+
+    public function bindValue($param, $value, $type = PDO::PARAM_STR): bool
+    {
+        if ($param === ':table_name' && is_string($value)) {
+            $this->tableName = $value;
+        }
+
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchColumn(int $column = 0): mixed
+    {
+        if ($this->tableName === null) {
+            return 0;
+        }
+
+        return ($this->tables[$this->tableName] ?? false) ? 1 : 0;
+    }
+}
+
+final class PlayerRankingUpdaterSwapTestDatabase extends PDO
+{
+    /** @var array<string, true> */
+    private array $tables = [
+        'player_ranking' => true,
+    ];
+
+    private int $renameAttempts = 0;
+
+    public function __construct()
+    {
+    }
+
+    public function getAttribute($attribute): mixed
+    {
+        if ($attribute === PDO::ATTR_DRIVER_NAME) {
+            return 'sqlite';
+        }
+
+        return parent::getAttribute($attribute);
+    }
+
+    public function getRenameAttempts(): int
+    {
+        return $this->renameAttempts;
+    }
+
+    public function hasTable(string $tableName): bool
+    {
+        return isset($this->tables[$tableName]);
+    }
+
+    public function exec(string $statement): int|false
+    {
+        if (str_contains($statement, 'CREATE TABLE IF NOT EXISTS player_ranking_new')) {
+            $this->tables['player_ranking_new'] = true;
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'TRUNCATE TABLE player_ranking_new')) {
+            return 0;
+        }
+
+        if (str_contains($statement, 'INSERT INTO player_ranking_new')) {
+            return 0;
+        }
+
+        if (str_contains($statement, 'RENAME TABLE')) {
+            $this->renameAttempts++;
+
+            if (!isset($this->tables['player_ranking_new'])) {
+                throw new RuntimeException('player_ranking_new must exist before RENAME TABLE.');
+            }
+
+            unset($this->tables['player_ranking_new']);
+            $this->tables['player_ranking_old'] = true;
+            $this->tables['player_ranking'] = true;
+
+            if ($this->renameAttempts === 1) {
+                throw new RuntimeException('Connection lost after RENAME TABLE.');
+            }
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'DROP TABLE IF EXISTS player_ranking_old')) {
+            unset($this->tables['player_ranking_old']);
+
+            return 0;
+        }
+
+        throw new RuntimeException('Unexpected exec call: ' . $statement);
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'information_schema.tables')) {
+            return new PlayerRankingUpdaterTableExistsStatement(
+                array_fill_keys(array_keys($this->tables), true)
+            );
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
 }
 
 final class PlayerRankingUpdaterFailingLogDatabase extends PDO
@@ -215,6 +426,11 @@ final class PlayerRankingUpdaterRetryTestDatabase extends PDO
 {
     private int $populateAttempts = 0;
 
+    /** @var array<string, true> */
+    private array $tables = [
+        'player_ranking' => true,
+    ];
+
     public function __construct()
     {
     }
@@ -230,12 +446,38 @@ final class PlayerRankingUpdaterRetryTestDatabase extends PDO
 
     public function exec(string $statement): int|false
     {
+        if (str_contains($statement, 'CREATE TABLE IF NOT EXISTS player_ranking_new')) {
+            $this->tables['player_ranking_new'] = true;
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'TRUNCATE TABLE player_ranking_new')) {
+            return 0;
+        }
+
         if (str_contains($statement, 'INSERT INTO player_ranking_new')) {
             $this->populateAttempts++;
 
             if ($this->populateAttempts < 3) {
                 throw new RuntimeException('Simulated populate failure.');
             }
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'RENAME TABLE')) {
+            unset($this->tables['player_ranking_new']);
+            $this->tables['player_ranking_old'] = true;
+            $this->tables['player_ranking'] = true;
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'DROP TABLE IF EXISTS player_ranking_old')) {
+            unset($this->tables['player_ranking_old']);
+
+            return 0;
         }
 
         return 0;
@@ -243,6 +485,12 @@ final class PlayerRankingUpdaterRetryTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (str_contains($query, 'information_schema.tables')) {
+            return new PlayerRankingUpdaterTableExistsStatement(
+                array_fill_keys(array_keys($this->tables), true)
+            );
+        }
+
         throw new RuntimeException('Unexpected prepare call: ' . $query);
     }
 }
@@ -250,6 +498,11 @@ final class PlayerRankingUpdaterRetryTestDatabase extends PDO
 final class PlayerRankingUpdaterLockTestDatabase extends PDO
 {
     private int $lockAttempts = 0;
+
+    /** @var array<string, true> */
+    private array $tables = [
+        'player_ranking' => true,
+    ];
 
     public function __construct(
         private readonly mixed $lockResult,
@@ -276,6 +529,12 @@ final class PlayerRankingUpdaterLockTestDatabase extends PDO
             return new PlayerRankingUpdaterLockTestStatement(1);
         }
 
+        if (str_contains($query, 'information_schema.tables')) {
+            return new PlayerRankingUpdaterTableExistsStatement(
+                array_fill_keys(array_keys($this->tables), true)
+            );
+        }
+
         throw new RuntimeException('Unexpected prepare call: ' . $query);
     }
 
@@ -295,13 +554,29 @@ final class PlayerRankingUpdaterLockTestDatabase extends PDO
 
     public function exec(string $statement): int|false
     {
+        if (str_contains($statement, 'CREATE TABLE IF NOT EXISTS player_ranking_new')) {
+            $this->tables['player_ranking_new'] = true;
+
+            return 0;
+        }
+
         if (
             str_contains($statement, 'DROP TABLE IF EXISTS')
-            || str_contains($statement, 'CREATE TABLE IF NOT EXISTS')
             || str_contains($statement, 'TRUNCATE TABLE')
             || str_contains($statement, 'INSERT INTO player_ranking_new')
-            || str_contains($statement, 'RENAME TABLE')
         ) {
+            if (str_contains($statement, 'DROP TABLE IF EXISTS player_ranking_old')) {
+                unset($this->tables['player_ranking_old']);
+            }
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'RENAME TABLE')) {
+            unset($this->tables['player_ranking_new']);
+            $this->tables['player_ranking_old'] = true;
+            $this->tables['player_ranking'] = true;
+
             return 0;
         }
 

--- a/tests/PlayerRankingUpdaterTest.php
+++ b/tests/PlayerRankingUpdaterTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerRankingUpdater.php';
+require_once __DIR__ . '/../wwwroot/classes/Psn100Logger.php';
+
+final class PlayerRankingUpdaterTest extends TestCase
+{
+    public function testUsesDropTableIfExistsForOrphanCleanup(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/PlayerRankingUpdater.php');
+        $this->assertTrue(is_string($source));
+        $this->assertStringContainsString("DROP TABLE IF EXISTS %s", $source);
+        $this->assertStringContainsString("PREVIOUS_TABLE = 'player_ranking_old'", $source);
+    }
+
+    public function testUsesMysqlAdvisoryLock(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/PlayerRankingUpdater.php');
+        $this->assertTrue(is_string($source));
+        $this->assertStringContainsString('SELECT GET_LOCK(:lock_name, 0)', $source);
+        $this->assertStringContainsString('SELECT RELEASE_LOCK(:lock_name)', $source);
+        $this->assertStringContainsString('psn100:player_ranking_recalc', $source);
+    }
+
+    public function testRecalculateUsesSeparateBuildSwapAndCleanupPhases(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/PlayerRankingUpdater.php');
+        $this->assertTrue(is_string($source));
+        $this->assertStringContainsString("'build'", $source);
+        $this->assertStringContainsString("'swap'", $source);
+        $this->assertStringContainsString("'cleanup'", $source);
+        $this->assertStringContainsString('cleanupOrphanedTables();', $source);
+    }
+
+    public function testExecuteWithRetryHasNoMaxAttempts(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/PlayerRankingUpdater.php');
+        $this->assertTrue(is_string($source));
+        $this->assertStringContainsString('while (true)', $source);
+        $this->assertFalse(str_contains($source, 'maxAttempt'));
+    }
+
+    public function testCalculateRetryDelayUsesExponentialBackoffWithCap(): void
+    {
+        $updater = new PlayerRankingUpdater(
+            new PDO('sqlite::memory:'),
+            retryDelaySeconds: 3,
+            maxRetryDelaySeconds: 60,
+        );
+        $method = new ReflectionMethod($updater, 'calculateRetryDelay');
+        $method->setAccessible(true);
+
+        $this->assertSame(3, $method->invoke($updater, 1));
+        $this->assertSame(6, $method->invoke($updater, 2));
+        $this->assertSame(12, $method->invoke($updater, 3));
+        $this->assertSame(60, $method->invoke($updater, 10));
+    }
+
+    public function testRecalculateRetriesUntilBuildPhaseSucceeds(): void
+    {
+        $database = new PlayerRankingUpdaterRetryTestDatabase();
+        $logDatabase = new PDO('sqlite::memory:');
+        $logDatabase->exec('CREATE TABLE log (id INTEGER PRIMARY KEY AUTOINCREMENT, message TEXT NOT NULL)');
+        $logger = new Psn100Logger($logDatabase);
+        $sleepCalls = [];
+
+        $updater = new PlayerRankingUpdater(
+            $database,
+            retryDelaySeconds: 1,
+            maxRetryDelaySeconds: 1,
+            logger: $logger,
+            sleeper: static function (int $seconds) use (&$sleepCalls): void {
+                $sleepCalls[] = $seconds;
+            },
+        );
+
+        $updater->recalculate();
+
+        $this->assertSame([1, 1], $sleepCalls);
+
+        $query = $logDatabase->query('SELECT message FROM log ORDER BY id');
+        $this->assertTrue($query instanceof PDOStatement);
+        $messages = $query->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertCount(2, $messages);
+        $this->assertStringContainsString('build failed (attempt 1)', $messages[0]);
+        $this->assertStringContainsString('build failed (attempt 2)', $messages[1]);
+    }
+
+    public function testAcquireLockReturnsFalseWhenMysqlLockIsUnavailable(): void
+    {
+        $database = new PlayerRankingUpdaterLockTestDatabase(false);
+        $updater = new PlayerRankingUpdater($database);
+        $method = new ReflectionMethod($updater, 'acquireLock');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($updater));
+    }
+
+    public function testAcquireLockReturnsTrueWhenMysqlLockIsAvailable(): void
+    {
+        $database = new PlayerRankingUpdaterLockTestDatabase(true);
+        $updater = new PlayerRankingUpdater($database);
+        $method = new ReflectionMethod($updater, 'acquireLock');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($updater));
+    }
+
+    public function testRecalculateSkipsWhenLockIsAlreadyHeld(): void
+    {
+        $database = new PlayerRankingUpdaterLockTestDatabase(false);
+        $logDatabase = new PDO('sqlite::memory:');
+        $logDatabase->exec('CREATE TABLE log (id INTEGER PRIMARY KEY AUTOINCREMENT, message TEXT NOT NULL)');
+        $logger = new Psn100Logger($logDatabase);
+
+        $updater = new PlayerRankingUpdater(
+            $database,
+            logger: $logger,
+            sleeper: static function (int $seconds): void {
+                throw new RuntimeException('Should not sleep when lock is unavailable.');
+            },
+        );
+
+        $updater->recalculate();
+
+        $query = $logDatabase->query('SELECT message FROM log ORDER BY id');
+        $this->assertTrue($query instanceof PDOStatement);
+        $messages = $query->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertCount(1, $messages);
+        $this->assertStringContainsString('skipped because another run is in progress', $messages[0]);
+    }
+}
+
+final class PlayerRankingUpdaterRetryTestDatabase extends PDO
+{
+    private int $populateAttempts = 0;
+
+    public function __construct()
+    {
+    }
+
+    public function getAttribute($attribute): mixed
+    {
+        if ($attribute === PDO::ATTR_DRIVER_NAME) {
+            return 'sqlite';
+        }
+
+        return parent::getAttribute($attribute);
+    }
+
+    public function exec(string $statement): int|false
+    {
+        if (str_contains($statement, 'INSERT INTO player_ranking_new')) {
+            $this->populateAttempts++;
+
+            if ($this->populateAttempts < 3) {
+                throw new RuntimeException('Simulated populate failure.');
+            }
+        }
+
+        return 0;
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
+final class PlayerRankingUpdaterLockTestDatabase extends PDO
+{
+    public function __construct(private readonly bool $lockAvailable)
+    {
+    }
+
+    public function getAttribute($attribute): mixed
+    {
+        if ($attribute === PDO::ATTR_DRIVER_NAME) {
+            return 'mysql';
+        }
+
+        return parent::getAttribute($attribute);
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (!str_contains($query, 'GET_LOCK')) {
+            throw new RuntimeException('Unexpected prepare call: ' . $query);
+        }
+
+        return new PlayerRankingUpdaterLockTestStatement($this->lockAvailable);
+    }
+
+    public function exec(string $statement): int|false
+    {
+        throw new RuntimeException('Should not execute ranking SQL when lock is unavailable.');
+    }
+}
+
+final class PlayerRankingUpdaterLockTestStatement extends PDOStatement
+{
+    public function __construct(private readonly bool $lockAvailable)
+    {
+    }
+
+    public function bindValue($param, $value, $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchColumn(int $column = 0): mixed
+    {
+        return $this->lockAvailable ? 1 : 0;
+    }
+}

--- a/tests/PlayerRankingUpdaterTest.php
+++ b/tests/PlayerRankingUpdaterTest.php
@@ -109,6 +109,28 @@ final class PlayerRankingUpdaterTest extends TestCase
         $this->assertTrue($method->invoke($updater));
     }
 
+    public function testRecalculateContinuesRetryingWhenDatabaseLoggingFails(): void
+    {
+        $database = new PlayerRankingUpdaterRetryTestDatabase();
+        $logDatabase = new PlayerRankingUpdaterFailingLogDatabase();
+        $logger = new Psn100Logger($logDatabase);
+        $sleepCalls = [];
+
+        $updater = new PlayerRankingUpdater(
+            $database,
+            retryDelaySeconds: 1,
+            maxRetryDelaySeconds: 1,
+            logger: $logger,
+            sleeper: static function (int $seconds) use (&$sleepCalls): void {
+                $sleepCalls[] = $seconds;
+            },
+        );
+
+        $updater->recalculate();
+
+        $this->assertSame([1, 1], $sleepCalls);
+    }
+
     public function testRecalculateSkipsWhenLockIsAlreadyHeld(): void
     {
         $database = new PlayerRankingUpdaterLockTestDatabase(false);
@@ -131,6 +153,18 @@ final class PlayerRankingUpdaterTest extends TestCase
         $messages = $query->fetchAll(PDO::FETCH_COLUMN);
         $this->assertCount(1, $messages);
         $this->assertStringContainsString('skipped because another run is in progress', $messages[0]);
+    }
+}
+
+final class PlayerRankingUpdaterFailingLogDatabase extends PDO
+{
+    public function __construct()
+    {
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        throw new RuntimeException('Simulated log insert failure.');
     }
 }
 

--- a/wwwroot/classes/Cron/PlayerRankingUpdater.php
+++ b/wwwroot/classes/Cron/PlayerRankingUpdater.php
@@ -2,12 +2,17 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../Psn100Logger.php';
+
 class PlayerRankingUpdater
 {
-    private const TEMPORARY_TABLE = 'player_ranking_new';
-    private const PRIMARY_TABLE = 'player_ranking';
-    private const PREVIOUS_TABLE = 'player_ranking_old';
-    private const INSERT_TEMPLATE = <<<'SQL'
+    private const string TEMPORARY_TABLE = 'player_ranking_new';
+    private const string PRIMARY_TABLE = 'player_ranking';
+    private const string PREVIOUS_TABLE = 'player_ranking_old';
+    private const string LOCK_NAME = 'psn100:player_ranking_recalc';
+    private const int DEFAULT_RETRY_DELAY_SECONDS = 3;
+    private const int DEFAULT_MAX_RETRY_DELAY_SECONDS = 60;
+    private const string INSERT_TEMPLATE = <<<'SQL'
 INSERT INTO %s (
     account_id,
     ranking,
@@ -48,33 +53,104 @@ SQL;
 
     private int $retryDelaySeconds;
 
-    public function __construct(PDO $database, int $retryDelaySeconds = 3)
-    {
+    private int $maxRetryDelaySeconds;
+
+    private ?Psn100Logger $logger;
+
+    /** @var callable(int): void */
+    private $sleeper;
+
+    public function __construct(
+        PDO $database,
+        int $retryDelaySeconds = self::DEFAULT_RETRY_DELAY_SECONDS,
+        int $maxRetryDelaySeconds = self::DEFAULT_MAX_RETRY_DELAY_SECONDS,
+        ?Psn100Logger $logger = null,
+        ?callable $sleeper = null,
+    ) {
         $this->database = $database;
         $this->retryDelaySeconds = $retryDelaySeconds;
+        $this->maxRetryDelaySeconds = $maxRetryDelaySeconds;
+        $this->logger = $logger;
+        $this->sleeper = $sleeper ?? static function (int $seconds): void {
+            sleep($seconds);
+        };
     }
 
     public function recalculate(): void
     {
-        $this->executeWithRetry(function (): void {
-            $this->createTemporaryTable();
-            $this->clearTemporaryTable();
-            $this->populateTemporaryTable();
-            $this->replaceRankingTable();
-        });
+        if (!$this->acquireLock()) {
+            $this->log('Player ranking recalculation skipped because another run is in progress.');
+
+            return;
+        }
+
+        try {
+            $this->executeWithRetry(
+                function (): void {
+                    $this->cleanupOrphanedTables();
+                    $this->createTemporaryTable();
+                    $this->clearTemporaryTable();
+                    $this->populateTemporaryTable();
+                },
+                'build'
+            );
+
+            $this->executeWithRetry(
+                function (): void {
+                    $this->cleanupOrphanedTables();
+                    $this->swapRankingTables();
+                },
+                'swap'
+            );
+
+            $this->executeWithRetry(
+                function (): void {
+                    $this->dropPreviousRankingTable();
+                },
+                'cleanup'
+            );
+        } finally {
+            $this->releaseLock();
+        }
     }
 
-    private function executeWithRetry(callable $operation): void
+    private function executeWithRetry(callable $operation, string $phase): void
     {
+        $attempt = 0;
+
         while (true) {
             try {
                 $operation();
 
                 return;
             } catch (Throwable $exception) {
-                sleep($this->retryDelaySeconds);
+                $attempt++;
+                $delay = $this->calculateRetryDelay($attempt);
+                $this->log(sprintf(
+                    'Player ranking %s failed (attempt %d): %s. Retrying in %d seconds.',
+                    $phase,
+                    $attempt,
+                    $exception->getMessage(),
+                    $delay
+                ));
+                ($this->sleeper)($delay);
             }
         }
+    }
+
+    private function calculateRetryDelay(int $attempt): int
+    {
+        $exponent = min($attempt - 1, 10);
+
+        return min(
+            $this->maxRetryDelaySeconds,
+            $this->retryDelaySeconds * (2 ** $exponent)
+        );
+    }
+
+    private function cleanupOrphanedTables(): void
+    {
+        $this->database->exec(sprintf('DROP TABLE IF EXISTS %s', self::PREVIOUS_TABLE));
     }
 
     private function createTemporaryTable(): void
@@ -100,7 +176,7 @@ SQL;
         $this->database->exec($sql);
     }
 
-    private function replaceRankingTable(): void
+    private function swapRankingTables(): void
     {
         $renameSql = sprintf(
             'RENAME TABLE %s TO %s, %s TO %s',
@@ -111,8 +187,51 @@ SQL;
         );
 
         $this->database->exec($renameSql);
+    }
 
-        $dropSql = sprintf('DROP TABLE %s', self::PREVIOUS_TABLE);
+    private function dropPreviousRankingTable(): void
+    {
+        $dropSql = sprintf('DROP TABLE IF EXISTS %s', self::PREVIOUS_TABLE);
         $this->database->exec($dropSql);
+    }
+
+    private function acquireLock(): bool
+    {
+        if (!$this->supportsNamedLocks()) {
+            return true;
+        }
+
+        $lockStatement = $this->database->prepare('SELECT GET_LOCK(:lock_name, 0)');
+        $lockStatement->bindValue(':lock_name', self::LOCK_NAME, PDO::PARAM_STR);
+        $lockStatement->execute();
+
+        return (int) ($lockStatement->fetchColumn() ?? 0) === 1;
+    }
+
+    private function releaseLock(): void
+    {
+        if (!$this->supportsNamedLocks()) {
+            return;
+        }
+
+        $releaseStatement = $this->database->prepare('SELECT RELEASE_LOCK(:lock_name)');
+        $releaseStatement->bindValue(':lock_name', self::LOCK_NAME, PDO::PARAM_STR);
+        $releaseStatement->execute();
+    }
+
+    private function supportsNamedLocks(): bool
+    {
+        return $this->database->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql';
+    }
+
+    private function log(string $message): void
+    {
+        if ($this->logger !== null) {
+            $this->logger->log($message);
+
+            return;
+        }
+
+        error_log($message);
     }
 }

--- a/wwwroot/classes/Cron/PlayerRankingUpdater.php
+++ b/wwwroot/classes/Cron/PlayerRankingUpdater.php
@@ -78,7 +78,7 @@ SQL;
 
     public function recalculate(): void
     {
-        if (!$this->acquireLock()) {
+        if (!$this->waitForLock()) {
             $this->log('Player ranking recalculation skipped because another run is in progress.');
 
             return;
@@ -195,6 +195,27 @@ SQL;
         $this->database->exec($dropSql);
     }
 
+    private function waitForLock(): bool
+    {
+        $attempt = 0;
+
+        while (true) {
+            try {
+                return $this->acquireLock();
+            } catch (Throwable $exception) {
+                $attempt++;
+                $delay = $this->calculateRetryDelay($attempt);
+                $this->log(sprintf(
+                    'Player ranking lock acquisition failed (attempt %d): %s. Retrying in %d seconds.',
+                    $attempt,
+                    $exception->getMessage(),
+                    $delay
+                ));
+                ($this->sleeper)($delay);
+            }
+        }
+    }
+
     private function acquireLock(): bool
     {
         if (!$this->supportsNamedLocks()) {
@@ -205,7 +226,23 @@ SQL;
         $lockStatement->bindValue(':lock_name', self::LOCK_NAME, PDO::PARAM_STR);
         $lockStatement->execute();
 
-        return (int) ($lockStatement->fetchColumn() ?? 0) === 1;
+        $result = $lockStatement->fetchColumn();
+        if ($result === null || $result === false) {
+            throw new RuntimeException('Unable to acquire player ranking recalculation lock.');
+        }
+
+        if ((string) $result === '1') {
+            return true;
+        }
+
+        if ((string) $result === '0') {
+            return false;
+        }
+
+        throw new RuntimeException(sprintf(
+            'Unexpected GET_LOCK result for player ranking recalculation: %s',
+            var_export($result, true)
+        ));
     }
 
     private function releaseLock(): void

--- a/wwwroot/classes/Cron/PlayerRankingUpdater.php
+++ b/wwwroot/classes/Cron/PlayerRankingUpdater.php
@@ -227,9 +227,13 @@ SQL;
     private function log(string $message): void
     {
         if ($this->logger !== null) {
-            $this->logger->log($message);
+            try {
+                $this->logger->log($message);
 
-            return;
+                return;
+            } catch (Throwable) {
+                // Keep retrying even when the database logger is unavailable.
+            }
         }
 
         error_log($message);

--- a/wwwroot/classes/Cron/PlayerRankingUpdater.php
+++ b/wwwroot/classes/Cron/PlayerRankingUpdater.php
@@ -97,8 +97,7 @@ SQL;
 
             $this->executeWithRetry(
                 function (): void {
-                    $this->cleanupOrphanedTables();
-                    $this->swapRankingTables();
+                    $this->swapRankingTablesIfNeeded();
                 },
                 'swap'
             );
@@ -174,6 +173,52 @@ SQL;
     {
         $sql = sprintf(self::INSERT_TEMPLATE, self::TEMPORARY_TABLE);
         $this->database->exec($sql);
+    }
+
+    private function swapRankingTablesIfNeeded(): void
+    {
+        if ($this->isRankingSwapAlreadyComplete()) {
+            return;
+        }
+
+        $this->cleanupOrphanedTables();
+        $this->swapRankingTables();
+    }
+
+    private function isRankingSwapAlreadyComplete(): bool
+    {
+        $hasPrimary = $this->tableExists(self::PRIMARY_TABLE);
+        $hasTemporary = $this->tableExists(self::TEMPORARY_TABLE);
+        $hasPrevious = $this->tableExists(self::PREVIOUS_TABLE);
+
+        if (!$hasTemporary && $hasPrevious) {
+            return true;
+        }
+
+        if (!$hasTemporary && !$hasPrevious && $hasPrimary) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function tableExists(string $tableName): bool
+    {
+        $statement = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                COUNT(*)
+            FROM
+                information_schema.tables
+            WHERE
+                table_schema = DATABASE()
+                AND table_name = :table_name
+            SQL
+        );
+        $statement->bindValue(':table_name', $tableName, PDO::PARAM_STR);
+        $statement->execute();
+
+        return (int) ($statement->fetchColumn() ?? 0) > 0;
     }
 
     private function swapRankingTables(): void

--- a/wwwroot/cron/5th_minute.php
+++ b/wwwroot/cron/5th_minute.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 require_once dirname(__DIR__) . '/classes/Cron/CronJobEntryPoint.php';
 require_once dirname(__DIR__) . '/classes/Cron/PlayerRankingCronJob.php';
+require_once dirname(__DIR__) . '/classes/Psn100Logger.php';
 
 $entryPoint = CronJobEntryPoint::create(dirname(__DIR__));
 $entryPoint->runWithFactory(static function (\PDO $database): CronJobInterface {
-    $playerRankingUpdater = new PlayerRankingUpdater($database);
+    $playerRankingUpdater = new PlayerRankingUpdater(
+        $database,
+        logger: new Psn100Logger($database),
+    );
 
     return new PlayerRankingCronJob($playerRankingUpdater);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Priority 1 hardening for `PlayerRankingUpdater` while preserving **uncapped retry until success**.

- **Advisory lock** (`GET_LOCK('psn100:player_ranking_recalc', 0)`) prevents overlapping 5-minute cron runs from corrupting the shared temp table. If the lock is held, the run exits cleanly and lets the in-flight recalculation finish.
- **Lock error handling** — `GET_LOCK` returning `NULL` is treated as a retryable error; only `0` is treated as real contention and causes a skip.
- **Idempotent swap retry** — if MySQL commits `RENAME TABLE` but the client loses the connection, a retry detects the already-completed swap instead of dropping `player_ranking_old` and failing forever on a missing temp table.
- **Orphan cleanup** drops `player_ranking_old` before build and swap phases, fixing the permanent retry loop when a prior run succeeded at `RENAME TABLE` but failed at `DROP TABLE`.
- **Split retry phases** — build, swap, and cleanup each have their own infinite retry loop so a successful swap is not rolled back by rebuilding from scratch.
- **Logging + exponential backoff** — failures are written to the `log` table via `Psn100Logger` (still retries forever; backoff caps at 60s). Logging failures fall back to `error_log()` so a broken log insert cannot escape the retry loop.
- **Tests** — unit tests for retry/lock/backoff/swap-idempotency behavior; MySQL integration tests for ranking rebuild, orphan recovery, and lock contention (using a separate MySQL session).

## Review feedback addressed

- Guard retry logging from throwing out of the loop (fallback to `error_log()`)
- Use a separate MySQL session for the lock contention integration test
- Isolate MySQL integration tests from real app data via explicit opt-in (`PSN100_INTEGRATION_TEST_DB`)
- Distinguish `GET_LOCK` errors (`NULL`) from contention (`0`)
- Make the swap retry idempotent after a committed `RENAME TABLE`

## Running MySQL integration tests

Integration tests are skipped by default. To run them against a disposable database:

```bash
# Ephemeral database (created and dropped automatically)
PSN100_INTEGRATION_TEST_DB=auto php tests/run.php

# Named disposable database (must not be `psn100`)
PSN100_INTEGRATION_TEST_DB=psn100_integration_test DB_HOST=127.0.0.1 DB_USER=psn100 DB_PASSWORD=psn100 php tests/run.php
```

## Test plan

- [x] `php tests/run.php` — 601 tests pass (21 new)
- [x] Unit tests cover uncapped retry, lock skip, lock error retry, swap idempotency, logging fallback, and exponential backoff
- [x] Integration tests skip unless `PSN100_INTEGRATION_TEST_DB` is explicitly set
- [x] Integration tests cover ranking rebuild, orphaned `_old` recovery, and lock skip via separate session (when MySQL is available)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04d9d93c-eaab-4064-8824-a12bc067465f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04d9d93c-eaab-4064-8824-a12bc067465f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

