### PR TITLE
Extract GameRescanProgressReporter from GameRescanService

### DIFF
--- a/tests/GameRescanProgressReporterTest.php
+++ b/tests/GameRescanProgressReporterTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanProgressListener.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanProgressReporter.php';
+
+final class GameRescanProgressReporterTest extends TestCase
+{
+    public function testNotifyIsNoOpWithoutListener(): void
+    {
+        $reporter = new GameRescanProgressReporter();
+
+        $reporter->notify(50, 'Halfway');
+
+        $this->assertTrue(true);
+    }
+
+    public function testNotifyClampsPercentAndEnforcesMonotonicProgress(): void
+    {
+        $events = [];
+        $reporter = new GameRescanProgressReporter(new class($events) implements GameRescanProgressListener {
+            /**
+             * @param list<array{int, string}> $events
+             */
+            public function __construct(private array &$events)
+            {
+            }
+
+            public function onProgress(int $percent, string $message): void
+            {
+                $this->events[] = [$percent, $message];
+            }
+        });
+
+        $reporter->notify(10, 'Start');
+        $reporter->notify(-5, 'Under min');
+        $reporter->notify(40, 'Step up');
+        $reporter->notify(30, 'Would regress');
+        $reporter->notify(150, 'Over max');
+
+        $this->assertSame([
+            [10, 'Start'],
+            [10, 'Under min'],
+            [40, 'Step up'],
+            [40, 'Would regress'],
+            [100, 'Over max'],
+        ], $events);
+    }
+
+    public function testNotifyRangeInterpolatesBetweenBounds(): void
+    {
+        $events = [];
+        $reporter = new GameRescanProgressReporter(new class($events) implements GameRescanProgressListener {
+            /**
+             * @param list<array{int, string}> $events
+             */
+            public function __construct(private array &$events)
+            {
+            }
+
+            public function onProgress(int $percent, string $message): void
+            {
+                $this->events[] = [$percent, $message];
+            }
+        });
+
+        $reporter->notifyRange(25, 70, 1, 4, 'First quarter');
+        $reporter->notifyRange(25, 70, 4, 4, 'Done');
+
+        $this->assertSame(36, $events[0][0]);
+        $this->assertSame(70, $events[1][0]);
+    }
+
+    public function testDescribeTrophyGroupPrefersNameThenDetailThenId(): void
+    {
+        $reporter = new GameRescanProgressReporter();
+
+        $withName = new class {
+            public function name(): string
+            {
+                return '  Base Game ';
+            }
+
+            public function detail(): string
+            {
+                return 'Ignored detail';
+            }
+
+            public function id(): string
+            {
+                return 'default';
+            }
+        };
+
+        $withDetailOnly = new class {
+            public function name(): string
+            {
+                return '';
+            }
+
+            public function detail(): string
+            {
+                return 'DLC Pack';
+            }
+
+            public function id(): string
+            {
+                return '002';
+            }
+        };
+
+        $withIdOnly = new class {
+            public function name(): string
+            {
+                return '';
+            }
+
+            public function detail(): string
+            {
+                return '';
+            }
+
+            public function id(): string
+            {
+                return '003';
+            }
+        };
+
+        $this->assertSame('Base Game', $reporter->describeTrophyGroup($withName));
+        $this->assertSame('DLC Pack', $reporter->describeTrophyGroup($withDetailOnly));
+        $this->assertSame('Group 003', $reporter->describeTrophyGroup($withIdOnly));
+    }
+
+    public function testDescribeTrophyPrefersNameThenDetailThenId(): void
+    {
+        $reporter = new GameRescanProgressReporter();
+
+        $withName = new class {
+            public function name(): string
+            {
+                return 'First Steps';
+            }
+
+            public function detail(): string
+            {
+                return 'Complete the tutorial';
+            }
+
+            public function id(): int
+            {
+                return 1;
+            }
+        };
+
+        $withDetailOnly = new class {
+            public function name(): string
+            {
+                return '';
+            }
+
+            public function detail(): string
+            {
+                return 'Beat the boss';
+            }
+
+            public function id(): int
+            {
+                return 2;
+            }
+        };
+
+        $withIdOnly = new class {
+            public function name(): string
+            {
+                return '';
+            }
+
+            public function detail(): string
+            {
+                return '';
+            }
+
+            public function id(): int
+            {
+                return 3;
+            }
+        };
+
+        $this->assertSame('First Steps', $reporter->describeTrophy($withName));
+        $this->assertSame('Beat the boss', $reporter->describeTrophy($withDetailOnly));
+        $this->assertSame('Trophy 3', $reporter->describeTrophy($withIdOnly));
+    }
+
+    public function testResetAllowsProgressToDropAgain(): void
+    {
+        $events = [];
+        $reporter = new GameRescanProgressReporter(new class($events) implements GameRescanProgressListener {
+            /**
+             * @param list<array{int, string}> $events
+             */
+            public function __construct(private array &$events)
+            {
+            }
+
+            public function onProgress(int $percent, string $message): void
+            {
+                $this->events[] = [$percent, $message];
+            }
+        });
+
+        $reporter->notify(80, 'High');
+        $reporter->reset();
+        $reporter->notify(10, 'Restarted');
+
+        $this->assertSame([
+            [80, 'High'],
+            [10, 'Restarted'],
+        ], $events);
+    }
+}

--- a/wwwroot/classes/Admin/GameRescanProgressReporter.php
+++ b/wwwroot/classes/Admin/GameRescanProgressReporter.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/GameRescanProgressListener.php';
+
+/**
+ * Reports monotonic rescan progress and formats trophy/group labels for status messages.
+ */
+final class GameRescanProgressReporter
+{
+    private int $lastProgress = 0;
+
+    public function __construct(
+        private readonly ?GameRescanProgressListener $listener = null,
+    ) {
+    }
+
+    public function reset(): void
+    {
+        $this->lastProgress = 0;
+    }
+
+    public function notify(int $percent, string $message): void
+    {
+        if ($this->listener === null) {
+            return;
+        }
+
+        $clampedPercent = max(0, min(100, $percent));
+        if ($clampedPercent < $this->lastProgress) {
+            $clampedPercent = $this->lastProgress;
+        } else {
+            $this->lastProgress = $clampedPercent;
+        }
+
+        $this->listener->onProgress($clampedPercent, $message);
+    }
+
+    public function notifyRange(
+        int $startPercent,
+        int $endPercent,
+        int $step,
+        int $totalSteps,
+        string $message
+    ): void {
+        if ($this->listener === null || $totalSteps <= 0) {
+            return;
+        }
+
+        $boundedStep = max(0, min($totalSteps, $step));
+        $progressSpan = $endPercent - $startPercent;
+
+        if ($progressSpan === 0) {
+            $targetPercent = $startPercent;
+        } else {
+            $progressRatio = $boundedStep / $totalSteps;
+            $interpolated = $startPercent + ($progressSpan * $progressRatio);
+
+            if ($boundedStep === $totalSteps) {
+                $interpolated = $endPercent;
+            }
+
+            $targetPercent = (int) floor($interpolated);
+
+            if ($progressSpan > 0) {
+                $targetPercent = min($targetPercent, $endPercent);
+            } else {
+                $targetPercent = max($targetPercent, $endPercent);
+            }
+        }
+
+        $this->notify($targetPercent, $message);
+    }
+
+    public function describeTrophyGroup(object $trophyGroup): string
+    {
+        $name = $this->normalizeProgressLabel((string) $trophyGroup->name());
+        if ($name !== '') {
+            return $name;
+        }
+
+        $detail = $this->normalizeProgressLabel((string) $trophyGroup->detail());
+        if ($detail !== '') {
+            return $detail;
+        }
+
+        return sprintf('Group %s', $this->normalizeProgressLabel((string) $trophyGroup->id()) ?: (string) $trophyGroup->id());
+    }
+
+    public function describeTrophy(object $trophy): string
+    {
+        $name = $this->normalizeProgressLabel((string) $trophy->name());
+        if ($name !== '') {
+            return $name;
+        }
+
+        $detail = $this->normalizeProgressLabel((string) $trophy->detail());
+        if ($detail !== '') {
+            return $detail;
+        }
+
+        return sprintf('Trophy %s', $this->normalizeProgressLabel((string) $trophy->id()) ?: (string) $trophy->id());
+    }
+
+    private function normalizeProgressLabel(string $label): string
+    {
+        $normalized = trim($label);
+        if ($normalized === '') {
+            return '';
+        }
+
+        $normalized = preg_replace('/\s+/', ' ', $normalized);
+        if (!is_string($normalized)) {
+            return '';
+        }
+
+        return $normalized;
+    }
+}

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/GameRescanProgressListener.php';
+require_once __DIR__ . '/GameRescanProgressReporter.php';
 require_once __DIR__ . '/GameRescanDifferenceTracker.php';
 require_once __DIR__ . '/GameRescanResult.php';
 require_once __DIR__ . '/../ImageHashCalculator.php';
@@ -25,7 +26,6 @@ class GameRescanService
 
     private PDO $database;
     private TrophyCalculator $trophyCalculator;
-    private int $lastProgress = 0;
     private TrophyMetaRepository $trophyMetaRepository;
 
     private TrophyHistoryRecorder $historyRecorder;
@@ -93,11 +93,11 @@ class GameRescanService
 
         try {
             $differenceTracker = new GameRescanDifferenceTracker();
-            $this->lastProgress = 0;
-            $this->notifyProgress($progressListener, 5, 'Validating game id…');
+            $progressReporter = new GameRescanProgressReporter($progressListener);
+            $progressReporter->notify(5, 'Validating game id…');
             $npCommunicationId = $this->getGameNpCommunicationId($gameId);
 
-            $this->notifyProgress($progressListener, 10, 'Checking game entry…');
+            $progressReporter->notify(10, 'Checking game entry…');
 
             if (!$this->isOriginalGame($npCommunicationId)) {
                 return new GameRescanResult(
@@ -106,9 +106,9 @@ class GameRescanService
                 );
             }
 
-            $this->notifyProgress($progressListener, 15, 'Signing in to worker account…');
+            $progressReporter->notify(15, 'Signing in to worker account…');
             $client = $this->loginToWorker();
-            $this->notifyProgress($progressListener, 20, 'Locating accessible player…');
+            $progressReporter->notify(20, 'Locating accessible player…');
             $user = $this->findAccessibleUserWithGame($client, $npCommunicationId);
 
             if ($user === null) {
@@ -121,30 +121,30 @@ class GameRescanService
                 throw new RuntimeException('Unable to find trophy title for the specified game.');
             }
 
-            $this->notifyProgress($progressListener, 25, 'Refreshing trophy details…');
+            $progressReporter->notify(25, 'Refreshing trophy details…');
             $trophyGroups = $this->updateTrophyTitle(
                 $client,
                 $trophyTitle,
                 $npCommunicationId,
-                $progressListener,
+                $progressReporter,
                 $differenceTracker
             );
-            $this->notifyProgress($progressListener, 70, 'Recalculating player statistics…');
+            $progressReporter->notify(70, 'Recalculating player statistics…');
             $this->recalculateTrophies(
                 $trophyTitle,
                 $npCommunicationId,
                 (int) $user->accountId(),
                 $trophyGroups,
-                $progressListener
+                $progressReporter
             );
 
-            $this->notifyProgress($progressListener, 85, 'Updating trophy set version…');
+            $progressReporter->notify(85, 'Updating trophy set version…');
             $this->updateTrophySetVersion(
                 $npCommunicationId,
                 $trophyTitle->trophySetVersion(),
                 $differenceTracker
             );
-            $this->notifyProgress($progressListener, 90, 'Recording rescan details…');
+            $progressReporter->notify(90, 'Recording rescan details…');
             $this->recordRescan($gameId);
 
             if ($differenceTracker->getDifferences() !== []) {
@@ -234,104 +234,6 @@ class GameRescanService
         return null;
     }
 
-    private function notifyProgress(?GameRescanProgressListener $progressListener, int $percent, string $message): void
-    {
-        if ($progressListener === null) {
-            return;
-        }
-
-        $clampedPercent = max(0, min(100, $percent));
-        if ($clampedPercent < $this->lastProgress) {
-            $clampedPercent = $this->lastProgress;
-        } else {
-            $this->lastProgress = $clampedPercent;
-        }
-
-        $progressListener->onProgress($clampedPercent, $message);
-    }
-
-    private function notifyProgressRange(
-        ?GameRescanProgressListener $progressListener,
-        int $startPercent,
-        int $endPercent,
-        int $step,
-        int $totalSteps,
-        string $message
-    ): void {
-        if ($progressListener === null || $totalSteps <= 0) {
-            return;
-        }
-
-        $boundedStep = max(0, min($totalSteps, $step));
-        $progressSpan = $endPercent - $startPercent;
-
-        if ($progressSpan === 0) {
-            $targetPercent = $startPercent;
-        } else {
-            $progressRatio = $boundedStep / $totalSteps;
-            $interpolated = $startPercent + ($progressSpan * $progressRatio);
-
-            if ($boundedStep === $totalSteps) {
-                $interpolated = $endPercent;
-            }
-
-            $targetPercent = (int) floor($interpolated);
-
-            if ($progressSpan > 0) {
-                $targetPercent = min($targetPercent, $endPercent);
-            } else {
-                $targetPercent = max($targetPercent, $endPercent);
-            }
-        }
-
-        $this->notifyProgress($progressListener, $targetPercent, $message);
-    }
-
-    private function describeTrophyGroup(object $trophyGroup): string
-    {
-        $name = $this->normalizeProgressLabel((string) $trophyGroup->name());
-        if ($name !== '') {
-            return $name;
-        }
-
-        $detail = $this->normalizeProgressLabel((string) $trophyGroup->detail());
-        if ($detail !== '') {
-            return $detail;
-        }
-
-        return sprintf('Group %s', $this->normalizeProgressLabel((string) $trophyGroup->id()) ?: (string) $trophyGroup->id());
-    }
-
-    private function describeTrophy(object $trophy): string
-    {
-        $name = $this->normalizeProgressLabel((string) $trophy->name());
-        if ($name !== '') {
-            return $name;
-        }
-
-        $detail = $this->normalizeProgressLabel((string) $trophy->detail());
-        if ($detail !== '') {
-            return $detail;
-        }
-
-        return sprintf('Trophy %s', $this->normalizeProgressLabel((string) $trophy->id()) ?: (string) $trophy->id());
-    }
-
-    private function normalizeProgressLabel(string $label): string
-    {
-        $normalized = trim($label);
-        if ($normalized === '') {
-            return '';
-        }
-
-        $normalized = preg_replace('/\s+/', ' ', $normalized);
-        if (!is_string($normalized)) {
-            return '';
-        }
-
-        return $normalized;
-    }
-
     private function findTrophyTitleForUser(object $user, string $npCommunicationId): ?object
     {
         foreach ($user->trophyTitles() as $trophyTitle) {
@@ -347,13 +249,13 @@ class GameRescanService
         Client $client,
         object $trophyTitle,
         string $npCommunicationId,
-        ?GameRescanProgressListener $progressListener,
+        GameRescanProgressReporter $progressReporter,
         GameRescanDifferenceTracker $differenceTracker
     ): array {
         $existingTitleInfo = $this->trophyCatalogSynchronizer->fetchExistingTrophyTitleInfo($npCommunicationId);
 
         if (!self::isSetVersionAtLeastCurrent((string) $trophyTitle->trophySetVersion(), $existingTitleInfo['set_version'])) {
-            $this->notifyProgress($progressListener, 70, 'Skipping trophy refresh because incoming set version is lower.');
+            $progressReporter->notify(70, 'Skipping trophy refresh because incoming set version is lower.');
 
             return [];
         }
@@ -394,7 +296,7 @@ class GameRescanService
         );
 
         if ($groupData === []) {
-            $this->notifyProgress($progressListener, 70, 'Refreshing trophy details…');
+            $progressReporter->notify(70, 'Refreshing trophy details…');
 
             return [];
         }
@@ -418,7 +320,7 @@ class GameRescanService
                 $existingGroup['icon']
             );
 
-            $groupLabel = $this->describeTrophyGroup($trophyGroup);
+            $groupLabel = $progressReporter->describeTrophyGroup($trophyGroup);
             $contextLabel = $groupLabel !== ''
                 ? $groupLabel
                 : ($existingGroup['name'] ?? ($existingGroup['detail'] ?? $groupId));
@@ -450,8 +352,7 @@ class GameRescanService
 
             $processedGroups++;
             $currentStep++;
-            $this->notifyProgressRange(
-                $progressListener,
+            $progressReporter->notifyRange(
                 25,
                 70,
                 $currentStep,
@@ -492,7 +393,7 @@ class GameRescanService
                     $existingTrophy['reward_image']
                 );
 
-                $trophyLabel = $this->describeTrophy($trophy);
+                $trophyLabel = $progressReporter->describeTrophy($trophy);
                 $trophyContextLabel = $trophyLabel !== ''
                     ? $trophyLabel
                     : ($existingTrophy['name'] ?? ('#' . $orderId));
@@ -599,8 +500,7 @@ class GameRescanService
 
                 $processedTrophiesInGroup++;
                 $currentStep++;
-                $this->notifyProgressRange(
-                    $progressListener,
+                $progressReporter->notifyRange(
                     25,
                     70,
                     $currentStep,
@@ -629,7 +529,7 @@ class GameRescanService
         string $npCommunicationId,
         int $accountId,
         array $trophyGroups,
-        ?GameRescanProgressListener $progressListener
+        GameRescanProgressReporter $progressReporter
     ): void {
         $baseMessage = 'Recalculating player statistics…';
         $totalGroups = count($trophyGroups);
@@ -639,8 +539,7 @@ class GameRescanService
             $this->trophyCalculator->recalculateTrophyGroup($npCommunicationId, $trophyGroup->id(), $accountId);
 
             $currentGroup++;
-            $this->notifyProgressRange(
-                $progressListener,
+            $progressReporter->notifyRange(
                 70,
                 82,
                 $currentGroup,
@@ -657,23 +556,23 @@ class GameRescanService
             false
         );
 
-        $this->notifyProgress($progressListener, 83, $baseMessage);
+        $progressReporter->notify(83, $baseMessage);
 
         $this->recalculateParentTitles(
             $npCommunicationId,
             $trophyTitle->lastUpdatedDateTime(),
             $accountId,
-            $progressListener
+            $progressReporter
         );
 
-        $this->notifyProgress($progressListener, 84, $baseMessage);
+        $progressReporter->notify(84, $baseMessage);
     }
 
     private function recalculateParentTitles(
         string $childNpCommunicationId,
         string $lastUpdatedDateTime,
         int $accountId,
-        ?GameRescanProgressListener $progressListener = null
+        GameRescanProgressReporter $progressReporter
     ): void {
         $query = $this->database->prepare(
             'SELECT DISTINCT parent_np_communication_id, parent_group_id
@@ -701,8 +600,7 @@ class GameRescanService
             );
 
             $currentParent++;
-            $this->notifyProgressRange(
-                $progressListener,
+            $progressReporter->notifyRange(
                 83,
                 84,
                 $currentParent,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`GameRescanService` (~824 lines) mixes PSN API orchestration, DB writes, image downloads, diff tracking, stat recalculation, and admin progress UX. This PR peels off the **progress reporting concern** as a first, low-risk step.

## Changes

- Add `GameRescanProgressReporter` with:
  - Monotonic percent clamping (`notify`, `notifyRange`)
  - Trophy/group label formatting for status messages (`describeTrophyGroup`, `describeTrophy`)
- Update `GameRescanService` to delegate all progress calls to the reporter
- Add unit tests for the extracted class

## Why this first

Progress reporting is self-contained (~100 lines), has no DB/API dependencies, and is already conceptually separate from rescan orchestration. Behavior is unchanged.

## Follow-up PRs (not in scope)

Other God-class peel-offs identified for future PRs:

1. `ThirtyMinuteCronJob` → `PlayerPrivacyResolver` (private-profile SQL block)
2. `GameCopyService` → `MergeTrophyConflictCopier` (`copyConflictingTrophies`)
3. `TrophyMergeService` → `MergedTrophyEarnedCopier` (`copyMergedTrophies`)
4. `GameHistoryRenderer` → `TextDiffHighlighter` (token diff algorithm)

## Test plan

- [x] `php tests/run.php` — all 722 tests pass
- [x] New `GameRescanProgressReporterTest` covers clamping, interpolation, labels, and reset
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-627772b6-17bc-4e0f-844d-512f1be9fe57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-627772b6-17bc-4e0f-844d-512f1be9fe57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

