### PR TITLE
Extract nested database transaction runner from TrophyMergeService

### DIFF
--- a/tests/TrophyMergeServiceTransactionTest.php
+++ b/tests/TrophyMergeServiceTransactionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/NestedDatabaseTransactionRunner.php';
 require_once __DIR__ . '/../wwwroot/classes/TrophyMergeService.php';
 
 final class TrophyMergeServiceTransactionTest extends TestCase
@@ -10,12 +11,10 @@ final class TrophyMergeServiceTransactionTest extends TestCase
     public function testNestedExecuteTransactionCommitsDatabaseOnlyOnce(): void
     {
         $database = new TransactionDepthTrackingPDO();
-        $service = new TrophyMergeService($database);
-        $executeTransaction = new ReflectionMethod(TrophyMergeService::class, 'executeTransaction');
-        $executeTransaction->setAccessible(true);
+        $runner = new NestedDatabaseTransactionRunner($database);
 
-        $executeTransaction->invoke($service, function () use ($executeTransaction, $service): void {
-            $executeTransaction->invoke($service, static function (): void {
+        $runner->execute(function () use ($runner): void {
+            $runner->execute(static function (): void {
             });
         });
 
@@ -27,13 +26,11 @@ final class TrophyMergeServiceTransactionTest extends TestCase
     public function testNestedExecuteTransactionRollsBackDatabaseOnInnerFailure(): void
     {
         $database = new TransactionDepthTrackingPDO();
-        $service = new TrophyMergeService($database);
-        $executeTransaction = new ReflectionMethod(TrophyMergeService::class, 'executeTransaction');
-        $executeTransaction->setAccessible(true);
+        $runner = new NestedDatabaseTransactionRunner($database);
 
         try {
-            $executeTransaction->invoke($service, function () use ($executeTransaction, $service): void {
-                $executeTransaction->invoke($service, static function (): void {
+            $runner->execute(function () use ($runner): void {
+                $runner->execute(static function (): void {
                     throw new RuntimeException('Inner failure.');
                 });
             });
@@ -68,12 +65,10 @@ final class TrophyMergeServiceTransactionTest extends TestCase
     public function testExecuteTransactionRollsBackWhenCommitFails(): void
     {
         $database = new TransactionDepthTrackingPDO(failOnCommit: true);
-        $service = new TrophyMergeService($database);
-        $executeTransaction = new ReflectionMethod(TrophyMergeService::class, 'executeTransaction');
-        $executeTransaction->setAccessible(true);
+        $runner = new NestedDatabaseTransactionRunner($database);
 
         try {
-            $executeTransaction->invoke($service, static function (): void {
+            $runner->execute(static function (): void {
             });
             $this->fail('Expected commit failure to bubble up.');
         } catch (PDOException $exception) {

--- a/wwwroot/classes/NestedDatabaseTransactionRunner.php
+++ b/wwwroot/classes/NestedDatabaseTransactionRunner.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Runs callables inside a single PDO transaction, tracking logical nesting depth so
+ * inner execute() calls reuse the outer database transaction.
+ *
+ * Extracted from TrophyMergeService, which nests transactions when merge steps call
+ * each other through shared helpers.
+ */
+final class NestedDatabaseTransactionRunner
+{
+    private int $transactionDepth = 0;
+
+    public function __construct(private readonly PDO $database)
+    {
+    }
+
+    public function execute(callable $operation): void
+    {
+        $this->beginTransaction();
+
+        try {
+            $operation();
+            $this->commitTransaction();
+        } catch (Throwable $exception) {
+            $this->rollBackTransaction();
+            throw $exception;
+        }
+    }
+
+    private function beginTransaction(): void
+    {
+        if ($this->transactionDepth === 0) {
+            $this->database->beginTransaction();
+        }
+
+        $this->transactionDepth++;
+    }
+
+    private function commitTransaction(): void
+    {
+        if ($this->transactionDepth === 0) {
+            return;
+        }
+
+        if ($this->transactionDepth === 1) {
+            if ($this->database->inTransaction()) {
+                $this->database->commit();
+            }
+
+            $this->transactionDepth = 0;
+
+            return;
+        }
+
+        $this->transactionDepth--;
+    }
+
+    private function rollBackTransaction(): void
+    {
+        $this->transactionDepth = 0;
+
+        if ($this->database->inTransaction()) {
+            $this->database->rollBack();
+        }
+    }
+}

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/Admin/GameCopyService.php';
 require_once __DIR__ . '/Admin/TrophyMergeProgressListener.php';
+require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
 require_once __DIR__ . '/TrophyMergePlayerProgressUpdater.php';
 
 class TrophyMergeService
@@ -12,13 +13,14 @@ class TrophyMergeService
 
     private PDO $database;
 
-    private int $transactionDepth = 0;
+    private NestedDatabaseTransactionRunner $transactionRunner;
 
     private ?TrophyMergePlayerProgressUpdater $playerProgressUpdater = null;
 
-    public function __construct(PDO $database)
+    public function __construct(PDO $database, ?NestedDatabaseTransactionRunner $transactionRunner = null)
     {
         $this->database = $database;
+        $this->transactionRunner = $transactionRunner ?? new NestedDatabaseTransactionRunner($database);
     }
 
     public function mergeSpecificTrophies(int $parentTrophyId, array $childTrophyIds): string
@@ -49,7 +51,7 @@ class TrophyMergeService
             ];
         }
 
-        $this->executeTransaction(function () use ($parentTrophy, $parentTrophyId, $childTrophies): void {
+        $this->transactionRunner->execute(function () use ($parentTrophy, $parentTrophyId, $childTrophies): void {
             foreach ($childTrophies as $childData) {
                 $childTrophyId = $childData['id'];
                 $childTrophy = $childData['trophy'];
@@ -99,7 +101,7 @@ class TrophyMergeService
 
         $message = '';
 
-        $this->executeTransaction(function () use (
+        $this->transactionRunner->execute(function () use (
             $childGameId,
             $childNpCommunicationId,
             $parentGameId,
@@ -219,7 +221,7 @@ SQL
 
         $cloneGameId = null;
 
-        $this->executeTransaction(function () use (
+        $this->transactionRunner->execute(function () use (
             $cloneNpCommunicationId,
             $childGameId,
             $childNpCommunicationId,
@@ -560,7 +562,7 @@ SQL
 
     private function insertTrophyMergeMappingFromIds(int $childTrophyId, int $parentTrophyId): void
     {
-        $this->executeTransaction(function () use ($childTrophyId, $parentTrophyId): void {
+        $this->transactionRunner->execute(function () use ($childTrophyId, $parentTrophyId): void {
             $query = $this->database->prepare(
                 <<<'SQL'
                 INSERT IGNORE
@@ -593,7 +595,7 @@ SQL
 
     private function markGameAsMergedByNpId(string $npCommunicationId): void
     {
-        $this->executeTransaction(function () use ($npCommunicationId): void {
+        $this->transactionRunner->execute(function () use ($npCommunicationId): void {
             $query = $this->database->prepare(
                 <<<'SQL'
                 UPDATE trophy_title_meta
@@ -608,7 +610,7 @@ SQL
 
     private function markGameAsMergedById(int $gameId): void
     {
-        $this->executeTransaction(function () use ($gameId): void {
+        $this->transactionRunner->execute(function () use ($gameId): void {
             $lookup = $this->database->prepare(
                 <<<'SQL'
                 SELECT np_communication_id
@@ -1247,56 +1249,6 @@ SQL
         }
 
         $historyQuery->closeCursor();
-    }
-
-    private function executeTransaction(callable $operation): void
-    {
-        $this->beginTransaction();
-
-        try {
-            $operation();
-            $this->commitTransaction();
-        } catch (Throwable $exception) {
-            $this->rollBackTransaction();
-            throw $exception;
-        }
-    }
-
-    private function beginTransaction(): void
-    {
-        if ($this->transactionDepth === 0) {
-            $this->database->beginTransaction();
-        }
-
-        $this->transactionDepth++;
-    }
-
-    private function commitTransaction(): void
-    {
-        if ($this->transactionDepth === 0) {
-            return;
-        }
-
-        if ($this->transactionDepth === 1) {
-            if ($this->database->inTransaction()) {
-                $this->database->commit();
-            }
-
-            $this->transactionDepth = 0;
-
-            return;
-        }
-
-        $this->transactionDepth--;
-    }
-
-    private function rollBackTransaction(): void
-    {
-        $this->transactionDepth = 0;
-
-        if ($this->database->inTransaction()) {
-            $this->database->rollBack();
-        }
     }
 
     private function notifyProgress(?TrophyMergeProgressListener $listener, int $percent, string $message): void


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels nested PDO transaction management out of `TrophyMergeService` (~1,310 lines) into a dedicated `NestedDatabaseTransactionRunner` class.

`TrophyMergeService` is the largest admin-domain God class after `ThirtyMinuteCronJob`. Its private `executeTransaction` / `beginTransaction` / `commitTransaction` / `rollBackTransaction` helpers were a self-contained concern: track logical nesting depth while issuing only one real `BEGIN`/`COMMIT` pair on the underlying PDO connection.

## Changes

- Add `NestedDatabaseTransactionRunner` with the depth-tracking logic previously embedded in `TrophyMergeService`.
- `TrophyMergeService` now holds a single runner instance (injectable for tests) and delegates all six `executeTransaction` call sites to `transactionRunner->execute()`.
- Update `TrophyMergeServiceTransactionTest` to exercise the runner directly instead of via reflection on a private method.

## Why this peel-off first

- Small, behavior-preserving diff (~50 lines moved).
- Existing transaction tests cover the extracted logic.
- No change to public merge APIs or admin workflows.

## Follow-up candidates (separate PRs)

| Class | Next peel-off |
|-------|---------------|
| `TrophyMergeService` | Trophy merge mapping strategies (`insertMappingsByName`, etc.) |
| `ThirtyMinuteCronJob` | Trophy catalog sync loop inside `run()` |
| `GameCopyService` | Numeric group-ID utilities → `TrophyGroupIdMapper` |
| `PsnGameLookupService` + `PlayerScanProfileSynchronizer` | Shared PSN HTTP error classifier |

## Test plan

- [x] `php tests/run.php` — all 679 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f7b6bb0-ec7b-4116-a685-bc92647b7508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f7b6bb0-ec7b-4116-a685-bc92647b7508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

