### PR TITLE
Extract PlayerScanProfileSynchronizer from ThirtyMinuteCronJob

### DIFF
--- a/tests/PlayerScanProfileSynchronizerTest.php
+++ b/tests/PlayerScanProfileSynchronizerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Psn100Logger.php';
+require_once __DIR__ . '/../wwwroot/classes/ImageHashCalculator.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/WorkerScanCoordinator.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanProfileSyncResult.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php';
+
+final class PlayerScanProfileSynchronizerTest extends TestCase
+{
+    private PlayerScanProfileSynchronizer $synchronizer;
+
+    protected function setUp(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE log (message TEXT NOT NULL)');
+        $database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY, scanning TEXT, scan_progress TEXT)');
+        $database->exec('CREATE TABLE player_queue (online_id TEXT PRIMARY KEY)');
+        $database->exec(
+            'CREATE TABLE player (
+                account_id INTEGER PRIMARY KEY,
+                online_id TEXT NOT NULL,
+                country TEXT,
+                status INTEGER NOT NULL DEFAULT 99,
+                last_updated_date TEXT
+            )'
+        );
+
+        $logger = new Psn100Logger($database);
+
+        $this->synchronizer = new PlayerScanProfileSynchronizer(
+            $database,
+            new ImageHashCalculator(),
+            $logger,
+            new WorkerScanCoordinator($database),
+        );
+    }
+
+    public function testDetermineResolvedOnlineIdPrefersCurrentOnlineId(): void
+    {
+        $profile = [
+            'currentOnlineId' => 'NewName',
+            'onlineId' => 'OldName',
+        ];
+
+        $result = $this->synchronizer->determineResolvedOnlineId($profile, 'FallbackName');
+
+        $this->assertSame('NewName', $result);
+    }
+
+    public function testDetermineResolvedOnlineIdFallsBackToOnlineId(): void
+    {
+        $profile = [
+            'onlineId' => 'StoredName',
+        ];
+
+        $result = $this->synchronizer->determineResolvedOnlineId($profile, 'FallbackName');
+
+        $this->assertSame('StoredName', $result);
+    }
+
+    public function testDetermineResolvedOnlineIdUsesFallbackWhenProfileIdsMissing(): void
+    {
+        $result = $this->synchronizer->determineResolvedOnlineId([], 'FallbackName');
+
+        $this->assertSame('FallbackName', $result);
+    }
+
+    public function testExtractCountryFromNpIdDecodesTrailingCountryCode(): void
+    {
+        $npId = base64_encode('ExamplePlayerUS');
+
+        $result = $this->synchronizer->extractCountryFromNpId($npId);
+
+        $this->assertSame('us', $result);
+    }
+
+    public function testExtractCountryFromNpIdReturnsNullForInvalidValues(): void
+    {
+        $this->assertSame(null, $this->synchronizer->extractCountryFromNpId(''));
+        $this->assertSame(null, $this->synchronizer->extractCountryFromNpId(null));
+        $this->assertSame(null, $this->synchronizer->extractCountryFromNpId('not-valid-base64!!!'));
+    }
+
+    public function testNormalizeAccountIdValueAcceptsIntegersAndDigitStrings(): void
+    {
+        $this->assertSame('12345', $this->synchronizer->normalizeAccountIdValue(12345));
+        $this->assertSame('12345', $this->synchronizer->normalizeAccountIdValue(' 12345 '));
+    }
+
+    public function testNormalizeAccountIdValueRejectsNonNumericValues(): void
+    {
+        $this->assertSame(null, $this->synchronizer->normalizeAccountIdValue(''));
+        $this->assertSame(null, $this->synchronizer->normalizeAccountIdValue('abc'));
+        $this->assertSame(null, $this->synchronizer->normalizeAccountIdValue(null));
+    }
+
+    public function testSyncResultHelpers(): void
+    {
+        $success = PlayerScanProfileSyncResult::success(['online_id' => 'player'], new stdClass(), 'us');
+        $skip = PlayerScanProfileSyncResult::skipPlayer();
+
+        $this->assertTrue($success->isSuccess());
+        $this->assertFalse($success->shouldSkipPlayer());
+        $this->assertFalse($skip->isSuccess());
+        $this->assertTrue($skip->shouldSkipPlayer());
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanProfileSyncResult.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSyncResult.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Outcome of resolving and persisting a queued player's PSN profile during a scan.
+ */
+final class PlayerScanProfileSyncResult
+{
+    public const STATUS_SUCCESS = 'success';
+    public const STATUS_SKIP_PLAYER = 'skip_player';
+
+    /**
+     * @param array<string, mixed> $player
+     */
+    private function __construct(
+        public readonly string $status,
+        public readonly array $player = [],
+        public readonly ?object $user = null,
+        public readonly ?string $country = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $player
+     */
+    public static function success(array $player, object $user, string $country): self
+    {
+        return new self(self::STATUS_SUCCESS, $player, $user, $country);
+    }
+
+    public static function skipPlayer(): self
+    {
+        return new self(self::STATUS_SKIP_PLAYER);
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->status === self::STATUS_SUCCESS;
+    }
+
+    public function shouldSkipPlayer(): bool
+    {
+        return $this->status === self::STATUS_SKIP_PLAYER;
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -1,0 +1,669 @@
+<?php
+
+declare(strict_types=1);
+
+use Tustin\Haste\Exception\NotFoundHttpException;
+use Tustin\PlayStation\Client;
+
+/**
+ * Resolves PSN profile data, synchronizes avatars, and upserts player rows during scans.
+ *
+ * Encapsulates profile lookup, country resolution, avatar caching, and player persistence
+ * that were previously embedded in ThirtyMinuteCronJob.
+ */
+final class PlayerScanProfileSynchronizer
+{
+    private const MAX_INVALID_API_RESPONSE_ATTEMPTS = 2;
+
+    public function __construct(
+        private readonly PDO $database,
+        private readonly ImageHashCalculator $imageHashCalculator,
+        private readonly Psn100Logger $logger,
+        private readonly WorkerScanCoordinator $workerScanCoordinator,
+        private readonly string $avatarStorageDirectory = '/home/psn100/public_html/img/avatar/',
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $player
+     */
+    public function synchronizeProfile(
+        Client $client,
+        array $player,
+        int $workerId,
+        string $displayOnlineId,
+    ): PlayerScanProfileSyncResult {
+        $this->workerScanCoordinator->setWaitingScanProgress(
+            $workerId,
+            sprintf('Updating profile data for %s.', $displayOnlineId)
+        );
+
+        $resolved = $this->resolvePlayerForScan($client, $player, $workerId, $displayOnlineId);
+
+        if ($resolved->shouldSkipPlayer()) {
+            return $resolved;
+        }
+
+        $user = $resolved->user;
+        $country = $resolved->country ?? 'zz';
+
+        if ($user === null) {
+            return PlayerScanProfileSyncResult::skipPlayer();
+        }
+
+        $this->workerScanCoordinator->setWaitingScanProgress(
+            $workerId,
+            sprintf('Updating avatar for %s.', $displayOnlineId)
+        );
+
+        $avatarFilename = $this->synchronizeAvatar($user);
+        $this->upsertPlayerRecord($user, $country, $avatarFilename);
+
+        return PlayerScanProfileSyncResult::success($resolved->player, $user, $country);
+    }
+
+    /**
+     * @param array<string, mixed> $profile
+     */
+    public function determineResolvedOnlineId(array $profile, string $fallbackOnlineId): string
+    {
+        $currentOnlineId = $profile['currentOnlineId'] ?? null;
+        if (is_string($currentOnlineId) && $currentOnlineId !== '') {
+            return $currentOnlineId;
+        }
+
+        $onlineId = $profile['onlineId'] ?? null;
+        if (is_string($onlineId) && $onlineId !== '') {
+            return $onlineId;
+        }
+
+        return $fallbackOnlineId;
+    }
+
+    public function extractCountryFromNpId(mixed $npId): ?string
+    {
+        if (!is_string($npId) || $npId === '') {
+            return null;
+        }
+
+        $decoded = base64_decode($npId, true);
+        if ($decoded === false || $decoded === '') {
+            return null;
+        }
+
+        $trimmed = trim($decoded);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (strlen($trimmed) < 2) {
+            return null;
+        }
+
+        return strtolower(substr($trimmed, -2));
+    }
+
+    public function normalizeAccountIdValue(mixed $accountId): ?string
+    {
+        if (is_int($accountId)) {
+            return (string) $accountId;
+        }
+
+        if (is_string($accountId)) {
+            $trimmed = trim($accountId);
+
+            if ($trimmed === '') {
+                return null;
+            }
+
+            return ctype_digit($trimmed) ? $trimmed : null;
+        }
+
+        if (is_float($accountId)) {
+            return (string) (int) $accountId;
+        }
+
+        if (is_numeric($accountId)) {
+            $numeric = (string) $accountId;
+
+            return ctype_digit($numeric) ? $numeric : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $player
+     */
+    private function resolvePlayerForScan(
+        Client $client,
+        array $player,
+        int $workerId,
+        string $displayOnlineId,
+    ): PlayerScanProfileSyncResult {
+        for ($attempt = 1; $attempt <= self::MAX_INVALID_API_RESPONSE_ATTEMPTS; $attempt++) {
+            try {
+                $originalOnlineId = (string) $player['online_id'];
+                $existingAccountId = $this->normalizeAccountIdValue($player['account_id'] ?? null);
+                $profileLookup = $this->lookupPlayerProfile($client, $originalOnlineId);
+                $country = 'zz';
+
+                if ($profileLookup !== null) {
+                    $profile = $profileLookup['profile'] ?? null;
+
+                    if (!is_array($profile)) {
+                        $this->markPlayerAsPrivate($originalOnlineId);
+
+                        return PlayerScanProfileSyncResult::skipPlayer();
+                    }
+
+                    $profileAccountId = $profile['accountId'] ?? null;
+
+                    if (!is_string($profileAccountId) || $profileAccountId === '') {
+                        $this->markPlayerAsPrivate($originalOnlineId);
+
+                        return PlayerScanProfileSyncResult::skipPlayer();
+                    }
+
+                    $resolvedOnlineId = $this->determineResolvedOnlineId($profile, $originalOnlineId);
+
+                    if ($resolvedOnlineId !== '' && strcasecmp($resolvedOnlineId, $originalOnlineId) !== 0) {
+                        $this->updateQueuedOnlineId($workerId, $originalOnlineId, $resolvedOnlineId);
+                        $player['online_id'] = $resolvedOnlineId;
+                    } else {
+                        $player['online_id'] = $originalOnlineId;
+                    }
+
+                    $player['account_id'] = $profileAccountId;
+                    $user = $client->users()->find($profileAccountId);
+
+                    $countryFromProfile = $this->extractCountryFromNpId($profile['npId'] ?? null);
+                    $country = $countryFromProfile;
+
+                    if ($country === null || strtolower($country) === 'zz') {
+                        $storedCountry = $this->fetchStoredCountryByAccountId((int) $profileAccountId);
+
+                        if (is_string($storedCountry) && $storedCountry !== '') {
+                            $country = $storedCountry;
+                        } else {
+                            $country = 'zz';
+                        }
+
+                        if (strtolower($country) === 'zz') {
+                            $resolvedCountry = $this->findPlayerCountry($client, $user->onlineId());
+
+                            if ($resolvedCountry !== null) {
+                                $country = $resolvedCountry;
+                                $this->updatePlayerCountry((int) $profileAccountId, $resolvedCountry);
+                            }
+                        }
+                    } else {
+                        $this->updatePlayerCountry((int) $profileAccountId, $country);
+                    }
+                } else {
+                    if ($existingAccountId === null) {
+                        $this->markPlayerAsPrivate($originalOnlineId);
+
+                        return PlayerScanProfileSyncResult::skipPlayer();
+                    }
+
+                    $player['account_id'] = $existingAccountId;
+                    $user = $client->users()->find($existingAccountId);
+
+                    $resolvedOnlineId = (string) $user->onlineId();
+
+                    if ($resolvedOnlineId !== '' && strcasecmp($resolvedOnlineId, $originalOnlineId) !== 0) {
+                        $this->updateQueuedOnlineId($workerId, $originalOnlineId, $resolvedOnlineId);
+                        $player['online_id'] = $resolvedOnlineId;
+                    } else {
+                        $player['online_id'] = $originalOnlineId;
+                    }
+
+                    $storedCountry = $this->fetchStoredCountryByAccountId((int) $existingAccountId);
+
+                    if (is_string($storedCountry) && $storedCountry !== '') {
+                        $country = $storedCountry;
+                    }
+
+                    if (strtolower($country) === 'zz') {
+                        $resolvedCountry = $this->findPlayerCountry($client, $user->onlineId());
+
+                        if ($resolvedCountry !== null) {
+                            $country = $resolvedCountry;
+                            $this->updatePlayerCountry((int) $existingAccountId, $resolvedCountry);
+                        }
+                    }
+                }
+
+                if (!is_string($country) || $country === '') {
+                    $country = 'zz';
+                }
+
+                $user->aboutMe();
+
+                if (strcasecmp($player['online_id'], $user->onlineId()) !== 0) {
+                    $this->updateQueuedOnlineId($workerId, (string) $player['online_id'], $user->onlineId());
+                    $player['online_id'] = $user->onlineId();
+                }
+
+                return PlayerScanProfileSyncResult::success($player, $user, $country);
+            } catch (TypeError $exception) {
+                if ($attempt < self::MAX_INVALID_API_RESPONSE_ATTEMPTS) {
+                    $this->pauseBeforeRetryingInvalidApiResponse($workerId, $displayOnlineId);
+
+                    continue;
+                }
+
+                $this->handleInvalidApiResponse($player, $workerId, $exception);
+
+                return PlayerScanProfileSyncResult::skipPlayer();
+            } catch (Exception $exception) {
+                $this->handlePlayerNotFoundDuringProfileSync($player, $exception);
+
+                return PlayerScanProfileSyncResult::skipPlayer();
+            } catch (Throwable $exception) {
+                if ($attempt < self::MAX_INVALID_API_RESPONSE_ATTEMPTS) {
+                    $this->pauseBeforeRetryingInvalidApiResponse($workerId, $displayOnlineId);
+
+                    continue;
+                }
+
+                $this->handleInvalidApiResponse($player, $workerId, $exception);
+
+                return PlayerScanProfileSyncResult::skipPlayer();
+            }
+        }
+
+        return PlayerScanProfileSyncResult::skipPlayer();
+    }
+
+    private function synchronizeAvatar(object $user): string
+    {
+        $avatarUrls = $user->avatarUrls();
+        $avatarFilename = '';
+
+        for ($i = 0; $i < 4; $i++) {
+            switch ($i) {
+                case 0:
+                    $size = 'xl';
+                    break;
+                case 1:
+                    $size = 'l';
+                    break;
+                case 2:
+                    $size = 'm';
+                    break;
+                case 3:
+                    $size = 's';
+                    break;
+                default:
+                    $size = 'xl';
+            }
+
+            $avatarUrl = $avatarUrls[$size];
+
+            $query = $this->database->prepare(
+                'SELECT md5_hash, extension FROM psn100_avatars WHERE avatar_url = :avatar_url'
+            );
+            $query->bindValue(':avatar_url', $avatarUrl, PDO::PARAM_STR);
+            $query->execute();
+            $result = $query->fetch();
+
+            if (!$result) {
+                $avatarContents = @file_get_contents($avatarUrl);
+                if ($avatarContents === false) {
+                    continue;
+                }
+
+                $newPHash = $this->imageHashCalculator->calculatePHash($avatarContents);
+                if ($newPHash === null) {
+                    continue;
+                }
+
+                $query = $this->database->prepare('SELECT DISTINCT md5_hash FROM psn100_avatars');
+                $query->execute();
+                $existingPHashes = $query->fetchAll(PDO::FETCH_COLUMN);
+
+                foreach ($existingPHashes as $existingPHash) {
+                    if ($this->imageHashCalculator->getHammingDistance($newPHash, $existingPHash) <= 10) {
+                        $newPHash = $existingPHash;
+                        break;
+                    }
+                }
+
+                $extension = strtolower(pathinfo($avatarUrl, PATHINFO_EXTENSION));
+                $avatarFilename = $newPHash . '.' . $extension;
+                $avatarPath = $this->avatarStorageDirectory . $avatarFilename;
+
+                if (!file_exists($avatarPath)) {
+                    file_put_contents($avatarPath, $avatarContents);
+                }
+
+                $query = $this->database->prepare(
+                    'INSERT INTO psn100_avatars(size, avatar_url, md5_hash, extension)
+                    VALUES(:size, :avatar_url, :md5_hash, :extension)'
+                );
+                $query->bindValue(':size', $size, PDO::PARAM_STR);
+                $query->bindValue(':avatar_url', $avatarUrl, PDO::PARAM_STR);
+                $query->bindValue(':md5_hash', $newPHash, PDO::PARAM_STR);
+                $query->bindValue(':extension', $extension, PDO::PARAM_STR);
+                $query->execute();
+            } else {
+                $avatarFilename = $result['md5_hash'] . '.' . $result['extension'];
+            }
+
+            break;
+        }
+
+        return $avatarFilename;
+    }
+
+    private function upsertPlayerRecord(object $user, string $country, string $avatarFilename): void
+    {
+        $plus = (bool) $user->hasPlus();
+
+        $query = $this->database->prepare(
+            'INSERT INTO player (
+                account_id,
+                online_id,
+                country,
+                avatar_url,
+                plus,
+                about_me
+            )
+            VALUES (
+                :account_id,
+                :online_id,
+                :country,
+                :avatar_url,
+                :plus,
+                :about_me
+            ) AS new ON DUPLICATE KEY
+            UPDATE
+                online_id = new.online_id,
+                avatar_url = new.avatar_url,
+                plus = new.plus,
+                about_me = new.about_me'
+        );
+        $query->bindValue(':account_id', $user->accountId(), PDO::PARAM_INT);
+        $query->bindValue(':online_id', $user->onlineId(), PDO::PARAM_STR);
+        $query->bindValue(':country', strtolower($country), PDO::PARAM_STR);
+        $query->bindValue(':avatar_url', $avatarFilename, PDO::PARAM_STR);
+        $query->bindValue(':plus', $plus, PDO::PARAM_BOOL);
+        $query->bindValue(':about_me', $user->aboutMe(), PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    private function lookupPlayerProfile(Client $client, string $onlineId): ?array
+    {
+        $path = sprintf(
+            'https://us-prof.np.community.playstation.net/userProfile/v1/users/%s/profile2',
+            rawurlencode($onlineId)
+        );
+
+        $query = [
+            'fields' => 'accountId,onlineId,currentOnlineId,npId',
+        ];
+
+        try {
+            $profile = $client->get($path, $query, ['content-type' => 'application/json']);
+        } catch (Throwable $exception) {
+            if ($this->determineStatusCode($exception) === 404) {
+                return null;
+            }
+
+            throw $exception;
+        }
+
+        $normalized = $this->normalizePlayerProfileResponse($profile);
+
+        return is_array($normalized) ? $normalized : null;
+    }
+
+    private function markPlayerAsPrivate(string $onlineId): void
+    {
+        $query = $this->database->prepare(
+            'UPDATE player
+            SET `status` = 3, last_updated_date = NOW()
+            WHERE online_id = :online_id AND `status` != 1'
+        );
+        $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
+        $query->execute();
+
+        $query = $this->database->prepare('DELETE FROM player_queue WHERE online_id = :online_id');
+        $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    private function updateQueuedOnlineId(int $workerId, string $previousOnlineId, string $newOnlineId): void
+    {
+        $query = $this->database->prepare(
+            'UPDATE player_queue SET online_id = :online_id_new WHERE online_id = :online_id_old'
+        );
+        $query->bindValue(':online_id_new', $newOnlineId, PDO::PARAM_STR);
+        $query->bindValue(':online_id_old', $previousOnlineId, PDO::PARAM_STR);
+        $query->execute();
+
+        $query = $this->database->prepare(
+            'UPDATE setting SET scanning = :scanning, scan_progress = NULL WHERE id = :worker_id'
+        );
+        $query->bindValue(':scanning', $newOnlineId, PDO::PARAM_STR);
+        $query->bindValue(':worker_id', $workerId, PDO::PARAM_INT);
+        $query->execute();
+    }
+
+    private function fetchStoredCountryByAccountId(int $accountId): ?string
+    {
+        $query = $this->database->prepare('SELECT country FROM player WHERE account_id = :account_id');
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+
+        $country = $query->fetchColumn();
+
+        if (!is_string($country) || $country === '') {
+            return null;
+        }
+
+        return $country;
+    }
+
+    private function findPlayerCountry(Client $client, string $onlineId): ?string
+    {
+        $normalizedOnlineId = strtolower($onlineId);
+        $userCounter = 0;
+
+        try {
+            foreach ($client->users()->search($onlineId) as $result) {
+                if (strtolower($result->onlineId()) === $normalizedOnlineId) {
+                    $country = $result->country();
+
+                    if (!is_string($country) || $country === '') {
+                        return null;
+                    }
+
+                    $normalizedCountry = strtolower($country);
+
+                    if ($normalizedCountry === 'zz') {
+                        return null;
+                    }
+
+                    return $normalizedCountry;
+                }
+
+                $userCounter++;
+
+                if ($userCounter >= 50) {
+                    break;
+                }
+            }
+        } catch (Throwable) {
+            return null;
+        }
+
+        return null;
+    }
+
+    private function updatePlayerCountry(int $accountId, string $country): void
+    {
+        $query = $this->database->prepare(
+            'UPDATE player SET country = :country WHERE account_id = :account_id'
+        );
+        $query->bindValue(':country', strtolower($country), PDO::PARAM_STR);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+    }
+
+    /**
+     * @param array<string, mixed> $player
+     */
+    private function handleInvalidApiResponse(array $player, int $workerId, Throwable $exception): void
+    {
+        $this->logger->log(
+            sprintf(
+                'Failed to scan %s because the PlayStation API returned an invalid response: %s',
+                (string) ($player['online_id'] ?? ''),
+                $exception->getMessage()
+            )
+        );
+
+        $this->workerScanCoordinator->deferPlayerScanAfterFailure($player, $workerId);
+    }
+
+    /**
+     * @param array<string, mixed> $player
+     */
+    private function handlePlayerNotFoundDuringProfileSync(array $player, Exception $exception): void
+    {
+        $query = $this->database->prepare('DELETE FROM player_queue WHERE online_id = :online_id');
+        $query->bindValue(':online_id', $player['online_id'], PDO::PARAM_STR);
+        $query->execute();
+
+        if ($exception instanceof NotFoundHttpException) {
+            $query = $this->database->prepare('SELECT account_id FROM player WHERE online_id = :online_id');
+            $query->bindValue(':online_id', $player['online_id'], PDO::PARAM_STR);
+            $query->execute();
+            $accountId = $query->fetchColumn();
+
+            if ($accountId) {
+                $this->logger->log(
+                    sprintf('Sony issues with %s (%s).', $player['online_id'], $accountId)
+                );
+
+                $query = $this->database->prepare(
+                    'UPDATE player SET `status` = 5, last_updated_date = NOW() WHERE account_id = :account_id'
+                );
+                $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+                $query->execute();
+            }
+        }
+    }
+
+    private function pauseBeforeRetryingInvalidApiResponse(int $workerId, string $onlineId): void
+    {
+        $this->workerScanCoordinator->setWaitingScanProgress(
+            $workerId,
+            sprintf(
+                'Encountered an invalid response from the PlayStation API while scanning %s. Waiting 1 minute before retrying.',
+                $onlineId
+            )
+        );
+
+        sleep(60);
+    }
+
+    private function determineStatusCode(Throwable $exception): ?int
+    {
+        $response = $this->findResponseFromThrowable($exception);
+
+        if ($response !== null) {
+            $status = $this->extractStatusCodeFromResponse($response);
+
+            if ($status !== null) {
+                return $status;
+            }
+        }
+
+        return $this->extractStatusCodeFromThrowable($exception);
+    }
+
+    private function findResponseFromThrowable(Throwable $exception): ?object
+    {
+        if (method_exists($exception, 'getResponse')) {
+            $response = $exception->getResponse();
+
+            if (is_object($response)) {
+                return $response;
+            }
+        }
+
+        $previous = $exception->getPrevious();
+
+        if ($previous instanceof Throwable) {
+            return $this->findResponseFromThrowable($previous);
+        }
+
+        return null;
+    }
+
+    private function extractStatusCodeFromResponse(object $response): ?int
+    {
+        if (method_exists($response, 'getStatusCode')) {
+            $statusCode = $response->getStatusCode();
+
+            if (is_int($statusCode)) {
+                return $statusCode;
+            }
+        }
+
+        if (method_exists($response, 'getStatus')) {
+            $status = $response->getStatus();
+
+            if (is_int($status)) {
+                return $status;
+            }
+        }
+
+        return null;
+    }
+
+    private function extractStatusCodeFromThrowable(Throwable $exception): ?int
+    {
+        $code = $exception->getCode();
+
+        if (is_int($code) && $code > 0) {
+            return $code;
+        }
+
+        $previous = $exception->getPrevious();
+
+        if ($previous instanceof Throwable) {
+            return $this->extractStatusCodeFromThrowable($previous);
+        }
+
+        return null;
+    }
+
+    private function normalizePlayerProfileResponse(mixed $profile): array
+    {
+        if (is_array($profile)) {
+            return $profile;
+        }
+
+        if (is_object($profile)) {
+            try {
+                $encoded = json_encode($profile, JSON_THROW_ON_ERROR);
+                $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
+
+                if (is_array($decoded)) {
+                    return $decoded;
+                }
+            } catch (JsonException) {
+                // Fall back to exposing public properties.
+            }
+
+            return get_object_vars($profile);
+        }
+
+        return [];
+    }
+}

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -18,6 +18,8 @@ require_once __DIR__ . '/../TrophyImageDownloader.php';
 require_once __DIR__ . '/WorkerScanCoordinator.php';
 require_once __DIR__ . '/PlayerScanQueueSelector.php';
 require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
+require_once __DIR__ . '/PlayerScanProfileSyncResult.php';
+require_once __DIR__ . '/PlayerScanProfileSynchronizer.php';
 require_once __DIR__ . '/../TrophyCatalogSynchronizer.php';
 require_once __DIR__ . '/../TrophyTitleNameFormatter.php';
 
@@ -41,6 +43,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
     private readonly PlayStationWorkerAuthenticator $workerAuthenticator;
     private readonly TrophyCatalogSynchronizer $trophyCatalogSynchronizer;
     private readonly PlayerScanTitleMetadataHelper $titleMetadataHelper;
+    private readonly PlayerScanProfileSynchronizer $profileSynchronizer;
 
     public function __construct(
         private readonly PDO $database,
@@ -60,6 +63,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         ?PlayStationWorkerAuthenticator $workerAuthenticator = null,
         ?TrophyCatalogSynchronizer $trophyCatalogSynchronizer = null,
         ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
+        ?PlayerScanProfileSynchronizer $profileSynchronizer = null,
     )
     {
         $this->trophyMetaRepository = $trophyMetaRepository ?? new TrophyMetaRepository($database);
@@ -86,6 +90,12 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         );
         $this->trophyCatalogSynchronizer = $trophyCatalogSynchronizer ?? new TrophyCatalogSynchronizer($database);
         $this->titleMetadataHelper = $titleMetadataHelper ?? new PlayerScanTitleMetadataHelper();
+        $this->profileSynchronizer = $profileSynchronizer ?? new PlayerScanProfileSynchronizer(
+            $database,
+            $this->imageHashCalculator,
+            $logger,
+            $this->workerScanCoordinator,
+        );
     }
 
     /**
@@ -380,297 +390,24 @@ final class ThirtyMinuteCronJob implements CronJobInterface
 
             $onlineId = (string) $player['online_id'];
 
-            $this->workerScanCoordinator->setWaitingScanProgress(
+            $profileSyncResult = $this->profileSynchronizer->synchronizeProfile(
+                $client,
+                $player,
                 (int) $worker['id'],
-                sprintf('Updating profile data for %s.', $onlineId)
+                $onlineId,
             );
 
-            $maxInvalidApiResponseAttempts = 2;
-
-            // Initialize the current player
-            for ($attempt = 1; $attempt <= $maxInvalidApiResponseAttempts; $attempt++) {
-                try {
-                    $originalOnlineId = (string) $player['online_id'];
-                    $existingAccountId = $this->normalizeAccountIdValue($player['account_id'] ?? null);
-                    $profileLookup = $this->lookupPlayerProfile($client, $originalOnlineId);
-                    $country = 'zz';
-
-                    if ($profileLookup !== null) {
-                        $profile = $profileLookup['profile'] ?? null;
-
-                        if (!is_array($profile)) {
-                            $this->markPlayerAsPrivate($originalOnlineId);
-                            continue 2;
-                        }
-
-                        $profileAccountId = $profile['accountId'] ?? null;
-
-                        if (!is_string($profileAccountId) || $profileAccountId === '') {
-                            $this->markPlayerAsPrivate($originalOnlineId);
-                            continue 2;
-                        }
-
-                        $resolvedOnlineId = $this->determineResolvedOnlineId($profile, $originalOnlineId);
-
-                        if ($resolvedOnlineId !== '' && strcasecmp($resolvedOnlineId, $originalOnlineId) !== 0) {
-                            $this->updateQueuedOnlineId((int) $worker['id'], $originalOnlineId, $resolvedOnlineId);
-                            $player['online_id'] = $resolvedOnlineId;
-                        } else {
-                            $player['online_id'] = $originalOnlineId;
-                        }
-
-                        $player['account_id'] = $profileAccountId;
-                        $user = $client->users()->find($profileAccountId);
-
-                        $countryFromProfile = $this->extractCountryFromNpId($profile['npId'] ?? null);
-                        $country = $countryFromProfile;
-
-                        if ($country === null || strtolower($country) === 'zz') {
-                            $storedCountry = $this->fetchStoredCountryByAccountId((int) $profileAccountId);
-
-                            if (is_string($storedCountry) && $storedCountry !== '') {
-                                $country = $storedCountry;
-                            } else {
-                                $country = 'zz';
-                            }
-
-                            if (strtolower($country) === 'zz') {
-                                $resolvedCountry = $this->findPlayerCountry($client, $user->onlineId());
-
-                                if ($resolvedCountry !== null) {
-                                    $country = $resolvedCountry;
-                                    $this->updatePlayerCountry((int) $profileAccountId, $resolvedCountry);
-                                }
-                            }
-                        } else {
-                            $this->updatePlayerCountry((int) $profileAccountId, $country);
-                        }
-                    } else {
-                        if ($existingAccountId === null) {
-                            $this->markPlayerAsPrivate($originalOnlineId);
-                            continue 2;
-                        }
-
-                        $player['account_id'] = $existingAccountId;
-                        $user = $client->users()->find($existingAccountId);
-
-                        $resolvedOnlineId = (string) $user->onlineId();
-
-                        if ($resolvedOnlineId !== '' && strcasecmp($resolvedOnlineId, $originalOnlineId) !== 0) {
-                            $this->updateQueuedOnlineId((int) $worker['id'], $originalOnlineId, $resolvedOnlineId);
-                            $player['online_id'] = $resolvedOnlineId;
-                        } else {
-                            $player['online_id'] = $originalOnlineId;
-                        }
-
-                        $storedCountry = $this->fetchStoredCountryByAccountId((int) $existingAccountId);
-
-                        if (is_string($storedCountry) && $storedCountry !== '') {
-                            $country = $storedCountry;
-                        }
-
-                        if (strtolower($country) === 'zz') {
-                            $resolvedCountry = $this->findPlayerCountry($client, $user->onlineId());
-
-                            if ($resolvedCountry !== null) {
-                                $country = $resolvedCountry;
-                                $this->updatePlayerCountry((int) $existingAccountId, $resolvedCountry);
-                            }
-                        }
-                    }
-
-                    if (!is_string($country) || $country === '') {
-                        $country = 'zz';
-                    }
-
-                    // To test for exception (and apparently collects/updates to new onlineId if changed).
-                    $user->aboutMe();
-
-                    if (strcasecmp($player['online_id'], $user->onlineId()) !== 0) {
-                        $this->updateQueuedOnlineId((int) $worker['id'], (string) $player['online_id'], $user->onlineId());
-                        $player['online_id'] = $user->onlineId();
-                    }
-
-                    break;
-                } catch (TypeError $exception) {
-                    if ($attempt < $maxInvalidApiResponseAttempts) {
-                        $this->pauseBeforeRetryingInvalidApiResponse((int) $worker['id'], $onlineId);
-
-                        continue;
-                    }
-
-                    $this->handleInvalidApiResponse($player, (int) $worker['id'], $exception);
-
-                    continue 2;
-                } catch (Exception $e) {
-                    // $e->getMessage() == "User not found", and another "Resource not found" error
-                    $query = $this->database->prepare("DELETE FROM player_queue
-                        WHERE  online_id = :online_id ");
-                    $query->bindValue(":online_id", $player["online_id"], PDO::PARAM_STR);
-                    $query->execute();
-
-                    if (get_class($e) == "Tustin\Haste\Exception\NotFoundHttpException") {
-                        $query = $this->database->prepare("SELECT account_id
-                            FROM   player
-                            WHERE  online_id = :online_id ");
-                        $query->bindValue(":online_id", $player["online_id"], PDO::PARAM_STR);
-                        $query->execute();
-                        $accountId = $query->fetchColumn();
-
-                        if ($accountId) {
-                            // Doesn't seem to exist on Sonys end anymore. Set to status = 5 and let an admin delete the player from our system later.
-                            $this->logger->log("Sony issues with ". $player["online_id"] ." (". $accountId .").");
-
-                            $query = $this->database->prepare("UPDATE player
-                                SET `status` = 5, last_updated_date = NOW()
-                                WHERE  account_id = :account_id ");
-                            $query->bindValue(":account_id", $accountId, PDO::PARAM_INT);
-                            $query->execute();
-                        }
-                    }
-
-                    continue 2;
-                } catch (Throwable $exception) {
-                    if ($attempt < $maxInvalidApiResponseAttempts) {
-                        $this->pauseBeforeRetryingInvalidApiResponse((int) $worker['id'], $onlineId);
-
-                        continue;
-                    }
-
-                    $this->handleInvalidApiResponse($player, (int) $worker['id'], $exception);
-
-                    continue 2;
-                }
-            }
-            $this->workerScanCoordinator->setWaitingScanProgress(
-                (int) $worker['id'],
-                sprintf('Updating avatar for %s.', $onlineId)
-            );
-
-            // Get the avatar url we want to save
-            $avatarUrls = $user->avatarUrls();
-            for ($i = 0; $i < 4; $i++) {
-                switch ($i) {
-                    case 0:
-                        $size = "xl";
-                        break;
-                    case 1:
-                        $size = "l";
-                        break;
-                    case 2:
-                        $size = "m";
-                        break;
-                    case 3:
-                        $size = "s";
-                        break;
-                }
-                $avatarUrl = $avatarUrls[$size];
-
-                // Check SQL
-                $query = $this->database->prepare("SELECT
-                        md5_hash,
-                        extension
-                    FROM
-                        psn100_avatars
-                    WHERE
-                        avatar_url = :avatar_url");
-                $query->bindValue(":avatar_url", $avatarUrl, PDO::PARAM_STR);
-                $query->execute();
-                $result = $query->fetch();
-
-                if (!$result) { // We doesn't seem to have this avatar
-                    $avatarContents = @file_get_contents($avatarUrl);
-                    if ($avatarContents === false) {
-                        // File not found. Try next.
-                        continue;
-                    }
-
-                    $newPHash = $this->imageHashCalculator->calculatePHash($avatarContents);
-                    if ($newPHash === null) {
-                        // Something went wrong with the image processing, skip saving this avatar.
-                        continue;
-                    }
-
-                    $query = $this->database->prepare("SELECT DISTINCT md5_hash FROM psn100_avatars");
-                    $query->execute();
-                    $existingPHashes = $query->fetchAll(PDO::FETCH_COLUMN);
-
-                    foreach ($existingPHashes as $existingPHash) {
-                        if ($this->imageHashCalculator->getHammingDistance($newPHash, $existingPHash) <= 10) {
-                            $newPHash = $existingPHash;
-                            break; 
-                        }
-                    }
-
-                    $extension = strtolower(pathinfo($avatarUrl, PATHINFO_EXTENSION));
-
-                    $avatarFilename = $newPHash .".". $extension;
-                    if (!file_exists("/home/psn100/public_html/img/avatar/". $avatarFilename)) {
-                        file_put_contents("/home/psn100/public_html/img/avatar/". $avatarFilename, $avatarContents);
-                    }
-
-                    // SQL Insert
-                    $query = $this->database->prepare("INSERT INTO psn100_avatars(
-                            size,
-                            avatar_url,
-                            md5_hash,
-                            extension
-                        )
-                        VALUES(
-                            :size,
-                            :avatar_url,
-                            :md5_hash,
-                            :extension
-                        )");
-                    $query->bindValue(":size", $size, PDO::PARAM_STR);
-                    $query->bindValue(":avatar_url", $avatarUrl, PDO::PARAM_STR);
-                    $query->bindValue(":md5_hash", $newPHash, PDO::PARAM_STR);
-                    $query->bindValue(":extension", $extension, PDO::PARAM_STR);
-                    $query->execute();
-                } else {
-                    $avatarFilename = $result["md5_hash"] .".". $result["extension"];
-                }
-
-                // We are done, no need to check other images.
-                break;
+            if ($profileSyncResult->shouldSkipPlayer()) {
+                continue;
             }
 
-            // Plus is null or 1, we don't want null so this will make it 0 if so.
-            $plus = (bool)$user->hasPlus();
+            $player = $profileSyncResult->player;
+            $user = $profileSyncResult->user;
+            $country = $profileSyncResult->country ?? 'zz';
 
-            // Add/update player into database
-            $query = $this->database->prepare("INSERT INTO
-                    player (
-                        account_id,
-                        online_id,
-                        country,
-                        avatar_url,
-                        plus,
-                        about_me
-                    )
-                VALUES
-                    (
-                        :account_id,
-                        :online_id,
-                        :country,
-                        :avatar_url,
-                        :plus,
-                        :about_me
-                    ) AS new ON DUPLICATE KEY
-                UPDATE
-                    online_id = new.online_id,
-                    avatar_url = new.avatar_url,
-                    plus = new.plus,
-                    about_me = new.about_me
-            ");
-            $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-            $query->bindValue(":online_id", $user->onlineId(), PDO::PARAM_STR);
-            $query->bindValue(":country", strtolower($country), PDO::PARAM_STR);
-            $query->bindValue(":avatar_url", $avatarFilename, PDO::PARAM_STR);
-            $query->bindValue(":plus", $plus, PDO::PARAM_BOOL);
-            $query->bindValue(":about_me", $user->aboutMe(), PDO::PARAM_STR);
-            // Don't insert level/progress/platinum/gold/silver/bronze here since our site recalculate this.
-            $query->execute();
+            if ($user === null) {
+                continue;
+            }
 
             try {
                 $level = 0;
@@ -1913,303 +1650,6 @@ final class ThirtyMinuteCronJob implements CronJobInterface
     {
         return $exception->getCode() === '40001'
             || (($exception->errorInfo[1] ?? null) === 1213);
-    }
-
-    private function lookupPlayerProfile(Client $client, string $onlineId): ?array
-    {
-        $path = sprintf(
-            'https://us-prof.np.community.playstation.net/userProfile/v1/users/%s/profile2',
-            rawurlencode($onlineId)
-        );
-
-        $query = [
-            'fields' => 'accountId,onlineId,currentOnlineId,npId',
-        ];
-
-        try {
-            $profile = $client->get($path, $query, ['content-type' => 'application/json']);
-        } catch (Throwable $exception) {
-            if ($this->determineStatusCode($exception) === 404) {
-                return null;
-            }
-
-            throw $exception;
-        }
-
-        $normalized = $this->normalizePlayerProfileResponse($profile);
-
-        return is_array($normalized) ? $normalized : null;
-    }
-
-    /**
-     * @param array<string, mixed> $profile
-     */
-    private function determineResolvedOnlineId(array $profile, string $fallbackOnlineId): string
-    {
-        $currentOnlineId = $profile['currentOnlineId'] ?? null;
-        if (is_string($currentOnlineId) && $currentOnlineId !== '') {
-            return $currentOnlineId;
-        }
-
-        $onlineId = $profile['onlineId'] ?? null;
-        if (is_string($onlineId) && $onlineId !== '') {
-            return $onlineId;
-        }
-
-        return $fallbackOnlineId;
-    }
-
-    private function extractCountryFromNpId(mixed $npId): ?string
-    {
-        if (!is_string($npId) || $npId === '') {
-            return null;
-        }
-
-        $decoded = base64_decode($npId, true);
-        if ($decoded === false || $decoded === '') {
-            return null;
-        }
-
-        $trimmed = trim($decoded);
-        if ($trimmed === '') {
-            return null;
-        }
-
-        if (strlen($trimmed) < 2) {
-            return null;
-        }
-
-        return strtolower(substr($trimmed, -2));
-    }
-
-    private function markPlayerAsPrivate(string $onlineId): void
-    {
-        $query = $this->database->prepare(
-            'UPDATE
-                player
-            SET
-                `status` = 3,
-                last_updated_date = NOW()
-            WHERE
-                online_id = :online_id
-                AND `status` != 1'
-        );
-        $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
-        $query->execute();
-
-        $query = $this->database->prepare(
-            'DELETE FROM player_queue WHERE online_id = :online_id'
-        );
-        $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
-        $query->execute();
-    }
-
-    private function updateQueuedOnlineId(int $workerId, string $previousOnlineId, string $newOnlineId): void
-    {
-        $query = $this->database->prepare(
-            'UPDATE player_queue SET online_id = :online_id_new WHERE online_id = :online_id_old'
-        );
-        $query->bindValue(':online_id_new', $newOnlineId, PDO::PARAM_STR);
-        $query->bindValue(':online_id_old', $previousOnlineId, PDO::PARAM_STR);
-        $query->execute();
-
-        $query = $this->database->prepare(
-            'UPDATE setting SET scanning = :scanning, scan_progress = NULL WHERE id = :worker_id'
-        );
-        $query->bindValue(':scanning', $newOnlineId, PDO::PARAM_STR);
-        $query->bindValue(':worker_id', $workerId, PDO::PARAM_INT);
-        $query->execute();
-    }
-
-    /**
-     * @param mixed $accountId
-     */
-    private function normalizeAccountIdValue($accountId): ?string
-    {
-        if (is_int($accountId)) {
-            return (string) $accountId;
-        }
-
-        if (is_string($accountId)) {
-            $trimmed = trim($accountId);
-
-            if ($trimmed === '') {
-                return null;
-            }
-
-            return ctype_digit($trimmed) ? $trimmed : null;
-        }
-
-        if (is_float($accountId)) {
-            return (string) (int) $accountId;
-        }
-
-        if (is_numeric($accountId)) {
-            $numeric = (string) $accountId;
-
-            return ctype_digit($numeric) ? $numeric : null;
-        }
-
-        return null;
-    }
-
-    private function fetchStoredCountryByAccountId(int $accountId): ?string
-    {
-        $query = $this->database->prepare(
-            'SELECT country FROM player WHERE account_id = :account_id'
-        );
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
-        $query->execute();
-
-        $country = $query->fetchColumn();
-
-        if (!is_string($country) || $country === '') {
-            return null;
-        }
-
-        return $country;
-    }
-
-    private function determineStatusCode(Throwable $exception): ?int
-    {
-        $response = $this->findResponseFromThrowable($exception);
-
-        if ($response !== null) {
-            $status = $this->extractStatusCodeFromResponse($response);
-
-            if ($status !== null) {
-                return $status;
-            }
-        }
-
-        return $this->extractStatusCodeFromThrowable($exception);
-    }
-
-    private function findResponseFromThrowable(Throwable $exception): ?object
-    {
-        if (method_exists($exception, 'getResponse')) {
-            $response = $exception->getResponse();
-
-            if (is_object($response)) {
-                return $response;
-            }
-        }
-
-        $previous = $exception->getPrevious();
-
-        if ($previous instanceof Throwable) {
-            return $this->findResponseFromThrowable($previous);
-        }
-
-        return null;
-    }
-
-    private function extractStatusCodeFromResponse(object $response): ?int
-    {
-        if (method_exists($response, 'getStatusCode')) {
-            $statusCode = $response->getStatusCode();
-
-            if (is_int($statusCode)) {
-                return $statusCode;
-            }
-        }
-
-        if (method_exists($response, 'getStatus')) {
-            $status = $response->getStatus();
-
-            if (is_int($status)) {
-                return $status;
-            }
-        }
-
-        return null;
-    }
-
-    private function extractStatusCodeFromThrowable(Throwable $exception): ?int
-    {
-        $code = $exception->getCode();
-
-        if (is_int($code) && $code > 0) {
-            return $code;
-        }
-
-        $previous = $exception->getPrevious();
-
-        if ($previous instanceof Throwable) {
-            return $this->extractStatusCodeFromThrowable($previous);
-        }
-
-        return null;
-    }
-
-    private function normalizePlayerProfileResponse(mixed $profile): array
-    {
-        if (is_array($profile)) {
-            return $profile;
-        }
-
-        if (is_object($profile)) {
-            try {
-                $encoded = json_encode($profile, JSON_THROW_ON_ERROR);
-                $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
-
-                if (is_array($decoded)) {
-                    return $decoded;
-                }
-            } catch (JsonException) {
-                // Fall back to exposing public properties.
-            }
-
-            return get_object_vars($profile);
-        }
-
-        return [];
-    }
-
-    private function findPlayerCountry(Client $client, string $onlineId): ?string
-    {
-        $normalizedOnlineId = strtolower($onlineId);
-        $userCounter = 0;
-
-        try {
-            foreach ($client->users()->search($onlineId) as $result) {
-                if (strtolower($result->onlineId()) === $normalizedOnlineId) {
-                    $country = $result->country();
-
-                    if (!is_string($country) || $country === '') {
-                        return null;
-                    }
-
-                    $normalizedCountry = strtolower($country);
-
-                    if ($normalizedCountry === 'zz') {
-                        return null;
-                    }
-
-                    return $normalizedCountry;
-                }
-
-                $userCounter++;
-
-                if ($userCounter >= 50) {
-                    break;
-                }
-            }
-        } catch (Throwable) {
-            return null;
-        }
-
-        return null;
-    }
-
-    private function updatePlayerCountry(int $accountId, string $country): void
-    {
-        $query = $this->database->prepare(
-            'UPDATE player SET country = :country WHERE account_id = :account_id'
-        );
-        $query->bindValue(':country', strtolower($country), PDO::PARAM_STR);
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
-        $query->execute();
     }
 
     private function findTrophyTitleId(string $npCommunicationId): ?int


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels player profile synchronization out of `ThirtyMinuteCronJob` — the largest god class in the codebase (~2,235 lines). This follows the same incremental extraction pattern used for `WorkerScanCoordinator`, `PlayerScanQueueSelector`, and `PlayerScanTitleMetadataHelper`.

**Extracted concern:** PSN profile lookup, online-ID resolution, country detection, avatar caching, and player row upsert.

## Changes

- Added `PlayerScanProfileSynchronizer` to own profile resolution, avatar download/hash, and `player` table upsert during scans.
- Added `PlayerScanProfileSyncResult` value object for scan-loop control flow (`success` vs `skip_player`).
- `ThirtyMinuteCronJob` now delegates profile sync via a single `synchronizeProfile()` call and drops ~560 lines of inline logic.
- Added `PlayerScanProfileSynchronizerTest` covering the pure helper methods (`determineResolvedOnlineId`, `extractCountryFromNpId`, `normalizeAccountIdValue`).

## Line counts

| File | Before | After |
|------|--------|-------|
| `ThirtyMinuteCronJob.php` | 2,235 | 1,675 |
| `PlayerScanProfileSynchronizer.php` | — | 669 |

## Testing

- `php tests/run.php` — all 666 tests pass.

## Follow-up candidates (future PRs)

Other god-class extractions identified but intentionally deferred:

1. **Externalize `PossibleCheaterService` rule data** (~1,400 lines of SQL config)
2. **Extract `TrophyMergeMappingService`** from `TrophyMergeService`
3. **Introduce `GameCopyRepository`** from `GameCopyService`
4. **Pull PSN API adapters** out of `GameRescanService`
5. **Share trophy catalog upsert** between cron and rescan paths
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c255528-5937-480a-8c20-510411a62239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c255528-5937-480a-8c20-510411a62239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

