### PR TITLE
Fix PlayerReportService duplicate race and explanation length validation

### DIFF
--- a/tests/PlayerReportServiceTest.php
+++ b/tests/PlayerReportServiceTest.php
@@ -22,7 +22,8 @@ final class PlayerReportServiceTest extends TestCase
                 report_id INTEGER PRIMARY KEY AUTOINCREMENT,
                 account_id INTEGER NOT NULL,
                 ip_address TEXT NOT NULL,
-                explanation TEXT NOT NULL
+                explanation TEXT NOT NULL,
+                UNIQUE (account_id, ip_address)
             )
             SQL
         );
@@ -91,5 +92,59 @@ final class PlayerReportServiceTest extends TestCase
 
         $count = (int) $this->pdo->query('SELECT COUNT(*) FROM player_report')->fetchColumn();
         $this->assertSame(10, $count);
+    }
+
+    public function testSubmitReportReturnsErrorWhenExplanationIsTooLong(): void
+    {
+        $result = $this->service->submitReport(123, '198.51.100.10', str_repeat('a', 257));
+
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame('Explanation must be 256 characters or fewer.', $result->getMessage());
+        $this->assertSame(0, (int) $this->pdo->query('SELECT COUNT(*) FROM player_report')->fetchColumn());
+    }
+
+    public function testSubmitReportAcceptsExplanationAtMaximumLength(): void
+    {
+        $explanation = str_repeat('a', 256);
+
+        $result = $this->service->submitReport(123, '198.51.100.10', $explanation);
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertSame(1, (int) $this->pdo->query('SELECT COUNT(*) FROM player_report')->fetchColumn());
+    }
+
+    public function testSubmitReportReturnsDuplicateErrorWhenUniqueConstraintIsViolated(): void
+    {
+        $service = new PlayerReportService($this->pdo);
+        $insertReport = new ReflectionMethod($service, 'insertReport');
+        $insertReport->setAccessible(true);
+        $isDuplicate = new ReflectionMethod($service, 'isDuplicateReportException');
+        $isDuplicate->setAccessible(true);
+
+        $insertReport->invoke($service, 789, '198.51.100.99', 'Existing report');
+
+        try {
+            $insertReport->invoke($service, 789, '198.51.100.99', 'Race condition report');
+            $this->fail('Expected PDOException was not thrown.');
+        } catch (PDOException $exception) {
+            $this->assertTrue($isDuplicate->invoke($service, $exception));
+        }
+    }
+
+    public function testSubmitReportPerformsDuplicateCheckInsideIpLock(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/PlayerReportService.php');
+        $this->assertTrue(is_string($source));
+
+        $methodStart = strpos($source, 'public function submitReport');
+        $this->assertTrue($methodStart !== false);
+
+        $methodSource = substr($source, $methodStart, 1200);
+        $lockPos = strpos($methodSource, 'getIpSubmissionLockExecutor()->execute');
+        $duplicatePos = strpos($methodSource, 'hasExistingReport($accountId, $ipAddress)');
+
+        $this->assertTrue($lockPos !== false);
+        $this->assertTrue($duplicatePos !== false);
+        $this->assertTrue($duplicatePos > $lockPos);
     }
 }

--- a/wwwroot/classes/PlayerReportService.php
+++ b/wwwroot/classes/PlayerReportService.php
@@ -9,6 +9,14 @@ class PlayerReportService
 {
     private const MAX_PENDING_REPORTS_PER_IP = 10;
 
+    private const MAX_EXPLANATION_LENGTH = 256;
+
+    private const SUBMIT_OUTCOME_SUCCESS = 'success';
+
+    private const SUBMIT_OUTCOME_DUPLICATE = 'duplicate';
+
+    private const SUBMIT_OUTCOME_LIMIT = 'limit';
+
     public function __construct(
         private readonly PDO $database,
         private readonly ?IpSubmissionLockExecutor $ipSubmissionLockExecutor = null,
@@ -17,28 +25,44 @@ class PlayerReportService
 
     public function submitReport(int $accountId, string $ipAddress, string $explanation): PlayerReportResult
     {
-        if ($this->hasExistingReport($accountId, $ipAddress)) {
-            return PlayerReportResult::error("You've already reported this player.");
+        if (mb_strlen($explanation) > self::MAX_EXPLANATION_LENGTH) {
+            return PlayerReportResult::error(
+                'Explanation must be ' . self::MAX_EXPLANATION_LENGTH . ' characters or fewer.'
+            );
         }
 
-        $inserted = $this->getIpSubmissionLockExecutor()->execute(
+        $outcome = $this->getIpSubmissionLockExecutor()->execute(
             $ipAddress,
-            function () use ($accountId, $ipAddress, $explanation): bool {
-                if ($this->getReportCountForIp($ipAddress) >= self::MAX_PENDING_REPORTS_PER_IP) {
-                    return false;
+            function () use ($accountId, $ipAddress, $explanation): string {
+                if ($this->hasExistingReport($accountId, $ipAddress)) {
+                    return self::SUBMIT_OUTCOME_DUPLICATE;
                 }
 
-                $this->insertReport($accountId, $ipAddress, $explanation);
+                if ($this->getReportCountForIp($ipAddress) >= self::MAX_PENDING_REPORTS_PER_IP) {
+                    return self::SUBMIT_OUTCOME_LIMIT;
+                }
 
-                return true;
+                try {
+                    $this->insertReport($accountId, $ipAddress, $explanation);
+                } catch (PDOException $exception) {
+                    if ($this->isDuplicateReportException($exception)) {
+                        return self::SUBMIT_OUTCOME_DUPLICATE;
+                    }
+
+                    throw $exception;
+                }
+
+                return self::SUBMIT_OUTCOME_SUCCESS;
             }
         );
 
-        if (!$inserted) {
-            return PlayerReportResult::error('You already have 10 reports waiting to be processed. Please try again later.');
-        }
-
-        return PlayerReportResult::success('Player reported successfully.');
+        return match ($outcome) {
+            self::SUBMIT_OUTCOME_SUCCESS => PlayerReportResult::success('Player reported successfully.'),
+            self::SUBMIT_OUTCOME_DUPLICATE => PlayerReportResult::error("You've already reported this player."),
+            self::SUBMIT_OUTCOME_LIMIT => PlayerReportResult::error(
+                'You already have 10 reports waiting to be processed. Please try again later.'
+            ),
+        };
     }
 
     private function getIpSubmissionLockExecutor(): IpSubmissionLockExecutor
@@ -103,5 +127,17 @@ class PlayerReportService
         $query->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
         $query->bindValue(':explanation', $explanation, PDO::PARAM_STR);
         $query->execute();
+    }
+
+    private function isDuplicateReportException(PDOException $exception): bool
+    {
+        if ($exception->getCode() === '23000') {
+            return true;
+        }
+
+        $message = $exception->getMessage();
+
+        return str_contains($message, 'UNIQUE constraint failed')
+            || str_contains($message, 'Duplicate entry');
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Implementation Order 4: fix race and validation issues in `PlayerReportService`.

- Move the duplicate-report check inside the IP submission lock so concurrent submissions cannot both pass the pre-check
- Catch unique-key violations on insert and return the existing friendly "already reported" message
- Validate explanation length before insert (`256` characters, matching the DB column and form `maxlength`)

## Test plan

- [x] `php tests/run.php` — 611 tests pass (4 new)
- [x] `PlayerReportServiceTest` covers duplicate handling, IP limit, max-length validation, unique-constraint detection, and in-lock duplicate ordering
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04d9d93c-eaab-4064-8824-a12bc067465f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04d9d93c-eaab-4064-8824-a12bc067465f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

