### PR TITLE
Extract PlayStationWorkerAuthenticator from God classes

### DIFF
--- a/tests/PlayStationWorkerAuthenticatorTest.php
+++ b/tests/PlayStationWorkerAuthenticatorTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/Worker.php';
+
+final class PlayStationWorkerAuthenticatorTest extends TestCase
+{
+    public function testAuthenticateWorkerUsesRefreshToken(): void
+    {
+        $worker = new Worker(1, 'stored-refresh-token', 'stored-npsso', '', new DateTimeImmutable('2024-01-01'), null);
+        $clients = [];
+
+        $authenticator = new PlayStationWorkerAuthenticator(
+            static fn (): array => [$worker],
+            static function () use (&$clients): object {
+                $client = new WorkerAuthStubClient();
+                $clients[] = $client;
+
+                return $client;
+            },
+        );
+
+        $authenticator->authenticateWorker($worker);
+
+        $this->assertSame(['refresh:stored-refresh-token'], $clients[0]->loginMethods);
+    }
+
+    public function testAuthenticateWorkerFallsBackToNpssoWhenRefreshTokenFails(): void
+    {
+        $worker = new Worker(2, 'expired-refresh-token', 'valid-npsso', '', new DateTimeImmutable('2024-01-01'), null);
+        $clients = [];
+
+        $authenticator = new PlayStationWorkerAuthenticator(
+            static fn (): array => [$worker],
+            static function () use (&$clients): object {
+                $client = new WorkerAuthStubClient(refreshTokenShouldFail: true);
+                $clients[] = $client;
+
+                return $client;
+            },
+        );
+
+        $authenticator->authenticateWorker($worker);
+
+        $this->assertSame(['refresh:expired-refresh-token', 'npsso:valid-npsso'], $clients[0]->loginMethods);
+    }
+
+    public function testAuthenticateWorkerThrowsWhenNoCredentialsConfigured(): void
+    {
+        $worker = new Worker(3, '', '', '', new DateTimeImmutable('2024-01-01'), null);
+
+        $authenticator = new PlayStationWorkerAuthenticator(
+            static fn (): array => [$worker],
+            static fn (): object => new WorkerAuthStubClient(),
+        );
+
+        try {
+            $authenticator->authenticateWorker($worker);
+            $this->fail('Expected RuntimeException when worker has no credentials.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Worker has no credentials configured.', $exception->getMessage());
+        }
+    }
+
+    public function testAuthenticateWorkerPersistsRefreshTokenBestEffort(): void
+    {
+        $worker = new Worker(4, '', 'valid-npsso', '', new DateTimeImmutable('2024-01-01'), null);
+        $savedTokens = [];
+
+        $authenticator = new PlayStationWorkerAuthenticator(
+            static fn (): array => [$worker],
+            static fn (): object => new WorkerAuthStubClient(
+                refreshTokenToReturn: 'new-refresh-token',
+            ),
+            static function (int $workerId, string $refreshToken) use (&$savedTokens): void {
+                $savedTokens[] = ['workerId' => $workerId, 'refreshToken' => $refreshToken];
+            },
+        );
+
+        $authenticator->authenticateWorker($worker);
+
+        $this->assertSame([['workerId' => 4, 'refreshToken' => 'new-refresh-token']], $savedTokens);
+    }
+
+    public function testAuthenticateWorkerDoesNotFailWhenRefreshTokenPersistenceFails(): void
+    {
+        $worker = new Worker(5, '', 'valid-npsso', '', new DateTimeImmutable('2024-01-01'), null);
+        $failureMessages = [];
+
+        $authenticator = new PlayStationWorkerAuthenticator(
+            static fn (): array => [$worker],
+            static fn (): object => new WorkerAuthStubClient(refreshTokenToReturn: 'issued-token'),
+            static function (): void {
+                throw new RuntimeException('Database unavailable.');
+            },
+            null,
+            static function (int $workerId, string $message) use (&$failureMessages): void {
+                $failureMessages[] = ['workerId' => $workerId, 'message' => $message];
+            },
+        );
+
+        $authenticator->authenticateWorker($worker);
+
+        $this->assertSame(1, count($failureMessages));
+        $this->assertSame(5, $failureMessages[0]['workerId']);
+        $this->assertSame('Database unavailable.', $failureMessages[0]['message']);
+    }
+
+    public function testAuthenticateWithNextAvailableWorkerTriesWorkersInOrder(): void
+    {
+        $firstWorker = new Worker(10, '', '', '', new DateTimeImmutable('2024-01-01'), null);
+        $secondWorker = new Worker(11, '', 'valid-npsso', '', new DateTimeImmutable('2024-01-01'), null);
+        $clients = [];
+
+        $authenticator = new PlayStationWorkerAuthenticator(
+            static fn (): array => [$firstWorker, $secondWorker],
+            static function () use (&$clients): object {
+                $client = new WorkerAuthStubClient();
+                $clients[] = $client;
+
+                return $client;
+            },
+        );
+
+        $authenticator->authenticateWithNextAvailableWorker();
+
+        $this->assertSame(['npsso:valid-npsso'], $clients[0]->loginMethods);
+    }
+
+    public function testAuthenticateWithNextAvailableWorkerThrowsWhenAllWorkersFail(): void
+    {
+        $worker = new Worker(12, '', '', '', new DateTimeImmutable('2024-01-01'), null);
+
+        $authenticator = new PlayStationWorkerAuthenticator(
+            static fn (): array => [$worker],
+            static fn (): object => new WorkerAuthStubClient(),
+        );
+
+        try {
+            $authenticator->authenticateWithNextAvailableWorker();
+            $this->fail('Expected RuntimeException when all workers fail.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Unable to login to any worker accounts.', $exception->getMessage());
+        }
+    }
+
+    public function testAuthenticateWithRetrySleepsBetweenAttempts(): void
+    {
+        $worker = new Worker(13, '', 'valid-npsso', '', new DateTimeImmutable('2024-01-01'), null);
+        $sleepDurations = [];
+        $attempts = 0;
+
+        $authenticator = new PlayStationWorkerAuthenticator(
+            static fn (): array => [$worker],
+            static function () use (&$attempts): object {
+                $attempts++;
+
+                return new WorkerAuthStubClient(
+                    shouldFailUntilAttempt: $attempts < 2 ? 1 : 0,
+                );
+            },
+            null,
+            static function (int $seconds) use (&$sleepDurations): void {
+                $sleepDurations[] = $seconds;
+            },
+        );
+
+        $authenticator->authenticateWithRetry(42);
+
+        $this->assertSame([42], $sleepDurations);
+        $this->assertSame(2, $attempts);
+    }
+
+    public function testAuthenticateWithRetryInvokesFailureHandler(): void
+    {
+        $failingWorker = new Worker(14, '', '', '', new DateTimeImmutable('2024-01-01'), null);
+        $workingWorker = new Worker(15, '', 'valid-npsso', '', new DateTimeImmutable('2024-01-01'), null);
+        $failureEvents = [];
+
+        $authenticator = new PlayStationWorkerAuthenticator(
+            static fn (): array => [$failingWorker, $workingWorker],
+            static fn (): object => new WorkerAuthStubClient(),
+        );
+
+        $authenticator->authenticateWithRetry(
+            7,
+            static function (int $workerId, Throwable $exception) use (&$failureEvents): void {
+                $failureEvents[] = ['workerId' => $workerId, 'message' => $exception->getMessage()];
+            },
+        );
+
+        $this->assertSame(1, count($failureEvents));
+        $this->assertSame(14, $failureEvents[0]['workerId']);
+        $this->assertSame('Worker has no credentials configured.', $failureEvents[0]['message']);
+    }
+}
+
+final class WorkerAuthStubClient
+{
+    /** @var list<string> */
+    public array $loginMethods = [];
+
+    public function __construct(
+        private readonly bool $refreshTokenShouldFail = false,
+        private readonly string $refreshTokenToReturn = '',
+        private readonly int $shouldFailUntilAttempt = 0,
+    ) {
+    }
+
+    public function loginWithRefreshToken(string $refreshToken): void
+    {
+        $this->recordLogin('refresh', $refreshToken);
+
+        if ($this->refreshTokenShouldFail) {
+            throw new RuntimeException('Refresh token expired.');
+        }
+    }
+
+    public function loginWithNpsso(string $npsso): void
+    {
+        $this->recordLogin('npsso', $npsso);
+    }
+
+    public function getRefreshToken(): object
+    {
+        return new class ($this->refreshTokenToReturn) {
+            public function __construct(private readonly string $token)
+            {
+            }
+
+            public function getToken(): string
+            {
+                return $this->token;
+            }
+        };
+    }
+
+    private function recordLogin(string $method, string $value): void
+    {
+        if ($this->shouldFailUntilAttempt > 0) {
+            throw new RuntimeException('Temporary login failure.');
+        }
+
+        $this->loginMethods[] = $method . ':' . $value;
+    }
+}

--- a/tests/ThirtyMinuteCronJobWorkerValidationTest.php
+++ b/tests/ThirtyMinuteCronJobWorkerValidationTest.php
@@ -7,7 +7,9 @@ require_once __DIR__ . '/../wwwroot/classes/Cron/ThirtyMinuteCronJob.php';
 require_once __DIR__ . '/../wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php';
 require_once __DIR__ . '/../wwwroot/classes/TrophyCalculator.php';
 require_once __DIR__ . '/../wwwroot/classes/Psn100Logger.php';
-require_once __DIR__ . '/../wwwroot/classes/TrophyHistoryRecorder.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/Worker.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerService.php';
 
 final class ThirtyMinuteCronJobWorkerValidationTest extends TestCase
 {
@@ -51,7 +53,7 @@ final class ThirtyMinuteCronJobWorkerValidationTest extends TestCase
         }
     }
 
-    public function testSaveWorkerRefreshTokenBestEffortLogsAndDoesNotThrowOnFailure(): void
+    public function testRefreshTokenPersistenceFailureLogsAndDoesNotThrow(): void
     {
         $database = new PDO('sqlite::memory:');
         $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -60,23 +62,25 @@ final class ThirtyMinuteCronJobWorkerValidationTest extends TestCase
         $database->exec("INSERT INTO setting (id, npsso, scanning, scan_progress, refresh_token) VALUES (1, 'token', NULL, NULL, NULL)");
 
         $logger = new Psn100Logger($database);
-        $cronJob = new ThirtyMinuteCronJob(
-            $database,
-            new TrophyCalculator($database),
-            $logger,
-            new TrophyHistoryRecorder($database, $logger),
-            1
+        $authenticator = PlayStationWorkerAuthenticator::fromWorkerService(
+            new WorkerService($database),
+            static fn (): object => new class {
+                public function loginWithNpsso(string $npsso): void
+                {
+                }
+
+                public function getRefreshToken(): object
+                {
+                    throw new RuntimeException('db unavailable');
+                }
+            },
+            function (int $workerId, string $message) use ($logger): void {
+                $logger->log(sprintf('Failed to persist refresh token for worker %d: %s', $workerId, $message));
+            },
         );
 
-        $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'saveWorkerRefreshTokenBestEffort');
-        $method->setAccessible(true);
-
-        $method->invoke($cronJob, 1, new class {
-            public function getRefreshToken(): object
-            {
-                throw new RuntimeException('db unavailable');
-            }
-        });
+        $worker = new Worker(1, '', 'token', '', new DateTimeImmutable('2024-01-01'), null);
+        $authenticator->authenticateWorker($worker);
 
         $statement = $database->query('SELECT message FROM log ORDER BY rowid DESC LIMIT 1');
         $message = $statement !== false ? $statement->fetchColumn() : false;

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -11,6 +11,8 @@ require_once __DIR__ . '/../TrophyMetaRepository.php';
 require_once __DIR__ . '/../TrophyImageDirectories.php';
 require_once __DIR__ . '/../TrophyImageDownloader.php';
 require_once __DIR__ . '/PsnGameLookupService.php';
+require_once __DIR__ . '/PlayStationWorkerAuthenticator.php';
+require_once __DIR__ . '/WorkerService.php';
 
 use Tustin\PlayStation\Client;
 
@@ -30,6 +32,7 @@ class GameRescanService
     private PsnGameLookupService $psnGameLookupService;
     private TrophyImageDirectories $imageDirectories;
     private TrophyImageDownloader $imageDownloader;
+    private PlayStationWorkerAuthenticator $workerAuthenticator;
 
     /**
      * @var \Closure(string):void|null
@@ -44,6 +47,7 @@ class GameRescanService
         ?PsnGameLookupService $psnGameLookupService = null,
         ?TrophyImageDirectories $imageDirectories = null,
         ?TrophyImageDownloader $imageDownloader = null,
+        ?PlayStationWorkerAuthenticator $workerAuthenticator = null,
     )
     {
         $this->database = $database;
@@ -54,6 +58,9 @@ class GameRescanService
         $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase($database);
         $this->imageDirectories = $imageDirectories ?? TrophyImageDirectories::productionDefault();
         $this->imageDownloader = $imageDownloader ?? new TrophyImageDownloader($this->imageHashCalculator);
+        $this->workerAuthenticator = $workerAuthenticator ?? PlayStationWorkerAuthenticator::fromWorkerService(
+            new WorkerService($database),
+        );
     }
 
     /**
@@ -165,81 +172,15 @@ class GameRescanService
 
     private function loginToWorker(): Client
     {
-        while (true) {
-            foreach ($this->fetchWorkers() as $worker) {
-                try {
-                    $client = new Client();
-                    $refreshToken = (string) ($worker['refresh_token'] ?? '');
-                    $npsso = (string) ($worker['npsso'] ?? '');
+        /** @var Client $client */
+        $client = $this->workerAuthenticator->authenticateWithRetry(
+            self::LOGIN_RETRY_DELAY_SECONDS,
+            function (int $workerId, Throwable $exception): void {
+                $this->logMessage("Can't login with worker " . $workerId);
+            },
+        );
 
-                    if ($refreshToken !== '') {
-                        try {
-                            $client->loginWithRefreshToken($refreshToken);
-                        } catch (Exception|TypeError $exception) {
-                            if ($npsso === '') {
-                                throw $exception;
-                            }
-
-                            $client->loginWithNpsso($npsso);
-                        }
-                    } elseif ($npsso !== '') {
-                        $client->loginWithNpsso($npsso);
-                    } else {
-                        continue;
-                    }
-
-                    $this->saveWorkerRefreshTokenBestEffort((int) $worker['id'], $client);
-
-                    return $client;
-                } catch (TypeError $exception) {
-                    // Something odd, try next worker.
-                } catch (Exception $exception) {
-                    $this->logMessage("Can't login with worker " . $worker['id']);
-                }
-            }
-
-            sleep(self::LOGIN_RETRY_DELAY_SECONDS);
-        }
-    }
-
-    private function fetchWorkers(): array
-    {
-        $query = $this->database->prepare('SELECT id, refresh_token, npsso FROM setting ORDER BY id');
-
-        $query->execute();
-
-        return $query->fetchAll(PDO::FETCH_ASSOC);
-    }
-
-    private function saveWorkerRefreshTokenBestEffort(int $workerId, object $client): void
-    {
-        try {
-            $this->saveWorkerRefreshToken($workerId, $client);
-        } catch (Throwable) {
-            // Refresh-token persistence is best-effort and must not fail authentication.
-        }
-    }
-
-    private function saveWorkerRefreshToken(int $workerId, object $client): void
-    {
-        if (!method_exists($client, 'getRefreshToken')) {
-            return;
-        }
-
-        $refreshToken = $client->getRefreshToken();
-        if (!is_object($refreshToken) || !method_exists($refreshToken, 'getToken')) {
-            return;
-        }
-
-        $tokenValue = $refreshToken->getToken();
-        if (!is_string($tokenValue) || $tokenValue === '') {
-            return;
-        }
-
-        $query = $this->database->prepare('UPDATE setting SET refresh_token = :refresh_token WHERE id = :id');
-        $query->bindValue(':refresh_token', $tokenValue, PDO::PARAM_STR);
-        $query->bindValue(':id', $workerId, PDO::PARAM_INT);
-        $query->execute();
+        return $client;
     }
 
     private function logMessage(string $message): void

--- a/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
+++ b/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Worker.php';
+require_once __DIR__ . '/WorkerService.php';
+
+use Tustin\PlayStation\Client;
+
+/**
+ * Authenticates PlayStation API worker accounts and persists refreshed tokens.
+ *
+ * Centralizes login orchestration that was previously duplicated across
+ * PsnGameLookupService, GameRescanService, and ThirtyMinuteCronJob.
+ */
+final class PlayStationWorkerAuthenticator
+{
+    /**
+     * @var \Closure(): iterable<Worker>
+     */
+    private readonly \Closure $workerFetcher;
+
+    /**
+     * @var \Closure(): object
+     */
+    private readonly \Closure $clientFactory;
+
+    /**
+     * @var \Closure(int, string): void
+     */
+    private readonly \Closure $refreshTokenSaver;
+
+    /**
+     * @var \Closure(int): void
+     */
+    private readonly \Closure $sleeper;
+
+    /**
+     * @var \Closure(int, string): void|null
+     */
+    private readonly ?\Closure $refreshTokenPersistenceFailureHandler;
+
+    public function __construct(
+        callable $workerFetcher,
+        ?callable $clientFactory = null,
+        ?callable $refreshTokenSaver = null,
+        ?callable $sleeper = null,
+        ?callable $refreshTokenPersistenceFailureHandler = null,
+    ) {
+        $this->workerFetcher = \Closure::fromCallable($workerFetcher);
+        $this->clientFactory = \Closure::fromCallable(
+            $clientFactory ?? static fn (): object => new Client()
+        );
+        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? static function (int $workerId, string $refreshToken): void {
+        });
+        $this->sleeper = \Closure::fromCallable($sleeper ?? static function (int $seconds): void {
+            sleep($seconds);
+        });
+        $this->refreshTokenPersistenceFailureHandler = $refreshTokenPersistenceFailureHandler !== null
+            ? \Closure::fromCallable($refreshTokenPersistenceFailureHandler)
+            : null;
+    }
+
+    public static function fromWorkerService(
+        WorkerService $workerService,
+        ?callable $clientFactory = null,
+        ?callable $refreshTokenPersistenceFailureHandler = null,
+    ): self {
+        return new self(
+            static fn (): array => $workerService->fetchWorkers(),
+            $clientFactory,
+            static function (int $workerId, string $refreshToken) use ($workerService): void {
+                $workerService->updateWorkerRefreshToken($workerId, $refreshToken);
+            },
+            null,
+            $refreshTokenPersistenceFailureHandler,
+        );
+    }
+
+  /** @return object Authenticated PlayStation API client. */
+    public function authenticateWorker(Worker $worker): object
+    {
+        $refreshToken = $worker->getRefreshToken();
+        $npsso = $worker->getNpsso();
+
+        if ($refreshToken === '' && $npsso === '') {
+            throw new RuntimeException('Worker has no credentials configured.');
+        }
+
+        $client = ($this->clientFactory)();
+        $this->loginClient($client, $refreshToken, $npsso);
+        $this->persistRefreshTokenBestEffort($worker->getId(), $client);
+
+        return $client;
+    }
+
+  /** @return object Authenticated PlayStation API client. */
+    public function authenticateWithNextAvailableWorker(): object
+    {
+        foreach (($this->workerFetcher)() as $worker) {
+            if (!$worker instanceof Worker) {
+                continue;
+            }
+
+            try {
+                return $this->authenticateWorker($worker);
+            } catch (Throwable) {
+                continue;
+            }
+        }
+
+        throw new RuntimeException('Unable to login to any worker accounts.');
+    }
+
+  /**
+   * @param callable(int, Throwable): void|null $onLoginFailure
+   * @return object Authenticated PlayStation API client.
+   */
+    public function authenticateWithRetry(
+        int $retryDelaySeconds = 300,
+        ?callable $onLoginFailure = null,
+    ): object {
+        $onLoginFailureClosure = $onLoginFailure !== null
+            ? \Closure::fromCallable($onLoginFailure)
+            : null;
+
+        while (true) {
+            foreach (($this->workerFetcher)() as $worker) {
+                if (!$worker instanceof Worker) {
+                    continue;
+                }
+
+                try {
+                    return $this->authenticateWorker($worker);
+                } catch (TypeError) {
+                    // Something odd, try next worker.
+                } catch (Throwable $exception) {
+                    if ($onLoginFailureClosure !== null) {
+                        $onLoginFailureClosure($worker->getId(), $exception);
+                    }
+                }
+            }
+
+            ($this->sleeper)($retryDelaySeconds);
+        }
+    }
+
+    private function loginClient(object $client, string $refreshToken, string $npsso): void
+    {
+        if ($refreshToken !== '' && method_exists($client, 'loginWithRefreshToken')) {
+            try {
+                $client->loginWithRefreshToken($refreshToken);
+
+                return;
+            } catch (Throwable $exception) {
+                if ($npsso === '') {
+                    throw $exception;
+                }
+            }
+        }
+
+        if ($npsso === '') {
+            throw new RuntimeException('Worker has no credentials configured.');
+        }
+
+        if (!method_exists($client, 'loginWithNpsso')) {
+            throw new RuntimeException('The PlayStation client does not support NPSSO authentication.');
+        }
+
+        $client->loginWithNpsso($npsso);
+    }
+
+    private function persistRefreshTokenBestEffort(int $workerId, object $client): void
+    {
+        try {
+            $this->saveRefreshToken($workerId, $client);
+        } catch (Throwable $exception) {
+            if ($this->refreshTokenPersistenceFailureHandler !== null) {
+                ($this->refreshTokenPersistenceFailureHandler)($workerId, $exception->getMessage());
+            }
+        }
+    }
+
+    private function saveRefreshToken(int $workerId, object $client): void
+    {
+        if (!method_exists($client, 'getRefreshToken')) {
+            return;
+        }
+
+        $refreshToken = $client->getRefreshToken();
+        if (!is_object($refreshToken) || !method_exists($refreshToken, 'getToken')) {
+            return;
+        }
+
+        $tokenValue = $refreshToken->getToken();
+        if (!is_string($tokenValue) || $tokenValue === '') {
+            return;
+        }
+
+        ($this->refreshTokenSaver)($workerId, $tokenValue);
+    }
+}

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -4,38 +4,27 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/WorkerService.php';
 require_once __DIR__ . '/Worker.php';
+require_once __DIR__ . '/PlayStationWorkerAuthenticator.php';
 require_once __DIR__ . '/PsnGameLookupException.php';
 
 use Tustin\PlayStation\Client;
 
 final class PsnGameLookupService
 {
-    /**
-     * @var \Closure(): iterable<Worker>
-     */
-    private readonly \Closure $workerFetcher;
-
-    /**
-     * @var \Closure(): object
-     */
-    private readonly \Closure $clientFactory;
-    /**
-     * @var \Closure(int, string): void
-     */
-    private readonly \Closure $refreshTokenSaver;
+    private readonly PlayStationWorkerAuthenticator $workerAuthenticator;
 
     public function __construct(
         private readonly PDO $database,
         callable $workerFetcher,
         ?callable $clientFactory = null,
-        ?callable $refreshTokenSaver = null
+        ?callable $refreshTokenSaver = null,
+        ?PlayStationWorkerAuthenticator $workerAuthenticator = null,
     ) {
-        $this->workerFetcher = \Closure::fromCallable($workerFetcher);
-        $this->clientFactory = \Closure::fromCallable(
-            $clientFactory ?? static fn (): object => new Client()
+        $this->workerAuthenticator = $workerAuthenticator ?? new PlayStationWorkerAuthenticator(
+            $workerFetcher,
+            $clientFactory,
+            $refreshTokenSaver,
         );
-        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? static function (int $workerId, string $refreshToken): void {
-        });
     }
 
     public static function fromDatabase(PDO $database): self
@@ -46,7 +35,8 @@ final class PsnGameLookupService
             $database,
             static fn (): array => $workerService->fetchWorkers(),
             null,
-            static fn (int $workerId, string $refreshToken): bool => $workerService->updateWorkerRefreshToken($workerId, $refreshToken)
+            static fn (int $workerId, string $refreshToken): bool => $workerService->updateWorkerRefreshToken($workerId, $refreshToken),
+            PlayStationWorkerAuthenticator::fromWorkerService($workerService),
         );
     }
 
@@ -375,76 +365,7 @@ final class PsnGameLookupService
 
     private function createAuthenticatedClient(): object
     {
-        $factory = $this->clientFactory;
-
-        foreach (($this->workerFetcher)() as $worker) {
-            if (!$worker instanceof Worker) {
-                continue;
-            }
-
-            $refreshToken = $worker->getRefreshToken();
-            $npsso = $worker->getNpsso();
-
-            if ($refreshToken === '' && $npsso === '') {
-                continue;
-            }
-
-            try {
-                $client = $factory();
-
-                if ($refreshToken !== '' && method_exists($client, 'loginWithRefreshToken')) {
-                    try {
-                        $client->loginWithRefreshToken($refreshToken);
-                        $this->persistRefreshTokenBestEffort($worker->getId(), $client);
-
-                        return $client;
-                    } catch (Throwable) {
-                        // Fall back to NPSSO for this worker below.
-                    }
-                }
-
-                if (!method_exists($client, 'loginWithNpsso')) {
-                    throw new RuntimeException('The PlayStation client does not support NPSSO authentication.');
-                }
-
-                $client->loginWithNpsso($npsso);
-                $this->persistRefreshTokenBestEffort($worker->getId(), $client);
-
-                return $client;
-            } catch (Throwable) {
-                continue;
-            }
-        }
-
-        throw new RuntimeException('Unable to login to any worker accounts.');
-    }
-
-    private function persistRefreshTokenBestEffort(int $workerId, object $client): void
-    {
-        try {
-            $this->saveRefreshToken($workerId, $client);
-        } catch (Throwable) {
-            // Refresh-token persistence is best-effort and must not fail authentication.
-        }
-    }
-
-    private function saveRefreshToken(int $workerId, object $client): void
-    {
-        if (!method_exists($client, 'getRefreshToken')) {
-            return;
-        }
-
-        $refreshToken = $client->getRefreshToken();
-        if (!is_object($refreshToken) || !method_exists($refreshToken, 'getToken')) {
-            return;
-        }
-
-        $tokenValue = $refreshToken->getToken();
-        if (!is_string($tokenValue) || $tokenValue === '') {
-            return;
-        }
-
-        ($this->refreshTokenSaver)($workerId, $tokenValue);
+        return $this->workerAuthenticator->authenticateWithNextAvailableWorker();
     }
 
     /**

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/CronJobInterface.php';
 require_once __DIR__ . '/../Admin/PsnGameLookupService.php';
+require_once __DIR__ . '/../Admin/PlayStationWorkerAuthenticator.php';
+require_once __DIR__ . '/../Admin/Worker.php';
+require_once __DIR__ . '/../Admin/WorkerService.php';
 require_once __DIR__ . '/../AutomaticTrophyTitleMergeService.php';
 require_once __DIR__ . '/../ImageHashCalculator.php';
 require_once __DIR__ . '/../Psn100Logger.php';
@@ -31,6 +34,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
     private readonly TrophyImageDownloader $imageDownloader;
     private readonly WorkerScanCoordinator $workerScanCoordinator;
     private readonly TrophyTitleNameFormatter $trophyTitleNameFormatter;
+    private readonly PlayStationWorkerAuthenticator $workerAuthenticator;
 
     public function __construct(
         private readonly PDO $database,
@@ -46,6 +50,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         ?TrophyImageDownloader $imageDownloader = null,
         ?WorkerScanCoordinator $workerScanCoordinator = null,
         ?TrophyTitleNameFormatter $trophyTitleNameFormatter = null,
+        ?PlayStationWorkerAuthenticator $workerAuthenticator = null,
     )
     {
         $this->trophyMetaRepository = $trophyMetaRepository ?? new TrophyMetaRepository($database);
@@ -62,6 +67,13 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         );
         $this->workerScanCoordinator = $workerScanCoordinator ?? new WorkerScanCoordinator($database);
         $this->trophyTitleNameFormatter = $trophyTitleNameFormatter ?? new TrophyTitleNameFormatter();
+        $this->workerAuthenticator = $workerAuthenticator ?? PlayStationWorkerAuthenticator::fromWorkerService(
+            new WorkerService($database),
+            null,
+            function (int $workerId, string $message) use ($logger): void {
+                $logger->log(sprintf('Failed to persist refresh token for worker %d: %s', $workerId, $message));
+            },
+        );
     }
 
     /**
@@ -307,28 +319,16 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                 }
 
                 try {
-                    $client = new Client();
-                    $refreshToken = (string) ($worker['refresh_token'] ?? '');
-                    $npsso = (string) ($worker['npsso'] ?? '');
-
-                    if ($refreshToken !== '') {
-                        try {
-                            $client->loginWithRefreshToken($refreshToken);
-                        } catch (Exception|TypeError $exception) {
-                            if ($npsso === '') {
-                                throw $exception;
-                            }
-
-                            $client->loginWithNpsso($npsso);
-                        }
-                    } elseif ($npsso !== '') {
-                        $client->loginWithNpsso($npsso);
-                    } else {
-                        throw new RuntimeException('Worker has no credentials configured.');
-                    }
-
+                    $workerAccount = new Worker(
+                        (int) $worker['id'],
+                        (string) ($worker['refresh_token'] ?? ''),
+                        (string) ($worker['npsso'] ?? ''),
+                        '',
+                        new DateTimeImmutable('1970-01-01 00:00:00'),
+                        null,
+                    );
+                    $client = $this->workerAuthenticator->authenticateWorker($workerAccount);
                     $loggedIn = true;
-                    $this->saveWorkerRefreshTokenBestEffort((int) $worker['id'], $client);
                 } catch (TypeError $e) {
                     // Something odd, let's wait a minute
                     $this->workerScanCoordinator->setWaitingScanProgress(
@@ -2128,39 +2128,6 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                 $this->workerScanCoordinator->setWorkerScanProgress((int) $worker['id'], null);
             }
         }
-    }
-
-    private function saveWorkerRefreshTokenBestEffort(int $workerId, object $client): void
-    {
-        try {
-            $this->saveWorkerRefreshToken($workerId, $client);
-        } catch (Throwable $exception) {
-            $this->logger->log(
-                sprintf('Failed to persist refresh token for worker %d: %s', $workerId, $exception->getMessage())
-            );
-        }
-    }
-
-    private function saveWorkerRefreshToken(int $workerId, object $client): void
-    {
-        if (!method_exists($client, 'getRefreshToken')) {
-            return;
-        }
-
-        $refreshToken = $client->getRefreshToken();
-        if (!is_object($refreshToken) || !method_exists($refreshToken, 'getToken')) {
-            return;
-        }
-
-        $tokenValue = $refreshToken->getToken();
-        if (!is_string($tokenValue) || $tokenValue === '') {
-            return;
-        }
-
-        $query = $this->database->prepare('UPDATE setting SET refresh_token = :refresh_token WHERE id = :id');
-        $query->bindValue(':refresh_token', $tokenValue, PDO::PARAM_STR);
-        $query->bindValue(':id', $workerId, PDO::PARAM_INT);
-        $query->execute();
     }
 
     /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First incremental peel-off from the codebase's largest God classes. Worker PlayStation login and refresh-token persistence were duplicated across three classes; they now live in a single `PlayStationWorkerAuthenticator`.

## What changed

- **New** `PlayStationWorkerAuthenticator` — handles refresh-token/NPSSO login, best-effort token persistence via `WorkerService`, single-worker auth, try-all-workers auth, and retry-with-sleep auth.
- **`PsnGameLookupService`** — delegates `createAuthenticatedClient()` to the authenticator (~70 lines removed).
- **`GameRescanService`** — replaces `loginToWorker()`, `fetchWorkers()`, and token helpers with `authenticateWithRetry()` (~60 lines removed).
- **`ThirtyMinuteCronJob`** — login block and `saveWorkerRefreshToken*` methods replaced with `authenticateWorker()` (~50 lines removed).

## Why this first

`ThirtyMinuteCronJob` (~2,600 lines) is the top God-class candidate, but its `run()` method is a single 1,800-line loop. Worker authentication was the smallest, clearest boundary — already partially peeled once via `WorkerScanCoordinator`, and duplicated verbatim in three places.

## Tests

- Added `PlayStationWorkerAuthenticatorTest` (9 cases covering login paths, token persistence, retry, and failure handling).
- Updated `ThirtyMinuteCronJobWorkerValidationTest` to assert logging through the authenticator.
- All **641** tests pass.

## Suggested follow-up PRs (one concern each)

1. `PlayerScanQueueSelector` — tiered UNION SQL from `ThirtyMinuteCronJob::run()`
2. `TrophyCatalogSynchronizer` — shared trophy upsert logic between cron and `GameRescanService`
3. `TrophyMergeMappingStrategy` — mapping strategies from `TrophyMergeService`
4. `GameHistoryDiffHighlighter` — diff algorithm from `GameHistoryPage`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bc69466-ffaa-4f04-87c5-4c57cbd2c035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bc69466-ffaa-4f04-87c5-4c57cbd2c035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

