### PR TITLE
Throw when GameStatusService cannot find the requested game (Order 6)

### DIFF
--- a/tests/GameStatusServiceTest.php
+++ b/tests/GameStatusServiceTest.php
@@ -113,4 +113,24 @@ final class GameStatusServiceTest extends TestCase
             $this->assertSame('Game ID must be a non-negative integer.', $exception->getMessage());
         }
     }
+
+    public function testUpdateGameStatusThrowsWhenGameDoesNotExist(): void
+    {
+        try {
+            $this->service->updateGameStatus(999, GameAvailabilityStatus::DELISTED);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('Unable to find the specified game.', $exception->getMessage());
+        }
+
+        $changeCount = $this->database
+            ->query('SELECT COUNT(*) FROM psn100_change')
+            ->fetchColumn();
+        $this->assertSame(0, (int) $changeCount);
+
+        $status = $this->database
+            ->query('SELECT status FROM trophy_title_meta WHERE np_communication_id = "NPWR-1"')
+            ->fetchColumn();
+        $this->assertSame(0, (int) $status);
+    }
 }

--- a/wwwroot/classes/GameStatusService.php
+++ b/wwwroot/classes/GameStatusService.php
@@ -42,7 +42,7 @@ class GameStatusService
         $npCommunicationId = $npCommunicationIdQuery->fetchColumn();
 
         if ($npCommunicationId === false) {
-            return;
+            throw new InvalidArgumentException('Unable to find the specified game.');
         }
 
         $query = $this->database->prepare(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a silent failure in `GameStatusService` (Implementation Order 6).

When `updateStatus()` could not find a `trophy_title` row for the given game ID, it returned early without updating anything. `updateGameStatus()` still logged a `psn100_change` entry and committed the transaction, producing a phantom changelog with no actual status change.

Now throws `InvalidArgumentException('Unable to find the specified game.')`, which rolls back the transaction and surfaces a clear error in `GameDetailPage` (which already catches `InvalidArgumentException`).

## Testing

- Added `testUpdateGameStatusThrowsWhenGameDoesNotExist` to verify the exception, no changelog row, and no status mutation.
- Full suite: **622 tests passed** (`php tests/run.php`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04d9d93c-eaab-4064-8824-a12bc067465f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04d9d93c-eaab-4064-8824-a12bc067465f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

