### PR TITLE
Extract PSN trophy lookup adapters from GameRescanService

### DIFF
--- a/tests/PsnTrophyLookupGroupDataProviderTest.php
+++ b/tests/PsnTrophyLookupGroupDataProviderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PsnTrophyLookupGroupDataProvider.php';
+
+final class PsnTrophyLookupGroupDataProviderTest extends TestCase
+{
+    public function testAdaptTrophyDataReturnsEmptyArrayWhenGroupsMissing(): void
+    {
+        $result = PsnTrophyLookupGroupDataProvider::adaptTrophyData([]);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testAdaptTrophyDataSkipsInvalidGroupEntries(): void
+    {
+        $result = PsnTrophyLookupGroupDataProvider::adaptTrophyData([
+            'trophyGroups' => [
+                'not-an-array',
+                [
+                    'trophyGroupId' => 'all',
+                    'trophyGroupName' => 'Base Game',
+                    'trophyGroupDetail' => 'Main campaign',
+                    'trophyGroupIconUrl' => 'https://example.com/group.png',
+                    'trophies' => [
+                        [
+                            'trophyId' => 7,
+                            'trophyHidden' => true,
+                            'trophyType' => 'gold',
+                            'trophyName' => 'Complete Story',
+                            'trophyDetail' => 'Finish the game',
+                            'trophyIconUrl' => 'https://example.com/trophy.png',
+                            'trophyProgressTargetValue' => 100,
+                            'trophyRewardName' => 'Reward',
+                            'trophyRewardImageUrl' => 'https://example.com/reward.png',
+                        ],
+                        'invalid-trophy',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('all', $result[0]['group']->id());
+        $this->assertSame('Base Game', $result[0]['group']->name());
+        $this->assertSame('Main campaign', $result[0]['group']->detail());
+        $this->assertSame('https://example.com/group.png', $result[0]['group']->iconUrl());
+
+        $this->assertCount(1, $result[0]['trophies']);
+        $trophy = $result[0]['trophies'][0];
+        $this->assertSame(7, $trophy->id());
+        $this->assertTrue($trophy->hidden());
+        $this->assertSame('gold', $trophy->type()->value);
+        $this->assertSame('Complete Story', $trophy->name());
+        $this->assertSame('Finish the game', $trophy->detail());
+        $this->assertSame('https://example.com/trophy.png', $trophy->iconUrl());
+        $this->assertSame('100', $trophy->progressTargetValue());
+        $this->assertSame('Reward', $trophy->rewardName());
+        $this->assertSame('https://example.com/reward.png', $trophy->rewardImageUrl());
+    }
+
+    public function testAdaptTrophyDataUsesDefaultsForMissingFields(): void
+    {
+        $result = PsnTrophyLookupGroupDataProvider::adaptTrophyData([
+            'trophyGroups' => [
+                [
+                    'trophies' => [
+                        [],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame('', $result[0]['group']->id());
+        $this->assertSame('', $result[0]['group']->name());
+        $this->assertSame(0, $result[0]['trophies'][0]->id());
+        $this->assertFalse($result[0]['trophies'][0]->hidden());
+        $this->assertSame('bronze', $result[0]['trophies'][0]->type()->value);
+        $this->assertSame(null, $result[0]['trophies'][0]->rewardImageUrl());
+    }
+}

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -12,6 +12,7 @@ require_once __DIR__ . '/../TrophyImageDirectories.php';
 require_once __DIR__ . '/../TrophyImageDownloader.php';
 require_once __DIR__ . '/../TrophyCatalogSynchronizer.php';
 require_once __DIR__ . '/PsnGameLookupService.php';
+require_once __DIR__ . '/PsnTrophyLookupGroupDataProvider.php';
 require_once __DIR__ . '/PlayStationWorkerAuthenticator.php';
 require_once __DIR__ . '/WorkerService.php';
 
@@ -31,6 +32,7 @@ class GameRescanService
 
     private ImageHashCalculator $imageHashCalculator;
     private PsnGameLookupService $psnGameLookupService;
+    private PsnTrophyLookupGroupDataProvider $trophyLookupGroupDataProvider;
     private TrophyImageDirectories $imageDirectories;
     private TrophyImageDownloader $imageDownloader;
     private PlayStationWorkerAuthenticator $workerAuthenticator;
@@ -47,6 +49,7 @@ class GameRescanService
         ?TrophyHistoryRecorder $historyRecorder = null,
         ?ImageHashCalculator $imageHashCalculator = null,
         ?PsnGameLookupService $psnGameLookupService = null,
+        ?PsnTrophyLookupGroupDataProvider $trophyLookupGroupDataProvider = null,
         ?TrophyImageDirectories $imageDirectories = null,
         ?TrophyImageDownloader $imageDownloader = null,
         ?PlayStationWorkerAuthenticator $workerAuthenticator = null,
@@ -59,6 +62,8 @@ class GameRescanService
         $this->trophyMetaRepository = new TrophyMetaRepository($database);
         $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
         $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase($database);
+        $this->trophyLookupGroupDataProvider = $trophyLookupGroupDataProvider
+            ?? new PsnTrophyLookupGroupDataProvider($this->psnGameLookupService);
         $this->imageDirectories = $imageDirectories ?? TrophyImageDirectories::productionDefault();
         $this->imageDownloader = $imageDownloader ?? new TrophyImageDownloader($this->imageHashCalculator);
         $this->trophyCatalogSynchronizer = $trophyCatalogSynchronizer ?? new TrophyCatalogSynchronizer($database);
@@ -381,7 +386,7 @@ class GameRescanService
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->execute();
 
-        $groupData = $this->fetchGameLookupGroupData($client, $npCommunicationId);
+        $groupData = $this->trophyLookupGroupDataProvider->fetchGroupData($client, $npCommunicationId);
         $totalSteps = array_reduce(
             $groupData,
             static fn (int $carry, array $data): int => $carry + 1 + count($data['trophies']),
@@ -617,158 +622,6 @@ class GameRescanService
             static fn (array $data) => $data['group'],
             $groupData
         );
-    }
-
-    /**
-     * @return array<int, array{group: object, trophies: array<int, object>}>
-     */
-    private function fetchGameLookupGroupData(Client $client, string $npCommunicationId): array
-    {
-        $trophyData = $this->psnGameLookupService->fetchTrophyDataForNpCommunicationId($npCommunicationId, $client);
-        $rawGroups = $trophyData['trophyGroups'] ?? [];
-
-        if (!is_array($rawGroups)) {
-            return [];
-        }
-
-        $groupData = [];
-
-        foreach ($rawGroups as $rawGroup) {
-            if (!is_array($rawGroup)) {
-                continue;
-            }
-
-            $groupId = (string) ($rawGroup['trophyGroupId'] ?? '');
-            $rawTrophies = $rawGroup['trophies'] ?? [];
-
-            if (!is_array($rawTrophies)) {
-                $rawTrophies = [];
-            }
-
-            $trophies = [];
-            foreach ($rawTrophies as $rawTrophy) {
-                if (!is_array($rawTrophy)) {
-                    continue;
-                }
-
-                $trophies[] = $this->createTrophyApiAdapter($rawTrophy);
-            }
-
-            $groupData[] = [
-                'group' => $this->createTrophyGroupApiAdapter($groupId, $rawGroup),
-                'trophies' => $trophies,
-            ];
-        }
-
-        return $groupData;
-    }
-
-    /**
-     * @param array<string, mixed> $rawGroup
-     */
-    private function createTrophyGroupApiAdapter(string $groupId, array $rawGroup): object
-    {
-        return new class ($groupId, $rawGroup) {
-            /**
-             * @param array<string, mixed> $rawGroup
-             */
-            public function __construct(
-                private readonly string $groupId,
-                private readonly array $rawGroup
-            ) {
-            }
-
-            public function id(): string
-            {
-                return $this->groupId;
-            }
-
-            public function name(): string
-            {
-                return (string) ($this->rawGroup['trophyGroupName'] ?? '');
-            }
-
-            public function detail(): string
-            {
-                return (string) ($this->rawGroup['trophyGroupDetail'] ?? '');
-            }
-
-            public function iconUrl(): string
-            {
-                return (string) ($this->rawGroup['trophyGroupIconUrl'] ?? '');
-            }
-        };
-    }
-
-    /**
-     * @param array<string, mixed> $rawTrophy
-     */
-    private function createTrophyApiAdapter(array $rawTrophy): object
-    {
-        return new class ($rawTrophy) {
-            /**
-             * @param array<string, mixed> $rawTrophy
-             */
-            public function __construct(private readonly array $rawTrophy)
-            {
-            }
-
-            public function id(): int
-            {
-                return (int) ($this->rawTrophy['trophyId'] ?? 0);
-            }
-
-            public function hidden(): bool
-            {
-                return (bool) ($this->rawTrophy['trophyHidden'] ?? false);
-            }
-
-            public function type(): object
-            {
-                return new class ((string) ($this->rawTrophy['trophyType'] ?? 'bronze')) {
-                    public function __construct(public readonly string $value)
-                    {
-                    }
-                };
-            }
-
-            public function name(): string
-            {
-                return (string) ($this->rawTrophy['trophyName'] ?? '');
-            }
-
-            public function detail(): string
-            {
-                return (string) ($this->rawTrophy['trophyDetail'] ?? '');
-            }
-
-            public function iconUrl(): string
-            {
-                return (string) ($this->rawTrophy['trophyIconUrl'] ?? '');
-            }
-
-            public function progressTargetValue(): string
-            {
-                $value = $this->rawTrophy['trophyProgressTargetValue'] ?? '';
-
-                return is_scalar($value) ? (string) $value : '';
-            }
-
-            public function rewardName(): string
-            {
-                return (string) ($this->rawTrophy['trophyRewardName'] ?? '');
-            }
-
-            public function rewardImageUrl(): ?string
-            {
-                $rewardImageUrl = $this->rawTrophy['trophyRewardImageUrl'] ?? null;
-                if (!is_string($rewardImageUrl) || $rewardImageUrl === '') {
-                    return null;
-                }
-
-                return $rewardImageUrl;
-            }
-        };
     }
 
     private function recalculateTrophies(

--- a/wwwroot/classes/Admin/PsnTrophyApiAdapter.php
+++ b/wwwroot/classes/Admin/PsnTrophyApiAdapter.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PsnTrophyTypeApiAdapter.php';
+
+final class PsnTrophyApiAdapter
+{
+    /**
+     * @param array<string, mixed> $rawTrophy
+     */
+    public function __construct(private readonly array $rawTrophy)
+    {
+    }
+
+    public function id(): int
+    {
+        return (int) ($this->rawTrophy['trophyId'] ?? 0);
+    }
+
+    public function hidden(): bool
+    {
+        return (bool) ($this->rawTrophy['trophyHidden'] ?? false);
+    }
+
+    public function type(): PsnTrophyTypeApiAdapter
+    {
+        return new PsnTrophyTypeApiAdapter((string) ($this->rawTrophy['trophyType'] ?? 'bronze'));
+    }
+
+    public function name(): string
+    {
+        return (string) ($this->rawTrophy['trophyName'] ?? '');
+    }
+
+    public function detail(): string
+    {
+        return (string) ($this->rawTrophy['trophyDetail'] ?? '');
+    }
+
+    public function iconUrl(): string
+    {
+        return (string) ($this->rawTrophy['trophyIconUrl'] ?? '');
+    }
+
+    public function progressTargetValue(): string
+    {
+        $value = $this->rawTrophy['trophyProgressTargetValue'] ?? '';
+
+        return is_scalar($value) ? (string) $value : '';
+    }
+
+    public function rewardName(): string
+    {
+        return (string) ($this->rawTrophy['trophyRewardName'] ?? '');
+    }
+
+    public function rewardImageUrl(): ?string
+    {
+        $rewardImageUrl = $this->rawTrophy['trophyRewardImageUrl'] ?? null;
+        if (!is_string($rewardImageUrl) || $rewardImageUrl === '') {
+            return null;
+        }
+
+        return $rewardImageUrl;
+    }
+}

--- a/wwwroot/classes/Admin/PsnTrophyGroupApiAdapter.php
+++ b/wwwroot/classes/Admin/PsnTrophyGroupApiAdapter.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+final class PsnTrophyGroupApiAdapter
+{
+    /**
+     * @param array<string, mixed> $rawGroup
+     */
+    public function __construct(
+        private readonly string $groupId,
+        private readonly array $rawGroup,
+    ) {
+    }
+
+    public function id(): string
+    {
+        return $this->groupId;
+    }
+
+    public function name(): string
+    {
+        return (string) ($this->rawGroup['trophyGroupName'] ?? '');
+    }
+
+    public function detail(): string
+    {
+        return (string) ($this->rawGroup['trophyGroupDetail'] ?? '');
+    }
+
+    public function iconUrl(): string
+    {
+        return (string) ($this->rawGroup['trophyGroupIconUrl'] ?? '');
+    }
+}

--- a/wwwroot/classes/Admin/PsnTrophyLookupGroupDataProvider.php
+++ b/wwwroot/classes/Admin/PsnTrophyLookupGroupDataProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PsnGameLookupService.php';
+require_once __DIR__ . '/PsnTrophyApiAdapter.php';
+require_once __DIR__ . '/PsnTrophyGroupApiAdapter.php';
+
+use Tustin\PlayStation\Client;
+
+/**
+ * Fetches PSN trophy group data and adapts raw API payloads to objects used during game rescans.
+ */
+final class PsnTrophyLookupGroupDataProvider
+{
+    public function __construct(
+        private readonly PsnGameLookupService $psnGameLookupService,
+    ) {
+    }
+
+    /**
+     * @return array<int, array{group: PsnTrophyGroupApiAdapter, trophies: array<int, PsnTrophyApiAdapter>}>
+     */
+    public function fetchGroupData(Client $client, string $npCommunicationId): array
+    {
+        $trophyData = $this->psnGameLookupService->fetchTrophyDataForNpCommunicationId($npCommunicationId, $client);
+
+        return self::adaptTrophyData($trophyData);
+    }
+
+    /**
+     * @param array<string, mixed> $trophyData
+     * @return array<int, array{group: PsnTrophyGroupApiAdapter, trophies: array<int, PsnTrophyApiAdapter>}>
+     */
+    public static function adaptTrophyData(array $trophyData): array
+    {
+        $rawGroups = $trophyData['trophyGroups'] ?? [];
+
+        if (!is_array($rawGroups)) {
+            return [];
+        }
+
+        $groupData = [];
+
+        foreach ($rawGroups as $rawGroup) {
+            if (!is_array($rawGroup)) {
+                continue;
+            }
+
+            $groupId = (string) ($rawGroup['trophyGroupId'] ?? '');
+            $rawTrophies = $rawGroup['trophies'] ?? [];
+
+            if (!is_array($rawTrophies)) {
+                $rawTrophies = [];
+            }
+
+            $trophies = [];
+            foreach ($rawTrophies as $rawTrophy) {
+                if (!is_array($rawTrophy)) {
+                    continue;
+                }
+
+                $trophies[] = new PsnTrophyApiAdapter($rawTrophy);
+            }
+
+            $groupData[] = [
+                'group' => new PsnTrophyGroupApiAdapter($groupId, $rawGroup),
+                'trophies' => $trophies,
+            ];
+        }
+
+        return $groupData;
+    }
+}

--- a/wwwroot/classes/Admin/PsnTrophyTypeApiAdapter.php
+++ b/wwwroot/classes/Admin/PsnTrophyTypeApiAdapter.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+final class PsnTrophyTypeApiAdapter
+{
+    public function __construct(public readonly string $value)
+    {
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`GameRescanService` (~970 lines) mixes several concerns: worker authentication, trophy catalog sync, progress reporting, recalculation, and raw PSN API response adaptation. This PR peels off the **PSN API adaptation** concern into dedicated classes.

## Changes

- Add `PsnTrophyGroupApiAdapter`, `PsnTrophyApiAdapter`, and `PsnTrophyTypeApiAdapter` to wrap raw PSN trophy group/trophy payloads with a stable interface.
- Add `PsnTrophyLookupGroupDataProvider` to fetch trophy data via `PsnGameLookupService` and adapt it for rescans.
- Update `GameRescanService` to delegate to the provider instead of inline anonymous adapter classes (~150 lines removed).

## Testing

- Added `PsnTrophyLookupGroupDataProviderTest` covering adaptation of valid payloads, invalid entries, and default field values.
- Full suite: `php tests/run.php` — 716 tests passed.

## Follow-up PR ideas

Other concerns still in `GameRescanService` that could be peeled off incrementally:

1. Progress reporting (`notifyProgress`, `describeTrophy*`, label normalization)
2. Trophy set version updates (`isSetVersionAtLeastCurrent`, `updateTrophySetVersion`) — overlaps with `PlayerScanTitleMetadataHelper`
3. Platform list building (`buildPlatformList`)
4. Parent title recalculation (`recalculateParentTitles`)

Similar god-class candidates elsewhere: `ThirtyMinuteCronJob` (~820 lines), `GameCopyService` (~781 lines), `TrophyMergeService` (~724 lines).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02c5e5d7-4fab-4d9a-a129-ef066ad81d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02c5e5d7-4fab-4d9a-a129-ef066ad81d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

