### PR TITLE
Retry WeeklyCronJob inactive rank reset with active snapshot

### DIFF
--- a/tests/WeeklyCronJobTest.php
+++ b/tests/WeeklyCronJobTest.php
@@ -30,18 +30,23 @@ final class WeeklyCronJobTest extends TestCase
         $this->assertStringContainsString('p.status != 0', $query);
     }
 
-    public function testRunRetriesBothUpdatesTogether(): void
+    public function testRunUsesSeparateRetryLoopsForActiveAndInactiveUpdates(): void
     {
         $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/WeeklyCronJob.php');
         $this->assertTrue(is_string($source));
-        $this->assertStringContainsString('$this->executeWithRetry(function (): void {', $source);
-        $this->assertStringContainsString('$this->updateLeaderboardsForActivePlayers();', $source);
-        $this->assertStringContainsString('$this->resetRankingsForInactivePlayers();', $source);
+        $this->assertStringContainsString(
+            '$this->executeWithRetry([$this, \'updateLeaderboardsForActivePlayers\']);',
+            $source
+        );
+        $this->assertStringContainsString(
+            '$this->executeWithRetry([$this, \'resetRankingsForInactivePlayers\']);',
+            $source
+        );
         $this->assertStringContainsString('while (true)', $source);
         $this->assertFalse(str_contains($source, 'maxAttempt'));
     }
 
-    public function testRunRetriesUntilInactiveResetSucceeds(): void
+    public function testRunRetriesOnlyInactiveResetAfterActiveSnapshotSucceeds(): void
     {
         $database = new WeeklyCronJobRetryTestDatabase();
         $sleepCalls = [];
@@ -57,8 +62,28 @@ final class WeeklyCronJobTest extends TestCase
         $job->run();
 
         $this->assertSame([1, 1], $sleepCalls);
-        $this->assertSame(3, $database->getActiveUpdateCount());
+        $this->assertSame(1, $database->getActiveUpdateCount());
         $this->assertSame(3, $database->getInactiveResetCount());
+    }
+
+    public function testRunRetriesActiveSnapshotUntilItSucceeds(): void
+    {
+        $database = new WeeklyCronJobActiveRetryTestDatabase();
+        $sleepCalls = [];
+
+        $job = new WeeklyCronJob(
+            $database,
+            retryDelaySeconds: 1,
+            sleeper: static function (int $seconds) use (&$sleepCalls): void {
+                $sleepCalls[] = $seconds;
+            },
+        );
+
+        $job->run();
+
+        $this->assertSame([1, 1], $sleepCalls);
+        $this->assertSame(3, $database->getActiveUpdateCount());
+        $this->assertSame(1, $database->getInactiveResetCount());
     }
 
     private function readPrivateConstantValue(ReflectionClass $class, string $name): string
@@ -107,6 +132,48 @@ final class WeeklyCronJobRetryTestDatabase extends PDO
                 if ($this->inactiveResetCount < 3) {
                     throw new RuntimeException('Simulated inactive reset failure.');
                 }
+            });
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
+final class WeeklyCronJobActiveRetryTestDatabase extends PDO
+{
+    private int $activeUpdateCount = 0;
+
+    private int $inactiveResetCount = 0;
+
+    public function __construct()
+    {
+    }
+
+    public function getActiveUpdateCount(): int
+    {
+        return $this->activeUpdateCount;
+    }
+
+    public function getInactiveResetCount(): int
+    {
+        return $this->inactiveResetCount;
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'WHERE p.status = 0')) {
+            return new WeeklyCronJobTestStatement(function (): void {
+                $this->activeUpdateCount++;
+
+                if ($this->activeUpdateCount < 3) {
+                    throw new RuntimeException('Simulated active snapshot failure.');
+                }
+            });
+        }
+
+        if (str_contains($query, 'p.status != 0')) {
+            return new WeeklyCronJobTestStatement(function (): void {
+                $this->inactiveResetCount++;
             });
         }
 

--- a/tests/WeeklyCronJobTest.php
+++ b/tests/WeeklyCronJobTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/WeeklyCronJob.php';
+
+final class WeeklyCronJobTest extends TestCase
+{
+    public function testUpdateQuerySnapshotsRankingsForActivePlayersOnly(): void
+    {
+        $class = new ReflectionClass(WeeklyCronJob::class);
+        $query = $this->readPrivateConstantValue($class, 'UPDATE_PLAYER_RANKINGS_QUERY');
+
+        $this->assertStringContainsString('UPDATE player p', $query);
+        $this->assertStringContainsString('JOIN player_ranking r ON p.account_id = r.account_id', $query);
+        $this->assertStringContainsString('p.rank_last_week = r.ranking', $query);
+        $this->assertStringContainsString('WHERE p.status = 0', $query);
+    }
+
+    public function testResetQueryClearsWeeklyRankingsForInactivePlayers(): void
+    {
+        $class = new ReflectionClass(WeeklyCronJob::class);
+        $query = $this->readPrivateConstantValue($class, 'RESET_INACTIVE_RANKINGS_QUERY');
+
+        $this->assertStringContainsString('UPDATE', $query);
+        $this->assertStringContainsString('p.rank_last_week = 0', $query);
+        $this->assertStringContainsString('p.in_game_rarity_rank_country_last_week = 0', $query);
+        $this->assertStringContainsString('WHERE', $query);
+        $this->assertStringContainsString('p.status != 0', $query);
+    }
+
+    public function testRunRetriesBothUpdatesTogether(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/WeeklyCronJob.php');
+        $this->assertTrue(is_string($source));
+        $this->assertStringContainsString('$this->executeWithRetry(function (): void {', $source);
+        $this->assertStringContainsString('$this->updateLeaderboardsForActivePlayers();', $source);
+        $this->assertStringContainsString('$this->resetRankingsForInactivePlayers();', $source);
+        $this->assertStringContainsString('while (true)', $source);
+        $this->assertFalse(str_contains($source, 'maxAttempt'));
+    }
+
+    public function testRunRetriesUntilInactiveResetSucceeds(): void
+    {
+        $database = new WeeklyCronJobRetryTestDatabase();
+        $sleepCalls = [];
+
+        $job = new WeeklyCronJob(
+            $database,
+            retryDelaySeconds: 1,
+            sleeper: static function (int $seconds) use (&$sleepCalls): void {
+                $sleepCalls[] = $seconds;
+            },
+        );
+
+        $job->run();
+
+        $this->assertSame([1, 1], $sleepCalls);
+        $this->assertSame(3, $database->getActiveUpdateCount());
+        $this->assertSame(3, $database->getInactiveResetCount());
+    }
+
+    private function readPrivateConstantValue(ReflectionClass $class, string $name): string
+    {
+        $constant = $class->getReflectionConstant($name);
+        $this->assertTrue($constant instanceof ReflectionClassConstant);
+        $value = $constant->getValue();
+        $this->assertTrue(is_string($value));
+
+        return $value;
+    }
+}
+
+final class WeeklyCronJobRetryTestDatabase extends PDO
+{
+    private int $activeUpdateCount = 0;
+
+    private int $inactiveResetCount = 0;
+
+    public function __construct()
+    {
+    }
+
+    public function getActiveUpdateCount(): int
+    {
+        return $this->activeUpdateCount;
+    }
+
+    public function getInactiveResetCount(): int
+    {
+        return $this->inactiveResetCount;
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'WHERE p.status = 0')) {
+            return new WeeklyCronJobTestStatement(function (): void {
+                $this->activeUpdateCount++;
+            });
+        }
+
+        if (str_contains($query, 'p.status != 0')) {
+            return new WeeklyCronJobTestStatement(function (): void {
+                $this->inactiveResetCount++;
+
+                if ($this->inactiveResetCount < 3) {
+                    throw new RuntimeException('Simulated inactive reset failure.');
+                }
+            });
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
+final class WeeklyCronJobTestStatement extends PDOStatement
+{
+    /** @var callable(): void */
+    private $callback;
+
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        ($this->callback)();
+
+        return true;
+    }
+}

--- a/wwwroot/classes/Cron/WeeklyCronJob.php
+++ b/wwwroot/classes/Cron/WeeklyCronJob.php
@@ -43,10 +43,8 @@ final readonly class WeeklyCronJob implements CronJobInterface
     #[\Override]
     public function run(): void
     {
-        $this->executeWithRetry(function (): void {
-            $this->updateLeaderboardsForActivePlayers();
-            $this->resetRankingsForInactivePlayers();
-        });
+        $this->executeWithRetry([$this, 'updateLeaderboardsForActivePlayers']);
+        $this->executeWithRetry([$this, 'resetRankingsForInactivePlayers']);
     }
 
     private function updateLeaderboardsForActivePlayers(): void

--- a/wwwroot/classes/Cron/WeeklyCronJob.php
+++ b/wwwroot/classes/Cron/WeeklyCronJob.php
@@ -33,15 +33,20 @@ final readonly class WeeklyCronJob implements CronJobInterface
             p.status != 0
         SQL;
 
-    public function __construct(private PDO $database, private int $retryDelaySeconds = 3)
-    {
+    public function __construct(
+        private PDO $database,
+        private int $retryDelaySeconds = 3,
+        private ?\Closure $sleeper = null,
+    ) {
     }
 
     #[\Override]
     public function run(): void
     {
-        $this->executeWithRetry([$this, 'updateLeaderboardsForActivePlayers']);
-        $this->resetRankingsForInactivePlayers();
+        $this->executeWithRetry(function (): void {
+            $this->updateLeaderboardsForActivePlayers();
+            $this->resetRankingsForInactivePlayers();
+        });
     }
 
     private function updateLeaderboardsForActivePlayers(): void
@@ -64,8 +69,16 @@ final readonly class WeeklyCronJob implements CronJobInterface
 
                 return;
             } catch (Throwable $exception) {
-                sleep($this->retryDelaySeconds);
+                ($this->getSleeper())($this->retryDelaySeconds);
             }
         }
+    }
+
+    /** @return \Closure(int): void */
+    private function getSleeper(): \Closure
+    {
+        return $this->sleeper ?? static function (int $seconds): void {
+            sleep($seconds);
+        };
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Implementation Order 2: fix the partial-update inconsistency in `WeeklyCronJob`.

Previously, only the active-player snapshot (`updateLeaderboardsForActivePlayers`) ran inside the infinite retry loop. If `resetRankingsForInactivePlayers()` failed, active players kept fresh `*_last_week` values while inactive/cheater/private players could retain stale weekly rank fields until the next weekly run.

The inactive reset now has its own uncapped retry loop, while the active snapshot keeps a separate retry loop so a delayed reset retry does not re-read `player_ranking` after the 5-minute ranking updater has moved rankings forward.

## Review feedback addressed

- Preserve the weekly snapshot source across reset retries by retrying only the inactive reset after the active snapshot succeeds

## Test plan

- [x] `php tests/run.php` — 606 tests pass (5 WeeklyCronJob tests)
- [x] `WeeklyCronJobTest` verifies separate retry loops, inactive-only retry behavior, and active snapshot retry behavior
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04d9d93c-eaab-4064-8824-a12bc067465f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04d9d93c-eaab-4064-8824-a12bc067465f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

