### PR TITLE
Extract TrophyGroupConflictResolver from GameCopyService

### DIFF
--- a/tests/TrophyGroupConflictResolverTest.php
+++ b/tests/TrophyGroupConflictResolverTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyGroupConflictResolver.php';
+
+final class TrophyGroupConflictResolverTest extends TestCase
+{
+    private TrophyGroupConflictResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new TrophyGroupConflictResolver();
+    }
+
+    public function testParseNumericGroupIdAcceptsZeroPaddedDigits(): void
+    {
+        $this->assertSame(1, $this->resolver->parseNumericGroupId('001'));
+        $this->assertSame(0, $this->resolver->parseNumericGroupId('000'));
+        $this->assertSame(123, $this->resolver->parseNumericGroupId('123'));
+    }
+
+    public function testParseNumericGroupIdRejectsNonNumericIds(): void
+    {
+        $this->assertSame(null, $this->resolver->parseNumericGroupId('default'));
+        $this->assertSame(null, $this->resolver->parseNumericGroupId('01a'));
+    }
+
+    public function testFormatGroupIdPadsToOriginalLength(): void
+    {
+        $this->assertSame('101', $this->resolver->formatGroupId(101, '001'));
+        $this->assertSame('0101', $this->resolver->formatGroupId(101, '0100'));
+    }
+
+    public function testFormatGroupIdUsesMinimumLengthOfThree(): void
+    {
+        $this->assertSame('101', $this->resolver->formatGroupId(101, '1'));
+    }
+
+    public function testDeterminePreferredGroupOffsetUsesFirstMappedParentBlock(): void
+    {
+        $this->assertSame(200, $this->resolver->determinePreferredGroupOffset([
+            '001' => '201',
+            '002' => '305',
+        ]));
+    }
+
+    public function testDeterminePreferredGroupOffsetReturnsNullWhenNoNumericMappingsExist(): void
+    {
+        $this->assertSame(null, $this->resolver->determinePreferredGroupOffset([
+            '001' => 'default',
+        ]));
+        $this->assertSame(null, $this->resolver->determinePreferredGroupOffset([]));
+    }
+
+    public function testDetermineGroupOffsetReturnsNextBlockAfterHighestExistingGroup(): void
+    {
+        $this->assertSame(300, $this->resolver->determineGroupOffset([
+            '001' => true,
+            '205' => true,
+        ]));
+    }
+
+    public function testDetermineGroupOffsetDefaultsToFirstBlockWhenNoNumericGroupsExist(): void
+    {
+        $this->assertSame(100, $this->resolver->determineGroupOffset([
+            'default' => true,
+        ]));
+        $this->assertSame(100, $this->resolver->determineGroupOffset([]));
+    }
+
+    public function testFindMatchingParentGroupIdMatchesBySortedTrophyNames(): void
+    {
+        $childNames = [
+            '002' => ['Alpha', 'Beta'],
+        ];
+        $parentNames = [
+            '001' => ['Alpha', 'Beta'],
+            '003' => ['Gamma'],
+        ];
+
+        $this->assertSame(
+            '001',
+            $this->resolver->findMatchingParentGroupId('002', $childNames, $parentNames, [])
+        );
+    }
+
+    public function testFindMatchingParentGroupIdSkipsUsedAndSameIdGroups(): void
+    {
+        $childNames = [
+            '002' => ['Alpha'],
+        ];
+        $parentNames = [
+            '002' => ['Alpha'],
+            '003' => ['Alpha'],
+            '004' => ['Alpha'],
+        ];
+
+        $this->assertSame(
+            '004',
+            $this->resolver->findMatchingParentGroupId('002', $childNames, $parentNames, [
+                '003' => true,
+            ])
+        );
+    }
+
+    public function testFindMatchingParentGroupIdReturnsNullWhenChildHasNoTrophies(): void
+    {
+        $this->assertSame(null, $this->resolver->findMatchingParentGroupId('002', [], ['001' => ['Alpha']], []));
+        $this->assertSame(null, $this->resolver->findMatchingParentGroupId('002', ['002' => []], ['001' => ['Alpha']], []));
+    }
+
+    public function testAllocateNonConflictingGroupIdUsesPreferredOffsetWhenAvailable(): void
+    {
+        $result = $this->resolver->allocateNonConflictingGroupId(
+            1,
+            '001',
+            [],
+            200,
+            300
+        );
+
+        $this->assertSame('201', $result['groupId']);
+        $this->assertSame(200, $result['preferredOffset']);
+        $this->assertSame(200, $result['groupOffset']);
+    }
+
+    public function testAllocateNonConflictingGroupIdFallsBackToGroupOffsetWhenPreferredIsNull(): void
+    {
+        $result = $this->resolver->allocateNonConflictingGroupId(
+            1,
+            '001',
+            [],
+            null,
+            300
+        );
+
+        $this->assertSame('301', $result['groupId']);
+        $this->assertSame(null, $result['preferredOffset']);
+        $this->assertSame(300, $result['groupOffset']);
+    }
+
+    public function testAllocateNonConflictingGroupIdIncrementsOffsetUntilUnusedIdIsFound(): void
+    {
+        $result = $this->resolver->allocateNonConflictingGroupId(
+            1,
+            '001',
+            ['201' => true],
+            200,
+            300
+        );
+
+        $this->assertSame('301', $result['groupId']);
+        $this->assertSame(null, $result['preferredOffset']);
+        $this->assertSame(300, $result['groupOffset']);
+    }
+}

--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
+require_once __DIR__ . '/TrophyGroupConflictResolver.php';
 
 class GameCopyService
 {
@@ -187,10 +188,16 @@ class GameCopyService
 
     private TrophyHistoryRecorder $historyRecorder;
 
-    public function __construct(PDO $database, ?TrophyHistoryRecorder $historyRecorder = null)
-    {
+    private TrophyGroupConflictResolver $groupConflictResolver;
+
+    public function __construct(
+        PDO $database,
+        ?TrophyHistoryRecorder $historyRecorder = null,
+        ?TrophyGroupConflictResolver $groupConflictResolver = null
+    ) {
         $this->database = $database;
         $this->historyRecorder = $historyRecorder ?? new TrophyHistoryRecorder($database);
+        $this->groupConflictResolver = $groupConflictResolver ?? new TrophyGroupConflictResolver();
     }
 
     public function copyChildToParent(
@@ -422,7 +429,7 @@ class GameCopyService
         while (($groupId = $query->fetchColumn()) !== false) {
             $groupId = (string) $groupId;
 
-            if ($this->parseNumericGroupId($groupId) === null) {
+            if ($this->groupConflictResolver->parseNumericGroupId($groupId) === null) {
                 continue;
             }
 
@@ -448,7 +455,7 @@ class GameCopyService
 
         if ($forcedGroupIds !== []) {
             foreach ($forcedGroupIds as $groupId) {
-                if ($this->parseNumericGroupId($groupId) === null) {
+                if ($this->groupConflictResolver->parseNumericGroupId($groupId) === null) {
                     continue;
                 }
 
@@ -474,8 +481,8 @@ class GameCopyService
             $usedParentGroups[(string) $parentGroupId] = true;
         }
 
-        $groupOffset = $this->determineGroupOffset($existingGroupIds);
-        $preferredOffset = $this->determinePreferredGroupOffset($existingGroupMappings);
+        $groupOffset = $this->groupConflictResolver->determineGroupOffset($existingGroupIds);
+        $preferredOffset = $this->groupConflictResolver->determinePreferredGroupOffset($existingGroupMappings);
 
         $select = $this->database->prepare(
             'SELECT group_id, name, detail, icon_url, bronze, silver, gold, platinum
@@ -527,7 +534,7 @@ class GameCopyService
                 continue;
             }
 
-            $numericGroupId = $this->parseNumericGroupId($groupId);
+            $numericGroupId = $this->groupConflictResolver->parseNumericGroupId($groupId);
 
             if ($numericGroupId === null) {
                 $select->closeCursor();
@@ -537,7 +544,7 @@ class GameCopyService
             $targetGroupId = $groupIdMapping[$groupId] ?? null;
 
             if ($targetGroupId === null) {
-                $targetGroupId = $this->findMatchingParentGroupId(
+                $targetGroupId = $this->groupConflictResolver->findMatchingParentGroupId(
                     $groupId,
                     $childGroupTrophyNames,
                     $parentGroupTrophyNames,
@@ -546,20 +553,17 @@ class GameCopyService
             }
 
             if ($targetGroupId === null) {
-                $candidateOffset = $preferredOffset ?? $groupOffset;
-                $newGroupId = $this->formatGroupId($numericGroupId + $candidateOffset, (string) $group['group_id']);
+                $allocation = $this->groupConflictResolver->allocateNonConflictingGroupId(
+                    $numericGroupId,
+                    (string) $group['group_id'],
+                    $existingGroupIds,
+                    $preferredOffset,
+                    $groupOffset
+                );
 
-                while (isset($existingGroupIds[$newGroupId])) {
-                    if ($preferredOffset !== null) {
-                        $preferredOffset = null;
-                    }
-
-                    $candidateOffset += 100;
-                    $newGroupId = $this->formatGroupId($numericGroupId + $candidateOffset, (string) $group['group_id']);
-                }
-
-                $groupOffset = $candidateOffset;
-                $targetGroupId = $newGroupId;
+                $preferredOffset = $allocation['preferredOffset'];
+                $groupOffset = $allocation['groupOffset'];
+                $targetGroupId = $allocation['groupId'];
             }
 
             $this->upsertTrophyGroup(
@@ -805,7 +809,7 @@ class GameCopyService
         while (($groupId = $query->fetchColumn()) !== false) {
             $groupId = (string) $groupId;
 
-            if ($this->parseNumericGroupId($groupId) === null) {
+            if ($this->groupConflictResolver->parseNumericGroupId($groupId) === null) {
                 continue;
             }
 
@@ -948,42 +952,6 @@ class GameCopyService
         unset($groupNames);
 
         return $names;
-    }
-
-    /**
-     * @param array<string, string[]> $childGroupTrophyNames
-     * @param array<string, string[]> $parentGroupTrophyNames
-     * @param array<string, bool> $usedParentGroups
-     */
-    private function findMatchingParentGroupId(
-        string $childGroupId,
-        array $childGroupTrophyNames,
-        array $parentGroupTrophyNames,
-        array $usedParentGroups
-    ): ?string {
-        $childNames = $childGroupTrophyNames[$childGroupId] ?? null;
-
-        if ($childNames === null || $childNames === []) {
-            return null;
-        }
-
-        foreach ($parentGroupTrophyNames as $parentGroupId => $parentNames) {
-            $parentGroupIdString = (string) $parentGroupId;
-
-            if ($parentGroupIdString === $childGroupId) {
-                continue;
-            }
-
-            if (isset($usedParentGroups[$parentGroupIdString])) {
-                continue;
-            }
-
-            if ($parentNames === $childNames) {
-                return $parentGroupIdString;
-            }
-        }
-
-        return null;
     }
 
     private function upsertTrophyGroup(PDOStatement $statement, string $parentNpCommunicationId, string $groupId, array $group): void
@@ -1149,78 +1117,6 @@ class GameCopyService
         ]);
 
         $statement->closeCursor();
-    }
-
-    /**
-     * @param array<string, string> $existingGroupMappings
-     */
-    private function determinePreferredGroupOffset(array $existingGroupMappings): ?int
-    {
-        foreach ($existingGroupMappings as $parentGroupId) {
-            $numericGroupId = $this->parseNumericGroupId($parentGroupId);
-
-            if ($numericGroupId === null) {
-                continue;
-            }
-
-            $block = intdiv($numericGroupId, 100);
-
-            return $block * 100;
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<string, bool> $existingGroupIds
-     */
-    private function determineGroupOffset(array $existingGroupIds): int
-    {
-        $maxBlock = -1;
-
-        foreach ($existingGroupIds as $groupId => $_) {
-            $groupId = (string) $groupId;
-
-            $numericGroupId = $this->parseNumericGroupId($groupId);
-
-            if ($numericGroupId === null) {
-                continue;
-            }
-
-            $block = intdiv($numericGroupId, 100);
-
-            if ($block > $maxBlock) {
-                $maxBlock = $block;
-            }
-        }
-
-        if ($maxBlock < 0) {
-            $maxBlock = 0;
-        }
-
-        return ($maxBlock + 1) * 100;
-    }
-
-    private function parseNumericGroupId(string $groupId): ?int
-    {
-        if (!ctype_digit($groupId)) {
-            return null;
-        }
-
-        $trimmed = ltrim($groupId, '0');
-
-        if ($trimmed === '') {
-            return 0;
-        }
-
-        return (int) $trimmed;
-    }
-
-    private function formatGroupId(int $numericValue, string $originalGroupId): string
-    {
-        $length = max(strlen($originalGroupId), 3);
-
-        return str_pad((string) $numericValue, $length, '0', STR_PAD_LEFT);
     }
 
     private function getNextOrderId(string $npCommunicationId): int

--- a/wwwroot/classes/Admin/TrophyGroupConflictResolver.php
+++ b/wwwroot/classes/Admin/TrophyGroupConflictResolver.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+final class TrophyGroupConflictResolver
+{
+    public function parseNumericGroupId(string $groupId): ?int
+    {
+        if (!ctype_digit($groupId)) {
+            return null;
+        }
+
+        $trimmed = ltrim($groupId, '0');
+
+        if ($trimmed === '') {
+            return 0;
+        }
+
+        return (int) $trimmed;
+    }
+
+    public function formatGroupId(int $numericValue, string $originalGroupId): string
+    {
+        $length = max(strlen($originalGroupId), 3);
+
+        return str_pad((string) $numericValue, $length, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * @param array<string, string> $existingGroupMappings
+     */
+    public function determinePreferredGroupOffset(array $existingGroupMappings): ?int
+    {
+        foreach ($existingGroupMappings as $parentGroupId) {
+            $numericGroupId = $this->parseNumericGroupId($parentGroupId);
+
+            if ($numericGroupId === null) {
+                continue;
+            }
+
+            $block = intdiv($numericGroupId, 100);
+
+            return $block * 100;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, bool> $existingGroupIds
+     */
+    public function determineGroupOffset(array $existingGroupIds): int
+    {
+        $maxBlock = -1;
+
+        foreach ($existingGroupIds as $groupId => $_) {
+            $groupId = (string) $groupId;
+
+            $numericGroupId = $this->parseNumericGroupId($groupId);
+
+            if ($numericGroupId === null) {
+                continue;
+            }
+
+            $block = intdiv($numericGroupId, 100);
+
+            if ($block > $maxBlock) {
+                $maxBlock = $block;
+            }
+        }
+
+        if ($maxBlock < 0) {
+            $maxBlock = 0;
+        }
+
+        return ($maxBlock + 1) * 100;
+    }
+
+    /**
+     * @param array<string, string[]> $childGroupTrophyNames
+     * @param array<string, string[]> $parentGroupTrophyNames
+     * @param array<string, bool> $usedParentGroups
+     */
+    public function findMatchingParentGroupId(
+        string $childGroupId,
+        array $childGroupTrophyNames,
+        array $parentGroupTrophyNames,
+        array $usedParentGroups
+    ): ?string {
+        $childNames = $childGroupTrophyNames[$childGroupId] ?? null;
+
+        if ($childNames === null || $childNames === []) {
+            return null;
+        }
+
+        foreach ($parentGroupTrophyNames as $parentGroupId => $parentNames) {
+            $parentGroupIdString = (string) $parentGroupId;
+
+            if ($parentGroupIdString === $childGroupId) {
+                continue;
+            }
+
+            if (isset($usedParentGroups[$parentGroupIdString])) {
+                continue;
+            }
+
+            if ($parentNames === $childNames) {
+                return $parentGroupIdString;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, bool> $existingGroupIds
+     * @return array{groupId: string, preferredOffset: ?int, groupOffset: int}
+     */
+    public function allocateNonConflictingGroupId(
+        int $numericGroupId,
+        string $originalGroupId,
+        array $existingGroupIds,
+        ?int $preferredOffset,
+        int $groupOffset
+    ): array {
+        $candidateOffset = $preferredOffset ?? $groupOffset;
+        $newGroupId = $this->formatGroupId($numericGroupId + $candidateOffset, $originalGroupId);
+
+        while (isset($existingGroupIds[$newGroupId])) {
+            if ($preferredOffset !== null) {
+                $preferredOffset = null;
+            }
+
+            $candidateOffset += 100;
+            $newGroupId = $this->formatGroupId($numericGroupId + $candidateOffset, $originalGroupId);
+        }
+
+        return [
+            'groupId' => $newGroupId,
+            'preferredOffset' => $preferredOffset,
+            'groupOffset' => $candidateOffset,
+        ];
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels one concern off `GameCopyService` (~1,248 lines): **trophy group ID conflict resolution**.

`GameCopyService` still owns DB orchestration for copying conflicting groups/trophies, but pure algorithmic logic now lives in `TrophyGroupConflictResolver`:

- Numeric group ID parsing and formatting
- Offset calculation for new group IDs
- Name-based parent group matching
- Non-conflicting ID allocation when offsets collide

## Motivation

`GameCopyService` is the largest God class in the codebase and had zero direct unit tests. The conflict-resolution block was self-contained algorithmic code mixed with SQL — a good first incremental extraction.

## Changes

- **New** `wwwroot/classes/Admin/TrophyGroupConflictResolver.php` (144 lines)
- **Updated** `GameCopyService` to inject and delegate to the resolver (~104 lines removed)
- **New** `tests/TrophyGroupConflictResolverTest.php` with 14 unit tests covering the extracted logic

## Follow-up PRs (not in scope)

Other God-class candidates identified for future one-concern extractions:

1. `GameRescanService` → `GameRescanProgressReporter`
2. `ThirtyMinuteCronJob` → `PlayerTitleScanProcessor`
3. `TrophyMergeService` → `MergedTrophyEarnedSynchronizer`
4. `AutomaticTrophyTitleMergeService` → `TrophySetComparator`

## Testing

- `php tests/run.php` — all 713 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-259b27e3-8ddb-4c94-a4b3-9bb756923c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-259b27e3-8ddb-4c94-a4b3-9bb756923c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

