### PR TITLE
Extract trophy title upsert into TrophyCatalogSynchronizer

### DIFF
--- a/tests/TrophyCatalogSynchronizerTest.php
+++ b/tests/TrophyCatalogSynchronizerTest.php
@@ -147,4 +147,12 @@ final class TrophyCatalogSynchronizerTest extends TestCase
         $this->assertSame('silver', $trophy['type']);
         $this->assertSame('three.png', $trophy['icon_url']);
     }
+
+    public function testUpsertTrophyTitleMethodAcceptsCatalogFields(): void
+    {
+        $method = new ReflectionMethod(TrophyCatalogSynchronizer::class, 'upsertTrophyTitle');
+
+        $this->assertSame(7, $method->getNumberOfParameters());
+        $this->assertSame('int', (string) $method->getReturnType());
+    }
 }

--- a/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
@@ -93,49 +93,17 @@ final class PlayerScanTitleCatalogSynchronizer
         }
 
         if ($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) {
-            $query = $this->database->prepare("INSERT INTO trophy_title(
-                    np_communication_id,
-                    name,
-                    detail,
-                    icon_url,
-                    platform,
-                    set_version
-                )
-                VALUES(
-                    :np_communication_id,
-                    :name,
-                    :detail,
-                    :icon_url,
-                    :platform,
-                    :set_version
-                ) AS new
-                ON DUPLICATE KEY
-                UPDATE
-                    detail = CASE
-                        WHEN :incoming_version_is_older = 1 THEN trophy_title.detail
-                        ELSE new.detail
-                    END,
-                    icon_url = new.icon_url,
-                    set_version = CASE
-                        WHEN trophy_title.set_version IS NULL OR TRIM(trophy_title.set_version) = '' THEN new.set_version
-                        WHEN CAST(SUBSTRING_INDEX(TRIM(new.set_version), '.', 1) AS UNSIGNED)
-                            > CAST(SUBSTRING_INDEX(TRIM(trophy_title.set_version), '.', 1) AS UNSIGNED) THEN new.set_version
-                        WHEN CAST(SUBSTRING_INDEX(TRIM(new.set_version), '.', 1) AS UNSIGNED)
-                            = CAST(SUBSTRING_INDEX(TRIM(trophy_title.set_version), '.', 1) AS UNSIGNED)
-                            AND CAST(SUBSTRING_INDEX(TRIM(new.set_version), '.', -1) AS UNSIGNED)
-                                >= CAST(SUBSTRING_INDEX(TRIM(trophy_title.set_version), '.', -1) AS UNSIGNED) THEN new.set_version
-                        ELSE trophy_title.set_version
-                    END");
-            $query->bindValue(':np_communication_id', $npid, PDO::PARAM_STR);
-            $query->bindValue(':name', $sanitizedTitleName, PDO::PARAM_STR);
-            $query->bindValue(':detail', $trophyTitle->detail(), PDO::PARAM_STR);
-            $query->bindValue(':icon_url', $titleIconFilename, PDO::PARAM_STR);
-            $query->bindValue(':platform', $platforms, PDO::PARAM_STR);
-            $query->bindValue(':set_version', $setVersionForUpdate, PDO::PARAM_STR);
-            $query->bindValue(':incoming_version_is_older', $incomingVersionIsOlderThanStored ? 1 : 0, PDO::PARAM_INT);
-            $query->execute();
+            $titleAffectedRows = $this->catalogSynchronizer()->upsertTrophyTitle(
+                $npid,
+                $sanitizedTitleName,
+                $trophyTitle->detail(),
+                $titleIconFilename,
+                $platforms,
+                $setVersionForUpdate,
+                $incomingVersionIsOlderThanStored,
+            );
 
-            if ($query->rowCount() > 0) {
+            if ($titleAffectedRows > 0) {
                 $titleDataChanged = true;
             }
         }

--- a/wwwroot/classes/TrophyCatalogSynchronizer.php
+++ b/wwwroot/classes/TrophyCatalogSynchronizer.php
@@ -164,6 +164,60 @@ final class TrophyCatalogSynchronizer
         return $row === false ? null : $row;
     }
 
+    public function upsertTrophyTitle(
+        string $npCommunicationId,
+        string $name,
+        string $detail,
+        string $iconFilename,
+        string $platform,
+        string $setVersion,
+        bool $incomingVersionIsOlderThanStored,
+    ): int {
+        $query = $this->database->prepare("INSERT INTO trophy_title(
+                np_communication_id,
+                name,
+                detail,
+                icon_url,
+                platform,
+                set_version
+            )
+            VALUES(
+                :np_communication_id,
+                :name,
+                :detail,
+                :icon_url,
+                :platform,
+                :set_version
+            ) AS new
+            ON DUPLICATE KEY
+            UPDATE
+                detail = CASE
+                    WHEN :incoming_version_is_older = 1 THEN trophy_title.detail
+                    ELSE new.detail
+                END,
+                icon_url = new.icon_url,
+                set_version = CASE
+                    WHEN trophy_title.set_version IS NULL OR TRIM(trophy_title.set_version) = '' THEN new.set_version
+                    WHEN CAST(SUBSTRING_INDEX(TRIM(new.set_version), '.', 1) AS UNSIGNED)
+                        > CAST(SUBSTRING_INDEX(TRIM(trophy_title.set_version), '.', 1) AS UNSIGNED) THEN new.set_version
+                    WHEN CAST(SUBSTRING_INDEX(TRIM(new.set_version), '.', 1) AS UNSIGNED)
+                        = CAST(SUBSTRING_INDEX(TRIM(trophy_title.set_version), '.', 1) AS UNSIGNED)
+                        AND CAST(SUBSTRING_INDEX(TRIM(new.set_version), '.', -1) AS UNSIGNED)
+                            >= CAST(SUBSTRING_INDEX(TRIM(trophy_title.set_version), '.', -1) AS UNSIGNED) THEN new.set_version
+                    ELSE trophy_title.set_version
+                END");
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':name', $name, PDO::PARAM_STR);
+        $query->bindValue(':detail', $detail, PDO::PARAM_STR);
+        $query->bindValue(':icon_url', $iconFilename, PDO::PARAM_STR);
+        $query->bindValue(':platform', $platform, PDO::PARAM_STR);
+        $query->bindValue(':set_version', $setVersion, PDO::PARAM_STR);
+        $query->bindValue(':incoming_version_is_older', $incomingVersionIsOlderThanStored ? 1 : 0, PDO::PARAM_INT);
+        $query->execute();
+
+        return (int) $query->rowCount();
+    }
+
     public function upsertTrophyGroup(
         string $npCommunicationId,
         string $groupId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels one concern out of `PlayerScanTitleCatalogSynchronizer` (560 lines, mixes catalog SQL, image downloads, PSN API calls, merge triggers, and audit logging).

Moves the inline `trophy_title` INSERT … ON DUPLICATE KEY UPDATE block into `TrophyCatalogSynchronizer::upsertTrophyTitle()`, alongside the existing `upsertTrophyGroup()` and `upsertTrophy()` methods.

## Why this first

- **Smallest safe slice**: pure SQL relocation, no behavior change.
- **Sets up catalog unification**: `GameRescanService::updateTrophyTitle()` has overlapping title-persistence logic that can adopt this method in a follow-up PR.
- **Reduces God-class surface**: `PlayerScanTitleCatalogSynchronizer` now delegates title row writes the same way it already delegates group/trophy writes.

## God classes identified (follow-up PRs)

| Class | Lines | Next extraction candidate |
|-------|-------|---------------------------|
| `ThirtyMinuteCronJob` | ~749 | Per-player scan body → `PlayerScanOrchestrator` |
| `GameCopyService` | ~781 | `copyConflictingTrophies()` → `ConflictingTrophyCopier` |
| `TrophyMergeService` | ~724 | `copyMergedTrophies()` → `TrophyEarnedMergeSynchronizer` |
| `GameRescanService` | ~721 | `updateTrophyTitle()` → reuse `TrophyCatalogSynchronizer` |
| `PlayerScanTitleCatalogSynchronizer` | ~515 | Trophy data fetch / group iteration (remaining concerns) |

## Testing

- All 726 tests pass (`php tests/run.php`).
- Added reflection-based API test for `upsertTrophyTitle()` (MySQL-specific upsert SQL cannot run against the in-memory SQLite test DB).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8680b22-5d1c-43c7-b441-cf724faf07a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8680b22-5d1c-43c7-b441-cf724faf07a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

