### PR TITLE
Extract post-scan player completion from ThirtyMinuteCronJob

### DIFF
--- a/tests/PlayerScanCompletionServiceTest.php
+++ b/tests/PlayerScanCompletionServiceTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanCompletionResult.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanCompletionService.php';
+
+final class PlayerScanCompletionServiceTest extends TestCase
+{
+    private PDO $database;
+
+    private PlayerScanCompletionService $service;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec(
+            'CREATE TABLE player (
+                account_id INTEGER PRIMARY KEY,
+                bronze INTEGER NOT NULL DEFAULT 0,
+                silver INTEGER NOT NULL DEFAULT 0,
+                gold INTEGER NOT NULL DEFAULT 0,
+                platinum INTEGER NOT NULL DEFAULT 0,
+                level INTEGER NOT NULL DEFAULT 0,
+                progress INTEGER NOT NULL DEFAULT 0,
+                points INTEGER NOT NULL DEFAULT 0,
+                status INTEGER NOT NULL DEFAULT 0,
+                trophy_count_npwr INTEGER NOT NULL DEFAULT 0,
+                trophy_count_sony INTEGER NOT NULL DEFAULT 0,
+                rarity_points INTEGER NOT NULL DEFAULT 0,
+                common INTEGER NOT NULL DEFAULT 0,
+                uncommon INTEGER NOT NULL DEFAULT 0,
+                rare INTEGER NOT NULL DEFAULT 0,
+                epic INTEGER NOT NULL DEFAULT 0,
+                legendary INTEGER NOT NULL DEFAULT 0,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
+                in_game_common INTEGER NOT NULL DEFAULT 0,
+                in_game_uncommon INTEGER NOT NULL DEFAULT 0,
+                in_game_rare INTEGER NOT NULL DEFAULT 0,
+                in_game_epic INTEGER NOT NULL DEFAULT 0,
+                in_game_legendary INTEGER NOT NULL DEFAULT 0
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_title (
+                id INTEGER PRIMARY KEY,
+                np_communication_id TEXT NOT NULL UNIQUE
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                status INTEGER NOT NULL DEFAULT 0
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_title_player (
+                account_id INTEGER NOT NULL,
+                np_communication_id TEXT NOT NULL,
+                bronze INTEGER NOT NULL DEFAULT 0,
+                silver INTEGER NOT NULL DEFAULT 0,
+                gold INTEGER NOT NULL DEFAULT 0,
+                platinum INTEGER NOT NULL DEFAULT 0,
+                last_updated_date TEXT,
+                rarity_points INTEGER NOT NULL DEFAULT 0,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
+                common INTEGER NOT NULL DEFAULT 0,
+                uncommon INTEGER NOT NULL DEFAULT 0,
+                rare INTEGER NOT NULL DEFAULT 0,
+                epic INTEGER NOT NULL DEFAULT 0,
+                legendary INTEGER NOT NULL DEFAULT 0,
+                in_game_common INTEGER NOT NULL DEFAULT 0,
+                in_game_uncommon INTEGER NOT NULL DEFAULT 0,
+                in_game_rare INTEGER NOT NULL DEFAULT 0,
+                in_game_epic INTEGER NOT NULL DEFAULT 0,
+                in_game_legendary INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (account_id, np_communication_id)
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_earned (
+                account_id INTEGER NOT NULL,
+                np_communication_id TEXT NOT NULL,
+                order_id INTEGER NOT NULL,
+                earned INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (account_id, np_communication_id, order_id)
+            )'
+        );
+
+        $this->service = new PlayerScanCompletionService($this->database);
+    }
+
+    public function testCalculateLevelAndProgressUsesFirstTierFormula(): void
+    {
+        $result = $this->service->calculateLevelAndProgress(120);
+
+        $this->assertSame(3, $result['level']);
+        $this->assertSame(0, $result['progress']);
+    }
+
+    public function testCalculateLevelAndProgressUsesSecondTierFormula(): void
+    {
+        $result = $this->service->calculateLevelAndProgress(6030);
+
+        $this->assertSame(101, $result['level']);
+        $this->assertSame(0, $result['progress']);
+    }
+
+    public function testCalculateLevelAndProgressUsesThirdTierFormula(): void
+    {
+        $result = $this->service->calculateLevelAndProgress(20000);
+
+        $this->assertSame(211, $result['level']);
+        $this->assertSame(24, $result['progress']);
+    }
+
+    public function testRecalculatePlayerTrophyStatsAndStatusRequestsRescanWhenNpwrCountExceedsSonyTotal(): void
+    {
+        $this->seedActiveTitle('NPWR00003_00');
+        $this->database->exec("INSERT INTO player (account_id, status, trophy_count_npwr) VALUES (9, 0, 10)");
+        $this->database->exec(
+            "INSERT INTO trophy_title_player (
+                account_id, np_communication_id, bronze, last_updated_date
+            ) VALUES (9, 'NPWR00003_00', 1, datetime('now'))"
+        );
+        $this->database->exec(
+            "INSERT INTO trophy_earned (account_id, np_communication_id, order_id, earned)
+            VALUES (9, 'NPWR00003_00', 1, 1)"
+        );
+
+        $result = $this->service->recalculatePlayerTrophyStatsAndStatus(9, 5, 'recheck');
+
+        $this->assertTrue($result->shouldContinueScan());
+        $npwrCount = $this->database->query('SELECT trophy_count_npwr FROM player WHERE account_id = 9')->fetchColumn();
+        $this->assertSame(1, (int) $npwrCount);
+    }
+
+    public function testRecalculatePlayerTrophyStatsAndStatusRequestsRescanForHiddenTrophies(): void
+    {
+        $this->seedActiveTitle('NPWR00003_00');
+        $this->database->exec("INSERT INTO player (account_id, status, trophy_count_npwr) VALUES (9, 0, 1)");
+        $this->database->exec(
+            "INSERT INTO trophy_title_player (
+                account_id, np_communication_id, bronze, last_updated_date
+            ) VALUES (9, 'NPWR00003_00', 1, datetime('now'))"
+        );
+
+        $result = $this->service->recalculatePlayerTrophyStatsAndStatus(9, 5, 'recheck');
+
+        $this->assertTrue($result->shouldContinueScan());
+    }
+
+    public function testServiceSourceRetainsMysqlSpecificInactiveStatusQuery(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/PlayerScanCompletionService.php');
+
+        $this->assertStringContainsString('INTERVAL 1 YEAR', $source);
+        $this->assertStringContainsString('AND p.status != 1', $source);
+    }
+
+    public function testUpdateRarityPointsForActivePlayerSkipsNonActiveStatuses(): void
+    {
+        $this->database->exec("INSERT INTO player (account_id, status, rarity_points) VALUES (15, 1, 0)");
+
+        $this->service->updateRarityPointsForActivePlayer(15);
+
+        $rarityPoints = $this->database->query('SELECT rarity_points FROM player WHERE account_id = 15')->fetchColumn();
+        $this->assertSame(0, (int) $rarityPoints);
+    }
+
+    private function seedActiveTitle(string $npCommunicationId): void
+    {
+        $this->database->exec("INSERT INTO trophy_title (id, np_communication_id) VALUES (1, '{$npCommunicationId}')");
+        $this->database->exec("INSERT INTO trophy_title_meta (np_communication_id, status) VALUES ('{$npCommunicationId}', 0)");
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanCompletionResult.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Outcome of post-scan player aggregation during a worker scan.
+ */
+final class PlayerScanCompletionResult
+{
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_CONTINUE_SCAN = 'continue_scan';
+
+    private function __construct(public readonly string $status)
+    {
+    }
+
+    public static function completed(): self
+    {
+        return new self(self::STATUS_COMPLETED);
+    }
+
+    public static function continueScan(): self
+    {
+        return new self(self::STATUS_CONTINUE_SCAN);
+    }
+
+    public function shouldContinueScan(): bool
+    {
+        return $this->status === self::STATUS_CONTINUE_SCAN;
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanCompletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionService.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Recalculates player trophy totals, PSN level/progress, status, and rarity rollups
+ * after a scan completes.
+ *
+ * Encapsulates post-scan aggregation that was previously embedded in ThirtyMinuteCronJob.
+ */
+final class PlayerScanCompletionService
+{
+    public function __construct(private readonly PDO $database)
+    {
+    }
+
+    /**
+     * @return array{level: int, progress: int}
+     */
+    public function calculateLevelAndProgress(int $points): array
+    {
+        if ($points <= 5940) {
+            return [
+                'level' => (int) floor($points / 60) + 1,
+                'progress' => (int) (floor($points / 60 * 100) % 100),
+            ];
+        }
+
+        if ($points <= 14940) {
+            return [
+                'level' => (int) floor(($points - 5940) / 90) + 100,
+                'progress' => (int) (floor(($points - 5940) / 90 * 100) % 100),
+            ];
+        }
+
+        $stage = 1;
+        $leftovers = $points - 14940;
+        while ($leftovers > 45000 * $stage) {
+            $leftovers -= 45000 * $stage;
+            $stage++;
+        }
+
+        return [
+            'level' => (int) floor($leftovers / (450 * $stage)) + (100 + 100 * $stage),
+            'progress' => (int) (floor($leftovers / (450 * $stage) * 100) % 100),
+        ];
+    }
+
+    public function recalculatePlayerTrophyStatsAndStatus(
+        int $accountId,
+        int $totalTrophiesSony,
+        string $recheck,
+    ): PlayerScanCompletionResult {
+        $query = $this->database->prepare("SELECT Ifnull(Sum(ttp.bronze), 0)   AS bronze,
+                Ifnull(Sum(ttp.silver), 0)   AS silver,
+                Ifnull(Sum(ttp.gold), 0)     AS gold,
+                Ifnull(Sum(ttp.platinum), 0) AS platinum
+            FROM   trophy_title_player ttp
+                JOIN trophy_title tt USING (np_communication_id)
+                JOIN trophy_title_meta ttm USING (np_communication_id)
+            WHERE  ttm.status = 0
+                AND ttp.account_id = :account_id ");
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+        $trophies = $query->fetch();
+        $points = $trophies['bronze'] * 15
+            + $trophies['silver'] * 30
+            + $trophies['gold'] * 90
+            + $trophies['platinum'] * 300;
+        $levelAndProgress = $this->calculateLevelAndProgress($points);
+
+        $query = $this->database->prepare("UPDATE player
+            SET    bronze = :bronze,
+                silver = :silver,
+                gold = :gold,
+                platinum = :platinum,
+                level = :level,
+                progress = :progress,
+                points = :points
+            WHERE  account_id = :account_id ");
+        $query->bindValue(':bronze', $trophies['bronze'], PDO::PARAM_INT);
+        $query->bindValue(':silver', $trophies['silver'], PDO::PARAM_INT);
+        $query->bindValue(':gold', $trophies['gold'], PDO::PARAM_INT);
+        $query->bindValue(':platinum', $trophies['platinum'], PDO::PARAM_INT);
+        $query->bindValue(':level', $levelAndProgress['level'], PDO::PARAM_INT);
+        $query->bindValue(':progress', $levelAndProgress['progress'], PDO::PARAM_INT);
+        $query->bindValue(':points', $points, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+
+        $playerStatus = 0;
+
+        $query = $this->database->prepare('SELECT trophy_count_npwr FROM player WHERE account_id = :account_id');
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+        $ourTotalTrophies = $query->fetchColumn();
+
+        if ($ourTotalTrophies > $totalTrophiesSony) {
+            $query = $this->database->prepare("UPDATE `player` SET trophy_count_npwr = (SELECT COUNT(*) FROM `trophy_earned` WHERE account_id = :account_id AND earned = 1 AND np_communication_id LIKE 'N%') WHERE account_id = :account_id");
+            $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+            $query->execute();
+
+            $query = $this->database->prepare('SELECT trophy_count_npwr FROM player WHERE account_id = :account_id');
+            $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+            $query->execute();
+            $ourTotalTrophies = $query->fetchColumn();
+
+            if ($recheck !== '') {
+                return PlayerScanCompletionResult::continueScan();
+            }
+        }
+
+        if ($ourTotalTrophies < $totalTrophiesSony && $recheck !== '') {
+            return PlayerScanCompletionResult::continueScan();
+        }
+
+        $query = $this->database->prepare("SELECT
+                IF(
+                MAX(last_updated_date) >= DATE(NOW()) - INTERVAL 1 YEAR,
+                TRUE,
+                FALSE
+                ) AS within_a_year
+            FROM
+                `trophy_title_player`
+            WHERE
+                account_id = :account_id
+            ");
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+        $withinAYear = $query->fetchColumn();
+        if ($withinAYear == 0) {
+            $playerStatus = 4;
+        }
+
+        $query = $this->database->prepare("UPDATE
+                player p
+            SET
+                p.status = :status,
+                p.trophy_count_sony = :trophy_count_sony
+            WHERE
+                p.account_id = :account_id
+                AND p.status != 1
+            ");
+        $query->bindValue(':status', $playerStatus, PDO::PARAM_INT);
+        $query->bindValue(':trophy_count_sony', $totalTrophiesSony, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+
+        return PlayerScanCompletionResult::completed();
+    }
+
+    public function updateRarityPointsForActivePlayer(int $accountId): void
+    {
+        $query = $this->database->prepare('SELECT
+                p.status
+            FROM
+                player p
+            WHERE
+                p.account_id = :account_id');
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->execute();
+        $playerStatus = $query->fetchColumn();
+
+        if ($playerStatus != 0) {
+            return;
+        }
+
+        $this->executeWithDeadlockRetry(function () use ($accountId): void {
+            $query = $this->database->prepare("WITH
+                    rarity AS(
+                    SELECT
+                        trophy_earned.np_communication_id,
+                        SUM(tm.rarity_point) AS points,
+                        SUM(tm.in_game_rarity_point) AS in_game_points,
+                        SUM(tm.rarity_name = 'COMMON') common,
+                        SUM(tm.rarity_name = 'UNCOMMON') uncommon,
+                        SUM(tm.rarity_name = 'RARE') rare,
+                        SUM(tm.rarity_name = 'EPIC') epic,
+                        SUM(tm.rarity_name = 'LEGENDARY') legendary,
+                        SUM(tm.in_game_rarity_name = 'COMMON') in_game_common,
+                        SUM(tm.in_game_rarity_name = 'UNCOMMON') in_game_uncommon,
+                        SUM(tm.in_game_rarity_name = 'RARE') in_game_rare,
+                        SUM(tm.in_game_rarity_name = 'EPIC') in_game_epic,
+                        SUM(tm.in_game_rarity_name = 'LEGENDARY') in_game_legendary
+                    FROM
+                        trophy_earned
+                    JOIN trophy t ON t.np_communication_id = trophy_earned.np_communication_id
+                        AND t.order_id = trophy_earned.order_id
+                    JOIN trophy_meta tm ON tm.trophy_id = t.id
+                    WHERE
+                        trophy_earned.account_id = :account_id AND trophy_earned.earned = 1
+                    GROUP BY
+                        trophy_earned.np_communication_id
+                    ORDER BY NULL
+                )
+                UPDATE
+                    trophy_title_player ttp,
+                    rarity
+                SET
+                    ttp.rarity_points = rarity.points,
+                    ttp.in_game_rarity_points = rarity.in_game_points,
+                    ttp.common = rarity.common,
+                    ttp.uncommon = rarity.uncommon,
+                    ttp.rare = rarity.rare,
+                    ttp.epic = rarity.epic,
+                    ttp.legendary = rarity.legendary,
+                    ttp.in_game_common = rarity.in_game_common,
+                    ttp.in_game_uncommon = rarity.in_game_uncommon,
+                    ttp.in_game_rare = rarity.in_game_rare,
+                    ttp.in_game_epic = rarity.in_game_epic,
+                    ttp.in_game_legendary = rarity.in_game_legendary
+                WHERE
+                    ttp.account_id = :account_id AND ttp.np_communication_id = rarity.np_communication_id");
+            $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+            $query->execute();
+
+            $query = $this->database->prepare("WITH
+                    rarity AS(
+                    SELECT
+                        IFNULL(SUM(rarity_points), 0) AS rarity_points,
+                        IFNULL(SUM(common), 0) AS common,
+                        IFNULL(SUM(uncommon), 0) AS uncommon,
+                        IFNULL(SUM(rare), 0) AS rare,
+                        IFNULL(SUM(epic), 0) AS epic,
+                        IFNULL(SUM(legendary), 0) AS legendary,
+                        IFNULL(SUM(in_game_rarity_points), 0) AS in_game_rarity_points,
+                        IFNULL(SUM(in_game_common), 0) AS in_game_common,
+                        IFNULL(SUM(in_game_uncommon), 0) AS in_game_uncommon,
+                        IFNULL(SUM(in_game_rare), 0) AS in_game_rare,
+                        IFNULL(SUM(in_game_epic), 0) AS in_game_epic,
+                        IFNULL(SUM(in_game_legendary), 0) AS in_game_legendary
+                    FROM
+                        trophy_title_player
+                    WHERE
+                        account_id = :account_id
+                    ORDER BY NULL
+                )
+                UPDATE
+                    player p,
+                    rarity
+                SET
+                    p.rarity_points = rarity.rarity_points,
+                    p.common = rarity.common,
+                    p.uncommon = rarity.uncommon,
+                    p.rare = rarity.rare,
+                    p.epic = rarity.epic,
+                    p.legendary = rarity.legendary,
+                    p.in_game_rarity_points = rarity.in_game_rarity_points,
+                    p.in_game_common = rarity.in_game_common,
+                    p.in_game_uncommon = rarity.in_game_uncommon,
+                    p.in_game_rare = rarity.in_game_rare,
+                    p.in_game_epic = rarity.in_game_epic,
+                    p.in_game_legendary = rarity.in_game_legendary
+                WHERE
+                    p.account_id = :account_id AND p.status = 0");
+            $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+            $query->execute();
+        });
+    }
+
+    /**
+     * @param callable(): void $operation
+     */
+    private function executeWithDeadlockRetry(callable $operation, int $maxAttempts = 3): void
+    {
+        $attempt = 0;
+
+        while (true) {
+            try {
+                $operation();
+                return;
+            } catch (PDOException $exception) {
+                if (!$this->isDeadlockException($exception) || $attempt >= $maxAttempts) {
+                    throw $exception;
+                }
+
+                $attempt++;
+                usleep(200000);
+            }
+        }
+    }
+
+    private function isDeadlockException(PDOException $exception): bool
+    {
+        return $exception->getCode() === '40001'
+            || (($exception->errorInfo[1] ?? null) === 1213);
+    }
+}

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -20,6 +20,8 @@ require_once __DIR__ . '/PlayerScanQueueSelector.php';
 require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
 require_once __DIR__ . '/PlayerScanProfileSyncResult.php';
 require_once __DIR__ . '/PlayerScanProfileSynchronizer.php';
+require_once __DIR__ . '/PlayerScanCompletionResult.php';
+require_once __DIR__ . '/PlayerScanCompletionService.php';
 require_once __DIR__ . '/../TrophyCatalogSynchronizer.php';
 require_once __DIR__ . '/../TrophyTitleNameFormatter.php';
 
@@ -44,6 +46,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
     private readonly TrophyCatalogSynchronizer $trophyCatalogSynchronizer;
     private readonly PlayerScanTitleMetadataHelper $titleMetadataHelper;
     private readonly PlayerScanProfileSynchronizer $profileSynchronizer;
+    private readonly PlayerScanCompletionService $scanCompletionService;
 
     public function __construct(
         private readonly PDO $database,
@@ -64,6 +67,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         ?TrophyCatalogSynchronizer $trophyCatalogSynchronizer = null,
         ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
         ?PlayerScanProfileSynchronizer $profileSynchronizer = null,
+        ?PlayerScanCompletionService $scanCompletionService = null,
     )
     {
         $this->trophyMetaRepository = $trophyMetaRepository ?? new TrophyMetaRepository($database);
@@ -96,6 +100,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             $logger,
             $this->workerScanCoordinator,
         );
+        $this->scanCompletionService = $scanCompletionService ?? new PlayerScanCompletionService($database);
     }
 
     /**
@@ -1360,226 +1365,18 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                             ));
                         }
 
-                        // Recalculate trophy count, level & progress for the player
-                        $query = $this->database->prepare("SELECT Ifnull(Sum(ttp.bronze), 0)   AS bronze,
-                                Ifnull(Sum(ttp.silver), 0)   AS silver,
-                                Ifnull(Sum(ttp.gold), 0)     AS gold,
-                                Ifnull(Sum(ttp.platinum), 0) AS platinum
-                            FROM   trophy_title_player ttp
-                                JOIN trophy_title tt USING (np_communication_id)
-                                JOIN trophy_title_meta ttm USING (np_communication_id)
-                            WHERE  ttm.status = 0
-                                AND ttp.account_id = :account_id ");
-                        $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                        $query->execute();
-                        $trophies = $query->fetch();
-                        $points = $trophies["bronze"]*15 + $trophies["silver"]*30 + $trophies["gold"]*90 + $trophies["platinum"]*300;
-                        if ($points <= 5940) {
-                            $level = floor($points / 60) + 1;
-                            $progress = floor($points / 60 * 100) % 100;
-                        } elseif ($points <= 14940) {
-                            $level = floor(($points - 5940) / 90) + 100;
-                            $progress = floor(($points - 5940) / 90 * 100) % 100;
-                        } else {
-                            $stage = 1;
-                            $leftovers = $points - 14940;
-                            while ($leftovers > 45000 * $stage) {
-                                $leftovers -= 45000 * $stage;
-                                $stage++;
-                            }
+                        $completionResult = $this->scanCompletionService->recalculatePlayerTrophyStatsAndStatus(
+                            (int) $user->accountId(),
+                            $totalTrophiesStart,
+                            $recheck,
+                        );
 
-                            $level = floor($leftovers / (450 * $stage)) + (100 + 100 * $stage);
-                            $progress = floor($leftovers / (450 * $stage) * 100) % 100;
+                        if ($completionResult->shouldContinueScan()) {
+                            continue;
                         }
-
-                        $query = $this->database->prepare("UPDATE player
-                            SET    bronze = :bronze,
-                                silver = :silver,
-                                gold = :gold,
-                                platinum = :platinum,
-                                level = :level,
-                                progress = :progress,
-                                points = :points
-                            WHERE  account_id = :account_id ");
-                        $query->bindValue(":bronze", $trophies["bronze"], PDO::PARAM_INT);
-                        $query->bindValue(":silver", $trophies["silver"], PDO::PARAM_INT);
-                        $query->bindValue(":gold", $trophies["gold"], PDO::PARAM_INT);
-                        $query->bindValue(":platinum", $trophies["platinum"], PDO::PARAM_INT);
-                        $query->bindValue(":level", $level, PDO::PARAM_INT);
-                        $query->bindValue(":progress", $progress, PDO::PARAM_INT);
-                        $query->bindValue(":points", $points, PDO::PARAM_INT);
-                        $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                        $query->execute();
-
-                        // Set player status if not a cheater
-                        $playerStatus = 0;
-
-                        // Check for hidden trophies
-                        $query = $this->database->prepare("SELECT trophy_count_npwr FROM player WHERE account_id = :account_id");
-                        $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                        $query->execute();
-                        $ourTotalTrophies = $query->fetchColumn();
-
-                        if ($ourTotalTrophies > $totalTrophiesStart) { // This should never happen, but just in case... Something has gone terrible wrong...
-                            $query = $this->database->prepare("UPDATE `player` SET trophy_count_npwr = (SELECT COUNT(*) FROM `trophy_earned` WHERE account_id = :account_id AND earned = 1 AND np_communication_id LIKE 'N%') WHERE account_id = :account_id");
-                            $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                            $query->execute();
-
-                            $query = $this->database->prepare("SELECT trophy_count_npwr FROM player WHERE account_id = :account_id");
-                            $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                            $query->execute();
-                            $ourTotalTrophies = $query->fetchColumn();
-
-                            if (!empty($recheck)) { // Do one more scan from the beginning just to be sure.
-                                continue;
-                            }
-                        }
-
-                        if ($ourTotalTrophies < $totalTrophiesStart) {
-                            if (!empty($recheck)) { // User seems to have hidden trophies, do one more scan from the beginning just to be sure.
-                                continue;
-                            }
-                        }
-
-                        // Check for inactive
-                        $query = $this->database->prepare("SELECT
-                                IF(
-                                MAX(last_updated_date) >= DATE(NOW()) - INTERVAL 1 YEAR,
-                                TRUE,
-                                FALSE
-                                ) AS within_a_year
-                            FROM
-                                `trophy_title_player`
-                            WHERE
-                                account_id = :account_id
-                            ");
-                        $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                        $query->execute();
-                        $withinAYear = $query->fetchColumn();
-                        if ($withinAYear == 0) {
-                            $playerStatus = 4;
-                        }
-
-                        $query = $this->database->prepare("UPDATE
-                                player p
-                            SET
-                                p.status = :status,
-                                p.trophy_count_sony = :trophy_count_sony
-                            WHERE
-                                p.account_id = :account_id
-                                AND p.status != 1
-                            ");
-                        $query->bindValue(":status", $playerStatus, PDO::PARAM_INT);
-                        $query->bindValue(":trophy_count_sony", $totalTrophiesStart, PDO::PARAM_INT);
-                        $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                        $query->execute();
                     }
 
-                    $query = $this->database->prepare("SELECT
-                            p.status
-                        FROM
-                            player p
-                        WHERE
-                            p.account_id = :account_id");
-                    $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                    $query->execute();
-                    $playerStatus = $query->fetchColumn();
-
-                    if ($playerStatus == 0) {
-                        $this->executeWithDeadlockRetry(function () use ($user): void {
-                            // Update user rarity points for each game
-                            $query = $this->database->prepare("WITH
-                                    rarity AS(
-                                    SELECT
-                                        trophy_earned.np_communication_id,
-                                        SUM(tm.rarity_point) AS points,
-                                        SUM(tm.in_game_rarity_point) AS in_game_points,
-                                        SUM(tm.rarity_name = 'COMMON') common,
-                                        SUM(tm.rarity_name = 'UNCOMMON') uncommon,
-                                        SUM(tm.rarity_name = 'RARE') rare,
-                                        SUM(tm.rarity_name = 'EPIC') epic,
-                                        SUM(tm.rarity_name = 'LEGENDARY') legendary,
-                                        SUM(tm.in_game_rarity_name = 'COMMON') in_game_common,
-                                        SUM(tm.in_game_rarity_name = 'UNCOMMON') in_game_uncommon,
-                                        SUM(tm.in_game_rarity_name = 'RARE') in_game_rare,
-                                        SUM(tm.in_game_rarity_name = 'EPIC') in_game_epic,
-                                        SUM(tm.in_game_rarity_name = 'LEGENDARY') in_game_legendary
-                                    FROM
-                                        trophy_earned
-                                    JOIN trophy t ON t.np_communication_id = trophy_earned.np_communication_id
-                                        AND t.order_id = trophy_earned.order_id
-                                    JOIN trophy_meta tm ON tm.trophy_id = t.id
-                                    WHERE
-                                        trophy_earned.account_id = :account_id AND trophy_earned.earned = 1
-                                    GROUP BY
-                                        trophy_earned.np_communication_id
-                                    ORDER BY NULL
-                                )
-                                UPDATE
-                                    trophy_title_player ttp,
-                                    rarity
-                                SET
-                                    ttp.rarity_points = rarity.points,
-                                    ttp.in_game_rarity_points = rarity.in_game_points,
-                                    ttp.common = rarity.common,
-                                    ttp.uncommon = rarity.uncommon,
-                                    ttp.rare = rarity.rare,
-                                    ttp.epic = rarity.epic,
-                                    ttp.legendary = rarity.legendary,
-                                    ttp.in_game_common = rarity.in_game_common,
-                                    ttp.in_game_uncommon = rarity.in_game_uncommon,
-                                    ttp.in_game_rare = rarity.in_game_rare,
-                                    ttp.in_game_epic = rarity.in_game_epic,
-                                    ttp.in_game_legendary = rarity.in_game_legendary
-                                WHERE
-                                    ttp.account_id = :account_id AND ttp.np_communication_id = rarity.np_communication_id");
-                            $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                            $query->execute();
-
-                            // Update user total rarity points
-                            $query = $this->database->prepare("WITH
-                                    rarity AS(
-                                    SELECT
-                                        IFNULL(SUM(rarity_points), 0) AS rarity_points,
-                                        IFNULL(SUM(common), 0) AS common,
-                                        IFNULL(SUM(uncommon), 0) AS uncommon,
-                                        IFNULL(SUM(rare), 0) AS rare,
-                                        IFNULL(SUM(epic), 0) AS epic,
-                                        IFNULL(SUM(legendary), 0) AS legendary,
-                                        IFNULL(SUM(in_game_rarity_points), 0) AS in_game_rarity_points,
-                                        IFNULL(SUM(in_game_common), 0) AS in_game_common,
-                                        IFNULL(SUM(in_game_uncommon), 0) AS in_game_uncommon,
-                                        IFNULL(SUM(in_game_rare), 0) AS in_game_rare,
-                                        IFNULL(SUM(in_game_epic), 0) AS in_game_epic,
-                                        IFNULL(SUM(in_game_legendary), 0) AS in_game_legendary
-                                    FROM
-                                        trophy_title_player
-                                    WHERE
-                                        account_id = :account_id
-                                    ORDER BY NULL
-                                )
-                                UPDATE
-                                    player p,
-                                    rarity
-                                SET
-                                    p.rarity_points = rarity.rarity_points,
-                                    p.common = rarity.common,
-                                    p.uncommon = rarity.uncommon,
-                                    p.rare = rarity.rare,
-                                    p.epic = rarity.epic,
-                                    p.legendary = rarity.legendary,
-                                    p.in_game_rarity_points = rarity.in_game_rarity_points,
-                                    p.in_game_common = rarity.in_game_common,
-                                    p.in_game_uncommon = rarity.in_game_uncommon,
-                                    p.in_game_rare = rarity.in_game_rare,
-                                    p.in_game_epic = rarity.in_game_epic,
-                                    p.in_game_legendary = rarity.in_game_legendary
-                                WHERE
-                                    p.account_id = :account_id AND p.status = 0");
-                            $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                            $query->execute();
-                        });
-                    }
+                    $this->scanCompletionService->updateRarityPointsForActivePlayer((int) $user->accountId());
 
                     // Done with the user, update the date
                     $query = $this->database->prepare("UPDATE player
@@ -1622,34 +1419,6 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                 $this->workerScanCoordinator->setWorkerScanProgress((int) $worker['id'], null);
             }
         }
-    }
-
-    /**
-     * @param callable(): void $operation
-     */
-    private function executeWithDeadlockRetry(callable $operation, int $maxAttempts = 3): void
-    {
-        $attempt = 0;
-
-        while (true) {
-            try {
-                $operation();
-                return;
-            } catch (PDOException $exception) {
-                if (!$this->isDeadlockException($exception) || $attempt >= $maxAttempts) {
-                    throw $exception;
-                }
-
-                $attempt++;
-                usleep(200000);
-            }
-        }
-    }
-
-    private function isDeadlockException(PDOException $exception): bool
-    {
-        return $exception->getCode() === '40001'
-            || (($exception->errorInfo[1] ?? null) === 1213);
     }
 
     private function findTrophyTitleId(string $npCommunicationId): ?int


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ThirtyMinuteCronJob` (~1,675 lines) is the largest God class in the codebase. This PR peels off one concern: **post-scan player aggregation** (trophy totals, PSN level/progress, inactive/cheater status, rarity rollups).

New classes:
- `PlayerScanCompletionService` — owns the extracted SQL and business logic
- `PlayerScanCompletionResult` — signals whether the scan loop should restart (hidden-trophy recheck)

This follows the same pattern as the earlier `PlayerScanProfileSynchronizer` extraction.

## Changes

- Move ~220 lines of inline SQL/logic out of `ThirtyMinuteCronJob::run()`
- Remove now-unused `executeWithDeadlockRetry()` from the cron job (deadlock retry lives in the new service)
- Add focused unit tests for PSN level calculation and hidden-trophy recheck signaling

## Test plan

- [x] `php tests/run.php` — all 673 tests pass
- [x] New `PlayerScanCompletionServiceTest` covers level tiers, hidden-trophy recheck, and cheater-status guard SQL snapshot

## Follow-up PR ideas (not in scope)

1. Extract per-game title sync loop into `PlayerScanTitleSynchronizer`
2. Move `PossibleCheaterService` rule data into a registry/config file
3. Extract trophy mapping strategies from `TrophyMergeService`
4. Extract PSN API adapters from `GameRescanService`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a8cfeae-6781-4ce8-9af8-c549a0b809a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a8cfeae-6781-4ce8-9af8-c549a0b809a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

