### PR TITLE
Extract PlayerAvatarSynchronizer from PlayerScanProfileSynchronizer

### DIFF
--- a/tests/PlayerAvatarSynchronizerTest.php
+++ b/tests/PlayerAvatarSynchronizerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/ImageHashCalculator.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerAvatarSynchronizer.php';
+
+final class PlayerAvatarSynchronizerTest extends TestCase
+{
+    private PDO $database;
+
+    private string $avatarStorageDirectory;
+
+    private string $avatarSourcePath;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec(
+            'CREATE TABLE psn100_avatars (
+                avatar_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                size TEXT NOT NULL,
+                avatar_url TEXT NOT NULL,
+                md5_hash TEXT,
+                extension TEXT NOT NULL
+            )'
+        );
+
+        $this->avatarStorageDirectory = sys_get_temp_dir() . '/psn100-avatar-test-' . bin2hex(random_bytes(4)) . '/';
+        mkdir($this->avatarStorageDirectory, 0777, true);
+
+        $this->avatarSourcePath = sys_get_temp_dir() . '/psn100-avatar-source-' . bin2hex(random_bytes(4)) . '.png';
+        file_put_contents(
+            $this->avatarSourcePath,
+            base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==', true)
+        );
+    }
+
+    public function testReturnsCachedFilenameWhenAvatarUrlAlreadyKnown(): void
+    {
+        $avatarUrl = 'https://example.test/avatar-xl.png';
+        $query = $this->database->prepare(
+            'INSERT INTO psn100_avatars(size, avatar_url, md5_hash, extension)
+            VALUES(:size, :avatar_url, :md5_hash, :extension)'
+        );
+        $query->execute([
+            ':size' => 'xl',
+            ':avatar_url' => $avatarUrl,
+            ':md5_hash' => 'cachedhash',
+            ':extension' => 'png',
+        ]);
+
+        $synchronizer = new PlayerAvatarSynchronizer(
+            $this->database,
+            new ImageHashCalculator(),
+            $this->avatarStorageDirectory,
+        );
+
+        $filename = $synchronizer->synchronizeFromPsnUser(new PlayerAvatarSynchronizerTestUser([
+            'xl' => $avatarUrl,
+            'l' => 'https://example.test/avatar-l.png',
+            'm' => 'https://example.test/avatar-m.png',
+            's' => 'https://example.test/avatar-s.png',
+        ]));
+
+        $this->assertSame('cachedhash.png', $filename);
+    }
+
+    public function testDownloadsAvatarAndPersistsCatalogRow(): void
+    {
+        $avatarUrl = 'file://' . $this->avatarSourcePath;
+        $synchronizer = new PlayerAvatarSynchronizer(
+            $this->database,
+            new ImageHashCalculator(),
+            $this->avatarStorageDirectory,
+        );
+
+        $filename = $synchronizer->synchronizeFromPsnUser(new PlayerAvatarSynchronizerTestUser([
+            'xl' => $avatarUrl,
+            'l' => 'file:///does-not-exist.png',
+            'm' => 'file:///does-not-exist.png',
+            's' => 'file:///does-not-exist.png',
+        ]));
+
+        $this->assertTrue($filename !== '');
+        $this->assertTrue(file_exists($this->avatarStorageDirectory . $filename));
+
+        $query = $this->database->prepare('SELECT size, avatar_url, extension FROM psn100_avatars');
+        $query->execute();
+        $row = $query->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertSame('xl', $row['size']);
+        $this->assertSame($avatarUrl, $row['avatar_url']);
+        $this->assertSame('png', $row['extension']);
+    }
+
+    public function testFallsBackToNextAvatarSizeWhenDownloadFails(): void
+    {
+        $largeAvatarUrl = 'file://' . $this->avatarSourcePath;
+        $synchronizer = new PlayerAvatarSynchronizer(
+            $this->database,
+            new ImageHashCalculator(),
+            $this->avatarStorageDirectory,
+        );
+
+        $filename = $synchronizer->synchronizeFromPsnUser(new PlayerAvatarSynchronizerTestUser([
+            'xl' => 'file:///does-not-exist-xl.png',
+            'l' => $largeAvatarUrl,
+            'm' => 'file:///does-not-exist-m.png',
+            's' => 'file:///does-not-exist-s.png',
+        ]));
+
+        $this->assertTrue($filename !== '');
+        $this->assertTrue(file_exists($this->avatarStorageDirectory . $filename));
+
+        $query = $this->database->prepare('SELECT size FROM psn100_avatars');
+        $query->execute();
+
+        $this->assertSame('l', $query->fetchColumn());
+    }
+
+    public function testReturnsEmptyStringWhenNoAvatarCanBeDownloaded(): void
+    {
+        $synchronizer = new PlayerAvatarSynchronizer(
+            $this->database,
+            new ImageHashCalculator(),
+            $this->avatarStorageDirectory,
+        );
+
+        $filename = $synchronizer->synchronizeFromPsnUser(new PlayerAvatarSynchronizerTestUser([
+            'xl' => 'file:///does-not-exist-xl.png',
+            'l' => 'file:///does-not-exist-l.png',
+            'm' => 'file:///does-not-exist-m.png',
+            's' => 'file:///does-not-exist-s.png',
+        ]));
+
+        $this->assertSame('', $filename);
+    }
+}
+
+/**
+ * @param array<string, string> $avatarUrls
+ */
+final class PlayerAvatarSynchronizerTestUser
+{
+    public function __construct(private readonly array $avatarUrls)
+    {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function avatarUrls(): array
+    {
+        return $this->avatarUrls;
+    }
+}

--- a/tests/PlayerScanProfileSynchronizerTest.php
+++ b/tests/PlayerScanProfileSynchronizerTest.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/Psn100Logger.php';
 require_once __DIR__ . '/../wwwroot/classes/ImageHashCalculator.php';
 require_once __DIR__ . '/../wwwroot/classes/Cron/WorkerScanCoordinator.php';
-require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanProfileSyncResult.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerAvatarSynchronizer.php';
 require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php';
 
 final class PlayerScanProfileSynchronizerTest extends TestCase
@@ -34,7 +34,6 @@ final class PlayerScanProfileSynchronizerTest extends TestCase
 
         $this->synchronizer = new PlayerScanProfileSynchronizer(
             $database,
-            new ImageHashCalculator(),
             $logger,
             new WorkerScanCoordinator($database),
         );

--- a/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../ImageHashCalculator.php';
+
+/**
+ * Downloads PSN profile avatars, deduplicates them via perceptual hash, and caches
+ * filenames in psn100_avatars.
+ *
+ * Encapsulates avatar filesystem and catalog logic that was previously embedded in
+ * PlayerScanProfileSynchronizer.
+ */
+final class PlayerAvatarSynchronizer
+{
+    public function __construct(
+        private readonly PDO $database,
+        private readonly ImageHashCalculator $imageHashCalculator,
+        private readonly string $avatarStorageDirectory = '/home/psn100/public_html/img/avatar/',
+    ) {
+    }
+
+    public function synchronizeFromPsnUser(object $user): string
+    {
+        $avatarUrls = $user->avatarUrls();
+        $avatarFilename = '';
+
+        for ($i = 0; $i < 4; $i++) {
+            switch ($i) {
+                case 0:
+                    $size = 'xl';
+                    break;
+                case 1:
+                    $size = 'l';
+                    break;
+                case 2:
+                    $size = 'm';
+                    break;
+                case 3:
+                    $size = 's';
+                    break;
+                default:
+                    $size = 'xl';
+            }
+
+            $avatarUrl = $avatarUrls[$size];
+
+            $query = $this->database->prepare(
+                'SELECT md5_hash, extension FROM psn100_avatars WHERE avatar_url = :avatar_url'
+            );
+            $query->bindValue(':avatar_url', $avatarUrl, PDO::PARAM_STR);
+            $query->execute();
+            $result = $query->fetch();
+
+            if (!$result) {
+                $avatarContents = @file_get_contents($avatarUrl);
+                if ($avatarContents === false) {
+                    continue;
+                }
+
+                $newPHash = $this->imageHashCalculator->calculatePHash($avatarContents);
+                if ($newPHash === null) {
+                    continue;
+                }
+
+                $query = $this->database->prepare('SELECT DISTINCT md5_hash FROM psn100_avatars');
+                $query->execute();
+                $existingPHashes = $query->fetchAll(PDO::FETCH_COLUMN);
+
+                foreach ($existingPHashes as $existingPHash) {
+                    if ($this->imageHashCalculator->getHammingDistance($newPHash, $existingPHash) <= 10) {
+                        $newPHash = $existingPHash;
+                        break;
+                    }
+                }
+
+                $extension = strtolower(pathinfo($avatarUrl, PATHINFO_EXTENSION));
+                $avatarFilename = $newPHash . '.' . $extension;
+                $avatarPath = $this->avatarStorageDirectory . $avatarFilename;
+
+                if (!file_exists($avatarPath)) {
+                    file_put_contents($avatarPath, $avatarContents);
+                }
+
+                $query = $this->database->prepare(
+                    'INSERT INTO psn100_avatars(size, avatar_url, md5_hash, extension)
+                    VALUES(:size, :avatar_url, :md5_hash, :extension)'
+                );
+                $query->bindValue(':size', $size, PDO::PARAM_STR);
+                $query->bindValue(':avatar_url', $avatarUrl, PDO::PARAM_STR);
+                $query->bindValue(':md5_hash', $newPHash, PDO::PARAM_STR);
+                $query->bindValue(':extension', $extension, PDO::PARAM_STR);
+                $query->execute();
+            } else {
+                $avatarFilename = $result['md5_hash'] . '.' . $result['extension'];
+            }
+
+            break;
+        }
+
+        return $avatarFilename;
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -3,27 +3,34 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
+require_once __DIR__ . '/PlayerAvatarSynchronizer.php';
+require_once __DIR__ . '/../ImageHashCalculator.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\PlayStation\Client;
 
 /**
- * Resolves PSN profile data, synchronizes avatars, and upserts player rows during scans.
+ * Resolves PSN profile data and upserts player rows during scans.
  *
- * Encapsulates profile lookup, country resolution, avatar caching, and player persistence
- * that were previously embedded in ThirtyMinuteCronJob.
+ * Encapsulates profile lookup, country resolution, and player persistence that were
+ * previously embedded in ThirtyMinuteCronJob.
  */
 final class PlayerScanProfileSynchronizer
 {
     private const MAX_INVALID_API_RESPONSE_ATTEMPTS = 2;
 
+    private readonly PlayerAvatarSynchronizer $avatarSynchronizer;
+
     public function __construct(
         private readonly PDO $database,
-        private readonly ImageHashCalculator $imageHashCalculator,
         private readonly Psn100Logger $logger,
         private readonly WorkerScanCoordinator $workerScanCoordinator,
-        private readonly string $avatarStorageDirectory = '/home/psn100/public_html/img/avatar/',
+        ?PlayerAvatarSynchronizer $avatarSynchronizer = null,
     ) {
+        $this->avatarSynchronizer = $avatarSynchronizer ?? new PlayerAvatarSynchronizer(
+            $database,
+            new ImageHashCalculator(),
+        );
     }
 
     /**
@@ -58,7 +65,7 @@ final class PlayerScanProfileSynchronizer
             sprintf('Updating avatar for %s.', $displayOnlineId)
         );
 
-        $avatarFilename = $this->synchronizeAvatar($user);
+        $avatarFilename = $this->avatarSynchronizer->synchronizeFromPsnUser($user);
         $this->upsertPlayerRecord($user, $country, $avatarFilename);
 
         return PlayerScanProfileSyncResult::success($resolved->player, $user, $country);
@@ -277,87 +284,6 @@ final class PlayerScanProfileSynchronizer
         }
 
         return PlayerScanProfileSyncResult::skipPlayer();
-    }
-
-    private function synchronizeAvatar(object $user): string
-    {
-        $avatarUrls = $user->avatarUrls();
-        $avatarFilename = '';
-
-        for ($i = 0; $i < 4; $i++) {
-            switch ($i) {
-                case 0:
-                    $size = 'xl';
-                    break;
-                case 1:
-                    $size = 'l';
-                    break;
-                case 2:
-                    $size = 'm';
-                    break;
-                case 3:
-                    $size = 's';
-                    break;
-                default:
-                    $size = 'xl';
-            }
-
-            $avatarUrl = $avatarUrls[$size];
-
-            $query = $this->database->prepare(
-                'SELECT md5_hash, extension FROM psn100_avatars WHERE avatar_url = :avatar_url'
-            );
-            $query->bindValue(':avatar_url', $avatarUrl, PDO::PARAM_STR);
-            $query->execute();
-            $result = $query->fetch();
-
-            if (!$result) {
-                $avatarContents = @file_get_contents($avatarUrl);
-                if ($avatarContents === false) {
-                    continue;
-                }
-
-                $newPHash = $this->imageHashCalculator->calculatePHash($avatarContents);
-                if ($newPHash === null) {
-                    continue;
-                }
-
-                $query = $this->database->prepare('SELECT DISTINCT md5_hash FROM psn100_avatars');
-                $query->execute();
-                $existingPHashes = $query->fetchAll(PDO::FETCH_COLUMN);
-
-                foreach ($existingPHashes as $existingPHash) {
-                    if ($this->imageHashCalculator->getHammingDistance($newPHash, $existingPHash) <= 10) {
-                        $newPHash = $existingPHash;
-                        break;
-                    }
-                }
-
-                $extension = strtolower(pathinfo($avatarUrl, PATHINFO_EXTENSION));
-                $avatarFilename = $newPHash . '.' . $extension;
-                $avatarPath = $this->avatarStorageDirectory . $avatarFilename;
-
-                if (!file_exists($avatarPath)) {
-                    file_put_contents($avatarPath, $avatarContents);
-                }
-
-                $query = $this->database->prepare(
-                    'INSERT INTO psn100_avatars(size, avatar_url, md5_hash, extension)
-                    VALUES(:size, :avatar_url, :md5_hash, :extension)'
-                );
-                $query->bindValue(':size', $size, PDO::PARAM_STR);
-                $query->bindValue(':avatar_url', $avatarUrl, PDO::PARAM_STR);
-                $query->bindValue(':md5_hash', $newPHash, PDO::PARAM_STR);
-                $query->bindValue(':extension', $extension, PDO::PARAM_STR);
-                $query->execute();
-            } else {
-                $avatarFilename = $result['md5_hash'] . '.' . $result['extension'];
-            }
-
-            break;
-        }
-
-        return $avatarFilename;
     }
 
     private function upsertPlayerRecord(object $user, string $country, string $avatarFilename): void

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -19,6 +19,7 @@ require_once __DIR__ . '/WorkerScanCoordinator.php';
 require_once __DIR__ . '/PlayerScanQueueSelector.php';
 require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
 require_once __DIR__ . '/PlayerScanProfileSyncResult.php';
+require_once __DIR__ . '/PlayerAvatarSynchronizer.php';
 require_once __DIR__ . '/PlayerScanProfileSynchronizer.php';
 require_once __DIR__ . '/PlayerScanCompletionResult.php';
 require_once __DIR__ . '/PlayerScanCompletionService.php';
@@ -102,9 +103,9 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         $this->titleMetadataHelper = $titleMetadataHelper ?? new PlayerScanTitleMetadataHelper();
         $this->profileSynchronizer = $profileSynchronizer ?? new PlayerScanProfileSynchronizer(
             $database,
-            $this->imageHashCalculator,
             $logger,
             $this->workerScanCoordinator,
+            new PlayerAvatarSynchronizer($database, $this->imageHashCalculator),
         );
         $this->scanCompletionService = $scanCompletionService ?? new PlayerScanCompletionService($database);
         $this->earnedTrophyPersister = $earnedTrophyPersister ?? new PlayerEarnedTrophyPersister(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels avatar synchronization out of `PlayerScanProfileSynchronizer` (~600 lines), which mixed PSN profile lookup, country resolution, avatar I/O, and player persistence.

New `PlayerAvatarSynchronizer` owns:
- Downloading avatar images from PSN URL sizes (xl → l → m → s)
- Perceptual-hash deduplication against existing `psn100_avatars` rows
- Filesystem caching under the avatar storage directory
- Inserting new catalog rows

`PlayerScanProfileSynchronizer` now delegates to the new service and focuses on profile/country/player-record concerns. `ThirtyMinuteCronJob` wires the shared `ImageHashCalculator` instance into the avatar synchronizer.

## Motivation

This is the first in a series of focused extractions from God classes. `PlayerScanProfileSynchronizer` was already a prior extraction from `ThirtyMinuteCronJob`; avatar sync was the most self-contained remaining concern (filesystem + hashing + DB catalog, unrelated to PSN profile API logic).

## Test plan

- [x] `php tests/run.php` — all 693 tests pass
- [x] New `PlayerAvatarSynchronizerTest` covers cache hits, fresh downloads, size fallback, and total failure
- [x] Existing `PlayerScanProfileSynchronizerTest` updated for the slimmer constructor

## Follow-up PRs (not in scope)

Other God-class candidates identified for future one-concern extractions:
1. `ThirtyMinuteCronJob` → `PlayerScanTrophyCatalogSynchronizer` (largest remaining block)
2. `GameCopyService` → trophy group conflict resolver
3. `TrophyMergeService` → `TrophyMergeCloneService`
4. `GameRescanService` → shared PSN payload adapters
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dcd215f-2870-4aaf-af10-7f3cfd05c530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dcd215f-2870-4aaf-af10-7f3cfd05c530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

