### PR TITLE
Complete DeletePlayerService related-table deletion and safe log cleanup

### DIFF
--- a/tests/DeletePlayerRequestHandlerTest.php
+++ b/tests/DeletePlayerRequestHandlerTest.php
@@ -176,6 +176,20 @@ final class DeletePlayerRequestHandlerTest extends TestCase
             in_game_epic INTEGER NOT NULL DEFAULT 0,
             in_game_legendary INTEGER NOT NULL DEFAULT 0
         )');
+        $this->database->exec('CREATE TABLE player_ranking (
+            account_id TEXT PRIMARY KEY,
+            ranking INTEGER NOT NULL
+        )');
+        $this->database->exec('CREATE TABLE player_report (
+            report_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_id TEXT NOT NULL,
+            ip_address TEXT NOT NULL,
+            explanation TEXT NOT NULL
+        )');
+        $this->database->exec('CREATE TABLE player_queue (
+            online_id TEXT PRIMARY KEY,
+            ip_address TEXT NOT NULL
+        )');
         $this->database->exec('CREATE TABLE player (
             account_id TEXT PRIMARY KEY,
             online_id TEXT
@@ -200,6 +214,18 @@ final class DeletePlayerRequestHandlerTest extends TestCase
         $this->database->exec(sprintf(
             "INSERT INTO trophy_title_player (account_id) VALUES ('%s')",
             $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO player_ranking (account_id, ranking) VALUES ('%s', 1)",
+            $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO player_report (account_id, ip_address, explanation) VALUES ('%s', '127.0.0.1', 'test')",
+            $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO player_queue (online_id, ip_address) VALUES ('%s', '127.0.0.1')",
+            $onlineId
         ));
         $this->database->exec(sprintf(
             "INSERT INTO log (message) VALUES ('Player (%s) deleted')",

--- a/tests/DeletePlayerServiceTest.php
+++ b/tests/DeletePlayerServiceTest.php
@@ -58,7 +58,7 @@ final class DeletePlayerServiceTest extends TestCase
         $this->assertSame(null, $player);
     }
 
-    public function testDeletePlayerByAccountIdDeletesData(): void
+    public function testDeletePlayerByAccountIdDeletesRelatedData(): void
     {
         $this->insertPlayerData('2002', 'PlayerOne');
         $this->insertPlayerData('3003', 'PlayerTwo');
@@ -70,6 +70,9 @@ final class DeletePlayerServiceTest extends TestCase
                 'trophy_earned' => 2,
                 'trophy_group_player' => 1,
                 'trophy_title_player' => 1,
+                'player_ranking' => 1,
+                'player_report' => 1,
+                'player_queue' => 1,
                 'player' => 1,
                 'log' => 1,
             ],
@@ -79,10 +82,26 @@ final class DeletePlayerServiceTest extends TestCase
         $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM trophy_earned WHERE account_id = '2002'")->fetchColumn());
         $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM trophy_group_player WHERE account_id = '2002'")->fetchColumn());
         $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM trophy_title_player WHERE account_id = '2002'")->fetchColumn());
+        $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM player_ranking WHERE account_id = '2002'")->fetchColumn());
+        $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM player_report WHERE account_id = '2002'")->fetchColumn());
+        $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM player_queue WHERE online_id = 'PlayerOne'")->fetchColumn());
         $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM player WHERE account_id = '2002'")->fetchColumn());
-        $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM log WHERE message LIKE '%2002%'")->fetchColumn());
+        $this->assertSame(0, (int) $this->database->query("SELECT COUNT(*) FROM log WHERE message = 'Player (2002) deleted'")->fetchColumn());
 
         $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM player WHERE account_id = '3003'")->fetchColumn());
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM player_queue WHERE online_id = 'PlayerTwo'")->fetchColumn());
+    }
+
+    public function testDeletePlayerByAccountIdDoesNotDeleteLogsWithSimilarNumericSubstrings(): void
+    {
+        $this->insertPlayerData('2002', 'PlayerOne');
+        $this->database->exec("INSERT INTO log (message) VALUES ('Scan failed for player 92002')");
+        $this->database->exec("INSERT INTO log (message) VALUES ('Sony issues with OtherUser (92002).')");
+
+        $this->service->deletePlayerByAccountId('2002');
+
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM log WHERE message = 'Scan failed for player 92002'")->fetchColumn());
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM log WHERE message = 'Sony issues with OtherUser (92002).'")->fetchColumn());
     }
 
     public function testDeletePlayerByAccountIdRollsBackOnFailure(): void
@@ -104,8 +123,11 @@ final class DeletePlayerServiceTest extends TestCase
         $this->assertSame(2, (int) $this->database->query("SELECT COUNT(*) FROM trophy_earned WHERE account_id = '4004'")->fetchColumn());
         $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM trophy_group_player WHERE account_id = '4004'")->fetchColumn());
         $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM trophy_title_player WHERE account_id = '4004'")->fetchColumn());
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM player_ranking WHERE account_id = '4004'")->fetchColumn());
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM player_report WHERE account_id = '4004'")->fetchColumn());
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM player_queue WHERE online_id = 'FailureUser'")->fetchColumn());
         $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM player WHERE account_id = '4004'")->fetchColumn());
-        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM log WHERE message LIKE '%4004%'")->fetchColumn());
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM log WHERE message = 'Player (4004) deleted'")->fetchColumn());
     }
 
     private function createTables(): void
@@ -129,6 +151,20 @@ final class DeletePlayerServiceTest extends TestCase
             in_game_rare INTEGER NOT NULL DEFAULT 0,
             in_game_epic INTEGER NOT NULL DEFAULT 0,
             in_game_legendary INTEGER NOT NULL DEFAULT 0
+        )');
+        $this->database->exec('CREATE TABLE player_ranking (
+            account_id TEXT PRIMARY KEY,
+            ranking INTEGER NOT NULL
+        )');
+        $this->database->exec('CREATE TABLE player_report (
+            report_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_id TEXT NOT NULL,
+            ip_address TEXT NOT NULL,
+            explanation TEXT NOT NULL
+        )');
+        $this->database->exec('CREATE TABLE player_queue (
+            online_id TEXT PRIMARY KEY,
+            ip_address TEXT NOT NULL
         )');
         $this->database->exec('CREATE TABLE player (
             account_id TEXT PRIMARY KEY,
@@ -154,6 +190,18 @@ final class DeletePlayerServiceTest extends TestCase
         $this->database->exec(sprintf(
             "INSERT INTO trophy_title_player (account_id) VALUES ('%s')",
             $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO player_ranking (account_id, ranking) VALUES ('%s', 1)",
+            $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO player_report (account_id, ip_address, explanation) VALUES ('%s', '127.0.0.1', 'test')",
+            $accountId
+        ));
+        $this->database->exec(sprintf(
+            "INSERT INTO player_queue (online_id, ip_address) VALUES ('%s', '127.0.0.1')",
+            $onlineId
         ));
         $this->database->exec(sprintf(
             "INSERT INTO log (message) VALUES ('Player (%s) deleted')",

--- a/wwwroot/classes/Admin/DeletePlayerService.php
+++ b/wwwroot/classes/Admin/DeletePlayerService.php
@@ -110,17 +110,9 @@ final class DeletePlayerService
     private function deleteLogMessagesForAccountId(string $accountId): int
     {
         $statement = $this->database->prepare(
-            <<<'SQL'
-            DELETE FROM log
-            WHERE
-                message LIKE :pattern_parentheses
-                OR message LIKE :pattern_parentheses_dot
-                OR message LIKE :pattern_parentheses_comma
-            SQL
+            'DELETE FROM log WHERE message LIKE :pattern_parentheses'
         );
         $statement->bindValue(':pattern_parentheses', '%(' . $accountId . ')%', PDO::PARAM_STR);
-        $statement->bindValue(':pattern_parentheses_dot', '%(' . $accountId . ').%', PDO::PARAM_STR);
-        $statement->bindValue(':pattern_parentheses_comma', '%(' . $accountId . '),%', PDO::PARAM_STR);
         $statement->execute();
 
         return (int) $statement->rowCount();

--- a/wwwroot/classes/Admin/DeletePlayerService.php
+++ b/wwwroot/classes/Admin/DeletePlayerService.php
@@ -62,6 +62,9 @@ final class DeletePlayerService
         }
 
         try {
+            $player = $this->findPlayerByAccountId($accountId);
+            $onlineId = $player['online_id'] ?? null;
+
             $counts = [];
             $counts['trophy_earned'] = $this->deleteByAccountId(
                 'DELETE FROM trophy_earned WHERE account_id = :account_id',
@@ -75,15 +78,22 @@ final class DeletePlayerService
                 'DELETE FROM trophy_title_player WHERE account_id = :account_id',
                 $accountId
             );
+            $counts['player_ranking'] = $this->deleteByAccountId(
+                'DELETE FROM player_ranking WHERE account_id = :account_id',
+                $accountId
+            );
+            $counts['player_report'] = $this->deleteByAccountId(
+                'DELETE FROM player_report WHERE account_id = :account_id',
+                $accountId
+            );
+            $counts['player_queue'] = $onlineId !== null && $onlineId !== ''
+                ? $this->deleteByOnlineId('DELETE FROM player_queue WHERE online_id = :online_id', $onlineId)
+                : 0;
             $counts['player'] = $this->deleteByAccountId(
                 'DELETE FROM player WHERE account_id = :account_id',
                 $accountId
             );
-
-            $logStatement = $this->database->prepare('DELETE FROM log WHERE message LIKE :message');
-            $logStatement->bindValue(':message', '%' . $accountId . '%', PDO::PARAM_STR);
-            $logStatement->execute();
-            $counts['log'] = (int) $logStatement->rowCount();
+            $counts['log'] = $this->deleteLogMessagesForAccountId($accountId);
 
             $this->database->commit();
 
@@ -97,10 +107,38 @@ final class DeletePlayerService
         }
     }
 
+    private function deleteLogMessagesForAccountId(string $accountId): int
+    {
+        $statement = $this->database->prepare(
+            <<<'SQL'
+            DELETE FROM log
+            WHERE
+                message LIKE :pattern_parentheses
+                OR message LIKE :pattern_parentheses_dot
+                OR message LIKE :pattern_parentheses_comma
+            SQL
+        );
+        $statement->bindValue(':pattern_parentheses', '%(' . $accountId . ')%', PDO::PARAM_STR);
+        $statement->bindValue(':pattern_parentheses_dot', '%(' . $accountId . ').%', PDO::PARAM_STR);
+        $statement->bindValue(':pattern_parentheses_comma', '%(' . $accountId . '),%', PDO::PARAM_STR);
+        $statement->execute();
+
+        return (int) $statement->rowCount();
+    }
+
     private function deleteByAccountId(string $sql, string $accountId): int
     {
         $statement = $this->database->prepare($sql);
         $statement->bindValue(':account_id', $accountId, PDO::PARAM_STR);
+        $statement->execute();
+
+        return (int) $statement->rowCount();
+    }
+
+    private function deleteByOnlineId(string $sql, string $onlineId): int
+    {
+        $statement = $this->database->prepare($sql);
+        $statement->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
         $statement->execute();
 
         return (int) $statement->rowCount();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Implementation Order 3: complete player deletion and safe log cleanup in `DeletePlayerService`.

- Delete related rows from `player_ranking`, `player_report`, and `player_queue` in the same transaction
- Remove queue entries by the player's `online_id` before deleting the `player` row
- Replace broad `LIKE '%account_id%'` log cleanup with parenthesized account ID patterns such as `(123)`, `(123).`, and `(123),` to avoid deleting unrelated logs like `92002` when removing account `2002`

## Test plan

- [x] `php tests/run.php` — 607 tests pass
- [x] `DeletePlayerServiceTest` covers related-table deletion, safe log cleanup, and rollback behavior
- [x] `DeletePlayerRequestHandlerTest` updated for the expanded deletion flow
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04d9d93c-eaab-4064-8824-a12bc067465f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04d9d93c-eaab-4064-8824-a12bc067465f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

