### PR TITLE
Extract TrophyMergeMappingService from TrophyMergeService

### DIFF
--- a/tests/TrophyMergeServiceNameMergeTest.php
+++ b/tests/TrophyMergeServiceNameMergeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../wwwroot/classes/TrophyMergeService.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMergeMappingService.php';
 
 final class TrophyMergeServiceNameMergeTest extends TestCase
 {
@@ -25,12 +25,9 @@ final class TrophyMergeServiceNameMergeTest extends TestCase
         ];
 
         $database = new NameMappingPDO($childTrophies, $parentTrophy);
-        $service = new TrophyMergeService($database);
+        $service = new TrophyMergeMappingService($database);
 
-        $method = new ReflectionMethod(TrophyMergeService::class, 'insertMappingsByName');
-        $method->setAccessible(true);
-
-        $message = $method->invoke($service, 1, 2);
+        $message = $service->insertMappingsByName(1, 2);
 
         $this->assertSame('', $message, 'Expected name-based merge to succeed without warnings.');
 

--- a/wwwroot/classes/TrophyMergeMappingService.php
+++ b/wwwroot/classes/TrophyMergeMappingService.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Matches child trophies to parent merge-title trophies and persists trophy_merge rows.
+ */
+final class TrophyMergeMappingService
+{
+    public function __construct(private readonly PDO $database)
+    {
+    }
+
+    public function insertMappingsByName(int $childGameId, int $parentGameId): string
+    {
+        $message = '';
+
+        $childTrophies = $this->database->prepare(
+            <<<'SQL'
+            SELECT np_communication_id,
+                   group_id,
+                   order_id,
+                   name
+            FROM   trophy
+            WHERE  np_communication_id = (SELECT np_communication_id
+                                          FROM   trophy_title
+                                          WHERE  id = :child_game_id)
+SQL
+        );
+        $childTrophies->bindValue(':child_game_id', $childGameId, PDO::PARAM_INT);
+        $childTrophies->execute();
+
+        $parentTrophies = $this->database->prepare(
+            <<<'SQL'
+            SELECT np_communication_id,
+                   group_id,
+                   order_id,
+                   name
+            FROM   trophy
+            WHERE  np_communication_id = (SELECT np_communication_id
+                                          FROM   trophy_title
+                                          WHERE  id = :parent_game_id)
+SQL
+        );
+        $parentTrophies->bindValue(':parent_game_id', $parentGameId, PDO::PARAM_INT);
+        $parentTrophies->execute();
+
+        $parentTrophyByName = [];
+
+        while ($parentTrophy = $parentTrophies->fetch(PDO::FETCH_ASSOC)) {
+            $name = $this->normalizeTrophyName((string) $parentTrophy['name']);
+            $parentTrophyByName[$name][] = $parentTrophy;
+        }
+
+        while ($childTrophy = $childTrophies->fetch(PDO::FETCH_ASSOC)) {
+            $childName = $this->normalizeTrophyName((string) $childTrophy['name']);
+            $parentTrophy = $parentTrophyByName[$childName] ?? [];
+
+            if (count($parentTrophy) === 1) {
+                $this->insertDirectMapping($childTrophy, $parentTrophy[0]);
+            } else {
+                $message .= $childTrophy['name'] . " couldn't be merged.<br>";
+            }
+        }
+
+        return $message;
+    }
+
+    public function insertMappingsByIcon(int $childGameId, int $parentGameId): string
+    {
+        $message = '';
+
+        $childTrophies = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                t.np_communication_id,
+                t.group_id,
+                t.order_id,
+                t.name,
+                t.icon_url,
+                tc.counter
+            FROM
+                trophy t,
+                (
+                SELECT
+                    icon_url,
+                    COUNT(icon_url) AS counter
+                FROM
+                    trophy
+                WHERE
+                    np_communication_id =(
+                    SELECT
+                        np_communication_id
+                    FROM
+                        trophy_title
+                    WHERE
+                        id = :child_game_id
+                )
+            GROUP BY
+                icon_url
+            ) AS tc
+            WHERE
+                t.icon_url = tc.icon_url AND t.np_communication_id =(
+                SELECT
+                    np_communication_id
+                FROM
+                    trophy_title
+                WHERE
+                    id = :child_game_id
+            );
+SQL
+        );
+        $childTrophies->bindValue(':child_game_id', $childGameId, PDO::PARAM_INT);
+        $childTrophies->execute();
+
+        while ($childTrophy = $childTrophies->fetch(PDO::FETCH_ASSOC)) {
+            $parentTrophies = $this->database->prepare(
+                <<<'SQL'
+                SELECT np_communication_id,
+                       group_id,
+                       order_id
+                FROM   trophy
+                WHERE  np_communication_id = (SELECT np_communication_id
+                                              FROM   trophy_title
+                                              WHERE  id = :parent_game_id)
+                       AND icon_url = :icon_url
+SQL
+            );
+            $parentTrophies->bindValue(':parent_game_id', $parentGameId, PDO::PARAM_INT);
+            $parentTrophies->bindValue(':icon_url', $childTrophy['icon_url'], PDO::PARAM_STR);
+            $parentTrophies->execute();
+
+            $parentTrophy = $parentTrophies->fetchAll(PDO::FETCH_ASSOC);
+
+            if ((int) $childTrophy['counter'] === 1 && count($parentTrophy) === 1) {
+                $this->insertDirectMapping($childTrophy, $parentTrophy[0]);
+            } else {
+                $message .= $childTrophy['name'] . " couldn't be merged.<br>";
+            }
+        }
+
+        return $message;
+    }
+
+    public function insertMappingsByOrder(int $childGameId, int $parentGameId): void
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            INSERT IGNORE
+            into   trophy_merge
+                   (
+                          child_np_communication_id,
+                          child_group_id,
+                          child_order_id,
+                          parent_np_communication_id,
+                          parent_group_id,
+                          parent_order_id
+                   )
+            SELECT     child.np_communication_id,
+                       child.group_id,
+                       child.order_id,
+                       parent.np_communication_id,
+                       parent.group_id,
+                       parent.order_id
+            FROM       trophy child
+            INNER JOIN trophy parent
+            USING      (group_id, order_id)
+            WHERE      child.np_communication_id =
+                       (
+                              SELECT np_communication_id
+                              FROM   trophy_title
+                              WHERE  id = :child_game_id)
+            AND        parent.np_communication_id =
+                       (
+                              SELECT np_communication_id
+                              FROM   trophy_title
+                              WHERE  id = :parent_game_id)
+SQL
+        );
+        $query->bindValue(':child_game_id', $childGameId, PDO::PARAM_INT);
+        $query->bindValue(':parent_game_id', $parentGameId, PDO::PARAM_INT);
+        $query->execute();
+    }
+
+    private function normalizeTrophyName(string $name): string
+    {
+        $name = trim($name);
+
+        return mb_strtolower($name, 'UTF-8');
+    }
+
+    /**
+     * @param array{np_communication_id:string, group_id:string, order_id:int|string, name?:string} $childTrophy
+     * @param array{np_communication_id:string, group_id:string, order_id:int|string} $parentTrophy
+     */
+    private function insertDirectMapping(array $childTrophy, array $parentTrophy): void
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            INSERT IGNORE
+            into   trophy_merge
+                   (
+                          child_np_communication_id,
+                          child_group_id,
+                          child_order_id,
+                          parent_np_communication_id,
+                          parent_group_id,
+                          parent_order_id
+                   )
+                   VALUES
+                   (
+                          :child_np_communication_id,
+                          :child_group_id,
+                          :child_order_id,
+                          :parent_np_communication_id,
+                          :parent_group_id,
+                          :parent_order_id
+                   )
+SQL
+        );
+        $query->bindValue(':child_np_communication_id', $childTrophy['np_communication_id'], PDO::PARAM_STR);
+        $query->bindValue(':child_group_id', $childTrophy['group_id'], PDO::PARAM_STR);
+        $query->bindValue(':child_order_id', (int) $childTrophy['order_id'], PDO::PARAM_INT);
+        $query->bindValue(':parent_np_communication_id', $parentTrophy['np_communication_id'], PDO::PARAM_STR);
+        $query->bindValue(':parent_group_id', $parentTrophy['group_id'], PDO::PARAM_STR);
+        $query->bindValue(':parent_order_id', (int) $parentTrophy['order_id'], PDO::PARAM_INT);
+        $query->execute();
+    }
+}

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/Admin/GameCopyService.php';
 require_once __DIR__ . '/Admin/TrophyMergeProgressListener.php';
 require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
+require_once __DIR__ . '/TrophyMergeMappingService.php';
 require_once __DIR__ . '/TrophyMergePlayerProgressUpdater.php';
 
 class TrophyMergeService
@@ -14,6 +15,8 @@ class TrophyMergeService
     private PDO $database;
 
     private NestedDatabaseTransactionRunner $transactionRunner;
+
+    private ?TrophyMergeMappingService $mappingService = null;
 
     private ?TrophyMergePlayerProgressUpdater $playerProgressUpdater = null;
 
@@ -113,15 +116,15 @@ class TrophyMergeService
             switch ($method) {
                 case 'name':
                     $this->notifyProgress($progressListener, 30, 'Matching trophies by name…');
-                    $message .= $this->insertMappingsByName($childGameId, $parentGameId);
+                    $message .= $this->mappingService()->insertMappingsByName($childGameId, $parentGameId);
                     break;
                 case 'icon':
                     $this->notifyProgress($progressListener, 30, 'Matching trophies by icon…');
-                    $message .= $this->insertMappingsByIcon($childGameId, $parentGameId);
+                    $message .= $this->mappingService()->insertMappingsByIcon($childGameId, $parentGameId);
                     break;
                 case 'order':
                     $this->notifyProgress($progressListener, 30, 'Matching trophies by list order…');
-                    $this->insertMappingsByOrder($childGameId, $parentGameId);
+                    $this->mappingService()->insertMappingsByOrder($childGameId, $parentGameId);
                     break;
                 default:
                     throw new InvalidArgumentException('Wrong input');
@@ -555,6 +558,11 @@ SQL
         $this->playerProgressUpdater()->updateTrophyTitlePlayer($childGameId);
     }
 
+    private function mappingService(): TrophyMergeMappingService
+    {
+        return $this->mappingService ??= new TrophyMergeMappingService($this->database);
+    }
+
     private function playerProgressUpdater(): TrophyMergePlayerProgressUpdater
     {
         return $this->playerProgressUpdater ??= new TrophyMergePlayerProgressUpdater($this->database);
@@ -890,218 +898,6 @@ SQL
         $query->bindValue(':change_type', $changeType, PDO::PARAM_STR);
         $query->bindValue(':param_1', $param1, PDO::PARAM_INT);
         $query->bindValue(':param_2', $param2, PDO::PARAM_INT);
-        $query->execute();
-    }
-
-    private function normalizeTrophyName(string $name): string
-    {
-        $name = trim($name);
-
-        return mb_strtolower($name, 'UTF-8');
-    }
-
-    private function insertMappingsByName(int $childGameId, int $parentGameId): string
-    {
-        $message = '';
-
-        $childTrophies = $this->database->prepare(
-            <<<'SQL'
-            SELECT np_communication_id,
-                   group_id,
-                   order_id,
-                   name
-            FROM   trophy
-            WHERE  np_communication_id = (SELECT np_communication_id
-                                          FROM   trophy_title
-                                          WHERE  id = :child_game_id)
-SQL
-        );
-        $childTrophies->bindValue(':child_game_id', $childGameId, PDO::PARAM_INT);
-        $childTrophies->execute();
-
-        $parentTrophies = $this->database->prepare(
-            <<<'SQL'
-            SELECT np_communication_id,
-                   group_id,
-                   order_id,
-                   name
-            FROM   trophy
-            WHERE  np_communication_id = (SELECT np_communication_id
-                                          FROM   trophy_title
-                                          WHERE  id = :parent_game_id)
-SQL
-        );
-        $parentTrophies->bindValue(':parent_game_id', $parentGameId, PDO::PARAM_INT);
-        $parentTrophies->execute();
-
-        $parentTrophyByName = [];
-
-        while ($parentTrophy = $parentTrophies->fetch(PDO::FETCH_ASSOC)) {
-            $name = $this->normalizeTrophyName((string) $parentTrophy['name']);
-            $parentTrophyByName[$name][] = $parentTrophy;
-        }
-
-        while ($childTrophy = $childTrophies->fetch(PDO::FETCH_ASSOC)) {
-            $childName = $this->normalizeTrophyName((string) $childTrophy['name']);
-            $parentTrophy = $parentTrophyByName[$childName] ?? [];
-
-            if (count($parentTrophy) === 1) {
-                $this->insertDirectMapping($childTrophy, $parentTrophy[0]);
-            } else {
-                $message .= $childTrophy['name'] . " couldn't be merged.<br>";
-            }
-        }
-
-        return $message;
-    }
-
-    private function insertMappingsByIcon(int $childGameId, int $parentGameId): string
-    {
-        $message = '';
-
-        $childTrophies = $this->database->prepare(
-            <<<'SQL'
-            SELECT
-                t.np_communication_id,
-                t.group_id,
-                t.order_id,
-                t.name,
-                t.icon_url,
-                tc.counter
-            FROM
-                trophy t,
-                (
-                SELECT
-                    icon_url,
-                    COUNT(icon_url) AS counter
-                FROM
-                    trophy
-                WHERE
-                    np_communication_id =(
-                    SELECT
-                        np_communication_id
-                    FROM
-                        trophy_title
-                    WHERE
-                        id = :child_game_id
-                )
-            GROUP BY
-                icon_url
-            ) AS tc
-            WHERE
-                t.icon_url = tc.icon_url AND t.np_communication_id =(
-                SELECT
-                    np_communication_id
-                FROM
-                    trophy_title
-                WHERE
-                    id = :child_game_id
-            );
-SQL
-        );
-        $childTrophies->bindValue(':child_game_id', $childGameId, PDO::PARAM_INT);
-        $childTrophies->execute();
-
-        while ($childTrophy = $childTrophies->fetch(PDO::FETCH_ASSOC)) {
-            $parentTrophies = $this->database->prepare(
-                <<<'SQL'
-                SELECT np_communication_id,
-                       group_id,
-                       order_id
-                FROM   trophy
-                WHERE  np_communication_id = (SELECT np_communication_id
-                                              FROM   trophy_title
-                                              WHERE  id = :parent_game_id)
-                       AND icon_url = :icon_url
-SQL
-            );
-            $parentTrophies->bindValue(':parent_game_id', $parentGameId, PDO::PARAM_INT);
-            $parentTrophies->bindValue(':icon_url', $childTrophy['icon_url'], PDO::PARAM_STR);
-            $parentTrophies->execute();
-
-            $parentTrophy = $parentTrophies->fetchAll(PDO::FETCH_ASSOC);
-
-            if ((int) $childTrophy['counter'] === 1 && count($parentTrophy) === 1) {
-                $this->insertDirectMapping($childTrophy, $parentTrophy[0]);
-            } else {
-                $message .= $childTrophy['name'] . " couldn't be merged.<br>";
-            }
-        }
-
-        return $message;
-    }
-
-    private function insertMappingsByOrder(int $childGameId, int $parentGameId): void
-    {
-        $query = $this->database->prepare(
-            <<<'SQL'
-            INSERT IGNORE
-            into   trophy_merge
-                   (
-                          child_np_communication_id,
-                          child_group_id,
-                          child_order_id,
-                          parent_np_communication_id,
-                          parent_group_id,
-                          parent_order_id
-                   )
-            SELECT     child.np_communication_id,
-                       child.group_id,
-                       child.order_id,
-                       parent.np_communication_id,
-                       parent.group_id,
-                       parent.order_id
-            FROM       trophy child
-            INNER JOIN trophy parent
-            USING      (group_id, order_id)
-            WHERE      child.np_communication_id =
-                       (
-                              SELECT np_communication_id
-                              FROM   trophy_title
-                              WHERE  id = :child_game_id)
-            AND        parent.np_communication_id =
-                       (
-                              SELECT np_communication_id
-                              FROM   trophy_title
-                              WHERE  id = :parent_game_id)
-SQL
-        );
-        $query->bindValue(':child_game_id', $childGameId, PDO::PARAM_INT);
-        $query->bindValue(':parent_game_id', $parentGameId, PDO::PARAM_INT);
-        $query->execute();
-    }
-
-    private function insertDirectMapping(array $childTrophy, array $parentTrophy): void
-    {
-        $query = $this->database->prepare(
-            <<<'SQL'
-            INSERT IGNORE
-            into   trophy_merge
-                   (
-                          child_np_communication_id,
-                          child_group_id,
-                          child_order_id,
-                          parent_np_communication_id,
-                          parent_group_id,
-                          parent_order_id
-                   )
-                   VALUES
-                   (
-                          :child_np_communication_id,
-                          :child_group_id,
-                          :child_order_id,
-                          :parent_np_communication_id,
-                          :parent_group_id,
-                          :parent_order_id
-                   )
-SQL
-        );
-        $query->bindValue(':child_np_communication_id', $childTrophy['np_communication_id'], PDO::PARAM_STR);
-        $query->bindValue(':child_group_id', $childTrophy['group_id'], PDO::PARAM_STR);
-        $query->bindValue(':child_order_id', (int) $childTrophy['order_id'], PDO::PARAM_INT);
-        $query->bindValue(':parent_np_communication_id', $parentTrophy['np_communication_id'], PDO::PARAM_STR);
-        $query->bindValue(':parent_group_id', $parentTrophy['group_id'], PDO::PARAM_STR);
-        $query->bindValue(':parent_order_id', (int) $parentTrophy['order_id'], PDO::PARAM_INT);
         $query->execute();
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels one concern off `TrophyMergeService` (1,262 → 1,058 lines): trophy mapping strategies that match child trophies to parent merge-title trophies and persist `trophy_merge` rows.

New `TrophyMergeMappingService` owns:
- `insertMappingsByName()` — case-insensitive, whitespace-trimmed name matching
- `insertMappingsByIcon()` — unique icon URL matching
- `insertMappingsByOrder()` — group/order position matching

`TrophyMergeService` delegates via lazy initialization, following the same pattern as `TrophyMergePlayerProgressUpdater`.

## Motivation

`TrophyMergeService` is a God class mixing game cloning, merge orchestration, mapping strategies, earned-trophy copying, player progress updates, and audit logging. Mapping logic is a self-contained subdomain (~200 lines) with existing test coverage, making it a low-risk first peel-off.

## Changes

- **Added** `wwwroot/classes/TrophyMergeMappingService.php`
- **Updated** `TrophyMergeService` to delegate mapping calls
- **Updated** `TrophyMergeServiceNameMergeTest` to test the new class directly (no reflection)

## Test plan

- [x] `php tests/run.php` — all 689 tests pass
- [x] `TrophyMergeServiceNameMergeTest` exercises `TrophyMergeMappingService` directly

## Follow-up PRs (not in scope)

Suggested next peel-offs from the same God-class audit:
1. `GameCloneService` — `cloneGameInternal` + `cloneGameHistory` (~300 lines)
2. `PsnTrophyApiResponseParser` — pure API response parsing from `PsnGameLookupService`
3. `PlayerScanTrophyCatalogSynchronizer` — per-title catalog sync from `ThirtyMinuteCronJob`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22ba864d-c9a2-4631-aa84-fc28cc298772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22ba864d-c9a2-4631-aa84-fc28cc298772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

