### PR TITLE
Extract TrophyTitleCloneService from TrophyMergeService

### DIFF
--- a/tests/TrophyTitleCloneServiceTest.php
+++ b/tests/TrophyTitleCloneServiceTest.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/NestedDatabaseTransactionRunner.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyTitleCloneService.php';
+
+final class TrophyTitleCloneServiceTest extends TestCase
+{
+    private PDO $database;
+
+    private TrophyTitleCloneService $service;
+
+    protected function setUp(): void
+    {
+        $this->database = new TrophyTitleCloneServiceTestDatabase();
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->createSchema();
+
+        $this->service = new TrophyTitleCloneService(
+            $this->database,
+            new NestedDatabaseTransactionRunner($this->database),
+        );
+    }
+
+    public function testCloneFromGameIdRejectsMergeTitle(): void
+    {
+        $this->insertGame(1, 'MERGE_000001', 'PS4');
+
+        try {
+            $this->service->cloneFromGameId(1);
+            $this->fail("Expected InvalidArgumentException for cloning a MERGE title.");
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame("Can't clone an already cloned game.", $exception->getMessage());
+        }
+    }
+
+    public function testCloneFromGameIdRejectsMissingGame(): void
+    {
+        try {
+            $this->service->cloneFromGameId(99);
+            $this->fail('Expected InvalidArgumentException for a missing game.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('Game not found.', $exception->getMessage());
+        }
+    }
+
+    public function testCloneFromGameIdClonesCatalogGroupsTrophiesAndHistory(): void
+    {
+        $this->seedSourceGame();
+
+        $result = $this->service->cloneFromGameId(1);
+
+        $this->assertSame(2, $result['clone_game_id']);
+        $this->assertSame('MERGE_000002', $result['clone_np_communication_id']);
+
+        $cloneTitle = $this->database
+            ->query("SELECT name, detail, platform, bronze, silver, gold, platinum, set_version FROM trophy_title WHERE id = 2")
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('Example Game', $cloneTitle['name']);
+        $this->assertSame('Original detail', $cloneTitle['detail']);
+        $this->assertSame('PS4', $cloneTitle['platform']);
+        $this->assertSame(1, (int) $cloneTitle['bronze']);
+        $this->assertSame('01.00', $cloneTitle['set_version']);
+
+        $cloneMeta = $this->database
+            ->query("SELECT status, parent_np_communication_id, region FROM trophy_title_meta WHERE np_communication_id = 'MERGE_000002'")
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame(0, (int) $cloneMeta['status']);
+        $this->assertSame(null, $cloneMeta['parent_np_communication_id']);
+        $this->assertSame('', $cloneMeta['region']);
+
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM trophy_group WHERE np_communication_id = 'MERGE_000002'")->fetchColumn());
+        $this->assertSame(1, (int) $this->database->query("SELECT COUNT(*) FROM trophy WHERE np_communication_id = 'MERGE_000002'")->fetchColumn());
+        $this->assertSame(
+            1,
+            (int) $this->database->query(
+                "SELECT COUNT(*)
+                 FROM trophy_meta tm
+                 INNER JOIN trophy t ON t.id = tm.trophy_id
+                 WHERE t.np_communication_id = 'MERGE_000002'"
+            )->fetchColumn()
+        );
+
+        $clonedHistoryCount = (int) $this->database
+            ->query('SELECT COUNT(*) FROM trophy_title_history WHERE trophy_title_id = 2')
+            ->fetchColumn();
+        $this->assertSame(1, $clonedHistoryCount);
+
+        $historyId = (int) $this->database
+            ->query('SELECT id FROM trophy_title_history WHERE trophy_title_id = 2')
+            ->fetchColumn();
+        $this->assertSame(1, (int) $this->database
+            ->query("SELECT COUNT(*) FROM trophy_group_history WHERE title_history_id = {$historyId}")
+            ->fetchColumn());
+        $this->assertSame(1, (int) $this->database
+            ->query("SELECT COUNT(*) FROM trophy_history WHERE title_history_id = {$historyId}")
+            ->fetchColumn());
+
+        $change = $this->database
+            ->query("SELECT change_type, param_1, param_2 FROM psn100_change WHERE change_type = 'GAME_CLONE'")
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('GAME_CLONE', $change['change_type']);
+        $this->assertSame(1, (int) $change['param_1']);
+        $this->assertSame(2, (int) $change['param_2']);
+    }
+
+    public function testCloneFromGameIdResetsMergedStatusOnCloneMeta(): void
+    {
+        $this->insertGame(1, 'NPWR00001_00', 'PS4');
+        $this->database->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status, message, region, rarity_points)
+             VALUES ('NPWR00001_00', 2, '', '', 0)"
+        );
+
+        $this->service->cloneFromGameId(1);
+
+        $status = (int) $this->database
+            ->query("SELECT status FROM trophy_title_meta WHERE np_communication_id = 'MERGE_000002'")
+            ->fetchColumn();
+        $this->assertSame(0, $status);
+    }
+
+    private function createSchema(): void
+    {
+        $this->database->exec(
+            'CREATE TABLE trophy_title (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                np_communication_id TEXT NOT NULL,
+                name TEXT,
+                detail TEXT,
+                icon_url TEXT,
+                platform TEXT,
+                bronze INTEGER,
+                silver INTEGER,
+                gold INTEGER,
+                platinum INTEGER,
+                set_version TEXT
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                owners INTEGER,
+                difficulty INTEGER,
+                message TEXT,
+                status INTEGER NOT NULL DEFAULT 0,
+                recent_players INTEGER,
+                owners_completed INTEGER,
+                parent_np_communication_id TEXT,
+                region TEXT,
+                rarity_points INTEGER
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_group (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                np_communication_id TEXT NOT NULL,
+                group_id TEXT NOT NULL,
+                name TEXT,
+                detail TEXT,
+                icon_url TEXT,
+                bronze INTEGER,
+                silver INTEGER,
+                gold INTEGER,
+                platinum INTEGER
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                np_communication_id TEXT NOT NULL,
+                group_id TEXT NOT NULL,
+                order_id INTEGER NOT NULL,
+                hidden INTEGER,
+                type TEXT,
+                name TEXT,
+                detail TEXT,
+                icon_url TEXT,
+                progress_target_value INTEGER,
+                reward_name TEXT,
+                reward_image_url TEXT
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_meta (
+                trophy_id INTEGER PRIMARY KEY,
+                rarity_percent REAL,
+                rarity_point INTEGER,
+                status INTEGER,
+                owners INTEGER,
+                rarity_name TEXT
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_title_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                trophy_title_id INTEGER NOT NULL,
+                detail TEXT,
+                icon_url TEXT,
+                set_version TEXT,
+                discovered_at TEXT
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_group_history (
+                title_history_id INTEGER NOT NULL,
+                group_id TEXT NOT NULL,
+                name TEXT,
+                detail TEXT,
+                icon_url TEXT
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_history (
+                title_history_id INTEGER NOT NULL,
+                group_id TEXT NOT NULL,
+                order_id INTEGER NOT NULL,
+                name TEXT,
+                detail TEXT,
+                icon_url TEXT,
+                progress_target_value INTEGER
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE psn100_change (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                change_type TEXT NOT NULL,
+                param_1 INTEGER NOT NULL,
+                param_2 INTEGER NOT NULL
+            )'
+        );
+    }
+
+    private function insertGame(int $id, string $npCommunicationId, string $platform): void
+    {
+        $query = $this->database->prepare(
+            'INSERT INTO trophy_title (id, np_communication_id, name, detail, icon_url, platform, bronze, silver, gold, platinum, set_version)
+             VALUES (:id, :np_communication_id, :name, :detail, :icon_url, :platform, :bronze, :silver, :gold, :platinum, :set_version)'
+        );
+        $query->execute([
+            ':id' => $id,
+            ':np_communication_id' => $npCommunicationId,
+            ':name' => 'Example Game',
+            ':detail' => 'Original detail',
+            ':icon_url' => 'title-icon.png',
+            ':platform' => $platform,
+            ':bronze' => 1,
+            ':silver' => 0,
+            ':gold' => 0,
+            ':platinum' => 0,
+            ':set_version' => '01.00',
+        ]);
+    }
+
+    private function seedSourceGame(): void
+    {
+        $this->insertGame(1, 'NPWR00001_00', 'PS4');
+        $this->database->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, status, message, region, rarity_points)
+             VALUES ('NPWR00001_00', 0, '', '', 0)"
+        );
+        $this->database->exec(
+            "INSERT INTO trophy_group (np_communication_id, group_id, name, detail, icon_url, bronze, silver, gold, platinum)
+             VALUES ('NPWR00001_00', 'default', 'Base Game', 'Group detail', 'group-icon.png', 1, 0, 0, 0)"
+        );
+        $this->database->exec(
+            "INSERT INTO trophy (np_communication_id, group_id, order_id, hidden, type, name, detail, icon_url)
+             VALUES ('NPWR00001_00', 'default', 1, 0, 'bronze', 'First Trophy', 'Trophy detail', 'trophy-icon.png')"
+        );
+        $this->database->exec(
+            'INSERT INTO trophy_meta (trophy_id, rarity_percent, rarity_point, status, owners, rarity_name)
+             VALUES (1, 10.5, 5, 0, 100, "Common")'
+        );
+        $this->database->exec(
+            "INSERT INTO trophy_title_history (trophy_title_id, detail, icon_url, set_version, discovered_at)
+             VALUES (1, 'Original detail', 'title-icon.png', '01.00', '2024-01-01 00:00:00')"
+        );
+        $this->database->exec(
+            "INSERT INTO trophy_group_history (title_history_id, group_id, name, detail, icon_url)
+             VALUES (1, 'default', 'Base Game', 'Group detail', 'group-icon.png')"
+        );
+        $this->database->exec(
+            "INSERT INTO trophy_history (title_history_id, group_id, order_id, name, detail, icon_url, progress_target_value)
+             VALUES (1, 'default', 1, 'First Trophy', 'Trophy detail', 'trophy-icon.png', NULL)"
+        );
+    }
+}
+
+/**
+ * SQLite test double that stubs MySQL-specific next-id lookup used during cloning.
+ */
+final class TrophyTitleCloneServiceTestDatabase extends PDO
+{
+    private const NEXT_TROPHY_TITLE_ID = 2;
+
+    public function __construct()
+    {
+        parent::__construct('sqlite::memory:');
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'information_schema.tables')) {
+            return new TrophyTitleCloneServiceNextIdStatement(self::NEXT_TROPHY_TITLE_ID);
+        }
+
+        if (str_starts_with(trim($query), 'ANALYZE TABLE')) {
+            return new TrophyTitleCloneServiceNoOpStatement();
+        }
+
+        return parent::prepare($query, $options);
+    }
+}
+
+final class TrophyTitleCloneServiceNextIdStatement extends PDOStatement
+{
+    public function __construct(private readonly int $nextId)
+    {
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchColumn(int $column = 0): mixed
+    {
+        return $this->nextId;
+    }
+}
+
+final class TrophyTitleCloneServiceNoOpStatement extends PDOStatement
+{
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+}

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/Admin/TrophyMergeProgressListener.php';
 require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
 require_once __DIR__ . '/TrophyMergeMappingService.php';
 require_once __DIR__ . '/TrophyMergePlayerProgressUpdater.php';
+require_once __DIR__ . '/TrophyTitleCloneService.php';
 
 class TrophyMergeService
 {
@@ -19,6 +20,8 @@ class TrophyMergeService
     private ?TrophyMergeMappingService $mappingService = null;
 
     private ?TrophyMergePlayerProgressUpdater $playerProgressUpdater = null;
+
+    private ?TrophyTitleCloneService $cloneService = null;
 
     public function __construct(PDO $database, ?NestedDatabaseTransactionRunner $transactionRunner = null)
     {
@@ -158,7 +161,7 @@ class TrophyMergeService
 
     public function cloneGame(int $childGameId): string
     {
-        $this->cloneGameInternal($childGameId);
+        $this->cloneService()->cloneFromGameId($childGameId);
 
         return 'The game have been cloned.';
     }
@@ -168,7 +171,7 @@ class TrophyMergeService
      */
     public function cloneGameWithInfo(int $childGameId): array
     {
-        return $this->cloneGameInternal($childGameId);
+        return $this->cloneService()->cloneFromGameId($childGameId);
     }
 
     public function copyGameData(string $sourceNpCommunicationId, string $targetNpCommunicationId): void
@@ -187,244 +190,6 @@ class TrophyMergeService
     public function recomputeMergeProgressByParent(string $parentNpCommunicationId): void
     {
         $this->playerProgressUpdater()->recomputeByParent($parentNpCommunicationId);
-    }
-
-    /**
-     * @return array{clone_game_id:int, clone_np_communication_id:string}
-     */
-    private function cloneGameInternal(int $childGameId): array
-    {
-        $childNpCommunicationId = $this->getGameNpCommunicationId($childGameId);
-
-        if (str_starts_with($childNpCommunicationId, 'MERGE')) {
-            throw new InvalidArgumentException("Can't clone an already cloned game.");
-        }
-
-        $analyze = $this->database->prepare('ANALYZE TABLE `trophy_title`');
-        $analyze->execute();
-
-        $query = $this->database->prepare(
-            <<<'SQL'
-            SELECT auto_increment
-            FROM   information_schema.tables
-            WHERE  table_name = 'trophy_title'
-SQL
-        );
-        $query->execute();
-
-        $gameId = $query->fetchColumn();
-
-        if ($gameId === false) {
-            throw new RuntimeException('Unable to determine next trophy title identifier.');
-        }
-
-        $gameId = (int) $gameId;
-
-        $cloneNpCommunicationId = 'MERGE_' . str_pad((string) $gameId, 6, '0', STR_PAD_LEFT);
-
-        $cloneGameId = null;
-
-        $this->transactionRunner->execute(function () use (
-            $cloneNpCommunicationId,
-            $childGameId,
-            $childNpCommunicationId,
-            &$cloneGameId
-        ): void {
-            $query = $this->database->prepare(
-                <<<'SQL'
-                INSERT INTO trophy_title
-                            (np_communication_id,
-                             name,
-                             detail,
-                             icon_url,
-                             platform,
-                             bronze,
-                             silver,
-                             gold,
-                             platinum,
-                             set_version)
-                SELECT :np_communication_id,
-                       name,
-                       detail,
-                       icon_url,
-                       platform,
-                       bronze,
-                       silver,
-                       gold,
-                       platinum,
-                       set_version
-                FROM   trophy_title
-                WHERE  id = :id
-SQL
-            );
-            $query->bindValue(':np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);
-            $query->bindValue(':id', $childGameId, PDO::PARAM_INT);
-            $query->execute();
-
-            $insertedGameId = $this->database->lastInsertId();
-
-            if ($insertedGameId === false) {
-                throw new RuntimeException('Unable to determine cloned trophy title identifier.');
-            }
-
-            $cloneGameId = (int) $insertedGameId;
-
-            $metaInsert = $this->database->prepare(
-                <<<'SQL'
-                INSERT INTO trophy_title_meta (
-                    np_communication_id,
-                    owners,
-                    difficulty,
-                    message,
-                    status,
-                    recent_players,
-                    owners_completed,
-                    parent_np_communication_id,
-                    region,
-                    rarity_points
-                )
-                SELECT
-                    :np_communication_id,
-                    owners,
-                    difficulty,
-                    message,
-                    CASE WHEN status = 2 THEN 0 ELSE status END,
-                    recent_players,
-                    owners_completed,
-                    NULL,
-                    '',
-                    rarity_points
-                FROM trophy_title_meta
-                WHERE np_communication_id = :child_np_communication_id
-SQL
-            );
-            $metaInsert->bindValue(':np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);
-            $metaInsert->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-            $metaInsert->execute();
-
-            if ($metaInsert->rowCount() === 0) {
-                $defaultMetaInsert = $this->database->prepare(
-                    <<<'SQL'
-                    INSERT INTO trophy_title_meta (
-                        np_communication_id,
-                        message
-                    )
-                    VALUES (
-                        :np_communication_id,
-                        ''
-                    )
-SQL
-                );
-                $defaultMetaInsert->bindValue(':np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);
-                $defaultMetaInsert->execute();
-            }
-
-            $query = $this->database->prepare(
-                <<<'SQL'
-                INSERT INTO trophy_group
-                            (np_communication_id,
-                             group_id,
-                             name,
-                             detail,
-                             icon_url,
-                             bronze,
-                             silver,
-                             gold,
-                             platinum)
-                SELECT :np_communication_id,
-                       group_id,
-                       name,
-                       detail,
-                       icon_url,
-                       bronze,
-                       silver,
-                       gold,
-                       platinum
-                FROM   trophy_group
-                WHERE  np_communication_id = :child_np_communication_id
-SQL
-            );
-            $query->bindValue(':np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);
-            $query->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-            $query->execute();
-
-            $query = $this->database->prepare(
-                <<<'SQL'
-                INSERT INTO trophy
-                            (np_communication_id,
-                             group_id,
-                             order_id,
-                             hidden,
-                             type,
-                             name,
-                             detail,
-                             icon_url,
-                             progress_target_value,
-                             reward_name,
-                             reward_image_url)
-                SELECT :np_communication_id,
-                       group_id,
-                       order_id,
-                       hidden,
-                       type,
-                       name,
-                       detail,
-                       icon_url,
-                       progress_target_value,
-                       reward_name,
-                       reward_image_url
-                FROM   trophy
-                WHERE  np_communication_id = :child_np_communication_id
-SQL
-            );
-            $query->bindValue(':np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);
-            $query->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-            $query->execute();
-
-            $trophyMetaInsert = $this->database->prepare(
-                <<<'SQL'
-                INSERT INTO trophy_meta (
-                    trophy_id,
-                    rarity_percent,
-                    rarity_point,
-                    status,
-                    owners,
-                    rarity_name
-                )
-                SELECT
-                    parent.id,
-                    tm.rarity_percent,
-                    tm.rarity_point,
-                    tm.status,
-                    tm.owners,
-                    tm.rarity_name
-                FROM trophy parent
-                INNER JOIN trophy child ON child.np_communication_id = :child_np_communication_id
-                    AND child.group_id = parent.group_id
-                    AND child.order_id = parent.order_id
-                INNER JOIN trophy_meta tm ON tm.trophy_id = child.id
-                LEFT JOIN trophy_meta existing ON existing.trophy_id = parent.id
-                WHERE parent.np_communication_id = :parent_np_communication_id
-                    AND existing.trophy_id IS NULL
-SQL
-            );
-            $trophyMetaInsert->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-            $trophyMetaInsert->bindValue(':parent_np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);
-            $trophyMetaInsert->execute();
-
-            $this->cloneGameHistory($childGameId, $cloneGameId);
-        });
-
-        if ($cloneGameId === null) {
-            throw new RuntimeException('Unable to determine cloned trophy title identifier.');
-        }
-
-        $this->logChange('GAME_CLONE', $childGameId, $cloneGameId);
-
-        return [
-            'clone_game_id' => $cloneGameId,
-            'clone_np_communication_id' => $cloneNpCommunicationId,
-        ];
     }
 
     private function getTrophyById(int $trophyId): array
@@ -566,6 +331,11 @@ SQL
     private function playerProgressUpdater(): TrophyMergePlayerProgressUpdater
     {
         return $this->playerProgressUpdater ??= new TrophyMergePlayerProgressUpdater($this->database);
+    }
+
+    private function cloneService(): TrophyTitleCloneService
+    {
+        return $this->cloneService ??= new TrophyTitleCloneService($this->database, $this->transactionRunner);
     }
 
     private function insertTrophyMergeMappingFromIds(int $childTrophyId, int $parentTrophyId): void
@@ -941,110 +711,6 @@ SQL
         }
 
         return (int) $gameId;
-    }
-
-    private function cloneGameHistory(int $sourceGameId, int $cloneGameId): void
-    {
-        $historyQuery = $this->database->prepare(
-            <<<'SQL'
-            SELECT id,
-                   detail,
-                   icon_url,
-                   set_version,
-                   discovered_at
-            FROM   trophy_title_history
-            WHERE  trophy_title_id = :game_id
-            ORDER BY id
-SQL
-        );
-        $historyQuery->bindValue(':game_id', $sourceGameId, PDO::PARAM_INT);
-        $historyQuery->execute();
-
-        $historyInsert = $this->database->prepare(
-            <<<'SQL'
-            INSERT INTO trophy_title_history (
-                trophy_title_id,
-                detail,
-                icon_url,
-                set_version,
-                discovered_at
-            )
-            VALUES (
-                :clone_game_id,
-                :detail,
-                :icon_url,
-                :set_version,
-                :discovered_at
-            )
-SQL
-        );
-
-        $groupHistoryInsert = $this->database->prepare(
-            <<<'SQL'
-            INSERT INTO trophy_group_history (
-                title_history_id,
-                group_id,
-                name,
-                detail,
-                icon_url
-            )
-            SELECT :new_history_id,
-                   group_id,
-                   name,
-                   detail,
-                   icon_url
-            FROM   trophy_group_history
-            WHERE  title_history_id = :old_history_id
-SQL
-        );
-
-        $trophyHistoryInsert = $this->database->prepare(
-            <<<'SQL'
-            INSERT INTO trophy_history (
-                title_history_id,
-                group_id,
-                order_id,
-                name,
-                detail,
-                icon_url,
-                progress_target_value
-            )
-            SELECT :new_history_id,
-                   group_id,
-                   order_id,
-                   name,
-                   detail,
-                   icon_url,
-                   progress_target_value
-            FROM   trophy_history
-            WHERE  title_history_id = :old_history_id
-SQL
-        );
-
-        while ($historyRow = $historyQuery->fetch(PDO::FETCH_ASSOC)) {
-            $historyInsert->execute([
-                ':clone_game_id' => $cloneGameId,
-                ':detail' => $historyRow['detail'],
-                ':icon_url' => $historyRow['icon_url'],
-                ':set_version' => $historyRow['set_version'],
-                ':discovered_at' => $historyRow['discovered_at'],
-            ]);
-
-            $newHistoryId = (int) $this->database->lastInsertId();
-            $oldHistoryId = (int) $historyRow['id'];
-
-            $groupHistoryInsert->execute([
-                ':new_history_id' => $newHistoryId,
-                ':old_history_id' => $oldHistoryId,
-            ]);
-
-            $trophyHistoryInsert->execute([
-                ':new_history_id' => $newHistoryId,
-                ':old_history_id' => $oldHistoryId,
-            ]);
-        }
-
-        $historyQuery->closeCursor();
     }
 
     private function notifyProgress(?TrophyMergeProgressListener $listener, int $percent, string $message): void

--- a/wwwroot/classes/TrophyTitleCloneService.php
+++ b/wwwroot/classes/TrophyTitleCloneService.php
@@ -1,0 +1,393 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
+
+/**
+ * Clones a trophy title into a new MERGE_* title, including catalog rows and history.
+ *
+ * Encapsulates clone persistence that was previously embedded in TrophyMergeService.
+ */
+final class TrophyTitleCloneService
+{
+    public function __construct(
+        private readonly PDO $database,
+        private readonly NestedDatabaseTransactionRunner $transactionRunner,
+    ) {
+    }
+
+    /**
+     * @return array{clone_game_id:int, clone_np_communication_id:string}
+     */
+    public function cloneFromGameId(int $childGameId): array
+    {
+        $childNpCommunicationId = $this->getGameNpCommunicationId($childGameId);
+
+        if (str_starts_with($childNpCommunicationId, 'MERGE')) {
+            throw new InvalidArgumentException("Can't clone an already cloned game.");
+        }
+
+        $analyze = $this->database->prepare('ANALYZE TABLE `trophy_title`');
+        $analyze->execute();
+
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT auto_increment
+            FROM   information_schema.tables
+            WHERE  table_name = 'trophy_title'
+SQL
+        );
+        $query->execute();
+
+        $gameId = $query->fetchColumn();
+
+        if ($gameId === false) {
+            throw new RuntimeException('Unable to determine next trophy title identifier.');
+        }
+
+        $gameId = (int) $gameId;
+
+        $cloneNpCommunicationId = 'MERGE_' . str_pad((string) $gameId, 6, '0', STR_PAD_LEFT);
+
+        $cloneGameId = null;
+
+        $this->transactionRunner->execute(function () use (
+            $cloneNpCommunicationId,
+            $childGameId,
+            $childNpCommunicationId,
+            &$cloneGameId
+        ): void {
+            $query = $this->database->prepare(
+                <<<'SQL'
+                INSERT INTO trophy_title
+                            (np_communication_id,
+                             name,
+                             detail,
+                             icon_url,
+                             platform,
+                             bronze,
+                             silver,
+                             gold,
+                             platinum,
+                             set_version)
+                SELECT :np_communication_id,
+                       name,
+                       detail,
+                       icon_url,
+                       platform,
+                       bronze,
+                       silver,
+                       gold,
+                       platinum,
+                       set_version
+                FROM   trophy_title
+                WHERE  id = :id
+SQL
+            );
+            $query->bindValue(':np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);
+            $query->bindValue(':id', $childGameId, PDO::PARAM_INT);
+            $query->execute();
+
+            $insertedGameId = $this->database->lastInsertId();
+
+            if ($insertedGameId === false) {
+                throw new RuntimeException('Unable to determine cloned trophy title identifier.');
+            }
+
+            $cloneGameId = (int) $insertedGameId;
+
+            $metaInsert = $this->database->prepare(
+                <<<'SQL'
+                INSERT INTO trophy_title_meta (
+                    np_communication_id,
+                    owners,
+                    difficulty,
+                    message,
+                    status,
+                    recent_players,
+                    owners_completed,
+                    parent_np_communication_id,
+                    region,
+                    rarity_points
+                )
+                SELECT
+                    :np_communication_id,
+                    owners,
+                    difficulty,
+                    message,
+                    CASE WHEN status = 2 THEN 0 ELSE status END,
+                    recent_players,
+                    owners_completed,
+                    NULL,
+                    '',
+                    rarity_points
+                FROM trophy_title_meta
+                WHERE np_communication_id = :child_np_communication_id
+SQL
+            );
+            $metaInsert->bindValue(':np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);
+            $metaInsert->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+            $metaInsert->execute();
+
+            if ($metaInsert->rowCount() === 0) {
+                $defaultMetaInsert = $this->database->prepare(
+                    <<<'SQL'
+                    INSERT INTO trophy_title_meta (
+                        np_communication_id,
+                        message
+                    )
+                    VALUES (
+                        :np_communication_id,
+                        ''
+                    )
+SQL
+                );
+                $defaultMetaInsert->bindValue(':np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);
+                $defaultMetaInsert->execute();
+            }
+
+            $query = $this->database->prepare(
+                <<<'SQL'
+                INSERT INTO trophy_group
+                            (np_communication_id,
+                             group_id,
+                             name,
+                             detail,
+                             icon_url,
+                             bronze,
+                             silver,
+                             gold,
+                             platinum)
+                SELECT :np_communication_id,
+                       group_id,
+                       name,
+                       detail,
+                       icon_url,
+                       bronze,
+                       silver,
+                       gold,
+                       platinum
+                FROM   trophy_group
+                WHERE  np_communication_id = :child_np_communication_id
+SQL
+            );
+            $query->bindValue(':np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);
+            $query->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+            $query->execute();
+
+            $query = $this->database->prepare(
+                <<<'SQL'
+                INSERT INTO trophy
+                            (np_communication_id,
+                             group_id,
+                             order_id,
+                             hidden,
+                             type,
+                             name,
+                             detail,
+                             icon_url,
+                             progress_target_value,
+                             reward_name,
+                             reward_image_url)
+                SELECT :np_communication_id,
+                       group_id,
+                       order_id,
+                       hidden,
+                       type,
+                       name,
+                       detail,
+                       icon_url,
+                       progress_target_value,
+                       reward_name,
+                       reward_image_url
+                FROM   trophy
+                WHERE  np_communication_id = :child_np_communication_id
+SQL
+            );
+            $query->bindValue(':np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);
+            $query->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+            $query->execute();
+
+            $trophyMetaInsert = $this->database->prepare(
+                <<<'SQL'
+                INSERT INTO trophy_meta (
+                    trophy_id,
+                    rarity_percent,
+                    rarity_point,
+                    status,
+                    owners,
+                    rarity_name
+                )
+                SELECT
+                    parent.id,
+                    tm.rarity_percent,
+                    tm.rarity_point,
+                    tm.status,
+                    tm.owners,
+                    tm.rarity_name
+                FROM trophy parent
+                INNER JOIN trophy child ON child.np_communication_id = :child_np_communication_id
+                    AND child.group_id = parent.group_id
+                    AND child.order_id = parent.order_id
+                INNER JOIN trophy_meta tm ON tm.trophy_id = child.id
+                LEFT JOIN trophy_meta existing ON existing.trophy_id = parent.id
+                WHERE parent.np_communication_id = :parent_np_communication_id
+                    AND existing.trophy_id IS NULL
+SQL
+            );
+            $trophyMetaInsert->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+            $trophyMetaInsert->bindValue(':parent_np_communication_id', $cloneNpCommunicationId, PDO::PARAM_STR);
+            $trophyMetaInsert->execute();
+
+            $this->cloneGameHistory($childGameId, $cloneGameId);
+        });
+
+        if ($cloneGameId === null) {
+            throw new RuntimeException('Unable to determine cloned trophy title identifier.');
+        }
+
+        $this->logClone($childGameId, $cloneGameId);
+
+        return [
+            'clone_game_id' => $cloneGameId,
+            'clone_np_communication_id' => $cloneNpCommunicationId,
+        ];
+    }
+
+    private function getGameNpCommunicationId(int $gameId): string
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT np_communication_id
+            FROM   trophy_title
+            WHERE  id = :id
+SQL
+        );
+        $query->bindValue(':id', $gameId, PDO::PARAM_INT);
+        $query->execute();
+
+        $npCommunicationId = $query->fetchColumn();
+
+        if ($npCommunicationId === false) {
+            throw new InvalidArgumentException('Game not found.');
+        }
+
+        return (string) $npCommunicationId;
+    }
+
+    private function cloneGameHistory(int $sourceGameId, int $cloneGameId): void
+    {
+        $historyQuery = $this->database->prepare(
+            <<<'SQL'
+            SELECT id,
+                   detail,
+                   icon_url,
+                   set_version,
+                   discovered_at
+            FROM   trophy_title_history
+            WHERE  trophy_title_id = :game_id
+            ORDER BY id
+SQL
+        );
+        $historyQuery->bindValue(':game_id', $sourceGameId, PDO::PARAM_INT);
+        $historyQuery->execute();
+
+        $historyInsert = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy_title_history (
+                trophy_title_id,
+                detail,
+                icon_url,
+                set_version,
+                discovered_at
+            )
+            VALUES (
+                :clone_game_id,
+                :detail,
+                :icon_url,
+                :set_version,
+                :discovered_at
+            )
+SQL
+        );
+
+        $groupHistoryInsert = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy_group_history (
+                title_history_id,
+                group_id,
+                name,
+                detail,
+                icon_url
+            )
+            SELECT :new_history_id,
+                   group_id,
+                   name,
+                   detail,
+                   icon_url
+            FROM   trophy_group_history
+            WHERE  title_history_id = :old_history_id
+SQL
+        );
+
+        $trophyHistoryInsert = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy_history (
+                title_history_id,
+                group_id,
+                order_id,
+                name,
+                detail,
+                icon_url,
+                progress_target_value
+            )
+            SELECT :new_history_id,
+                   group_id,
+                   order_id,
+                   name,
+                   detail,
+                   icon_url,
+                   progress_target_value
+            FROM   trophy_history
+            WHERE  title_history_id = :old_history_id
+SQL
+        );
+
+        while ($historyRow = $historyQuery->fetch(PDO::FETCH_ASSOC)) {
+            $historyInsert->execute([
+                ':clone_game_id' => $cloneGameId,
+                ':detail' => $historyRow['detail'],
+                ':icon_url' => $historyRow['icon_url'],
+                ':set_version' => $historyRow['set_version'],
+                ':discovered_at' => $historyRow['discovered_at'],
+            ]);
+
+            $newHistoryId = (int) $this->database->lastInsertId();
+            $oldHistoryId = (int) $historyRow['id'];
+
+            $groupHistoryInsert->execute([
+                ':new_history_id' => $newHistoryId,
+                ':old_history_id' => $oldHistoryId,
+            ]);
+
+            $trophyHistoryInsert->execute([
+                ':new_history_id' => $newHistoryId,
+                ':old_history_id' => $oldHistoryId,
+            ]);
+        }
+
+        $historyQuery->closeCursor();
+    }
+
+    private function logClone(int $childGameId, int $cloneGameId): void
+    {
+        $query = $this->database->prepare(
+            "INSERT INTO `psn100_change` (`change_type`, `param_1`, `param_2`) VALUES (:change_type, :param_1, :param_2)"
+        );
+        $query->bindValue(':change_type', 'GAME_CLONE', PDO::PARAM_STR);
+        $query->bindValue(':param_1', $childGameId, PDO::PARAM_INT);
+        $query->bindValue(':param_2', $cloneGameId, PDO::PARAM_INT);
+        $query->execute();
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels trophy-title **cloning** out of `TrophyMergeService` into a new `TrophyTitleCloneService`, continuing the incremental decomposition of merge-related god classes.

`TrophyMergeService` was ~1,058 lines and mixed merge orchestration, cloning, earned-trophy migration, platform rollup, and changelog logging. Cloning alone was ~280 lines of SQL spanning title/meta/groups/trophies/history tables.

## Changes

- **New** `TrophyTitleCloneService` — owns `cloneFromGameId()`, history duplication, and `GAME_CLONE` changelog writes
- **Updated** `TrophyMergeService` — `cloneGame()` / `cloneGameWithInfo()` delegate via a lazy-loaded clone service (same pattern as `TrophyMergeMappingService` and `TrophyMergePlayerProgressUpdater`)
- **New** `TrophyTitleCloneServiceTest` — validation and full clone behavior (catalog + history + changelog)

## Impact

- `TrophyMergeService`: **1,058 → 724 lines** (~32% smaller)
- Public API unchanged (`cloneGame`, `cloneGameWithInfo`, callers in admin + auto-merge)
- All **699 tests pass**

## Follow-up PR ideas (other god-class peel-offs)

| Class | Suggested next extraction |
|---|---|
| `GameCopyService` (~1,248 lines) | Group conflict resolution |
| `ThirtyMinuteCronJob` (~820 lines) | Private-profile handling |
| `PsnGameLookupService` (~633 lines) | NP Communication ID payload validation |
| `PlayerScanTitleCatalogSynchronizer` (~560 lines) | Title upsert into `TrophyCatalogSynchronizer` |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87bb30ca-0309-4384-a22f-e6bd457cbeca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87bb30ca-0309-4384-a22f-e6bd457cbeca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

