### PR TITLE
Escape admin merge and copy handler error messages (Order 5)

### DIFF
--- a/tests/GameCopyHandlerTest.php
+++ b/tests/GameCopyHandlerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameCopyService.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameCopyHandler.php';
+
+final class GameCopyHandlerTest extends TestCase
+{
+    public function testHandleReturnsEmptyStringWhenRequiredIdsAreMissing(): void
+    {
+        $handler = new GameCopyHandler(new ThrowingGameCopyService(new RuntimeException('unused')));
+
+        $this->assertSame('', $handler->handle([]));
+        $this->assertSame('', $handler->handle(['child' => '1']));
+    }
+
+    public function testHandleReturnsValidationMessageForNonNumericIds(): void
+    {
+        $handler = new GameCopyHandler(new ThrowingGameCopyService(new RuntimeException('unused')));
+
+        $message = $handler->handle([
+            'child' => 'abc',
+            'parent' => '2',
+        ]);
+
+        $this->assertSame('Child and parent must be numeric IDs.', $message);
+    }
+
+    public function testHandleEscapesRuntimeExceptionMessage(): void
+    {
+        $handler = new GameCopyHandler(
+            new ThrowingGameCopyService(
+                new RuntimeException('<script>alert("copy")</script>')
+            )
+        );
+
+        $message = $handler->handle([
+            'child' => '1',
+            'parent' => '2',
+        ]);
+
+        $this->assertSame('&lt;script&gt;alert(&quot;copy&quot;)&lt;/script&gt;', $message);
+    }
+
+    public function testHandleReturnsGenericMessageForUnexpectedErrors(): void
+    {
+        $handler = new GameCopyHandler(
+            new ThrowingGameCopyService(
+                new Exception('<img src=x onerror=alert(1)>')
+            )
+        );
+
+        $message = $handler->handle([
+            'child' => '1',
+            'parent' => '2',
+        ]);
+
+        $this->assertSame('An unexpected error occurred while copying game data.', $message);
+    }
+
+    public function testHandleReturnsSuccessMessageWhenCopySucceeds(): void
+    {
+        $handler = new GameCopyHandler(new ThrowingGameCopyService(null));
+
+        $message = $handler->handle([
+            'child' => '1',
+            'parent' => '2',
+        ]);
+
+        $this->assertSame('The group and trophy data have been copied.', $message);
+    }
+}
+
+final class ThrowingGameCopyService extends GameCopyService
+{
+    public function __construct(private readonly ?Throwable $throwable)
+    {
+        parent::__construct(new PDO('sqlite::memory:'));
+    }
+
+    public function copyChildToParent(
+        int $childId,
+        int $parentId,
+        bool $copyIconUrl = true,
+        bool $copySetVersion = true
+    ): void {
+        if ($this->throwable !== null) {
+            throw $this->throwable;
+        }
+    }
+}

--- a/tests/TrophyMergeRequestHandlerTest.php
+++ b/tests/TrophyMergeRequestHandlerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMergeService.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyMergeRequestHandler.php';
+
+final class TrophyMergeRequestHandlerTest extends TestCase
+{
+    public function testHandleReturnsEmptyStringForEmptyPostData(): void
+    {
+        $handler = new TrophyMergeRequestHandler(new ThrowingTrophyMergeService(new RuntimeException('unused')));
+
+        $this->assertSame('', $handler->handle([]));
+    }
+
+    public function testHandleEscapesInvalidArgumentExceptionMessage(): void
+    {
+        $handler = new TrophyMergeRequestHandler(
+            new ThrowingTrophyMergeService(
+                new InvalidArgumentException('<script>alert(1)</script>')
+            )
+        );
+
+        $message = $handler->handle([
+            'trophyparent' => '1',
+            'trophychild' => '2',
+        ]);
+
+        $this->assertSame('&lt;script&gt;alert(1)&lt;/script&gt;', $message);
+    }
+
+    public function testHandleEscapesRuntimeExceptionMessage(): void
+    {
+        $handler = new TrophyMergeRequestHandler(
+            new ThrowingTrophyMergeService(
+                new RuntimeException('Unable to locate child & trophy titles.')
+            )
+        );
+
+        $message = $handler->handle([
+            'clone' => '42',
+        ]);
+
+        $this->assertSame('Unable to locate child &amp; trophy titles.', $message);
+    }
+
+    public function testHandleReturnsGenericMessageForUnexpectedErrors(): void
+    {
+        $handler = new TrophyMergeRequestHandler(
+            new ThrowingTrophyMergeService(
+                new Exception('<img src=x onerror=alert(1)>')
+            )
+        );
+
+        $message = $handler->handle([
+            'parent' => '10',
+            'child' => '20',
+        ]);
+
+        $this->assertSame('An unexpected error occurred while processing the request.', $message);
+    }
+
+    public function testHandleEscapesValidationErrorsBeforeCallingService(): void
+    {
+        $handler = new TrophyMergeRequestHandler(
+            new ThrowingTrophyMergeService(new RuntimeException('Service should not be called.'))
+        );
+
+        $message = $handler->handle([
+            'trophyparent' => '1',
+            'trophychild' => 'abc',
+        ]);
+
+        $this->assertSame('Child trophy ids must be numeric.', $message);
+    }
+}
+
+final class ThrowingTrophyMergeService extends TrophyMergeService
+{
+    public function __construct(private readonly Throwable $throwable)
+    {
+        parent::__construct(new PDO('sqlite::memory:'));
+    }
+
+    public function mergeSpecificTrophies(int $parentTrophyId, array $childTrophyIds): string
+    {
+        throw $this->throwable;
+    }
+
+    public function cloneGame(int $childGameId): string
+    {
+        throw $this->throwable;
+    }
+
+    public function mergeGames(
+        int $childGameId,
+        int $parentGameId,
+        string $method,
+        ?TrophyMergeProgressListener $progressListener = null
+    ): string {
+        throw $this->throwable;
+    }
+}

--- a/wwwroot/classes/Admin/GameCopyHandler.php
+++ b/wwwroot/classes/Admin/GameCopyHandler.php
@@ -32,7 +32,9 @@ class GameCopyHandler
                 $copySetVersion
             );
         } catch (RuntimeException $exception) {
-            return $exception->getMessage();
+            return $this->escape($exception->getMessage());
+        } catch (Throwable $exception) {
+            return 'An unexpected error occurred while copying game data.';
         }
 
         return 'The group and trophy data have been copied.';
@@ -71,5 +73,10 @@ class GameCopyHandler
         $value = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
 
         return $value ?? true;
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlentities($value, ENT_QUOTES, 'UTF-8');
     }
 }

--- a/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
+++ b/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
@@ -32,9 +32,9 @@ class TrophyMergeRequestHandler
                 return $this->handleGameMerge($postData);
             }
         } catch (InvalidArgumentException | RuntimeException $exception) {
-            return $exception->getMessage();
+            return $this->escape($exception->getMessage());
         } catch (Throwable $exception) {
-            return 'An unexpected error occurred: ' . $exception->getMessage();
+            return 'An unexpected error occurred while processing the request.';
         }
 
         return '';
@@ -141,5 +141,10 @@ class TrophyMergeRequestHandler
         }
 
         return ctype_digit((string) $value);
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlentities($value, ENT_QUOTES, 'UTF-8');
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes admin XSS vectors in the merge and copy request handlers (Implementation Order 5).

- **`TrophyMergeRequestHandler`**: Escape `InvalidArgumentException` and `RuntimeException` messages with `htmlentities` before returning them to `merge.php`. Unexpected errors now return a generic message instead of leaking raw exception text.
- **`GameCopyHandler`**: Same treatment for `RuntimeException`, plus a generic fallback for unexpected errors before echoing in `copy.php`.

Both handlers now follow the same pattern as `GameResetRequestHandler` and `CheaterRequestHandler`.

## Testing

- Added `tests/TrophyMergeRequestHandlerTest.php` (5 tests) covering escaped known exceptions, generic unexpected errors, and validation paths.
- Added `tests/GameCopyHandlerTest.php` (5 tests) covering the same scenarios plus success path.
- Full suite: **621 tests passed** (`php tests/run.php`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04d9d93c-eaab-4064-8824-a12bc067465f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04d9d93c-eaab-4064-8824-a12bc067465f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

