### PR TITLE
Extract PlayerEarnedTrophyPersister from ThirtyMinuteCronJob

### DIFF
--- a/tests/PlayerEarnedTrophyPersisterTest.php
+++ b/tests/PlayerEarnedTrophyPersisterTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerEarnedTrophyPersister.php';
+
+final class PlayerEarnedTrophyPersisterTest extends TestCase
+{
+    public function testPersistEarnedTrophyUpsertsChildWithoutMergeParent(): void
+    {
+        $pdo = new PlayerEarnedTrophyPersisterRecordingPDO(null);
+        $persister = new PlayerEarnedTrophyPersister($pdo);
+
+        $persister->persistEarnedTrophy(
+            'NPWR12345_00',
+            'default',
+            3,
+            42,
+            true,
+            '',
+            '2024-06-15T10:30:00Z',
+        );
+
+        $this->assertSame(1, $pdo->upsertExecutions, 'Expected a single child trophy upsert.');
+        $this->assertSame(1, $pdo->mergeLookupExecutions, 'Expected a merge-parent lookup.');
+
+        $this->assertTrue(
+            str_contains($pdo->upsertSql[0], 'IF(trophy_earned.earned = 0, new.earned_date, trophy_earned.earned_date)'),
+            'Child upsert should use child-specific earned_date merge rule.'
+        );
+
+        $this->assertSame([
+            ':np_communication_id' => 'NPWR12345_00',
+            ':group_id' => 'default',
+            ':order_id' => 3,
+            ':account_id' => 42,
+            ':earned_date' => '2024-06-15 10:30:00',
+            ':progress' => null,
+            ':earned' => true,
+        ], $pdo->upsertParameters[0], 'Unexpected child upsert parameters.');
+    }
+
+    public function testPersistEarnedTrophyPropagatesToMergeParent(): void
+    {
+        $pdo = new PlayerEarnedTrophyPersisterRecordingPDO([
+            'parent_np_communication_id' => 'NPWR99999_00',
+            'parent_group_id' => 'default',
+            'parent_order_id' => 7,
+        ]);
+        $persister = new PlayerEarnedTrophyPersister($pdo);
+
+        $persister->persistEarnedTrophy(
+            'NPWR12345_00',
+            'default',
+            3,
+            42,
+            false,
+            '55',
+            '',
+        );
+
+        $this->assertSame(2, $pdo->upsertExecutions, 'Expected child and parent trophy upserts.');
+        $this->assertTrue(
+            str_contains($pdo->upsertSql[1], 'IF(trophy_earned.earned = 1, trophy_earned.earned, new.earned)'),
+            'Parent upsert should use parent-specific earned merge rule.'
+        );
+
+        $this->assertSame([
+            ':np_communication_id' => 'NPWR99999_00',
+            ':group_id' => 'default',
+            ':order_id' => 7,
+            ':account_id' => 42,
+            ':earned_date' => null,
+            ':progress' => 55,
+            ':earned' => false,
+        ], $pdo->upsertParameters[1], 'Unexpected parent upsert parameters.');
+    }
+}
+
+/**
+ * @phpstan-type MergeParentRow array{
+ *     parent_np_communication_id: string,
+ *     parent_group_id: string,
+ *     parent_order_id: int|string
+ * }
+ */
+final class PlayerEarnedTrophyPersisterRecordingPDO extends PDO
+{
+    /** @var list<string> */
+    public array $upsertSql = [];
+
+    /** @var list<array<string, scalar|null|bool>> */
+    public array $upsertParameters = [];
+
+    public int $upsertExecutions = 0;
+
+    public int $mergeLookupExecutions = 0;
+
+    /** @var MergeParentRow|null */
+    private ?array $mergeParent;
+
+    /**
+     * @param MergeParentRow|null $mergeParent
+     */
+    public function __construct(?array $mergeParent)
+    {
+        $this->mergeParent = $mergeParent;
+    }
+
+    public function prepare(string $statement, array $options = []): PDOStatement
+    {
+        $trimmed = trim($statement);
+
+        if (str_contains($trimmed, 'INSERT INTO trophy_earned')) {
+            return new PlayerEarnedTrophyPersisterRecordingUpsertStatement($this, $trimmed);
+        }
+
+        if (str_contains($trimmed, 'FROM   trophy_merge')) {
+            return new PlayerEarnedTrophyPersisterRecordingMergeLookupStatement($this, $this->mergeParent);
+        }
+
+        throw new RuntimeException('Unexpected SQL statement: ' . $trimmed);
+    }
+
+    /** @param array<string, scalar|null|bool> $parameters */
+    public function recordUpsert(string $sql, array $parameters): void
+    {
+        $this->upsertSql[] = $sql;
+        $this->upsertParameters[] = $parameters;
+        $this->upsertExecutions++;
+    }
+
+    public function recordMergeLookup(): void
+    {
+        $this->mergeLookupExecutions++;
+    }
+}
+
+final class PlayerEarnedTrophyPersisterRecordingUpsertStatement extends PDOStatement
+{
+    /** @var array<string, scalar|null|bool> */
+    private array $parameters = [];
+
+    public function __construct(
+        private readonly PlayerEarnedTrophyPersisterRecordingPDO $pdo,
+        private readonly string $sql,
+    ) {
+    }
+
+    public function bindValue(int|string $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        $this->parameters[(string) $param] = $value;
+
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        $this->pdo->recordUpsert($this->sql, $this->parameters);
+
+        return true;
+    }
+}
+
+final class PlayerEarnedTrophyPersisterRecordingMergeLookupStatement extends PDOStatement
+{
+    /** @var MergeParentRow|null */
+    private ?array $mergeParent;
+
+    /**
+     * @param MergeParentRow|null $mergeParent
+     */
+    public function __construct(
+        private readonly PlayerEarnedTrophyPersisterRecordingPDO $pdo,
+        ?array $mergeParent,
+    ) {
+        $this->mergeParent = $mergeParent;
+    }
+
+    public function bindValue(int|string $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        $this->pdo->recordMergeLookup();
+
+        return true;
+    }
+
+    public function fetch(int $mode = PDO::FETCH_DEFAULT, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0): mixed
+    {
+        return $this->mergeParent ?? false;
+    }
+}

--- a/tests/PlayerEarnedTrophyPersisterTest.php
+++ b/tests/PlayerEarnedTrophyPersisterTest.php
@@ -16,7 +16,7 @@ final class PlayerEarnedTrophyPersisterTest extends TestCase
             'NPWR12345_00',
             'default',
             3,
-            42,
+            '42',
             true,
             '',
             '2024-06-15T10:30:00Z',
@@ -34,7 +34,7 @@ final class PlayerEarnedTrophyPersisterTest extends TestCase
             ':np_communication_id' => 'NPWR12345_00',
             ':group_id' => 'default',
             ':order_id' => 3,
-            ':account_id' => 42,
+            ':account_id' => '42',
             ':earned_date' => '2024-06-15 10:30:00',
             ':progress' => null,
             ':earned' => true,
@@ -54,7 +54,7 @@ final class PlayerEarnedTrophyPersisterTest extends TestCase
             'NPWR12345_00',
             'default',
             3,
-            42,
+            '42',
             false,
             '55',
             '',
@@ -70,11 +70,30 @@ final class PlayerEarnedTrophyPersisterTest extends TestCase
             ':np_communication_id' => 'NPWR99999_00',
             ':group_id' => 'default',
             ':order_id' => 7,
-            ':account_id' => 42,
+            ':account_id' => '42',
             ':earned_date' => null,
             ':progress' => 55,
             ':earned' => false,
         ], $pdo->upsertParameters[1], 'Unexpected parent upsert parameters.');
+    }
+
+    public function testPersistEarnedTrophyPreservesAccountIdsAbovePhpIntMax(): void
+    {
+        $pdo = new PlayerEarnedTrophyPersisterRecordingPDO(null);
+        $persister = new PlayerEarnedTrophyPersister($pdo);
+        $largeAccountId = '9223372036854775808';
+
+        $persister->persistEarnedTrophy(
+            'NPWR12345_00',
+            'default',
+            1,
+            $largeAccountId,
+            true,
+            '',
+            '2024-06-15T10:30:00Z',
+        );
+
+        $this->assertSame($largeAccountId, $pdo->upsertParameters[0][':account_id']);
     }
 }
 

--- a/wwwroot/classes/Cron/PlayerEarnedTrophyPersister.php
+++ b/wwwroot/classes/Cron/PlayerEarnedTrophyPersister.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
+
+/**
+ * Persists player trophy earned/progress rows during scans and propagates state to
+ * merge-parent trophies when mappings exist.
+ *
+ * Encapsulates trophy_earned upsert logic that was previously embedded in ThirtyMinuteCronJob.
+ */
+final class PlayerEarnedTrophyPersister
+{
+    private readonly PlayerScanTitleMetadataHelper $titleMetadataHelper;
+
+    public function __construct(
+        private readonly PDO $database,
+        ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
+    ) {
+        $this->titleMetadataHelper = $titleMetadataHelper ?? new PlayerScanTitleMetadataHelper();
+    }
+
+    public function persistEarnedTrophy(
+        string $npCommunicationId,
+        string $groupId,
+        int $orderId,
+        int $accountId,
+        bool $earned,
+        string $rawProgress,
+        string $rawEarnedDateTime,
+    ): void {
+        $earnedDate = $rawEarnedDateTime === ''
+            ? null
+            : $this->titleMetadataHelper->formatDateTimeForDatabase($rawEarnedDateTime);
+        $progress = $rawProgress === '' ? null : (int) $rawProgress;
+
+        $this->upsertChildEarnedTrophy(
+            $npCommunicationId,
+            $groupId,
+            $orderId,
+            $accountId,
+            $earnedDate,
+            $progress,
+            $earned,
+        );
+
+        $parent = $this->findMergeParent($npCommunicationId, $groupId, $orderId);
+        if ($parent === null) {
+            return;
+        }
+
+        $this->upsertParentEarnedTrophy(
+            $parent['parent_np_communication_id'],
+            $parent['parent_group_id'],
+            (int) $parent['parent_order_id'],
+            $accountId,
+            $earnedDate,
+            $progress,
+            $earned,
+        );
+    }
+
+    private function upsertChildEarnedTrophy(
+        string $npCommunicationId,
+        string $groupId,
+        int $orderId,
+        int $accountId,
+        ?string $earnedDate,
+        ?int $progress,
+        bool $earned,
+    ): void {
+        $query = $this->database->prepare("INSERT INTO trophy_earned(
+                np_communication_id,
+                group_id,
+                order_id,
+                account_id,
+                earned_date,
+                progress,
+                earned
+            )
+            VALUES(
+                :np_communication_id,
+                :group_id,
+                :order_id,
+                :account_id,
+                :earned_date,
+                :progress,
+                :earned
+            ) AS new
+            ON DUPLICATE KEY
+            UPDATE
+                earned_date = IF(trophy_earned.earned = 0, new.earned_date, trophy_earned.earned_date),
+                progress = new.progress,
+                earned = new.earned");
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
+        $query->bindValue(':order_id', $orderId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':earned_date', $earnedDate, PDO::PARAM_STR);
+        $query->bindValue(':progress', $progress, PDO::PARAM_INT);
+        $query->bindValue(':earned', $earned, PDO::PARAM_INT);
+        $query->execute();
+    }
+
+    /**
+     * @return array{parent_np_communication_id: string, parent_group_id: string, parent_order_id: int|string}|null
+     */
+    private function findMergeParent(string $npCommunicationId, string $groupId, int $orderId): ?array
+    {
+        $query = $this->database->prepare("SELECT parent_np_communication_id,
+                    parent_group_id,
+                    parent_order_id
+            FROM   trophy_merge
+            WHERE  child_np_communication_id = :child_np_communication_id
+                    AND child_group_id = :child_group_id
+                    AND child_order_id = :child_order_id ");
+        $query->bindValue(':child_np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':child_group_id', $groupId, PDO::PARAM_STR);
+        $query->bindValue(':child_order_id', $orderId, PDO::PARAM_INT);
+        $query->execute();
+        $parent = $query->fetch();
+
+        if ($parent === false) {
+            return null;
+        }
+
+        return $parent;
+    }
+
+    private function upsertParentEarnedTrophy(
+        string $npCommunicationId,
+        string $groupId,
+        int $orderId,
+        int $accountId,
+        ?string $earnedDate,
+        ?int $progress,
+        bool $earned,
+    ): void {
+        $query = $this->database->prepare("INSERT INTO trophy_earned(
+                np_communication_id,
+                group_id,
+                order_id,
+                account_id,
+                earned_date,
+                progress,
+                earned
+            )
+            VALUES(
+                :np_communication_id,
+                :group_id,
+                :order_id,
+                :account_id,
+                :earned_date,
+                :progress,
+                :earned
+            ) AS new
+            ON DUPLICATE KEY
+            UPDATE
+                earned_date = IF(trophy_earned.earned_date < new.earned_date, trophy_earned.earned_date, new.earned_date),
+                progress = IF(trophy_earned.progress IS NULL, new.progress,
+                    IF(new.progress IS NULL, trophy_earned.progress,
+                        IF(trophy_earned.progress > new.progress, trophy_earned.progress, new.progress)
+                    )
+                ),
+                earned = IF(trophy_earned.earned = 1, trophy_earned.earned, new.earned)");
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
+        $query->bindValue(':order_id', $orderId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':earned_date', $earnedDate, PDO::PARAM_STR);
+        $query->bindValue(':progress', $progress, PDO::PARAM_INT);
+        $query->bindValue(':earned', $earned, PDO::PARAM_INT);
+        $query->execute();
+    }
+}

--- a/wwwroot/classes/Cron/PlayerEarnedTrophyPersister.php
+++ b/wwwroot/classes/Cron/PlayerEarnedTrophyPersister.php
@@ -25,7 +25,7 @@ final class PlayerEarnedTrophyPersister
         string $npCommunicationId,
         string $groupId,
         int $orderId,
-        int $accountId,
+        string $accountId,
         bool $earned,
         string $rawProgress,
         string $rawEarnedDateTime,
@@ -65,7 +65,7 @@ final class PlayerEarnedTrophyPersister
         string $npCommunicationId,
         string $groupId,
         int $orderId,
-        int $accountId,
+        string $accountId,
         ?string $earnedDate,
         ?int $progress,
         bool $earned,
@@ -96,7 +96,9 @@ final class PlayerEarnedTrophyPersister
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
         $query->bindValue(':order_id', $orderId, PDO::PARAM_INT);
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        // Account IDs are stored as BIGINT UNSIGNED. Bind as string to avoid
+        // truncating larger values when PHP integers overflow.
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->bindValue(':earned_date', $earnedDate, PDO::PARAM_STR);
         $query->bindValue(':progress', $progress, PDO::PARAM_INT);
         $query->bindValue(':earned', $earned, PDO::PARAM_INT);
@@ -132,7 +134,7 @@ final class PlayerEarnedTrophyPersister
         string $npCommunicationId,
         string $groupId,
         int $orderId,
-        int $accountId,
+        string $accountId,
         ?string $earnedDate,
         ?int $progress,
         bool $earned,
@@ -167,7 +169,9 @@ final class PlayerEarnedTrophyPersister
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
         $query->bindValue(':order_id', $orderId, PDO::PARAM_INT);
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        // Account IDs are stored as BIGINT UNSIGNED. Bind as string to avoid
+        // truncating larger values when PHP integers overflow.
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->bindValue(':earned_date', $earnedDate, PDO::PARAM_STR);
         $query->bindValue(':progress', $progress, PDO::PARAM_INT);
         $query->bindValue(':earned', $earned, PDO::PARAM_INT);

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -1095,7 +1095,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                             $npid,
                                             $trophyGroup->id(),
                                             (int) $trophy->id(),
-                                            (int) $user->accountId(),
+                                            (string) $user->accountId(),
                                             $trophyEarned,
                                             $progress,
                                             $trophy->earnedDateTime(),

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -22,6 +22,7 @@ require_once __DIR__ . '/PlayerScanProfileSyncResult.php';
 require_once __DIR__ . '/PlayerScanProfileSynchronizer.php';
 require_once __DIR__ . '/PlayerScanCompletionResult.php';
 require_once __DIR__ . '/PlayerScanCompletionService.php';
+require_once __DIR__ . '/PlayerEarnedTrophyPersister.php';
 require_once __DIR__ . '/../TrophyCatalogSynchronizer.php';
 require_once __DIR__ . '/../TrophyTitleNameFormatter.php';
 
@@ -47,6 +48,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
     private readonly PlayerScanTitleMetadataHelper $titleMetadataHelper;
     private readonly PlayerScanProfileSynchronizer $profileSynchronizer;
     private readonly PlayerScanCompletionService $scanCompletionService;
+    private readonly PlayerEarnedTrophyPersister $earnedTrophyPersister;
 
     public function __construct(
         private readonly PDO $database,
@@ -68,6 +70,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
         ?PlayerScanProfileSynchronizer $profileSynchronizer = null,
         ?PlayerScanCompletionService $scanCompletionService = null,
+        ?PlayerEarnedTrophyPersister $earnedTrophyPersister = null,
     )
     {
         $this->trophyMetaRepository = $trophyMetaRepository ?? new TrophyMetaRepository($database);
@@ -101,6 +104,10 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             $this->workerScanCoordinator,
         );
         $this->scanCompletionService = $scanCompletionService ?? new PlayerScanCompletionService($database);
+        $this->earnedTrophyPersister = $earnedTrophyPersister ?? new PlayerEarnedTrophyPersister(
+            $database,
+            $this->titleMetadataHelper,
+        );
     }
 
     /**
@@ -1084,99 +1091,15 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                     $trophyEarned = $trophy->earned();
                                     $progress = (clone $trophy)->progress();
                                     if ($trophyEarned || ($progress != '' && intval($progress) > 0)) {
-                                        if ($trophy->earnedDateTime() === '') {
-                                            $dtAsTextForInsert = null;
-                                        } else {
-                                            $dtAsTextForInsert = $this->titleMetadataHelper->formatDateTimeForDatabase($trophy->earnedDateTime());
-                                        }
-
-                                        $query = $this->database->prepare("INSERT INTO trophy_earned(
-                                                np_communication_id,
-                                                group_id,
-                                                order_id,
-                                                account_id,
-                                                earned_date,
-                                                progress,
-                                                earned
-                                            )
-                                            VALUES(
-                                                :np_communication_id,
-                                                :group_id,
-                                                :order_id,
-                                                :account_id,
-                                                :earned_date,
-                                                :progress,
-                                                :earned
-                                            ) AS new
-                                            ON DUPLICATE KEY
-                                            UPDATE
-                                                earned_date = IF(trophy_earned.earned = 0, new.earned_date, trophy_earned.earned_date),
-                                                progress = new.progress,
-                                                earned = new.earned");
-                                        $query->bindValue(":np_communication_id", $npid, PDO::PARAM_STR);
-                                        $query->bindValue(":group_id", $trophyGroup->id(), PDO::PARAM_STR);
-                                        $query->bindValue(":order_id", $trophy->id(), PDO::PARAM_INT);
-                                        $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                                        $query->bindValue(":earned_date", $dtAsTextForInsert, PDO::PARAM_STR);
-                                        if ($progress === '') {
-                                            $progress = null;
-                                        } else {
-                                            $progress = intval($progress);
-                                        }
-                                        $query->bindValue(":progress", $progress, PDO::PARAM_INT);
-                                        $query->bindValue(":earned", $trophyEarned, PDO::PARAM_INT);
-                                        $query->execute();
-
-                                        // Check if "merge"-trophy
-                                        $query = $this->database->prepare("SELECT parent_np_communication_id,
-                                                    parent_group_id,
-                                                    parent_order_id
-                                            FROM   trophy_merge
-                                            WHERE  child_np_communication_id = :child_np_communication_id
-                                                    AND child_group_id = :child_group_id
-                                                    AND child_order_id = :child_order_id ");
-                                        $query->bindValue(":child_np_communication_id", $npid, PDO::PARAM_STR);
-                                        $query->bindValue(":child_group_id", $trophyGroup->id(), PDO::PARAM_STR);
-                                        $query->bindValue(":child_order_id", $trophy->id(), PDO::PARAM_INT);
-                                        $query->execute();
-                                        $parent = $query->fetch();
-                                        if ($parent !== false) {
-                                            $query = $this->database->prepare("INSERT INTO trophy_earned(
-                                                    np_communication_id,
-                                                    group_id,
-                                                    order_id,
-                                                    account_id,
-                                                    earned_date,
-                                                    progress,
-                                                    earned
-                                                )
-                                                VALUES(
-                                                    :np_communication_id,
-                                                    :group_id,
-                                                    :order_id,
-                                                    :account_id,
-                                                    :earned_date,
-                                                    :progress,
-                                                    :earned
-                                                ) AS new
-                                                ON DUPLICATE KEY
-                                                UPDATE
-                                                    earned_date = IF(trophy_earned.earned_date < new.earned_date, trophy_earned.earned_date, new.earned_date),
-                                                    progress = IF(trophy_earned.progress IS NULL, new.progress,
-                                                        IF(new.progress IS NULL, trophy_earned.progress,
-                                                            IF(trophy_earned.progress > new.progress, trophy_earned.progress, new.progress)
-                                                        )
-                                                    ),
-                                                    earned = IF(trophy_earned.earned = 1, trophy_earned.earned, new.earned)");
-                                            $query->bindValue(":np_communication_id", $parent["parent_np_communication_id"], PDO::PARAM_STR);
-                                            $query->bindValue(":group_id", $parent["parent_group_id"], PDO::PARAM_STR);
-                                            $query->bindValue(":order_id", $parent["parent_order_id"], PDO::PARAM_INT);
-                                            $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                                            $query->bindValue(":earned_date", $dtAsTextForInsert, PDO::PARAM_STR);
-                                            $query->bindValue(":progress", $progress, PDO::PARAM_INT);
-                                            $query->bindValue(":earned", $trophyEarned, PDO::PARAM_INT);
-                                            $query->execute();
-                                        }
+                                        $this->earnedTrophyPersister->persistEarnedTrophy(
+                                            $npid,
+                                            $trophyGroup->id(),
+                                            (int) $trophy->id(),
+                                            (int) $user->accountId(),
+                                            $trophyEarned,
+                                            $progress,
+                                            $trophy->earnedDateTime(),
+                                        );
                                     }
                                 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels one concern out of `ThirtyMinuteCronJob` (1,444 → 1,367 lines): persisting `trophy_earned` rows during player scans and propagating earned/progress state to merge-parent trophies.

This follows the same incremental refactor pattern already used for `PlayerScanCompletionService`, `PlayerScanProfileSynchronizer`, and `WorkerScanCoordinator`.

## Changes

- **New `PlayerEarnedTrophyPersister`** — owns child trophy upserts, merge-parent lookups, and parent trophy upserts with their distinct `ON DUPLICATE KEY UPDATE` rules.
- **`ThirtyMinuteCronJob`** — delegates the inner trophy loop to the persister; no behavior change.
- **Tests** — `PlayerEarnedTrophyPersisterTest` verifies child-only, merge-parent propagation, and preservation of account IDs above `PHP_INT_MAX`.

## Review feedback addressed

- Account IDs are now accepted as `string` and bound with `PDO::PARAM_STR` (matching `GameRecentPlayersService`) to avoid truncating `BIGINT UNSIGNED` values above `PHP_INT_MAX`.

## God-class backlog (future PRs)

| Class | Lines | Suggested next extraction |
|-------|-------|---------------------------|
| `PossibleCheaterService` | 1,532 | `PossibleCheaterRuleCatalog` (move rule data constants) |
| `ThirtyMinuteCronJob` | 1,367 | `upsertTrophyTitle()` into `TrophyCatalogSynchronizer` |
| `TrophyMergeService` | 1,310 | `TrophyMergeMappingInserter` |
| `GameCopyService` | 1,248 | `ConflictingTrophyCatalogCopier` |
| `GameRescanService` | 970 | Named PSN trophy response adapters |

## Test plan

- [x] `php tests/run.php` — all 676 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec966571-c5cd-49f8-9210-08216f396810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec966571-c5cd-49f8-9210-08216f396810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

