### PR TITLE
Extract PlayerScanTrophyProgressSynchronizer from ThirtyMinuteCronJob

### DIFF
--- a/tests/PlayerScanTrophyProgressSynchronizerTest.php
+++ b/tests/PlayerScanTrophyProgressSynchronizerTest.php
@@ -1,0 +1,418 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/PlayerEarnedTrophyPersisterTest.php';
+require_once __DIR__ . '/TrophyCalculatorTest.php';
+require_once __DIR__ . '/AutomaticTrophyTitleMergeServiceTest.php';
+require_once __DIR__ . '/../wwwroot/classes/Psn100Logger.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerEarnedTrophyPersister.php';
+require_once __DIR__ . '/../wwwroot/classes/AutomaticTrophyTitleMergeService.php';
+
+use Tustin\Haste\Exception\NotFoundHttpException;
+
+final class PlayerScanTrophyProgressSynchronizerTest extends TestCase
+{
+    public function testSynchronizeTrophyProgressPersistsEarnedTrophiesAndRecalculatesGroups(): void
+    {
+        $mergeDatabase = new PlayerScanTrophyProgressSynchronizerMergePDO([]);
+        $earnedDatabase = new PlayerEarnedTrophyPersisterRecordingPDO(null);
+        $calculatorDatabase = new PlayerScanTrophyProgressSynchronizerCalculatorPDO();
+        $calculatorDatabase->setTrophyGroup('NPWR12345_00', 'default');
+        $calculatorDatabase->addTrophy('NPWR12345_00', 'default', 1, 'bronze');
+
+        $loggerDatabase = new PDO('sqlite::memory:');
+        $loggerDatabase->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $loggerDatabase->exec('CREATE TABLE log (message TEXT NOT NULL)');
+
+        $mergeService = new RecordingTrophyMergeService($mergeDatabase);
+        $synchronizer = new PlayerScanTrophyProgressSynchronizer(
+            $mergeDatabase,
+            new TrophyCalculator($calculatorDatabase),
+            new Psn100Logger($loggerDatabase),
+            new PlayerEarnedTrophyPersister($earnedDatabase),
+            new AutomaticTrophyTitleMergeService($mergeDatabase, $mergeService),
+        );
+
+        $user = new PlayerScanTrophyProgressSynchronizerTestUser(42);
+        $trophyTitle = new PlayerScanTrophyProgressSynchronizerTestTrophyTitle(
+            'NPWR12345_00',
+            'Example Game',
+            '2024-06-15T10:30:00Z',
+            [
+                new PlayerScanTrophyProgressSynchronizerTestTrophyGroup(
+                    'default',
+                    [
+                        new PlayerScanTrophyProgressSynchronizerTestTrophy(1, true, '', '2024-06-15T10:30:00Z'),
+                        new PlayerScanTrophyProgressSynchronizerTestTrophy(2, false, '0', ''),
+                    ],
+                ),
+            ],
+        );
+
+        $synchronizer->synchronizeTrophyProgress($user, $trophyTitle, 'NPWR12345_00', false, []);
+
+        $this->assertSame(1, $earnedDatabase->upsertExecutions, 'Only earned trophies should be persisted.');
+        $this->assertSame('42', $earnedDatabase->upsertParameters[0][':account_id']);
+        $this->assertTrue(
+            $calculatorDatabase->getTrophyGroupPlayer('NPWR12345_00', 'default', 42) !== null,
+            'Group progress should be recalculated.'
+        );
+        $this->assertSame([], $mergeService->recomputedParents);
+    }
+
+    public function testSynchronizeTrophyProgressRecalculatesMergeParentsFromDatabaseAndCatalog(): void
+    {
+        $mergeDatabase = new PlayerScanTrophyProgressSynchronizerMergePDO([
+            [
+                'parent_np_communication_id' => 'NPWR99999_00',
+                'parent_group_id' => 'default',
+            ],
+        ]);
+        $earnedDatabase = new PlayerEarnedTrophyPersisterRecordingPDO(null);
+        $calculatorDatabase = new PlayerScanTrophyProgressSynchronizerCalculatorPDO();
+        $calculatorDatabase->setTrophyGroup('NPWR12345_00', 'default');
+        $calculatorDatabase->setTrophyGroup('NPWR99999_00', 'default');
+
+        $loggerDatabase = new PDO('sqlite::memory:');
+        $loggerDatabase->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $loggerDatabase->exec('CREATE TABLE log (message TEXT NOT NULL)');
+
+        $mergeService = new RecordingTrophyMergeService($mergeDatabase);
+        $synchronizer = new PlayerScanTrophyProgressSynchronizer(
+            $mergeDatabase,
+            new TrophyCalculator($calculatorDatabase),
+            new Psn100Logger($loggerDatabase),
+            new PlayerEarnedTrophyPersister($earnedDatabase),
+            new AutomaticTrophyTitleMergeService($mergeDatabase, $mergeService),
+        );
+
+        $user = new PlayerScanTrophyProgressSynchronizerTestUser(7);
+        $trophyTitle = new PlayerScanTrophyProgressSynchronizerTestTrophyTitle(
+            'NPWR12345_00',
+            'Example Game',
+            '2024-06-15T10:30:00Z',
+            [
+                new PlayerScanTrophyProgressSynchronizerTestTrophyGroup('default', []),
+            ],
+        );
+
+        $synchronizer->synchronizeTrophyProgress(
+            $user,
+            $trophyTitle,
+            'NPWR12345_00',
+            false,
+            ['NPWR88888_00'],
+        );
+
+        $this->assertSame(
+            ['NPWR88888_00'],
+            $mergeService->recomputedParents,
+            'Catalog merge parents should be recomputed via merge service.'
+        );
+        $this->assertTrue(
+            $calculatorDatabase->getTrophyGroupPlayer('NPWR99999_00', 'default', 7) !== null,
+            'Merge parent group progress should be recalculated.'
+        );
+    }
+
+    public function testRetryNotFoundReturnsResultAfterTransientNotFound(): void
+    {
+        $synchronizer = $this->createSynchronizerForRetryTests();
+        $retryMethod = new ReflectionMethod(PlayerScanTrophyProgressSynchronizer::class, 'retryNotFound');
+        $retryMethod->setAccessible(true);
+
+        $attempts = 0;
+        $result = $retryMethod->invoke($synchronizer, function () use (&$attempts): string {
+            $attempts++;
+
+            if ($attempts < 2) {
+                throw new NotFoundHttpException('temporary');
+            }
+
+            return 'ok';
+        }, 'test operation');
+
+        $this->assertSame('ok', $result);
+        $this->assertSame(2, $attempts);
+    }
+
+    private function createSynchronizerForRetryTests(): PlayerScanTrophyProgressSynchronizer
+    {
+        $loggerDatabase = new PDO('sqlite::memory:');
+        $loggerDatabase->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $loggerDatabase->exec('CREATE TABLE log (message TEXT NOT NULL)');
+
+        return new PlayerScanTrophyProgressSynchronizer(
+            new PlayerScanTrophyProgressSynchronizerMergePDO([]),
+            new TrophyCalculator(new FakePDO()),
+            new Psn100Logger($loggerDatabase),
+            new PlayerEarnedTrophyPersister(new PlayerEarnedTrophyPersisterRecordingPDO(null)),
+            new AutomaticTrophyTitleMergeService(
+                new PlayerScanTrophyProgressSynchronizerMergePDO([]),
+                new RecordingTrophyMergeService(new PlayerScanTrophyProgressSynchronizerMergePDO([])),
+            ),
+        );
+    }
+}
+
+/**
+ * @phpstan-type MergeParentRow array{
+ *     parent_np_communication_id: string,
+ *     parent_group_id: string
+ * }
+ */
+final class PlayerScanTrophyProgressSynchronizerCalculatorPDO extends PDO
+{
+    private FakePDO $delegate;
+
+    public function __construct()
+    {
+        $this->delegate = new FakePDO();
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement
+    {
+        $trimmed = trim($query);
+
+        if (str_starts_with($trimmed, 'SELECT SUM(bronze)')) {
+            return new PlayerScanTrophyProgressSynchronizerNoOpStatement([
+                'bronze' => 0,
+                'silver' => 0,
+                'gold' => 0,
+                'platinum' => 0,
+            ]);
+        }
+
+        if (
+            str_starts_with($trimmed, 'UPDATE trophy_title')
+            || str_contains($trimmed, 'INSERT INTO trophy_title_player')
+        ) {
+            return new PlayerScanTrophyProgressSynchronizerNoOpStatement(null);
+        }
+
+        return $this->delegate->prepare($query, $options);
+    }
+
+    public function setTrophyGroup(string $npCommunicationId, string $groupId): void
+    {
+        $this->delegate->setTrophyGroup($npCommunicationId, $groupId);
+    }
+
+    public function addTrophy(string $npCommunicationId, string $groupId, int $orderId, string $type, int $status = 0): void
+    {
+        $this->delegate->addTrophy($npCommunicationId, $groupId, $orderId, $type, $status);
+    }
+
+    public function addEarnedTrophy(string $npCommunicationId, string $groupId, int $orderId, int $accountId, int $earned = 1): void
+    {
+        $this->delegate->addEarnedTrophy($npCommunicationId, $groupId, $orderId, $accountId, $earned);
+    }
+
+    /**
+     * @return array{np_communication_id:string,group_id:string,account_id:int,bronze:int,silver:int,gold:int,platinum:int,progress:int}|null
+     */
+    public function getTrophyGroupPlayer(string $npCommunicationId, string $groupId, int $accountId): ?array
+    {
+        return $this->delegate->getTrophyGroupPlayer($npCommunicationId, $groupId, $accountId);
+    }
+}
+
+final class PlayerScanTrophyProgressSynchronizerNoOpStatement extends PDOStatement
+{
+    /** @var array<string, int>|null */
+    private ?array $row;
+
+    /** @param array<string, int>|null $row */
+    public function __construct(?array $row)
+    {
+        $this->row = $row;
+    }
+
+    public function bindValue(int|string $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetch(int $mode = PDO::FETCH_DEFAULT, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0): mixed
+    {
+        if ($this->row === null) {
+            return false;
+        }
+
+        $row = $this->row;
+        $this->row = null;
+
+        return $row;
+    }
+}
+
+/**
+ * @phpstan-type MergeParentRow array{
+ *     parent_np_communication_id: string,
+ *     parent_group_id: string
+ * }
+ */
+final class PlayerScanTrophyProgressSynchronizerMergePDO extends PDO
+{
+    /** @var list<MergeParentRow> */
+    private array $mergeRows;
+
+    /** @param list<MergeParentRow> $mergeRows */
+    public function __construct(array $mergeRows)
+    {
+        $this->mergeRows = $mergeRows;
+    }
+
+    public function prepare(string $statement, array $options = []): PDOStatement
+    {
+        if (str_contains($statement, 'FROM   trophy_merge')) {
+            return new PlayerScanTrophyProgressSynchronizerMergeStatement($this->mergeRows);
+        }
+
+        throw new RuntimeException('Unexpected SQL statement: ' . $statement);
+    }
+}
+
+final class PlayerScanTrophyProgressSynchronizerMergeStatement extends PDOStatement
+{
+    /** @var list<MergeParentRow> */
+    private array $rows;
+
+    private int $position = 0;
+
+    /** @param list<MergeParentRow> $rows */
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+
+    public function bindValue(int|string $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        $this->position = 0;
+
+        return true;
+    }
+
+    public function fetch(int $mode = PDO::FETCH_DEFAULT, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0): mixed
+    {
+        if (!isset($this->rows[$this->position])) {
+            return false;
+        }
+
+        return $this->rows[$this->position++];
+    }
+}
+
+final class PlayerScanTrophyProgressSynchronizerTestUser
+{
+    public function __construct(private readonly int $accountId)
+    {
+    }
+
+    public function accountId(): int
+    {
+        return $this->accountId;
+    }
+}
+
+final class PlayerScanTrophyProgressSynchronizerTestTrophyTitle
+{
+    /**
+     * @param list<PlayerScanTrophyProgressSynchronizerTestTrophyGroup> $groups
+     */
+    public function __construct(
+        private readonly string $npCommunicationId,
+        private readonly string $name,
+        private readonly string $lastUpdatedDateTime,
+        private readonly array $groups,
+    ) {
+    }
+
+    public function npCommunicationId(): string
+    {
+        return $this->npCommunicationId;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function lastUpdatedDateTime(): string
+    {
+        return $this->lastUpdatedDateTime;
+    }
+
+    /** @return list<PlayerScanTrophyProgressSynchronizerTestTrophyGroup> */
+    public function trophyGroups(): array
+    {
+        return $this->groups;
+    }
+}
+
+final class PlayerScanTrophyProgressSynchronizerTestTrophyGroup
+{
+    /**
+     * @param list<PlayerScanTrophyProgressSynchronizerTestTrophy> $trophies
+     */
+    public function __construct(
+        private readonly string $id,
+        private readonly array $trophies,
+    ) {
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    /** @return list<PlayerScanTrophyProgressSynchronizerTestTrophy> */
+    public function trophies(): array
+    {
+        return $this->trophies;
+    }
+}
+
+final class PlayerScanTrophyProgressSynchronizerTestTrophy
+{
+    public function __construct(
+        private readonly int $id,
+        private readonly bool $earned,
+        private readonly string $progress,
+        private readonly string $earnedDateTime,
+    ) {
+    }
+
+    public function id(): int
+    {
+        return $this->id;
+    }
+
+    public function earned(): bool
+    {
+        return $this->earned;
+    }
+
+    public function progress(): string
+    {
+        return $this->progress;
+    }
+
+    public function earnedDateTime(): string
+    {
+        return $this->earnedDateTime;
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../AutomaticTrophyTitleMergeService.php';
+require_once __DIR__ . '/../Psn100Logger.php';
+require_once __DIR__ . '/PlayerEarnedTrophyPersister.php';
+
+use Tustin\Haste\Exception\NotFoundHttpException;
+
+/**
+ * Fetches earned trophy progress for one title during player scans and recalculates
+ * player aggregates for the title, its groups, and any merge parents.
+ *
+ * Encapsulates per-title trophy progress synchronization that was previously embedded in
+ * ThirtyMinuteCronJob.
+ */
+final class PlayerScanTrophyProgressSynchronizer
+{
+    public function __construct(
+        private readonly PDO $database,
+        private readonly TrophyCalculator $trophyCalculator,
+        private readonly Psn100Logger $logger,
+        private readonly PlayerEarnedTrophyPersister $earnedTrophyPersister,
+        private readonly AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService,
+    ) {
+    }
+
+    /**
+     * @param list<string> $mergeParentsToRecompute
+     */
+    public function synchronizeTrophyProgress(
+        object $user,
+        object $trophyTitle,
+        string $npCommunicationId,
+        bool $newTrophies,
+        array $mergeParentsToRecompute,
+    ): void {
+        $trophyGroups = $this->retryNotFound(
+            fn () => $trophyTitle->trophyGroups(),
+            sprintf('Fetching trophy groups for %s (%s)', $trophyTitle->name(), $npCommunicationId)
+        );
+
+        foreach ($trophyGroups as $trophyGroup) {
+            $groupTrophies = $this->retryNotFound(
+                fn () => $trophyGroup->trophies(),
+                sprintf(
+                    'Fetching trophies for %s (%s/%s)',
+                    $trophyTitle->name(),
+                    $npCommunicationId,
+                    $trophyGroup->id()
+                )
+            );
+
+            foreach ($groupTrophies as $trophy) {
+                $trophyEarned = $trophy->earned();
+                $progress = (clone $trophy)->progress();
+                if ($trophyEarned || ($progress != '' && intval($progress) > 0)) {
+                    $this->earnedTrophyPersister->persistEarnedTrophy(
+                        $npCommunicationId,
+                        $trophyGroup->id(),
+                        (int) $trophy->id(),
+                        (string) $user->accountId(),
+                        $trophyEarned,
+                        $progress,
+                        $trophy->earnedDateTime(),
+                    );
+                }
+            }
+
+            $this->trophyCalculator->recalculateTrophyGroup(
+                $npCommunicationId,
+                $trophyGroup->id(),
+                (int) $user->accountId()
+            );
+        }
+
+        $this->trophyCalculator->recalculateTrophyTitle(
+            $npCommunicationId,
+            $trophyTitle->lastUpdatedDateTime(),
+            $newTrophies,
+            (int) $user->accountId(),
+            false
+        );
+
+        $query = $this->database->prepare("SELECT DISTINCT parent_np_communication_id,
+                                                parent_group_id
+                            FROM   trophy_merge
+                            WHERE  child_np_communication_id = :child_np_communication_id ");
+        $query->bindValue(':child_np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+        while ($row = $query->fetch()) {
+            $this->trophyCalculator->recalculateTrophyGroup(
+                $row['parent_np_communication_id'],
+                $row['parent_group_id'],
+                (int) $user->accountId()
+            );
+            $this->trophyCalculator->recalculateTrophyTitle(
+                $row['parent_np_communication_id'],
+                $trophyTitle->lastUpdatedDateTime(),
+                false,
+                (int) $user->accountId(),
+                true
+            );
+        }
+
+        foreach ($mergeParentsToRecompute as $mergeParent) {
+            $this->automaticTrophyTitleMergeService->recomputeMergeProgressByParent($mergeParent);
+        }
+    }
+
+    /**
+     * @template T
+     * @param callable():T $operation
+     * @return T
+     */
+    private function retryNotFound(callable $operation, string $description)
+    {
+        $attempt = 0;
+        $delay = 2;
+        $maxAttempts = 5;
+
+        while (true) {
+            try {
+                return $operation();
+            } catch (NotFoundHttpException $exception) {
+                $attempt++;
+
+                if ($attempt >= $maxAttempts) {
+                    $this->logger->log(sprintf(
+                        '%s failed with %s after %d attempts. Aborting retries.',
+                        $description,
+                        $exception->getMessage(),
+                        $attempt
+                    ));
+
+                    throw $exception;
+                }
+
+                sleep($delay);
+                $delay = min($delay * 2, 60);
+            }
+        }
+    }
+}

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -23,6 +23,7 @@ require_once __DIR__ . '/PlayerEarnedTrophyPersister.php';
 require_once __DIR__ . '/PlayerScanStaleGameDeletionService.php';
 require_once __DIR__ . '/PlayerScanTitleCatalogSynchronizer.php';
 require_once __DIR__ . '/PlayerScanTitleCatalogSyncResult.php';
+require_once __DIR__ . '/PlayerScanTrophyProgressSynchronizer.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\Haste\Exception\UnauthorizedHttpException;
@@ -42,6 +43,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
     private readonly PlayerEarnedTrophyPersister $earnedTrophyPersister;
     private readonly PlayerScanStaleGameDeletionService $staleGameDeletionService;
     private readonly PlayerScanTitleCatalogSynchronizer $titleCatalogSynchronizer;
+    private readonly PlayerScanTrophyProgressSynchronizer $trophyProgressSynchronizer;
 
     public function __construct(
         private readonly PDO $database,
@@ -60,6 +62,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         ?PlayerEarnedTrophyPersister $earnedTrophyPersister = null,
         ?PlayerScanStaleGameDeletionService $staleGameDeletionService = null,
         ?PlayerScanTitleCatalogSynchronizer $titleCatalogSynchronizer = null,
+        ?PlayerScanTrophyProgressSynchronizer $trophyProgressSynchronizer = null,
     )
     {
         $this->automaticTrophyTitleMergeService = $automaticTrophyTitleMergeService
@@ -92,6 +95,13 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             $logger,
             historyRecorder: $historyRecorder,
             automaticTrophyTitleMergeService: $this->automaticTrophyTitleMergeService,
+        );
+        $this->trophyProgressSynchronizer = $trophyProgressSynchronizer ?? new PlayerScanTrophyProgressSynchronizer(
+            $database,
+            $trophyCalculator,
+            $logger,
+            $this->earnedTrophyPersister,
+            $this->automaticTrophyTitleMergeService,
         );
     }
 
@@ -163,40 +173,6 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         );
 
         sleep(60);
-    }
-
-    /**
-     * @template T
-     * @param callable():T $operation
-     * @return T
-     */
-    private function retryNotFound(callable $operation, string $description)
-    {
-        $attempt = 0;
-        $delay = 2;
-        $maxAttempts = 5;
-
-        while (true) {
-            try {
-                return $operation();
-            } catch (NotFoundHttpException $exception) {
-                $attempt++;
-
-                if ($attempt >= $maxAttempts) {
-                    $this->logger->log(sprintf(
-                        '%s failed with %s after %d attempts. Aborting retries.',
-                        $description,
-                        $exception->getMessage(),
-                        $attempt
-                    ));
-
-                    throw $exception;
-                }
-
-                sleep($delay);
-                $delay = min($delay * 2, 60);
-            }
-        }
     }
 
     private function ensureTrophyTitleIcon(
@@ -623,61 +599,13 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                             $newTrophies = $catalogSyncResult->newTrophies;
                             $mergeParentsToRecompute = $catalogSyncResult->mergeParentsToRecompute;
 
-                            // Fetch user trophies
-                            $trophyGroups = $this->retryNotFound(
-                                fn () => $trophyTitle->trophyGroups(),
-                                sprintf('Fetching trophy groups for %s (%s)', $trophyTitle->name(), $npid)
+                            $this->trophyProgressSynchronizer->synchronizeTrophyProgress(
+                                $user,
+                                $trophyTitle,
+                                $npid,
+                                $newTrophies,
+                                $mergeParentsToRecompute,
                             );
-
-                            foreach ($trophyGroups as $trophyGroup) {
-                                $groupTrophies = $this->retryNotFound(
-                                    fn () => $trophyGroup->trophies(),
-                                    sprintf(
-                                        'Fetching trophies for %s (%s/%s)',
-                                        $trophyTitle->name(),
-                                        $npid,
-                                        $trophyGroup->id()
-                                    )
-                                );
-
-                                foreach ($groupTrophies as $trophy) {
-                                    $trophyEarned = $trophy->earned();
-                                    $progress = (clone $trophy)->progress();
-                                    if ($trophyEarned || ($progress != '' && intval($progress) > 0)) {
-                                        $this->earnedTrophyPersister->persistEarnedTrophy(
-                                            $npid,
-                                            $trophyGroup->id(),
-                                            (int) $trophy->id(),
-                                            (string) $user->accountId(),
-                                            $trophyEarned,
-                                            $progress,
-                                            $trophy->earnedDateTime(),
-                                        );
-                                    }
-                                }
-
-                                // Recalculate trophies for trophy group and player
-                                $this->trophyCalculator->recalculateTrophyGroup($npid, $trophyGroup->id(), (int) $user->accountId());
-                            }
-
-                            // Recalculate trophies for trophy title and player
-                            $this->trophyCalculator->recalculateTrophyTitle($npid, $trophyTitle->lastUpdatedDateTime(), $newTrophies, (int) $user->accountId(), false);
-
-                            // Game Merge stuff
-                            $query = $this->database->prepare("SELECT DISTINCT parent_np_communication_id, 
-                                                parent_group_id 
-                                FROM   trophy_merge 
-                                WHERE  child_np_communication_id = :child_np_communication_id ");
-                            $query->bindValue(":child_np_communication_id", $npid, PDO::PARAM_STR);
-                            $query->execute();
-                            while ($row = $query->fetch()) {
-                                $this->trophyCalculator->recalculateTrophyGroup($row["parent_np_communication_id"], $row["parent_group_id"], (int) $user->accountId());
-                                $this->trophyCalculator->recalculateTrophyTitle($row["parent_np_communication_id"], $trophyTitle->lastUpdatedDateTime(), false, (int) $user->accountId(), true);
-                            }
-
-                            foreach ($mergeParentsToRecompute as $mergeParent) {
-                                $this->automaticTrophyTitleMergeService->recomputeMergeProgressByParent($mergeParent);
-                            }
                         }
 
                         if ($restartScan) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels one concern off `ThirtyMinuteCronJob` (~820 → ~748 lines): per-title earned trophy fetching, persistence, and recalculation.

Adds `PlayerScanTrophyProgressSynchronizer`, following the same extraction pattern already used for profile sync, catalog sync, and scan completion.

## What moved

For each game during a player scan, the cron job now delegates to `PlayerScanTrophyProgressSynchronizer::synchronizeTrophyProgress()` instead of inlining:

- PSN trophy group/trophy fetching (with `NotFoundHttpException` retry/backoff)
- Earned trophy persistence via `PlayerEarnedTrophyPersister`
- Trophy group/title recalculation via `TrophyCalculator`
- Merge-parent group/title recalculation from `trophy_merge` mappings
- Catalog-driven merge parent recomputation via `AutomaticTrophyTitleMergeService`

## Testing

- Added `PlayerScanTrophyProgressSynchronizerTest` covering earned-trophy persistence, merge-parent recomputation, and retry behavior.
- Full suite: `php tests/run.php` — 725 tests passed.

## Follow-up candidates (future PRs)

Other God classes identified for incremental extraction:

1. `GameCopyService` — extract `copyConflictingTrophies` (parallel to existing `MergeTrophyGroupCopier`)
2. `TrophyMergeService` — extract `copyMergedTrophies` / `copyTrophyEarned`
3. `GameRescanService` — extract `updateTrophyTitle()` catalog updater
4. `PsnGameLookupService` — extract PSN response normalization/validation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a966f1e-2e9b-4078-af41-a2c6e906a15a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a966f1e-2e9b-4078-af41-a2c6e906a15a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

