### PR TITLE
Extract TrophyCatalogSynchronizer from God classes

### DIFF
--- a/tests/TrophyCatalogSynchronizerTest.php
+++ b/tests/TrophyCatalogSynchronizerTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyCatalogSynchronizer.php';
+
+final class TrophyCatalogSynchronizerTest extends TestCase
+{
+    private PDO $database;
+    private TrophyCatalogSynchronizer $synchronizer;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec(
+            'CREATE TABLE trophy_title (
+                np_communication_id TEXT PRIMARY KEY,
+                name TEXT,
+                detail TEXT,
+                icon_url TEXT,
+                platform TEXT,
+                set_version TEXT
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_group (
+                np_communication_id TEXT NOT NULL,
+                group_id TEXT NOT NULL,
+                name TEXT,
+                detail TEXT,
+                icon_url TEXT,
+                PRIMARY KEY (np_communication_id, group_id)
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy (
+                np_communication_id TEXT NOT NULL,
+                group_id TEXT NOT NULL,
+                order_id INTEGER NOT NULL,
+                hidden INTEGER,
+                type TEXT,
+                name TEXT,
+                detail TEXT,
+                icon_url TEXT,
+                progress_target_value INTEGER,
+                reward_name TEXT,
+                reward_image_url TEXT,
+                PRIMARY KEY (np_communication_id, group_id, order_id)
+            )'
+        );
+
+        $this->synchronizer = new TrophyCatalogSynchronizer($this->database);
+    }
+
+    public function testFetchExistingTrophyTitleInfoReturnsDefaultsWhenMissing(): void
+    {
+        $result = $this->synchronizer->fetchExistingTrophyTitleInfo('NPWR00001_00');
+
+        $this->assertSame(null, $result['detail']);
+        $this->assertSame(null, $result['icon']);
+        $this->assertSame('', $result['platform']);
+        $this->assertSame([], $result['platforms']);
+        $this->assertSame(null, $result['set_version']);
+    }
+
+    public function testFetchExistingTrophyTitleInfoParsesPlatformList(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, detail, icon_url, platform, set_version)
+            VALUES ('NPWR00001_00', 'Details', 'icon.png', 'PS5, PS4', '01.00')"
+        );
+
+        $result = $this->synchronizer->fetchExistingTrophyTitleInfo('NPWR00001_00');
+
+        $this->assertSame('Details', $result['detail']);
+        $this->assertSame('icon.png', $result['icon']);
+        $this->assertSame('PS5, PS4', $result['platform']);
+        $this->assertSame(['PS5', 'PS4'], $result['platforms']);
+        $this->assertSame('01.00', $result['set_version']);
+    }
+
+    public function testFetchExistingTrophyTitleRowReturnsNullWhenMissing(): void
+    {
+        $this->assertSame(null, $this->synchronizer->fetchExistingTrophyTitleRow('NPWR00001_00'));
+    }
+
+    public function testFetchExistingTrophyGroupDataIndexesByGroupId(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_group (np_communication_id, group_id, name, detail, icon_url) VALUES
+                ('NPWR00001_00', 'default', 'Base Game', 'Base detail', 'base.png'),
+                ('NPWR00001_00', '001', 'DLC', 'DLC detail', 'dlc.png')"
+        );
+
+        $groups = $this->synchronizer->fetchExistingTrophyGroupData('NPWR00001_00');
+
+        $this->assertSame('Base Game', $groups['default']['name']);
+        $this->assertSame('DLC detail', $groups['001']['detail']);
+        $this->assertSame('dlc.png', $groups['001']['icon']);
+    }
+
+    public function testFetchExistingTrophyGroupReturnsSingleRow(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_group (np_communication_id, group_id, name, detail, icon_url)
+            VALUES ('NPWR00001_00', 'default', 'Base Game', 'Base detail', 'base.png')"
+        );
+
+        $group = $this->synchronizer->fetchExistingTrophyGroup('NPWR00001_00', 'default');
+
+        $this->assertSame('Base Game', $group['name']);
+        $this->assertSame('base.png', $group['icon_url']);
+    }
+
+    public function testFetchExistingTrophyDataIndexesByGroupAndOrderId(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy (
+                np_communication_id, group_id, order_id, hidden, type, name, detail, icon_url,
+                progress_target_value, reward_name, reward_image_url
+            ) VALUES
+                ('NPWR00001_00', 'default', 1, 0, 'bronze', 'Trophy One', 'Detail', 'one.png', NULL, NULL, NULL),
+                ('NPWR00001_00', 'default', 2, 1, 'gold', 'Trophy Two', 'Detail 2', 'two.png', 10, 'Reward', 'reward.png')"
+        );
+
+        $trophies = $this->synchronizer->fetchExistingTrophyData('NPWR00001_00');
+
+        $this->assertSame('0', $trophies['default'][1]['hidden']);
+        $this->assertSame('gold', $trophies['default'][2]['type']);
+        $this->assertSame('10', $trophies['default'][2]['progress_target_value']);
+        $this->assertSame('reward.png', $trophies['default'][2]['reward_image']);
+    }
+
+    public function testFetchExistingTrophyReturnsSingleRow(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy (
+                np_communication_id, group_id, order_id, hidden, type, name, detail, icon_url,
+                progress_target_value, reward_name, reward_image_url
+            ) VALUES ('NPWR00001_00', 'default', 3, 0, 'silver', 'Trophy Three', 'Detail', 'three.png', NULL, NULL, NULL)"
+        );
+
+        $trophy = $this->synchronizer->fetchExistingTrophy('NPWR00001_00', 'default', 3);
+
+        $this->assertSame('silver', $trophy['type']);
+        $this->assertSame('three.png', $trophy['icon_url']);
+    }
+}

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../TrophyMetaRepository.php';
 require_once __DIR__ . '/../TrophyImageDirectories.php';
 require_once __DIR__ . '/../TrophyImageDownloader.php';
+require_once __DIR__ . '/../TrophyCatalogSynchronizer.php';
 require_once __DIR__ . '/PsnGameLookupService.php';
 require_once __DIR__ . '/PlayStationWorkerAuthenticator.php';
 require_once __DIR__ . '/WorkerService.php';
@@ -33,6 +34,7 @@ class GameRescanService
     private TrophyImageDirectories $imageDirectories;
     private TrophyImageDownloader $imageDownloader;
     private PlayStationWorkerAuthenticator $workerAuthenticator;
+    private TrophyCatalogSynchronizer $trophyCatalogSynchronizer;
 
     /**
      * @var \Closure(string):void|null
@@ -48,6 +50,7 @@ class GameRescanService
         ?TrophyImageDirectories $imageDirectories = null,
         ?TrophyImageDownloader $imageDownloader = null,
         ?PlayStationWorkerAuthenticator $workerAuthenticator = null,
+        ?TrophyCatalogSynchronizer $trophyCatalogSynchronizer = null,
     )
     {
         $this->database = $database;
@@ -58,6 +61,7 @@ class GameRescanService
         $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase($database);
         $this->imageDirectories = $imageDirectories ?? TrophyImageDirectories::productionDefault();
         $this->imageDownloader = $imageDownloader ?? new TrophyImageDownloader($this->imageHashCalculator);
+        $this->trophyCatalogSynchronizer = $trophyCatalogSynchronizer ?? new TrophyCatalogSynchronizer($database);
         $this->workerAuthenticator = $workerAuthenticator ?? PlayStationWorkerAuthenticator::fromWorkerService(
             new WorkerService($database),
         );
@@ -341,7 +345,7 @@ class GameRescanService
         ?GameRescanProgressListener $progressListener,
         GameRescanDifferenceTracker $differenceTracker
     ): array {
-        $existingTitleInfo = $this->fetchExistingTrophyTitleInfo($npCommunicationId);
+        $existingTitleInfo = $this->trophyCatalogSynchronizer->fetchExistingTrophyTitleInfo($npCommunicationId);
 
         if (!self::isSetVersionAtLeastCurrent((string) $trophyTitle->trophySetVersion(), $existingTitleInfo['set_version'])) {
             $this->notifyProgress($progressListener, 70, 'Skipping trophy refresh because incoming set version is lower.');
@@ -349,8 +353,8 @@ class GameRescanService
             return [];
         }
 
-        $existingGroupData = $this->fetchExistingTrophyGroupData($npCommunicationId);
-        $existingTrophyData = $this->fetchExistingTrophyData($npCommunicationId);
+        $existingGroupData = $this->trophyCatalogSynchronizer->fetchExistingTrophyGroupData($npCommunicationId);
+        $existingTrophyData = $this->trophyCatalogSynchronizer->fetchExistingTrophyData($npCommunicationId);
 
         $titleDetail = (string) $trophyTitle->detail();
         $titleIconFilename = $this->imageDownloader->downloadMandatoryForRescan(
@@ -430,7 +434,14 @@ class GameRescanService
                 $groupIconFilename
             );
 
-            $this->upsertTrophyGroup($npCommunicationId, $trophyGroup, $groupIconFilename);
+            $this->trophyCatalogSynchronizer->upsertTrophyGroup(
+                $npCommunicationId,
+                (string) $trophyGroup->id(),
+                $trophyGroup->name(),
+                (string) $trophyGroup->detail(),
+                $groupIconFilename,
+                false,
+            );
 
             $processedGroups++;
             $currentStep++;
@@ -566,13 +577,18 @@ class GameRescanService
                     $rewardImageFilename
                 );
 
-                $this->upsertTrophy(
+                $this->trophyCatalogSynchronizer->upsertTrophy(
                     $npCommunicationId,
-                    $trophyGroup->id(),
-                    $trophy,
+                    (string) $trophyGroup->id(),
+                    (int) $trophy->id(),
+                    (int) $trophy->hidden(),
+                    $trophy->type()->value,
+                    $trophy->name(),
+                    $trophy->detail(),
                     $trophyIconFilename,
+                    $normalizedProgressTargetValue,
+                    $normalizedRewardName,
                     $rewardImageFilename,
-                    $normalizedProgressTargetValue
                 );
                 $this->trophyMetaRepository->ensureExists($npCommunicationId, $trophyGroup->id(), (int) $trophy->id());
 
@@ -800,118 +816,6 @@ class GameRescanService
         $this->notifyProgress($progressListener, 84, $baseMessage);
     }
 
-    private function upsertTrophyGroup(string $npCommunicationId, object $trophyGroup, string $iconFilename): void
-    {
-        $query = $this->database->prepare(
-            'INSERT INTO trophy_group (
-                np_communication_id,
-                group_id,
-                name,
-                detail,
-                icon_url
-            )
-            VALUES (
-                :np_communication_id,
-                :group_id,
-                :name,
-                :detail,
-                :icon_url
-            ) AS new
-            ON DUPLICATE KEY UPDATE
-                detail = new.detail,
-                icon_url = new.icon_url'
-        );
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->bindValue(':group_id', $trophyGroup->id(), PDO::PARAM_STR);
-        $query->bindValue(':name', $trophyGroup->name(), PDO::PARAM_STR);
-        $query->bindValue(':detail', $trophyGroup->detail(), PDO::PARAM_STR);
-        $query->bindValue(':icon_url', $iconFilename, PDO::PARAM_STR);
-        $query->execute();
-    }
-
-    private function upsertTrophy(
-        string $npCommunicationId,
-        string $groupId,
-        object $trophy,
-        string $iconFilename,
-        ?string $rewardImageFilename,
-        ?int $progressTargetValue
-    ): void {
-        $query = $this->database->prepare(
-            'INSERT INTO trophy (
-                np_communication_id,
-                group_id,
-                order_id,
-                hidden,
-                type,
-                name,
-                detail,
-                icon_url,
-                progress_target_value,
-                reward_name,
-                reward_image_url
-            )
-            VALUES (
-                :np_communication_id,
-                :group_id,
-                :order_id,
-                :hidden,
-                :type,
-                :name,
-                :detail,
-                :icon_url,
-                :progress_target_value,
-                :reward_name,
-                :reward_image_url
-            ) AS new
-            ON DUPLICATE KEY UPDATE
-                hidden = new.hidden,
-                type = new.type,
-                name = new.name,
-                detail = new.detail,
-                icon_url = new.icon_url,
-                progress_target_value = new.progress_target_value,
-                reward_name = new.reward_name,
-                reward_image_url = new.reward_image_url'
-        );
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
-        $query->bindValue(':order_id', $trophy->id(), PDO::PARAM_INT);
-        $query->bindValue(':hidden', (int) $trophy->hidden(), PDO::PARAM_INT);
-        $query->bindValue(':type', $trophy->type()->value, PDO::PARAM_STR);
-        $query->bindValue(':name', $trophy->name(), PDO::PARAM_STR);
-        $query->bindValue(':detail', $trophy->detail(), PDO::PARAM_STR);
-        $query->bindValue(':icon_url', $iconFilename, PDO::PARAM_STR);
-
-        if ($progressTargetValue === null) {
-            $query->bindValue(':progress_target_value', null, PDO::PARAM_NULL);
-        } else {
-            $query->bindValue(':progress_target_value', $progressTargetValue, PDO::PARAM_INT);
-        }
-
-        $rewardName = $trophy->rewardName();
-        if ($rewardName === '') {
-            $this->bindNullable($query, ':reward_name', null);
-        } else {
-            $query->bindValue(':reward_name', $rewardName, PDO::PARAM_STR);
-        }
-
-        $this->bindNullable($query, ':reward_image_url', $rewardImageFilename);
-
-        $query->execute();
-    }
-
-    private function bindNullable(PDOStatement $query, string $parameter, ?string $value): void
-    {
-        if ($value === null) {
-            $query->bindValue($parameter, null, PDO::PARAM_NULL);
-
-            return;
-        }
-
-        $query->bindValue($parameter, $value, PDO::PARAM_STR);
-    }
-
     private function recalculateParentTitles(
         string $childNpCommunicationId,
         string $lastUpdatedDateTime,
@@ -996,99 +900,6 @@ class GameRescanService
         );
         $query->bindValue(':param_1', $gameId, PDO::PARAM_INT);
         $query->execute();
-    }
-
-    /**
-     * @return array{detail: ?string, icon: ?string, platform: string, platforms: array<int, string>, set_version: ?string}
-     */
-    private function fetchExistingTrophyTitleInfo(string $npCommunicationId): array
-    {
-        $query = $this->database->prepare(
-            'SELECT detail, icon_url, platform, set_version FROM trophy_title WHERE np_communication_id = :np_communication_id'
-        );
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->execute();
-
-        $row = $query->fetch(PDO::FETCH_ASSOC);
-
-        if ($row === false) {
-            return [
-                'detail' => null,
-                'icon' => null,
-                'platform' => '',
-                'platforms' => [],
-                'set_version' => null,
-            ];
-        }
-
-        $platform = isset($row['platform']) ? (string) $row['platform'] : '';
-        $platforms = array_values(array_filter(array_map(
-            'trim',
-            $platform === '' ? [] : explode(',', $platform)
-        ), static fn(string $value): bool => $value !== ''));
-
-        return [
-            'detail' => $row['detail'] === null ? null : (string) $row['detail'],
-            'icon' => $row['icon_url'] === null ? null : (string) $row['icon_url'],
-            'platform' => $platform,
-            'platforms' => $platforms,
-            'set_version' => $row['set_version'] === null ? null : (string) $row['set_version'],
-        ];
-    }
-
-    /**
-     * @return array<string, array<string, string|null>>
-     */
-    private function fetchExistingTrophyGroupData(string $npCommunicationId): array
-    {
-        $query = $this->database->prepare(
-            'SELECT group_id, name, detail, icon_url FROM trophy_group WHERE np_communication_id = :np_communication_id'
-        );
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->execute();
-
-        $groups = [];
-        while (($row = $query->fetch(PDO::FETCH_ASSOC)) !== false) {
-            $groupId = (string) $row['group_id'];
-            $groups[$groupId] = [
-                'name' => $row['name'] === null ? null : (string) $row['name'],
-                'detail' => $row['detail'] === null ? null : (string) $row['detail'],
-                'icon' => $row['icon_url'] === null ? null : (string) $row['icon_url'],
-            ];
-        }
-
-        return $groups;
-    }
-
-    /**
-     * @return array<string, array<int, array<string, string|null>>>
-     */
-    private function fetchExistingTrophyData(string $npCommunicationId): array
-    {
-        $query = $this->database->prepare(
-            'SELECT group_id, order_id, hidden, type, name, detail, icon_url, progress_target_value, reward_name, reward_image_url'
-            . ' FROM trophy WHERE np_communication_id = :np_communication_id'
-        );
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->execute();
-
-        $trophies = [];
-        while (($row = $query->fetch(PDO::FETCH_ASSOC)) !== false) {
-            $groupId = (string) $row['group_id'];
-            $orderId = (int) $row['order_id'];
-            $trophies[$groupId][$orderId] = [
-                'hidden' => $row['hidden'] === null ? null : (string) $row['hidden'],
-                'type' => $row['type'] === null ? null : (string) $row['type'],
-                'name' => $row['name'] === null ? null : (string) $row['name'],
-                'detail' => $row['detail'] === null ? null : (string) $row['detail'],
-                'icon' => $row['icon_url'] === null ? null : (string) $row['icon_url'],
-                'progress_target_value' => $row['progress_target_value'] === null ? null : (string) $row['progress_target_value'],
-                'reward_name' => $row['reward_name'] === null ? null : (string) $row['reward_name'],
-                'reward_image' => $row['reward_image_url'] === null ? null : (string) $row['reward_image_url'],
-            ];
-        }
-
-        return $trophies;
     }
 
     private function fetchCurrentTrophySetVersion(string $npCommunicationId): ?string

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/../TrophyImageDirectories.php';
 require_once __DIR__ . '/../TrophyImageDownloader.php';
 require_once __DIR__ . '/WorkerScanCoordinator.php';
 require_once __DIR__ . '/PlayerScanQueueSelector.php';
+require_once __DIR__ . '/../TrophyCatalogSynchronizer.php';
 require_once __DIR__ . '/../TrophyTitleNameFormatter.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
@@ -37,6 +38,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
     private readonly PlayerScanQueueSelector $playerScanQueueSelector;
     private readonly TrophyTitleNameFormatter $trophyTitleNameFormatter;
     private readonly PlayStationWorkerAuthenticator $workerAuthenticator;
+    private readonly TrophyCatalogSynchronizer $trophyCatalogSynchronizer;
 
     public function __construct(
         private readonly PDO $database,
@@ -54,6 +56,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         ?PlayerScanQueueSelector $playerScanQueueSelector = null,
         ?TrophyTitleNameFormatter $trophyTitleNameFormatter = null,
         ?PlayStationWorkerAuthenticator $workerAuthenticator = null,
+        ?TrophyCatalogSynchronizer $trophyCatalogSynchronizer = null,
     )
     {
         $this->trophyMetaRepository = $trophyMetaRepository ?? new TrophyMetaRepository($database);
@@ -78,6 +81,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                 $logger->log(sprintf('Failed to persist refresh token for worker %d: %s', $workerId, $message));
             },
         );
+        $this->trophyCatalogSynchronizer = $trophyCatalogSynchronizer ?? new TrophyCatalogSynchronizer($database);
     }
 
     /**
@@ -904,14 +908,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
 
                             $sanitizedTitleName = $this->trophyTitleNameFormatter->format($trophyTitle->name());
 
-                            $existingTitleQuery = $this->database->prepare(
-                                'SELECT name, detail, icon_url, platform, set_version
-                                FROM trophy_title
-                                WHERE np_communication_id = :np_communication_id'
-                            );
-                            $existingTitleQuery->bindValue(':np_communication_id', $npid, PDO::PARAM_STR);
-                            $existingTitleQuery->execute();
-                            $existingTitle = $existingTitleQuery->fetch(PDO::FETCH_ASSOC) ?: null;
+                            $existingTitle = $this->trophyCatalogSynchronizer->fetchExistingTrophyTitleRow($npid);
                             $isNewTitle = $existingTitle === null;
                             $incomingSetVersion = $trophyTitle->trophySetVersion();
                             $setVersionForUpdate = $this->resolveSetVersionForUpdate(
@@ -1061,15 +1058,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 $trophyGroupIconUrl = (string) ($trophyGroup['trophyGroupIconUrl'] ?? '');
                                 $groupNewTrophies = false;
                                 // Add trophy group (game + dlcs) into database
-                                $existingGroupQuery = $this->database->prepare(
-                                    'SELECT name, detail, icon_url
-                                    FROM trophy_group
-                                    WHERE np_communication_id = :np_communication_id AND group_id = :group_id'
-                                );
-                                $existingGroupQuery->bindValue(':np_communication_id', $npid, PDO::PARAM_STR);
-                                $existingGroupQuery->bindValue(':group_id', $trophyGroupId, PDO::PARAM_STR);
-                                $existingGroupQuery->execute();
-                                $existingGroup = $existingGroupQuery->fetch(PDO::FETCH_ASSOC) ?: null;
+                                $existingGroup = $this->trophyCatalogSynchronizer->fetchExistingTrophyGroup($npid, $trophyGroupId);
 
                                 $previousGroupIconFilename = $existingGroup['icon_url'] ?? null;
                                 $groupIconFilename = $previousGroupIconFilename;
@@ -1090,34 +1079,15 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 }
 
                                 if ($existingGroup === null || $groupNeedsUpdate || $groupIconMissing || $titleNeedsUpdate) {
-                                    $query = $this->database->prepare("INSERT INTO trophy_group(
-                                            np_communication_id,
-                                            group_id,
-                                            name,
-                                            detail,
-                                            icon_url
-                                        )
-                                        VALUES(
-                                            :np_communication_id,
-                                            :group_id,
-                                            :name,
-                                            :detail,
-                                            :icon_url
-                                        ) AS new
-                                        ON DUPLICATE KEY
-                                        UPDATE
-                                            name = new.name,
-                                            detail = new.detail,
-                                            icon_url = new.icon_url");
-                                    $query->bindValue(":np_communication_id", $npid, PDO::PARAM_STR);
-                                    $query->bindValue(":group_id", $trophyGroupId, PDO::PARAM_STR);
-                                    $query->bindValue(":name", $trophyGroupName, PDO::PARAM_STR);
-                                    $query->bindValue(":detail", $trophyGroupDetail, PDO::PARAM_STR);
-                                    $query->bindValue(":icon_url", $groupIconFilename, PDO::PARAM_STR);
-                                    // Don't insert platinum/gold/silver/bronze here since our site recalculate this.
-                                    $query->execute();
+                                    $groupAffectedRows = $this->trophyCatalogSynchronizer->upsertTrophyGroup(
+                                        $npid,
+                                        $trophyGroupId,
+                                        $trophyGroupName,
+                                        $trophyGroupDetail,
+                                        $groupIconFilename,
+                                    );
 
-                                    if ($query->rowCount() > 0) {
+                                    if ($groupAffectedRows > 0) {
                                         $groupDataChanged = true;
                                     }
                                 }
@@ -1159,18 +1129,11 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                         continue;
                                     }
 
-                                    $existingTrophyQuery = $this->database->prepare(
-                                        'SELECT hidden, type, name, detail, icon_url, progress_target_value, reward_name, reward_image_url
-                                        FROM trophy
-                                        WHERE np_communication_id = :np_communication_id
-                                        AND group_id = :group_id
-                                        AND order_id = :order_id'
+                                    $existingTrophy = $this->trophyCatalogSynchronizer->fetchExistingTrophy(
+                                        $npid,
+                                        $trophyGroupId,
+                                        $trophyOrderId,
                                     );
-                                    $existingTrophyQuery->bindValue(':np_communication_id', $npid, PDO::PARAM_STR);
-                                    $existingTrophyQuery->bindValue(':group_id', $trophyGroupId, PDO::PARAM_STR);
-                                    $existingTrophyQuery->bindValue(':order_id', $trophyOrderId, PDO::PARAM_INT);
-                                    $existingTrophyQuery->execute();
-                                    $existingTrophy = $existingTrophyQuery->fetch(PDO::FETCH_ASSOC) ?: null;
 
                                     $trophyHidden = (int) ($trophy['trophyHidden'] ?? 0);
 
@@ -1275,61 +1238,19 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                     $trophyAffectedRows = 0;
 
                                     if ($shouldUpsertTrophy) {
-                                        $query = $this->database->prepare("INSERT INTO trophy(
-                                                np_communication_id,
-                                                group_id,
-                                                order_id,
-                                                hidden,
-                                                type,
-                                                name,
-                                                detail,
-                                                icon_url,
-                                                progress_target_value,
-                                                reward_name,
-                                                reward_image_url
-                                            )
-                                            VALUES(
-                                                :np_communication_id,
-                                                :group_id,
-                                                :order_id,
-                                                :hidden,
-                                                :type,
-                                                :name,
-                                                :detail,
-                                                :icon_url,
-                                                :progress_target_value,
-                                                :reward_name,
-                                                :reward_image_url
-                                            ) AS new
-                                            ON DUPLICATE KEY
-                                            UPDATE
-                                                hidden = new.hidden,
-                                                type = new.type,
-                                                name = new.name,
-                                                detail = new.detail,
-                                                icon_url = new.icon_url,
-                                                progress_target_value = new.progress_target_value,
-                                                reward_name = new.reward_name,
-                                                reward_image_url = new.reward_image_url");
-                                        $query->bindValue(":np_communication_id", $npid, PDO::PARAM_STR);
-                                        $query->bindValue(":group_id", $trophyGroupId, PDO::PARAM_STR);
-                                        $query->bindValue(":order_id", $trophyOrderId, PDO::PARAM_INT);
-                                        $query->bindValue(":hidden", $trophyHidden, PDO::PARAM_INT);
-                                        $query->bindValue(":type", $trophyTypeEnumValue, PDO::PARAM_STR);
-                                        $query->bindValue(":name", $trophyName, PDO::PARAM_STR);
-                                        $query->bindValue(":detail", $trophyDetail, PDO::PARAM_STR);
-                                        $query->bindValue(":icon_url", $trophyIconFilename, PDO::PARAM_STR);
-                                        if ($progressTargetValue === null) {
-                                            $query->bindValue(":progress_target_value", null, PDO::PARAM_NULL);
-                                        } else {
-                                            $query->bindValue(":progress_target_value", $progressTargetValue, PDO::PARAM_INT);
-                                        }
-                                        $query->bindValue(":reward_name", $rewardName, PDO::PARAM_STR);
-                                        $query->bindValue(":reward_image_url", $rewardImageFilename, PDO::PARAM_STR);
-                                        // Don't insert platinum/gold/silver/bronze here since our site recalculate this.
-                                        $query->execute();
-
-                                        $trophyAffectedRows = (int) $query->rowCount();
+                                        $trophyAffectedRows = $this->trophyCatalogSynchronizer->upsertTrophy(
+                                            $npid,
+                                            $trophyGroupId,
+                                            $trophyOrderId,
+                                            $trophyHidden,
+                                            $trophyTypeEnumValue,
+                                            $trophyName,
+                                            $trophyDetail,
+                                            $trophyIconFilename,
+                                            $progressTargetValue,
+                                            $rewardName,
+                                            $rewardImageFilename,
+                                        );
 
                                         if ($trophyAffectedRows > 0) {
                                             $trophyDataChanged = true;

--- a/wwwroot/classes/TrophyCatalogSynchronizer.php
+++ b/wwwroot/classes/TrophyCatalogSynchronizer.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Persists trophy catalog rows shared between player scans and admin rescans.
+ */
+final class TrophyCatalogSynchronizer
+{
+    public function __construct(
+        private readonly PDO $database,
+    ) {
+    }
+
+    /**
+     * @return array{detail: ?string, icon: ?string, platform: string, platforms: array<int, string>, set_version: ?string}
+     */
+    public function fetchExistingTrophyTitleInfo(string $npCommunicationId): array
+    {
+        $query = $this->database->prepare(
+            'SELECT detail, icon_url, platform, set_version FROM trophy_title WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        $row = $query->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return [
+                'detail' => null,
+                'icon' => null,
+                'platform' => '',
+                'platforms' => [],
+                'set_version' => null,
+            ];
+        }
+
+        $platform = isset($row['platform']) ? (string) $row['platform'] : '';
+        $platforms = array_values(array_filter(array_map(
+            'trim',
+            $platform === '' ? [] : explode(',', $platform)
+        ), static fn (string $value): bool => $value !== ''));
+
+        return [
+            'detail' => $row['detail'] === null ? null : (string) $row['detail'],
+            'icon' => $row['icon_url'] === null ? null : (string) $row['icon_url'],
+            'platform' => $platform,
+            'platforms' => $platforms,
+            'set_version' => $row['set_version'] === null ? null : (string) $row['set_version'],
+        ];
+    }
+
+    /**
+     * @return array{name: ?string, detail: ?string, icon_url: ?string, set_version: ?string}|null
+     */
+    public function fetchExistingTrophyTitleRow(string $npCommunicationId): ?array
+    {
+        $query = $this->database->prepare(
+            'SELECT name, detail, icon_url, platform, set_version
+            FROM trophy_title
+            WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        $row = $query->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * @return array<string, array{name: ?string, detail: ?string, icon: ?string}>
+     */
+    public function fetchExistingTrophyGroupData(string $npCommunicationId): array
+    {
+        $query = $this->database->prepare(
+            'SELECT group_id, name, detail, icon_url FROM trophy_group WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        $groups = [];
+        while (($row = $query->fetch(PDO::FETCH_ASSOC)) !== false) {
+            $groupId = (string) $row['group_id'];
+            $groups[$groupId] = [
+                'name' => $row['name'] === null ? null : (string) $row['name'],
+                'detail' => $row['detail'] === null ? null : (string) $row['detail'],
+                'icon' => $row['icon_url'] === null ? null : (string) $row['icon_url'],
+            ];
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @return array{name: ?string, detail: ?string, icon_url: ?string}|null
+     */
+    public function fetchExistingTrophyGroup(string $npCommunicationId, string $groupId): ?array
+    {
+        $query = $this->database->prepare(
+            'SELECT name, detail, icon_url
+            FROM trophy_group
+            WHERE np_communication_id = :np_communication_id AND group_id = :group_id'
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
+        $query->execute();
+
+        $row = $query->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * @return array<string, array<int, array<string, ?string>>>
+     */
+    public function fetchExistingTrophyData(string $npCommunicationId): array
+    {
+        $query = $this->database->prepare(
+            'SELECT group_id, order_id, hidden, type, name, detail, icon_url, progress_target_value, reward_name, reward_image_url'
+            . ' FROM trophy WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        $trophies = [];
+        while (($row = $query->fetch(PDO::FETCH_ASSOC)) !== false) {
+            $groupId = (string) $row['group_id'];
+            $orderId = (int) $row['order_id'];
+            $trophies[$groupId][$orderId] = [
+                'hidden' => $row['hidden'] === null ? null : (string) $row['hidden'],
+                'type' => $row['type'] === null ? null : (string) $row['type'],
+                'name' => $row['name'] === null ? null : (string) $row['name'],
+                'detail' => $row['detail'] === null ? null : (string) $row['detail'],
+                'icon' => $row['icon_url'] === null ? null : (string) $row['icon_url'],
+                'progress_target_value' => $row['progress_target_value'] === null ? null : (string) $row['progress_target_value'],
+                'reward_name' => $row['reward_name'] === null ? null : (string) $row['reward_name'],
+                'reward_image' => $row['reward_image_url'] === null ? null : (string) $row['reward_image_url'],
+            ];
+        }
+
+        return $trophies;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function fetchExistingTrophy(string $npCommunicationId, string $groupId, int $orderId): ?array
+    {
+        $query = $this->database->prepare(
+            'SELECT hidden, type, name, detail, icon_url, progress_target_value, reward_name, reward_image_url
+            FROM trophy
+            WHERE np_communication_id = :np_communication_id
+            AND group_id = :group_id
+            AND order_id = :order_id'
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
+        $query->bindValue(':order_id', $orderId, PDO::PARAM_INT);
+        $query->execute();
+
+        $row = $query->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    public function upsertTrophyGroup(
+        string $npCommunicationId,
+        string $groupId,
+        string $name,
+        string $detail,
+        string $iconFilename,
+        bool $updateNameOnDuplicate = true,
+    ): int {
+        $duplicateUpdate = $updateNameOnDuplicate
+            ? 'name = new.name, detail = new.detail, icon_url = new.icon_url'
+            : 'detail = new.detail, icon_url = new.icon_url';
+
+        $query = $this->database->prepare(
+            "INSERT INTO trophy_group (
+                np_communication_id,
+                group_id,
+                name,
+                detail,
+                icon_url
+            )
+            VALUES (
+                :np_communication_id,
+                :group_id,
+                :name,
+                :detail,
+                :icon_url
+            ) AS new
+            ON DUPLICATE KEY UPDATE
+                {$duplicateUpdate}"
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
+        $query->bindValue(':name', $name, PDO::PARAM_STR);
+        $query->bindValue(':detail', $detail, PDO::PARAM_STR);
+        $query->bindValue(':icon_url', $iconFilename, PDO::PARAM_STR);
+        $query->execute();
+
+        return (int) $query->rowCount();
+    }
+
+    public function upsertTrophy(
+        string $npCommunicationId,
+        string $groupId,
+        int $orderId,
+        int $hidden,
+        string $type,
+        string $name,
+        string $detail,
+        string $iconFilename,
+        ?int $progressTargetValue,
+        ?string $rewardName,
+        ?string $rewardImageFilename,
+    ): int {
+        $query = $this->database->prepare(
+            'INSERT INTO trophy (
+                np_communication_id,
+                group_id,
+                order_id,
+                hidden,
+                type,
+                name,
+                detail,
+                icon_url,
+                progress_target_value,
+                reward_name,
+                reward_image_url
+            )
+            VALUES (
+                :np_communication_id,
+                :group_id,
+                :order_id,
+                :hidden,
+                :type,
+                :name,
+                :detail,
+                :icon_url,
+                :progress_target_value,
+                :reward_name,
+                :reward_image_url
+            ) AS new
+            ON DUPLICATE KEY UPDATE
+                hidden = new.hidden,
+                type = new.type,
+                name = new.name,
+                detail = new.detail,
+                icon_url = new.icon_url,
+                progress_target_value = new.progress_target_value,
+                reward_name = new.reward_name,
+                reward_image_url = new.reward_image_url'
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
+        $query->bindValue(':order_id', $orderId, PDO::PARAM_INT);
+        $query->bindValue(':hidden', $hidden, PDO::PARAM_INT);
+        $query->bindValue(':type', $type, PDO::PARAM_STR);
+        $query->bindValue(':name', $name, PDO::PARAM_STR);
+        $query->bindValue(':detail', $detail, PDO::PARAM_STR);
+        $query->bindValue(':icon_url', $iconFilename, PDO::PARAM_STR);
+
+        if ($progressTargetValue === null) {
+            $query->bindValue(':progress_target_value', null, PDO::PARAM_NULL);
+        } else {
+            $query->bindValue(':progress_target_value', $progressTargetValue, PDO::PARAM_INT);
+        }
+
+        $this->bindNullable($query, ':reward_name', $rewardName);
+        $this->bindNullable($query, ':reward_image_url', $rewardImageFilename);
+
+        $query->execute();
+
+        return (int) $query->rowCount();
+    }
+
+    private function bindNullable(PDOStatement $query, string $parameter, ?string $value): void
+    {
+        if ($value === null) {
+            $query->bindValue($parameter, null, PDO::PARAM_NULL);
+
+            return;
+        }
+
+        $query->bindValue($parameter, $value, PDO::PARAM_STR);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Third incremental peel-off from the codebase's largest God classes. Shared trophy catalog persistence — fetching existing rows and upserting groups/trophies — now lives in `TrophyCatalogSynchronizer`.

Follows #16052 (`PlayStationWorkerAuthenticator`) and #16053 (`PlayerScanQueueSelector`).

## What changed

- **New** `TrophyCatalogSynchronizer` centralizes:
  - `fetchExistingTrophyTitleInfo` / `fetchExistingTrophyTitleRow`
  - `fetchExistingTrophyGroupData` / `fetchExistingTrophyGroup`
  - `fetchExistingTrophyData` / `fetchExistingTrophy`
  - `upsertTrophyGroup` (optional `updateNameOnDuplicate` flag)
  - `upsertTrophy`
- **`GameRescanService`** delegates fetch + upsert calls; keeps orchestration (progress, difference tracking, image download, API adapters).
- **`ThirtyMinuteCronJob`** delegates fetch + upsert calls; keeps scan-loop conditionals, set-version policy, and earned-trophy sync.

`GameRescanService` continues to skip group name updates on duplicate keys (`updateNameOnDuplicate: false`), matching prior rescan behavior.

## Tests

- Added `TrophyCatalogSynchronizerTest` (7 cases) covering all fetch helpers on SQLite.
- All **658** tests pass.

## Suggested next PRs

1. `TrophyMergeMappingStrategy` — mapping strategies from `TrophyMergeService`
2. `GameHistoryDiffHighlighter` — diff algorithm from `GameHistoryPage`
3. Title upsert unification (`trophy_title` INSERT with set-version policy) — larger follow-up

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bc69466-ffaa-4f04-87c5-4c57cbd2c035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bc69466-ffaa-4f04-87c5-4c57cbd2c035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

