### PR TITLE
Extract trophy image downloading from god classes

### DIFF
--- a/tests/GameRescanServiceSetVersionTest.php
+++ b/tests/GameRescanServiceSetVersionTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/ImageHashCalculatorTest.php';
 require_once __DIR__ . '/../wwwroot/classes/TrophyCalculator.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyImageDownloader.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanDifferenceTracker.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanService.php';
 
@@ -47,5 +49,33 @@ final class GameRescanServiceSetVersionTest extends TestCase
 
         $this->assertSame('01.10', $updatedVersion);
         $this->assertSame([], $differenceTracker->getDifferences());
+    }
+
+    public function testRescanPreservesInjectedImageDownloader(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE trophy_title (id INTEGER PRIMARY KEY, np_communication_id TEXT NOT NULL)');
+        $database->exec("INSERT INTO trophy_title (id, np_communication_id) VALUES (1, 'CUSA12345_00')");
+
+        $injectedDownloader = new TrophyImageDownloader(
+            new ImageHashCalculator(new FakeImageProcessor(supported: false)),
+            null,
+            static fn (string $url): ?string => null,
+        );
+
+        $service = new GameRescanService(
+            $database,
+            new TrophyCalculator($database),
+            imageDownloader: $injectedDownloader,
+        );
+
+        $result = $service->rescan(1);
+
+        $this->assertStringContainsString('Can only rescan original game entries.', $result->getMessage());
+
+        $property = new ReflectionProperty(GameRescanService::class, 'imageDownloader');
+        $property->setAccessible(true);
+        $this->assertSame($injectedDownloader, $property->getValue($service));
     }
 }

--- a/tests/TrophyImageDownloaderTest.php
+++ b/tests/TrophyImageDownloaderTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/ImageHashCalculatorTest.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyImageDirectories.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyImageDownloader.php';
+
+final class TrophyImageDownloaderTest extends TestCase
+{
+    private string $tempDirectory;
+
+    protected function setUp(): void
+    {
+        $this->tempDirectory = sys_get_temp_dir() . '/psn100-image-downloader-' . uniqid('', true) . '/';
+        mkdir($this->tempDirectory, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDirectory);
+    }
+
+    public function testBuildFilenameUsesHashCalculatorAndPreservesExtension(): void
+    {
+        $downloader = $this->createDownloader(static fn (): ?string => null);
+
+        $filename = $downloader->buildFilename('https://example.test/icon.PNG', 'image-data');
+
+        $this->assertSame(md5('image-data') . '.png', $filename);
+    }
+
+    public function testDownloadMandatoryForScanStoresFileAndReturnsFilename(): void
+    {
+        $downloader = $this->createDownloader(static fn (string $url): ?string => $url === 'https://example.test/title.png'
+            ? 'title-bytes'
+            : null);
+        $messages = [];
+
+        $downloader = new TrophyImageDownloader(
+            new ImageHashCalculator(new FakeImageProcessor(supported: false)),
+            static function (string $message) use (&$messages): void {
+                $messages[] = $message;
+            },
+            static fn (string $url): ?string => $url === 'https://example.test/title.png' ? 'title-bytes' : null,
+        );
+
+        $filename = $downloader->downloadMandatoryForScan(
+            'https://example.test/title.png',
+            $this->tempDirectory,
+            'title icon',
+        );
+
+        $this->assertSame(md5('title-bytes') . '.png', $filename);
+        $this->assertTrue(file_exists($this->tempDirectory . $filename));
+        $this->assertSame([], $messages);
+    }
+
+    public function testDownloadMandatoryForScanReturnsPlaceholderWhenFetchFails(): void
+    {
+        $messages = [];
+        $downloader = new TrophyImageDownloader(
+            new ImageHashCalculator(new FakeImageProcessor(supported: false)),
+            static function (string $message) use (&$messages): void {
+                $messages[] = $message;
+            },
+            static fn (string $url): ?string => null,
+        );
+
+        $filename = $downloader->downloadMandatoryForScan(
+            'https://example.test/title.png',
+            $this->tempDirectory,
+            'title icon',
+        );
+
+        $this->assertSame(TrophyImageDownloader::PLACEHOLDER_FILENAME, $filename);
+        $this->assertSame(
+            ['Unable to download title icon from "https://example.test/title.png".'],
+            $messages
+        );
+    }
+
+    public function testDownloadMandatoryForScanSkipsLoggingWhenPlaceholderAlreadyCached(): void
+    {
+        $messages = [];
+        $downloader = new TrophyImageDownloader(
+            new ImageHashCalculator(new FakeImageProcessor(supported: false)),
+            static function (string $message) use (&$messages): void {
+                $messages[] = $message;
+            },
+            static fn (string $url): ?string => null,
+        );
+
+        $filename = $downloader->downloadMandatoryForScan(
+            'https://example.test/title.png',
+            $this->tempDirectory,
+            'title icon',
+            TrophyImageDownloader::PLACEHOLDER_FILENAME,
+        );
+
+        $this->assertSame(TrophyImageDownloader::PLACEHOLDER_FILENAME, $filename);
+        $this->assertSame([], $messages);
+    }
+
+    public function testDownloadOptionalForScanReturnsNullForEmptyUrl(): void
+    {
+        $downloader = $this->createDownloader(static fn (string $url): ?string => 'bytes');
+
+        $this->assertSame(null, $downloader->downloadOptionalForScan('', $this->tempDirectory, 'reward image'));
+        $this->assertSame(null, $downloader->downloadOptionalForScan(null, $this->tempDirectory, 'reward image'));
+    }
+
+    public function testDownloadMandatoryForRescanReusesExistingFilenameWhenFetchFails(): void
+    {
+        $messages = [];
+        $downloader = new TrophyImageDownloader(
+            new ImageHashCalculator(new FakeImageProcessor(supported: false)),
+            static function (string $message) use (&$messages): void {
+                $messages[] = $message;
+            },
+            static fn (string $url): ?string => null,
+        );
+
+        $filename = $downloader->downloadMandatoryForRescan(
+            'https://example.test/title.png',
+            $this->tempDirectory,
+            'cached-title.png',
+        );
+
+        $this->assertSame('cached-title.png', $filename);
+        $this->assertSame(
+            ['Reusing cached image "cached-title.png" because "https://example.test/title.png" is unavailable.'],
+            $messages
+        );
+    }
+
+    public function testDownloadMandatoryForRescanThrowsWhenFetchFailsWithoutCache(): void
+    {
+        $downloader = $this->createDownloader(static fn (string $url): ?string => null);
+
+        try {
+            $downloader->downloadMandatoryForRescan(
+                'https://example.test/title.png',
+                $this->tempDirectory,
+            );
+            $this->fail('Expected RuntimeException when mandatory rescan download fails without cache.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame(
+                'Unable to download image from "https://example.test/title.png".',
+                $exception->getMessage()
+            );
+        }
+    }
+
+    public function testDownloadOptionalForRescanReturnsExistingFilenameForEmptyUrl(): void
+    {
+        $downloader = $this->createDownloader(static fn (string $url): ?string => 'bytes');
+
+        $this->assertSame(
+            'cached-reward.png',
+            $downloader->downloadOptionalForRescan(null, $this->tempDirectory, 'cached-reward.png')
+        );
+    }
+
+    public function testDownloadOptionalForRescanKeepsCachedFilenameWhenFetchFails(): void
+    {
+        $messages = [];
+        $downloader = new TrophyImageDownloader(
+            new ImageHashCalculator(new FakeImageProcessor(supported: false)),
+            static function (string $message) use (&$messages): void {
+                $messages[] = $message;
+            },
+            static fn (string $url): ?string => null,
+        );
+
+        $filename = $downloader->downloadOptionalForRescan(
+            'https://example.test/reward.png',
+            $this->tempDirectory,
+            'cached-reward.png',
+        );
+
+        $this->assertSame('cached-reward.png', $filename);
+        $this->assertSame(
+            ['Keeping cached optional image "cached-reward.png" because "https://example.test/reward.png" is unavailable.'],
+            $messages
+        );
+    }
+
+    public function testProductionDefaultDirectoriesExposeExpectedPaths(): void
+    {
+        $directories = TrophyImageDirectories::productionDefault();
+
+        $this->assertSame('/home/psn100/public_html/img/title/', $directories->title);
+        $this->assertSame('/home/psn100/public_html/img/group/', $directories->group);
+        $this->assertSame('/home/psn100/public_html/img/trophy/', $directories->trophy);
+        $this->assertSame('/home/psn100/public_html/img/reward/', $directories->reward);
+    }
+
+    private function createDownloader(?\Closure $remoteFileFetcher): TrophyImageDownloader
+    {
+        return new TrophyImageDownloader(
+            new ImageHashCalculator(new FakeImageProcessor(supported: false)),
+            null,
+            $remoteFileFetcher,
+        );
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $entries = scandir($directory);
+        if ($entries === false) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $directory . $entry;
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+                continue;
+            }
+
+            unlink($path);
+        }
+
+        rmdir($directory);
+    }
+}

--- a/tests/TrophyImageDownloaderTest.php
+++ b/tests/TrophyImageDownloaderTest.php
@@ -187,6 +187,26 @@ final class TrophyImageDownloaderTest extends TestCase
         );
     }
 
+    public function testWithLoggerPreservesRemoteFileFetcher(): void
+    {
+        $downloader = new TrophyImageDownloader(
+            new ImageHashCalculator(new FakeImageProcessor(supported: false)),
+            null,
+            static fn (string $url): ?string => 'image-bytes',
+        );
+
+        $withLogger = $downloader->withLogger(static function (string $message): void {
+        });
+
+        $filename = $withLogger->downloadMandatoryForScan(
+            'https://example.test/title.png',
+            $this->tempDirectory,
+            'title icon',
+        );
+
+        $this->assertSame(md5('image-bytes') . '.png', $filename);
+    }
+
     public function testProductionDefaultDirectoriesExposeExpectedPaths(): void
     {
         $directories = TrophyImageDirectories::productionDefault();

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -68,11 +68,11 @@ class GameRescanService
         $this->logListener = $logListener !== null
             ? \Closure::fromCallable($logListener)
             : null;
-        $this->imageDownloader = new TrophyImageDownloader(
-            $this->imageHashCalculator,
+        $previousImageDownloader = $this->imageDownloader;
+        $this->imageDownloader = $this->imageDownloader->withLogger(
             function (string $message): void {
                 $this->logMessage($message);
-            },
+            }
         );
 
         try {
@@ -140,6 +140,7 @@ class GameRescanService
             return new GameRescanResult($message, $differenceTracker->getDifferences());
         } finally {
             $this->logListener = $previousLogListener;
+            $this->imageDownloader = $previousImageDownloader;
         }
     }
 

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -8,16 +8,14 @@ require_once __DIR__ . '/GameRescanResult.php';
 require_once __DIR__ . '/../ImageHashCalculator.php';
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../TrophyMetaRepository.php';
+require_once __DIR__ . '/../TrophyImageDirectories.php';
+require_once __DIR__ . '/../TrophyImageDownloader.php';
 require_once __DIR__ . '/PsnGameLookupService.php';
 
 use Tustin\PlayStation\Client;
 
 class GameRescanService
 {
-    private const TITLE_ICON_DIRECTORY = '/home/psn100/public_html/img/title/';
-    private const GROUP_ICON_DIRECTORY = '/home/psn100/public_html/img/group/';
-    private const TROPHY_ICON_DIRECTORY = '/home/psn100/public_html/img/trophy/';
-    private const REWARD_ICON_DIRECTORY = '/home/psn100/public_html/img/reward/';
     private const ORIGINAL_GAME_PREFIX = 'NPWR';
     private const LOGIN_RETRY_DELAY_SECONDS = 300;
 
@@ -30,6 +28,8 @@ class GameRescanService
 
     private ImageHashCalculator $imageHashCalculator;
     private PsnGameLookupService $psnGameLookupService;
+    private TrophyImageDirectories $imageDirectories;
+    private TrophyImageDownloader $imageDownloader;
 
     /**
      * @var \Closure(string):void|null
@@ -41,7 +41,9 @@ class GameRescanService
         TrophyCalculator $trophyCalculator,
         ?TrophyHistoryRecorder $historyRecorder = null,
         ?ImageHashCalculator $imageHashCalculator = null,
-        ?PsnGameLookupService $psnGameLookupService = null
+        ?PsnGameLookupService $psnGameLookupService = null,
+        ?TrophyImageDirectories $imageDirectories = null,
+        ?TrophyImageDownloader $imageDownloader = null,
     )
     {
         $this->database = $database;
@@ -50,6 +52,8 @@ class GameRescanService
         $this->trophyMetaRepository = new TrophyMetaRepository($database);
         $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
         $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase($database);
+        $this->imageDirectories = $imageDirectories ?? TrophyImageDirectories::productionDefault();
+        $this->imageDownloader = $imageDownloader ?? new TrophyImageDownloader($this->imageHashCalculator);
     }
 
     /**
@@ -64,6 +68,12 @@ class GameRescanService
         $this->logListener = $logListener !== null
             ? \Closure::fromCallable($logListener)
             : null;
+        $this->imageDownloader = new TrophyImageDownloader(
+            $this->imageHashCalculator,
+            function (string $message): void {
+                $this->logMessage($message);
+            },
+        );
 
         try {
             $differenceTracker = new GameRescanDifferenceTracker();
@@ -401,9 +411,9 @@ class GameRescanService
         $existingTrophyData = $this->fetchExistingTrophyData($npCommunicationId);
 
         $titleDetail = (string) $trophyTitle->detail();
-        $titleIconFilename = $this->downloadImage(
+        $titleIconFilename = $this->imageDownloader->downloadMandatoryForRescan(
             $trophyTitle->iconUrl(),
-            self::TITLE_ICON_DIRECTORY,
+            $this->imageDirectories->title,
             $existingTitleInfo['icon']
         );
         $platforms = $this->buildPlatformList($trophyTitle, $existingTitleInfo['platforms']);
@@ -451,9 +461,9 @@ class GameRescanService
                 'icon' => null,
             ];
 
-            $groupIconFilename = $this->downloadImage(
+            $groupIconFilename = $this->imageDownloader->downloadMandatoryForRescan(
                 $trophyGroup->iconUrl(),
-                self::GROUP_ICON_DIRECTORY,
+                $this->imageDirectories->group,
                 $existingGroup['icon']
             );
 
@@ -513,14 +523,14 @@ class GameRescanService
                     'reward_image' => null,
                 ];
 
-                $trophyIconFilename = $this->downloadImage(
+                $trophyIconFilename = $this->imageDownloader->downloadMandatoryForRescan(
                     $trophy->iconUrl(),
-                    self::TROPHY_ICON_DIRECTORY,
+                    $this->imageDirectories->trophy,
                     $existingTrophy['icon']
                 );
-                $rewardImageFilename = $this->downloadOptionalImage(
+                $rewardImageFilename = $this->imageDownloader->downloadOptionalForRescan(
                     $trophy->rewardImageUrl(),
-                    self::REWARD_ICON_DIRECTORY,
+                    $this->imageDirectories->reward,
                     $existingTrophy['reward_image']
                 );
 
@@ -1156,100 +1166,6 @@ class GameRescanService
         $version = (string) $version;
 
         return $version === '' ? null : $version;
-    }
-
-    private function downloadImage(string $url, string $directory, ?string $existingFilename = null): string
-    {
-        $contents = $this->fetchRemoteFile($url);
-
-        if ($contents === null) {
-            if ($existingFilename !== null && $existingFilename !== '') {
-                $this->logMessage(
-                    sprintf('Reusing cached image "%s" because "%s" is unavailable.', $existingFilename, $url)
-                );
-
-                return $existingFilename;
-            }
-
-            $this->logMessage(sprintf('Unable to download image from "%s".', $url));
-
-            throw new RuntimeException(sprintf('Unable to download image from "%s".', $url));
-        }
-
-        $filename = $this->buildFilename($url, $contents);
-        $path = $directory . $filename;
-
-        if (!file_exists($path)) {
-            file_put_contents($path, $contents);
-        }
-
-        return $filename;
-    }
-
-    private function downloadOptionalImage(?string $url, string $directory, ?string $existingFilename = null): ?string
-    {
-        if ($url === null || $url === '') {
-            return $existingFilename;
-        }
-
-        $contents = $this->fetchRemoteFile($url);
-
-        if ($contents === null) {
-            if ($existingFilename !== null && $existingFilename !== '') {
-                $this->logMessage(
-                    sprintf('Keeping cached optional image "%s" because "%s" is unavailable.', $existingFilename, $url)
-                );
-            }
-
-            return $existingFilename;
-        }
-
-        $filename = $this->buildFilename($url, $contents);
-        $path = $directory . $filename;
-
-        if (!file_exists($path)) {
-            file_put_contents($path, $contents);
-        }
-
-        return $filename;
-    }
-
-    private function fetchRemoteFile(string $url): ?string
-    {
-        for ($attempt = 1; $attempt <= 2; $attempt++) {
-            $context = stream_context_create([
-                'http' => [
-                    'timeout' => 30,
-                    'ignore_errors' => true,
-                ],
-            ]);
-
-            $contents = @file_get_contents($url, false, $context);
-            if ($contents !== false) {
-                $statusLine = $http_response_header[0] ?? '';
-                if ($statusLine === '' || preg_match('/^HTTP\/\S+\s+2\d\d\b/', $statusLine)) {
-                    return $contents;
-                }
-            }
-
-            if ($attempt === 1) {
-                sleep(3);
-            }
-        }
-
-        return null;
-    }
-
-    private function buildFilename(string $url, string $contents): string
-    {
-        $hash = $this->imageHashCalculator->calculate($contents);
-        if ($hash === null) {
-            $hash = md5($contents);
-        }
-        $extensionPosition = strrpos($url, '.');
-        $extension = $extensionPosition === false ? '' : strtolower(substr($url, $extensionPosition));
-
-        return $hash . $extension;
     }
 
     /**

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -10,6 +10,8 @@ require_once __DIR__ . '/../Psn100Logger.php';
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../TrophyMergeService.php';
 require_once __DIR__ . '/../TrophyMetaRepository.php';
+require_once __DIR__ . '/../TrophyImageDirectories.php';
+require_once __DIR__ . '/../TrophyImageDownloader.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\Haste\Exception\UnauthorizedHttpException;
@@ -17,17 +19,14 @@ use Tustin\PlayStation\Client;
 
 final class ThirtyMinuteCronJob implements CronJobInterface
 {
-    private const string TITLE_ICON_DIRECTORY = '/home/psn100/public_html/img/title/';
-    private const string GROUP_ICON_DIRECTORY = '/home/psn100/public_html/img/group/';
-    private const string TROPHY_ICON_DIRECTORY = '/home/psn100/public_html/img/trophy/';
-    private const string REWARD_ICON_DIRECTORY = '/home/psn100/public_html/img/reward/';
-
     private readonly TrophyMetaRepository $trophyMetaRepository;
 
     private readonly AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService;
 
     private readonly ImageHashCalculator $imageHashCalculator;
     private readonly PsnGameLookupService $psnGameLookupService;
+    private readonly TrophyImageDirectories $imageDirectories;
+    private readonly TrophyImageDownloader $imageDownloader;
 
     public function __construct(
         private readonly PDO $database,
@@ -38,7 +37,9 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         ?TrophyMetaRepository $trophyMetaRepository = null,
         ?AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService = null,
         ?ImageHashCalculator $imageHashCalculator = null,
-        ?PsnGameLookupService $psnGameLookupService = null
+        ?PsnGameLookupService $psnGameLookupService = null,
+        ?TrophyImageDirectories $imageDirectories = null,
+        ?TrophyImageDownloader $imageDownloader = null,
     )
     {
         $this->trophyMetaRepository = $trophyMetaRepository ?? new TrophyMetaRepository($database);
@@ -46,6 +47,13 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             ?? new AutomaticTrophyTitleMergeService($database, new TrophyMergeService($database));
         $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
         $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase($database);
+        $this->imageDirectories = $imageDirectories ?? TrophyImageDirectories::productionDefault();
+        $this->imageDownloader = $imageDownloader ?? new TrophyImageDownloader(
+            $this->imageHashCalculator,
+            function (string $message) use ($logger): void {
+                $logger->log($message);
+            },
+        );
     }
 
     private function setWaitingScanProgress(int $workerId, string $message): void
@@ -1255,7 +1263,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                             $previousTitleIconFilename = $existingTitle['icon_url'] ?? null;
                             $titleIconFilename = $previousTitleIconFilename;
                             $titleIconMissing = $titleIconFilename === null
-                                || !file_exists(self::TITLE_ICON_DIRECTORY . $titleIconFilename);
+                                || !file_exists($this->imageDirectories->title . $titleIconFilename);
 
                             $titleNeedsUpdate = $existingTitle === null
                                 || (
@@ -1267,9 +1275,9 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 );
 
                             if ($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) {
-                                $titleIconFilename = $this->downloadMandatoryImage(
+                                $titleIconFilename = $this->imageDownloader->downloadMandatoryForScan(
                                     $trophyTitle->iconUrl(),
-                                    self::TITLE_ICON_DIRECTORY,
+                                    $this->imageDirectories->title,
                                     sprintf('title icon for "%s" (%s)', $trophyTitle->name(), $npid),
                                     $previousTitleIconFilename
                                 );
@@ -1403,16 +1411,16 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 $previousGroupIconFilename = $existingGroup['icon_url'] ?? null;
                                 $groupIconFilename = $previousGroupIconFilename;
                                 $groupIconMissing = $groupIconFilename === null
-                                    || !file_exists(self::GROUP_ICON_DIRECTORY . $groupIconFilename);
+                                    || !file_exists($this->imageDirectories->group . $groupIconFilename);
 
                                 $groupNeedsUpdate = $existingGroup === null
                                     || $existingGroup['name'] !== $trophyGroupName
                                     || $existingGroup['detail'] !== $trophyGroupDetail;
 
                                 if ($existingGroup === null || $groupNeedsUpdate || $groupIconMissing || $titleNeedsUpdate) {
-                                    $groupIconFilename = $this->downloadMandatoryImage(
+                                    $groupIconFilename = $this->imageDownloader->downloadMandatoryForScan(
                                         $trophyGroupIconUrl,
-                                        self::GROUP_ICON_DIRECTORY,
+                                        $this->imageDirectories->group,
                                         sprintf('trophy group icon for "%s" (%s/%s)', $trophyGroupName, $npid, $trophyGroupId),
                                         $previousGroupIconFilename
                                     );
@@ -1549,14 +1557,14 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                         || (!$rewardImageShouldBeNull && $existingRewardImageFilename === null);
 
                                     $iconMissing = $existingIconFilename === null
-                                        || !file_exists(self::TROPHY_ICON_DIRECTORY . $existingIconFilename);
+                                        || !file_exists($this->imageDirectories->trophy . $existingIconFilename);
 
                                     $previousIconFilename = $existingIconFilename;
 
                                     if ($existingTrophy === null || $trophyNeedsUpdate || $iconMissing || $groupNeedsUpdate || $titleNeedsUpdate) {
-                                        $trophyIconFilename = $this->downloadMandatoryImage(
+                                        $trophyIconFilename = $this->imageDownloader->downloadMandatoryForScan(
                                             $trophyIconUrl,
-                                            self::TROPHY_ICON_DIRECTORY,
+                                            $this->imageDirectories->trophy,
                                             sprintf(
                                                 'trophy icon for "%s" (%s/%s/%d)',
                                                 $trophyName,
@@ -1576,12 +1584,12 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                         $rewardImageFilename = null;
                                     } else {
                                         $rewardImageMissing = $existingRewardImageFilename === null
-                                            || !file_exists(self::REWARD_ICON_DIRECTORY . $existingRewardImageFilename);
+                                            || !file_exists($this->imageDirectories->reward . $existingRewardImageFilename);
 
                                         if ($existingTrophy === null || $trophyNeedsUpdate || $rewardImageMissing || $groupNeedsUpdate || $titleNeedsUpdate) {
-                                            $rewardImageFilename = $this->downloadOptionalImage(
+                                            $rewardImageFilename = $this->imageDownloader->downloadOptionalForScan(
                                                 $rewardImageUrl === null ? '' : (string) $rewardImageUrl,
-                                                self::REWARD_ICON_DIRECTORY,
+                                                $this->imageDirectories->reward,
                                                 sprintf(
                                                     'reward image for "%s" (%s/%s/%d)',
                                                     $trophyName,
@@ -2724,122 +2732,9 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         return (int) $id;
     }
 
-    private function downloadMandatoryImage(
-        string $url,
-        string $directory,
-        string $description,
-        ?string $existingFilename = null
-    ): string
-    {
-        $contents = $this->fetchRemoteFile($url);
-        if ($contents === null) {
-            if ($this->shouldLogDownloadFailure($existingFilename)) {
-                $this->logger->log(sprintf('Unable to download %s from "%s".', $description, $url));
-            }
-
-            return '.png';
-        }
-
-        $storedFilename = $this->storeImageContents($url, $directory, $description, $contents);
-
-        return $storedFilename ?? '.png';
-    }
-
-    private function downloadOptionalImage(
-        ?string $url,
-        string $directory,
-        string $description,
-        ?string $existingFilename = null
-    ): ?string
-    {
-        if ($url === null || $url === '') {
-            return null;
-        }
-
-        $contents = $this->fetchRemoteFile($url);
-        if ($contents === null) {
-            if ($this->shouldLogDownloadFailure($existingFilename)) {
-                $this->logger->log(sprintf('Unable to download %s from "%s".', $description, $url));
-            }
-
-            return '.png';
-        }
-
-        $storedFilename = $this->storeImageContents($url, $directory, $description, $contents);
-
-        return $storedFilename ?? '.png';
-    }
-
-    private function shouldLogDownloadFailure(?string $existingFilename): bool
-    {
-        if ($existingFilename === null || $existingFilename === '') {
-            return true;
-        }
-
-        return $existingFilename !== '.png';
-    }
-
-    private function storeImageContents(string $url, string $directory, string $description, string $contents): ?string
-    {
-        $filename = $this->buildFilename($url, $contents);
-        $path = $directory . $filename;
-
-        if (!file_exists($path)) {
-            if (@file_put_contents($path, $contents) === false) {
-                $this->logger->log(sprintf('Unable to save %s from "%s" to "%s".', $description, $url, $path));
-
-                return null;
-            }
-        }
-
-        return $filename;
-    }
-
     private function ensureTrophyMetaRow(string $npCommunicationId, string $groupId, int $orderId): void
     {
         $this->trophyMetaRepository->ensureExists($npCommunicationId, $groupId, $orderId);
-    }
-
-    private function fetchRemoteFile(string $url): ?string
-    {
-        if ($url === '') {
-            return null;
-        }
-
-        for ($attempt = 1; $attempt <= 2; $attempt++) {
-            $context = stream_context_create([
-                'http' => [
-                    'timeout' => 30,
-                    'ignore_errors' => true,
-                ],
-            ]);
-
-            $contents = @file_get_contents($url, false, $context);
-            if ($contents !== false) {
-                $statusLine = $http_response_header[0] ?? '';
-                if ($statusLine === '' || preg_match('/^HTTP\/\S+\s+2\d\d\b/', $statusLine)) {
-                    return $contents;
-                }
-            }
-
-            if ($attempt === 1) {
-                sleep(3);
-            }
-        }
-
-        return null;
-    }
-
-    private function buildFilename(string $url, string $contents): string
-    {
-        $hash = $this->imageHashCalculator->calculate($contents);
-        if ($hash === null) {
-            $hash = md5($contents);
-        }
-        $extensionPosition = strrpos($url, '.');
-        $extension = $extensionPosition === false ? '' : strtolower(substr($url, $extensionPosition));
-
-        return $hash . $extension;
     }
 
     private function sanitizeTrophyTitleName(string $name): string

--- a/wwwroot/classes/TrophyImageDirectories.php
+++ b/wwwroot/classes/TrophyImageDirectories.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Filesystem locations for cached PSN trophy artwork.
+ *
+ * Centralises the paths that were previously duplicated across cron and admin
+ * rescan code so future environment-based configuration only needs one place.
+ */
+final readonly class TrophyImageDirectories
+{
+    public function __construct(
+        public string $title,
+        public string $group,
+        public string $trophy,
+        public string $reward,
+    ) {
+    }
+
+    public static function productionDefault(): self
+    {
+        return new self(
+            '/home/psn100/public_html/img/title/',
+            '/home/psn100/public_html/img/group/',
+            '/home/psn100/public_html/img/trophy/',
+            '/home/psn100/public_html/img/reward/',
+        );
+    }
+}

--- a/wwwroot/classes/TrophyImageDownloader.php
+++ b/wwwroot/classes/TrophyImageDownloader.php
@@ -21,6 +21,11 @@ final class TrophyImageDownloader
     ) {
     }
 
+    public function withLogger(?\Closure $logger): self
+    {
+        return new self($this->imageHashCalculator, $logger, $this->remoteFileFetcher);
+    }
+
     /**
      * Player-scan flow: log download failures when no usable cache exists and
      * fall back to the shared placeholder filename.

--- a/wwwroot/classes/TrophyImageDownloader.php
+++ b/wwwroot/classes/TrophyImageDownloader.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/ImageHashCalculator.php';
+
+/**
+ * Downloads PSN trophy artwork and stores hashed filenames on disk.
+ *
+ * Encapsulates the remote fetch, filename hashing, and persistence rules that
+ * were previously duplicated in ThirtyMinuteCronJob and GameRescanService.
+ */
+final class TrophyImageDownloader
+{
+    public const string PLACEHOLDER_FILENAME = '.png';
+
+    public function __construct(
+        private readonly ImageHashCalculator $imageHashCalculator,
+        private readonly ?\Closure $logger = null,
+        private readonly ?\Closure $remoteFileFetcher = null,
+    ) {
+    }
+
+    /**
+     * Player-scan flow: log download failures when no usable cache exists and
+     * fall back to the shared placeholder filename.
+     */
+    public function downloadMandatoryForScan(
+        string $url,
+        string $directory,
+        string $description,
+        ?string $existingFilename = null,
+    ): string {
+        $contents = $this->fetchRemoteFile($url);
+        if ($contents === null) {
+            if ($this->shouldLogDownloadFailure($existingFilename)) {
+                $this->log(sprintf('Unable to download %s from "%s".', $description, $url));
+            }
+
+            return self::PLACEHOLDER_FILENAME;
+        }
+
+        $storedFilename = $this->storeImageContentsForScan($url, $directory, $description, $contents);
+
+        return $storedFilename ?? self::PLACEHOLDER_FILENAME;
+    }
+
+    /**
+     * Player-scan flow for optional reward images.
+     */
+    public function downloadOptionalForScan(
+        ?string $url,
+        string $directory,
+        string $description,
+        ?string $existingFilename = null,
+    ): ?string {
+        if ($url === null || $url === '') {
+            return null;
+        }
+
+        $contents = $this->fetchRemoteFile($url);
+        if ($contents === null) {
+            if ($this->shouldLogDownloadFailure($existingFilename)) {
+                $this->log(sprintf('Unable to download %s from "%s".', $description, $url));
+            }
+
+            return self::PLACEHOLDER_FILENAME;
+        }
+
+        $storedFilename = $this->storeImageContentsForScan($url, $directory, $description, $contents);
+
+        return $storedFilename ?? self::PLACEHOLDER_FILENAME;
+    }
+
+    /**
+     * Admin rescan flow: reuse an existing cached filename when the remote file
+     * is unavailable, otherwise throw so the rescan can abort visibly.
+     */
+    public function downloadMandatoryForRescan(
+        string $url,
+        string $directory,
+        ?string $existingFilename = null,
+    ): string {
+        $contents = $this->fetchRemoteFile($url);
+        if ($contents === null) {
+            if ($existingFilename !== null && $existingFilename !== '') {
+                $this->log(
+                    sprintf('Reusing cached image "%s" because "%s" is unavailable.', $existingFilename, $url)
+                );
+
+                return $existingFilename;
+            }
+
+            $this->log(sprintf('Unable to download image from "%s".', $url));
+
+            throw new RuntimeException(sprintf('Unable to download image from "%s".', $url));
+        }
+
+        return $this->storeImageContentsForRescan($url, $directory, $contents);
+    }
+
+    /**
+     * Admin rescan flow for optional reward images.
+     */
+    public function downloadOptionalForRescan(
+        ?string $url,
+        string $directory,
+        ?string $existingFilename = null,
+    ): ?string {
+        if ($url === null || $url === '') {
+            return $existingFilename;
+        }
+
+        $contents = $this->fetchRemoteFile($url);
+        if ($contents === null) {
+            if ($existingFilename !== null && $existingFilename !== '') {
+                $this->log(
+                    sprintf(
+                        'Keeping cached optional image "%s" because "%s" is unavailable.',
+                        $existingFilename,
+                        $url
+                    )
+                );
+            }
+
+            return $existingFilename;
+        }
+
+        return $this->storeImageContentsForRescan($url, $directory, $contents);
+    }
+
+    public function fetchRemoteFile(string $url): ?string
+    {
+        if ($url === '') {
+            return null;
+        }
+
+        if ($this->remoteFileFetcher !== null) {
+            return ($this->remoteFileFetcher)($url);
+        }
+
+        for ($attempt = 1; $attempt <= 2; $attempt++) {
+            $context = stream_context_create([
+                'http' => [
+                    'timeout' => 30,
+                    'ignore_errors' => true,
+                ],
+            ]);
+
+            $contents = @file_get_contents($url, false, $context);
+            if ($contents !== false) {
+                $statusLine = $http_response_header[0] ?? '';
+                if ($statusLine === '' || preg_match('/^HTTP\/\S+\s+2\d\d\b/', $statusLine)) {
+                    return $contents;
+                }
+            }
+
+            if ($attempt === 1) {
+                sleep(3);
+            }
+        }
+
+        return null;
+    }
+
+    public function buildFilename(string $url, string $contents): string
+    {
+        $hash = $this->imageHashCalculator->calculate($contents);
+        if ($hash === null) {
+            $hash = md5($contents);
+        }
+        $extensionPosition = strrpos($url, '.');
+        $extension = $extensionPosition === false ? '' : strtolower(substr($url, $extensionPosition));
+
+        return $hash . $extension;
+    }
+
+    private function shouldLogDownloadFailure(?string $existingFilename): bool
+    {
+        if ($existingFilename === null || $existingFilename === '') {
+            return true;
+        }
+
+        return $existingFilename !== self::PLACEHOLDER_FILENAME;
+    }
+
+    private function storeImageContentsForScan(
+        string $url,
+        string $directory,
+        string $description,
+        string $contents,
+    ): ?string {
+        $filename = $this->buildFilename($url, $contents);
+        $path = $directory . $filename;
+
+        if (!file_exists($path)) {
+            if (@file_put_contents($path, $contents) === false) {
+                $this->log(sprintf('Unable to save %s from "%s" to "%s".', $description, $url, $path));
+
+                return null;
+            }
+        }
+
+        return $filename;
+    }
+
+    private function storeImageContentsForRescan(string $url, string $directory, string $contents): string
+    {
+        $filename = $this->buildFilename($url, $contents);
+        $path = $directory . $filename;
+
+        if (!file_exists($path)) {
+            file_put_contents($path, $contents);
+        }
+
+        return $filename;
+    }
+
+    private function log(string $message): void
+    {
+        if ($this->logger === null) {
+            return;
+        }
+
+        ($this->logger)($message);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First incremental step toward breaking up the largest god classes: extract duplicated PSN trophy artwork download/store logic from `ThirtyMinuteCronJob` (~3,200 lines) and `GameRescanService` (~1,100 lines) into dedicated classes.

## Changes

- Add `TrophyImageDirectories` to centralise the four cached image path constants that were duplicated in both classes.
- Add `TrophyImageDownloader` with shared remote fetch, filename hashing, and disk persistence logic.
- Preserve existing behaviour via explicit scan vs rescan entry points:
  - **Scan** (`ThirtyMinuteCronJob`): log failures when no usable cache exists; fall back to `.png` placeholder.
  - **Rescan** (`GameRescanService`): reuse cached filenames when downloads fail; throw when mandatory images have no cache.
- Wire both callers to inject the new classes (optional constructor overrides kept for tests).
- Add `TrophyImageDownloader::withLogger()` so `GameRescanService::rescan()` can attach per-rescan logging without replacing an injected downloader.
- Add focused tests covering both flows and injected-downloader preservation.

## Review feedback addressed

- **Preserve injected image downloader during rescans**: `rescan()` now wraps the existing downloader with `withLogger()` for the duration of the call and restores it in `finally`, so constructor-injected test doubles / custom fetchers are not discarded.

## Test plan

- [x] `php tests/run.php` — all 626 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cdd2764-bed0-4c8d-abca-a6014fcfc59a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cdd2764-bed0-4c8d-abca-a6014fcfc59a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

