### PR TITLE
Extract PsnHttpExceptionClassifier from PSN lookup services

### DIFF
--- a/tests/PsnHttpExceptionClassifierTest.php
+++ b/tests/PsnHttpExceptionClassifierTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PsnHttpExceptionClassifier.php';
+
+if (!class_exists('Tustin\\Haste\\Exception\\NotFoundHttpException')) {
+    eval('namespace Tustin\\Haste\\Exception; final class NotFoundHttpException extends \RuntimeException {}');
+}
+
+final class PsnHttpExceptionClassifierTest extends TestCase
+{
+    public function testDetermineStatusCodeReadsStatusFromResponse(): void
+    {
+        $exception = new ClassifierStubHttpException(
+            new ClassifierStubResponse(404)
+        );
+
+        $this->assertSame(404, PsnHttpExceptionClassifier::determineStatusCode($exception));
+    }
+
+    public function testDetermineStatusCodeFallsBackToExceptionCode(): void
+    {
+        $exception = new RuntimeException('Forbidden', 403);
+
+        $this->assertSame(403, PsnHttpExceptionClassifier::determineStatusCode($exception));
+    }
+
+    public function testDetermineStatusCodeWalksPreviousExceptions(): void
+    {
+        $inner = new RuntimeException('Not found', 404);
+        $outer = new RuntimeException('Wrapped', 0, $inner);
+
+        $this->assertSame(404, PsnHttpExceptionClassifier::determineStatusCode($outer));
+    }
+
+    public function testShouldRetryWithDifferentServiceNameForClientErrors(): void
+    {
+        $this->assertTrue(
+            PsnHttpExceptionClassifier::shouldRetryWithDifferentServiceName(
+                new RuntimeException('Bad request', 400)
+            )
+        );
+        $this->assertTrue(
+            PsnHttpExceptionClassifier::shouldRetryWithDifferentServiceName(
+                new RuntimeException('Forbidden', 403)
+            )
+        );
+        $this->assertTrue(
+            PsnHttpExceptionClassifier::shouldRetryWithDifferentServiceName(
+                new RuntimeException('Not found', 404)
+            )
+        );
+    }
+
+    public function testShouldNotRetryWithDifferentServiceNameForOtherStatusCodes(): void
+    {
+        $this->assertFalse(
+            PsnHttpExceptionClassifier::shouldRetryWithDifferentServiceName(
+                new RuntimeException('Server error', 500)
+            )
+        );
+    }
+
+    public function testShouldRetryWithDifferentServiceNameForKnownHttpExceptionTypes(): void
+    {
+        $this->assertTrue(
+            PsnHttpExceptionClassifier::shouldRetryWithDifferentServiceName(
+                new \Tustin\Haste\Exception\NotFoundHttpException('Not found')
+            )
+        );
+    }
+
+    public function testIsRetryableKnownHttpExceptionWalksPreviousExceptions(): void
+    {
+        $inner = new \Tustin\Haste\Exception\NotFoundHttpException('Not found');
+        $outer = new RuntimeException('Wrapped', 0, $inner);
+
+        $this->assertTrue(PsnHttpExceptionClassifier::isRetryableKnownHttpException($outer));
+    }
+}
+
+final class ClassifierStubResponse
+{
+    public function __construct(private readonly int $statusCode)
+    {
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+}
+
+final class ClassifierStubHttpException extends RuntimeException
+{
+    public function __construct(private readonly ClassifierStubResponse $response)
+    {
+        parent::__construct('HTTP error');
+    }
+
+    public function getResponse(): ClassifierStubResponse
+    {
+        return $this->response;
+    }
+}

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/WorkerService.php';
 require_once __DIR__ . '/Worker.php';
 require_once __DIR__ . '/PlayStationWorkerAuthenticator.php';
 require_once __DIR__ . '/PsnGameLookupException.php';
+require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
 
 use Tustin\PlayStation\Client;
 
@@ -115,7 +116,7 @@ final class PsnGameLookupService
                     'trophyGroups'
                 );
             } catch (Throwable $trophyGroupsException) {
-                if (!$this->shouldRetryWithDifferentServiceName($trophyGroupsException)) {
+                if (!PsnHttpExceptionClassifier::shouldRetryWithDifferentServiceName($trophyGroupsException)) {
                     throw $trophyGroupsException;
                 }
 
@@ -162,7 +163,7 @@ final class PsnGameLookupService
                 throw $exception;
             }
 
-            $statusCode = $this->determineStatusCode($exception);
+            $statusCode = PsnHttpExceptionClassifier::determineStatusCode($exception);
 
             throw new PsnGameLookupException(
                 'Failed to retrieve trophy data from PlayStation Network. Please try again later.',
@@ -398,7 +399,7 @@ final class PsnGameLookupService
             } catch (Throwable $exception) {
                 $lastException = $exception;
 
-                if ($pinnedQuery !== null || !$this->shouldRetryWithDifferentServiceName($exception)) {
+                if ($pinnedQuery !== null || !PsnHttpExceptionClassifier::shouldRetryWithDifferentServiceName($exception)) {
                     throw $exception;
                 }
             }
@@ -447,116 +448,6 @@ final class PsnGameLookupService
             if ($queryVariant !== $winningQuery) {
                 return $queryVariant;
             }
-        }
-
-        return null;
-    }
-
-    private function shouldRetryWithDifferentServiceName(Throwable $exception): bool
-    {
-        $statusCode = $this->determineStatusCode($exception);
-
-        if ($statusCode === 400 || $statusCode === 403 || $statusCode === 404) {
-            return true;
-        }
-
-        if ($statusCode !== null) {
-            return false;
-        }
-
-        return $this->isRetryableKnownHttpException($exception);
-    }
-
-    private function isRetryableKnownHttpException(Throwable $exception): bool
-    {
-        $retryableExceptionClasses = [
-            'Tustin\\Haste\\Exception\\ApiException',
-            'Tustin\\Haste\\Exception\\AccessDeniedHttpException',
-            'Tustin\\Haste\\Exception\\NotFoundHttpException',
-        ];
-
-        foreach ($retryableExceptionClasses as $retryableExceptionClass) {
-            if ($exception instanceof $retryableExceptionClass) {
-                return true;
-            }
-        }
-
-        $previous = $exception->getPrevious();
-
-        if ($previous instanceof Throwable) {
-            return $this->isRetryableKnownHttpException($previous);
-        }
-
-        return false;
-    }
-
-    private function determineStatusCode(Throwable $exception): ?int
-    {
-        $response = $this->findResponse($exception);
-
-        if ($response !== null) {
-            $statusCode = $this->extractStatusCodeFromResponse($response);
-
-            if ($statusCode !== null) {
-                return $statusCode;
-            }
-        }
-
-        return $this->extractStatusCodeFromThrowable($exception);
-    }
-
-    private function findResponse(Throwable $exception): ?object
-    {
-        if (method_exists($exception, 'getResponse')) {
-            $response = $exception->getResponse();
-
-            if (is_object($response)) {
-                return $response;
-            }
-        }
-
-        $previous = $exception->getPrevious();
-
-        if ($previous instanceof Throwable) {
-            return $this->findResponse($previous);
-        }
-
-        return null;
-    }
-
-    private function extractStatusCodeFromResponse(object $response): ?int
-    {
-        if (method_exists($response, 'getStatusCode')) {
-            $statusCode = $response->getStatusCode();
-
-            if (is_int($statusCode)) {
-                return $statusCode;
-            }
-        }
-
-        if (method_exists($response, 'getStatus')) {
-            $status = $response->getStatus();
-
-            if (is_int($status)) {
-                return $status;
-            }
-        }
-
-        return null;
-    }
-
-    private function extractStatusCodeFromThrowable(Throwable $exception): ?int
-    {
-        $code = $exception->getCode();
-
-        if (is_int($code) && $code > 0) {
-            return $code;
-        }
-
-        $previous = $exception->getPrevious();
-
-        if ($previous instanceof Throwable) {
-            return $this->extractStatusCodeFromThrowable($previous);
         }
 
         return null;

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/WorkerService.php';
 require_once __DIR__ . '/Worker.php';
 require_once __DIR__ . '/PsnPlayerLookupException.php';
+require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
 
 use Tustin\PlayStation\Client;
 
@@ -68,7 +69,7 @@ final class PsnPlayerLookupService
             $profile = $this->executeUserProfileRequest($client, $normalizedOnlineId);
             $normalizedProfile = $this->normalizeProfileResponse($profile);
         } catch (Throwable $exception) {
-            $statusCode = $this->determineStatusCode($exception);
+            $statusCode = PsnHttpExceptionClassifier::determineStatusCode($exception);
 
             if ($statusCode === 404) {
                 throw new PsnPlayerLookupException(
@@ -221,78 +222,6 @@ final class PsnPlayerLookupService
         $normalizedSummary = $this->normalizeProfileResponse($summary);
 
         return $normalizedSummary === [] ? null : $normalizedSummary;
-    }
-
-    private function determineStatusCode(Throwable $exception): ?int
-    {
-        $response = $this->findResponse($exception);
-
-        if ($response !== null) {
-            $status = $this->extractStatusCodeFromResponse($response);
-
-            if ($status !== null) {
-                return $status;
-            }
-        }
-
-        return $this->extractStatusCodeFromThrowable($exception);
-    }
-
-    private function findResponse(Throwable $exception): ?object
-    {
-        if (method_exists($exception, 'getResponse')) {
-            $response = $exception->getResponse();
-
-            if (is_object($response)) {
-                return $response;
-            }
-        }
-
-        $previous = $exception->getPrevious();
-
-        if ($previous instanceof Throwable) {
-            return $this->findResponse($previous);
-        }
-
-        return null;
-    }
-
-    private function extractStatusCodeFromResponse(object $response): ?int
-    {
-        if (method_exists($response, 'getStatusCode')) {
-            $statusCode = $response->getStatusCode();
-
-            if (is_int($statusCode)) {
-                return $statusCode;
-            }
-        }
-
-        if (method_exists($response, 'getStatus')) {
-            $status = $response->getStatus();
-
-            if (is_int($status)) {
-                return $status;
-            }
-        }
-
-        return null;
-    }
-
-    private function extractStatusCodeFromThrowable(Throwable $exception): ?int
-    {
-        $code = $exception->getCode();
-
-        if (is_int($code) && $code > 0) {
-            return $code;
-        }
-
-        $previous = $exception->getPrevious();
-
-        if ($previous instanceof Throwable) {
-            return $this->extractStatusCodeFromThrowable($previous);
-        }
-
-        return null;
     }
 
     /**

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/Worker.php';
 require_once __DIR__ . '/WorkerService.php';
 require_once __DIR__ . '/PsnTrophyTitleComparisonException.php';
+require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
 
 use Tustin\PlayStation\Client;
 
@@ -212,7 +213,7 @@ final class PsnTrophyTitleComparisonService
             } catch (Throwable $exception) {
                 throw new PsnTrophyTitleComparisonException(
                     'Failed to retrieve trophy titles from the direct endpoint.',
-                    $this->determineStatusCode($exception),
+                    PsnHttpExceptionClassifier::determineStatusCode($exception),
                     $exception
                 );
             }
@@ -292,7 +293,7 @@ final class PsnTrophyTitleComparisonService
         } catch (Throwable $exception) {
             throw new PsnTrophyTitleComparisonException(
                 'Failed to retrieve trophy titles via tustin/psn-php.',
-                $this->determineStatusCode($exception),
+                PsnHttpExceptionClassifier::determineStatusCode($exception),
                 $exception
             );
         }
@@ -302,23 +303,6 @@ final class PsnTrophyTitleComparisonService
             'count' => $count,
             'durationMs' => round(($endTime - $startTime) * 1000, 2),
         ];
-    }
-
-    private function determineStatusCode(Throwable $exception): ?int
-    {
-        $code = $exception->getCode();
-
-        if (is_int($code) && $code > 0) {
-            return $code;
-        }
-
-        $previous = $exception->getPrevious();
-
-        if ($previous instanceof Throwable) {
-            return $this->determineStatusCode($previous);
-        }
-
-        return null;
     }
 
     /**

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
+
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\PlayStation\Client;
 
@@ -408,7 +410,7 @@ final class PlayerScanProfileSynchronizer
         try {
             $profile = $client->get($path, $query, ['content-type' => 'application/json']);
         } catch (Throwable $exception) {
-            if ($this->determineStatusCode($exception) === 404) {
+            if (PsnHttpExceptionClassifier::determineStatusCode($exception) === 404) {
                 return null;
             }
 
@@ -569,78 +571,6 @@ final class PlayerScanProfileSynchronizer
         );
 
         sleep(60);
-    }
-
-    private function determineStatusCode(Throwable $exception): ?int
-    {
-        $response = $this->findResponseFromThrowable($exception);
-
-        if ($response !== null) {
-            $status = $this->extractStatusCodeFromResponse($response);
-
-            if ($status !== null) {
-                return $status;
-            }
-        }
-
-        return $this->extractStatusCodeFromThrowable($exception);
-    }
-
-    private function findResponseFromThrowable(Throwable $exception): ?object
-    {
-        if (method_exists($exception, 'getResponse')) {
-            $response = $exception->getResponse();
-
-            if (is_object($response)) {
-                return $response;
-            }
-        }
-
-        $previous = $exception->getPrevious();
-
-        if ($previous instanceof Throwable) {
-            return $this->findResponseFromThrowable($previous);
-        }
-
-        return null;
-    }
-
-    private function extractStatusCodeFromResponse(object $response): ?int
-    {
-        if (method_exists($response, 'getStatusCode')) {
-            $statusCode = $response->getStatusCode();
-
-            if (is_int($statusCode)) {
-                return $statusCode;
-            }
-        }
-
-        if (method_exists($response, 'getStatus')) {
-            $status = $response->getStatus();
-
-            if (is_int($status)) {
-                return $status;
-            }
-        }
-
-        return null;
-    }
-
-    private function extractStatusCodeFromThrowable(Throwable $exception): ?int
-    {
-        $code = $exception->getCode();
-
-        if (is_int($code) && $code > 0) {
-            return $code;
-        }
-
-        $previous = $exception->getPrevious();
-
-        if ($previous instanceof Throwable) {
-            return $this->extractStatusCodeFromThrowable($previous);
-        }
-
-        return null;
     }
 
     private function normalizePlayerProfileResponse(mixed $profile): array

--- a/wwwroot/classes/PsnHttpExceptionClassifier.php
+++ b/wwwroot/classes/PsnHttpExceptionClassifier.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Resolves HTTP status codes and retry policy from PlayStation API exceptions.
+ *
+ * Shared by PSN lookup services and player scan profile synchronization.
+ */
+final class PsnHttpExceptionClassifier
+{
+    public static function determineStatusCode(Throwable $exception): ?int
+    {
+        $response = self::findResponse($exception);
+
+        if ($response !== null) {
+            $statusCode = self::extractStatusCodeFromResponse($response);
+
+            if ($statusCode !== null) {
+                return $statusCode;
+            }
+        }
+
+        return self::extractStatusCodeFromThrowable($exception);
+    }
+
+    public static function shouldRetryWithDifferentServiceName(Throwable $exception): bool
+    {
+        $statusCode = self::determineStatusCode($exception);
+
+        if ($statusCode === 400 || $statusCode === 403 || $statusCode === 404) {
+            return true;
+        }
+
+        if ($statusCode !== null) {
+            return false;
+        }
+
+        return self::isRetryableKnownHttpException($exception);
+    }
+
+    public static function isRetryableKnownHttpException(Throwable $exception): bool
+    {
+        $retryableExceptionClasses = [
+            'Tustin\\Haste\\Exception\\ApiException',
+            'Tustin\\Haste\\Exception\\AccessDeniedHttpException',
+            'Tustin\\Haste\\Exception\\NotFoundHttpException',
+        ];
+
+        foreach ($retryableExceptionClasses as $retryableExceptionClass) {
+            if ($exception instanceof $retryableExceptionClass) {
+                return true;
+            }
+        }
+
+        $previous = $exception->getPrevious();
+
+        if ($previous instanceof Throwable) {
+            return self::isRetryableKnownHttpException($previous);
+        }
+
+        return false;
+    }
+
+    public static function findResponse(Throwable $exception): ?object
+    {
+        if (method_exists($exception, 'getResponse')) {
+            $response = $exception->getResponse();
+
+            if (is_object($response)) {
+                return $response;
+            }
+        }
+
+        $previous = $exception->getPrevious();
+
+        if ($previous instanceof Throwable) {
+            return self::findResponse($previous);
+        }
+
+        return null;
+    }
+
+    public static function extractStatusCodeFromResponse(object $response): ?int
+    {
+        if (method_exists($response, 'getStatusCode')) {
+            $statusCode = $response->getStatusCode();
+
+            if (is_int($statusCode)) {
+                return $statusCode;
+            }
+        }
+
+        if (method_exists($response, 'getStatus')) {
+            $status = $response->getStatus();
+
+            if (is_int($status)) {
+                return $status;
+            }
+        }
+
+        return null;
+    }
+
+    public static function extractStatusCodeFromThrowable(Throwable $exception): ?int
+    {
+        $code = $exception->getCode();
+
+        if (is_int($code) && $code > 0) {
+            return $code;
+        }
+
+        $previous = $exception->getPrevious();
+
+        if ($previous instanceof Throwable) {
+            return self::extractStatusCodeFromThrowable($previous);
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels duplicated HTTP status-code resolution and retry-policy logic out of four PSN integration services into a shared `PsnHttpExceptionClassifier` utility.

This is the first incremental step toward reducing God-class size in the PSN layer — one concern per PR, no big-bang rewrite.

## God classes identified (for follow-up PRs)

| Class | ~Lines | Suggested next extraction |
|-------|--------|---------------------------|
| `ThirtyMinuteCronJob` | 1,367 | `PlayerScanTitleSynchronizer` (per-title catalog sync loop) |
| `TrophyMergeService` | 1,262 | `TrophyMergeMappingService` (name/icon/order mapping strategies) |
| `GameCopyService` | 1,248 | `TrophyGroupConflictResolver` (group ID remapping on conflicts) |
| `GameRescanService` | 970 | `PsnTrophyApiAdapters` (anonymous API adapter classes) |

## Changes

- **New** `PsnHttpExceptionClassifier` — static utility for:
  - `determineStatusCode()` — walks exception chain, reads response `getStatusCode()` / `getStatus()`, falls back to exception code
  - `shouldRetryWithDifferentServiceName()` — retry policy for NP service name variants
  - `isRetryableKnownHttpException()` — recognizes Tustin Haste HTTP exception types
- **Updated** four consumers to delegate instead of maintaining private copies:
  - `PsnGameLookupService` (~110 lines removed)
  - `PsnPlayerLookupService` (~70 lines removed)
  - `PlayerScanProfileSynchronizer` (~70 lines removed)
  - `PsnTrophyTitleComparisonService` (~15 lines removed; now uses the full response-aware classifier)
- **New tests** `PsnHttpExceptionClassifierTest` (7 cases)

## Test plan

- [x] `php tests/run.php` — all 686 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2311d70-e728-40e8-ae09-995dfeaf1a65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2311d70-e728-40e8-ae09-995dfeaf1a65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

