### PR TITLE
Handle null trophy earned values from PSN API

### DIFF
--- a/tests/ThirtyMinuteCronJobDateParsingTest.php
+++ b/tests/ThirtyMinuteCronJobDateParsingTest.php
@@ -386,6 +386,34 @@ final class ThirtyMinuteCronJobDateParsingTest extends TestCase
         $this->assertSame('75', $result->progress());
     }
 
+    public function testIsTrophyEarnedTreatsNullApiValueAsFalse(): void
+    {
+        $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'isTrophyEarned');
+        $method->setAccessible(true);
+
+        $trophyWithNullEarned = new ThirtyMinuteCronJobDateParsingTestCachedTrophy(['earned' => null]);
+        $trophyWithMissingEarned = new ThirtyMinuteCronJobDateParsingTestCachedTrophy([]);
+        $trophyWithTrueEarned = new ThirtyMinuteCronJobDateParsingTestCachedTrophy(['earned' => true]);
+        $trophyWithFalseEarned = new ThirtyMinuteCronJobDateParsingTestCachedTrophy(['earned' => false]);
+        $legacyTrophy = new ThirtyMinuteCronJobDateParsingTestTrophy(1, '', true);
+
+        $this->assertFalse($method->invoke($this->cronJob, $trophyWithNullEarned));
+        $this->assertFalse($method->invoke($this->cronJob, $trophyWithMissingEarned));
+        $this->assertTrue($method->invoke($this->cronJob, $trophyWithTrueEarned));
+        $this->assertFalse($method->invoke($this->cronJob, $trophyWithFalseEarned));
+        $this->assertTrue($method->invoke($this->cronJob, $legacyTrophy));
+    }
+
+    public function testIsTrophyEarnedTreatsTypeErrorFromEarnedAccessorAsFalse(): void
+    {
+        $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'isTrophyEarned');
+        $method->setAccessible(true);
+
+        $trophy = new ThirtyMinuteCronJobDateParsingTestTypeErrorTrophy();
+
+        $this->assertFalse($method->invoke($this->cronJob, $trophy));
+    }
+
     public function testShouldRetryInvalidTrophyEarnedDateReturnsFalseAfterMarkedRetried(): void
     {
         $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'shouldRetryInvalidTrophyEarnedDate');
@@ -484,6 +512,32 @@ final class ThirtyMinuteCronJobDateParsingTestTrophy
     public function progress(): string
     {
         return $this->progress;
+    }
+}
+
+final class ThirtyMinuteCronJobDateParsingTestCachedTrophy
+{
+    /**
+     * @param array<string, mixed> $cache
+     */
+    public function __construct(private readonly array $cache)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getCache(): array
+    {
+        return $this->cache;
+    }
+}
+
+final class ThirtyMinuteCronJobDateParsingTestTypeErrorTrophy
+{
+    public function earned(): bool
+    {
+        throw new TypeError('Return value must be of type bool, null returned');
     }
 }
 

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1743,7 +1743,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 );
 
                                 foreach ($groupTrophies as $trophy) {
-                                    $trophyEarned = $trophy->earned();
+                                    $trophyEarned = $this->isTrophyEarned($trophy);
                                     $progress = (clone $trophy)->progress();
                                     if ($trophyEarned || ($progress != '' && intval($progress) > 0)) {
                                         $orderId = (int) $trophy->id();
@@ -1796,7 +1796,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                             continue 4;
                                         }
 
-                                        $trophyEarned = $trophy->earned();
+                                        $trophyEarned = $this->isTrophyEarned($trophy);
                                         $progress = (clone $trophy)->progress();
 
                                         if (!$trophyEarned && ($progress === '' || intval($progress) <= 0)) {
@@ -2944,6 +2944,19 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         }
 
         return $this->parseSonyDateTime($earnedDateTime) !== null;
+    }
+
+    private function isTrophyEarned(object $trophy): bool
+    {
+        if (method_exists($trophy, 'getCache')) {
+            return (bool) ($trophy->getCache()['earned'] ?? false);
+        }
+
+        try {
+            return $trophy->earned();
+        } catch (TypeError) {
+            return false;
+        }
     }
 
     private function buildInvalidTitleDateRetryKey(string $onlineId, string $npCommunicationId): string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a fatal `TypeError` in the 30-minute cron when Sony's trophy API returns `null` for the `earned` field.

`Tustin\PlayStation\Model\Trophy\Trophy::earned()` is declared to return `bool`, but `pluck('earned')` can be `null` when the field is missing from the API payload. PHP 8.5 then throws before the cron can fall back to progress-based handling.

## Changes

- Add `ThirtyMinuteCronJob::isTrophyEarned()` to read `earned` from the trophy cache when available, coercing `null`/missing values to `false`
- Fall back to the library accessor with a `TypeError` guard for test doubles and other non-cache trophies
- Use the helper at both trophy-processing call sites in the cron loop
- Add unit tests covering `null`, missing, true/false, and `TypeError` cases

## Test plan

- [x] `php tests/run.php --filter ThirtyMinuteCronJobDateParsingTest`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-669d7e12-5625-42a3-a666-6731264f2b70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-669d7e12-5625-42a3-a666-6731264f2b70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

