### PR TITLE
Extract private-profile handling from ThirtyMinuteCronJob

### DIFF
--- a/tests/PlayerScanPrivacyServiceTest.php
+++ b/tests/PlayerScanPrivacyServiceTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerStatus.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/WorkerScanCoordinator.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanPrivacyService.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php';
+
+final class PlayerScanPrivacyServiceTest extends TestCase
+{
+    private PDO $database;
+
+    private PlayerScanPrivacyService $service;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY, scanning TEXT, scan_progress TEXT)');
+        $this->database->exec('CREATE TABLE player_queue (online_id TEXT PRIMARY KEY)');
+        $this->database->exec(
+            'CREATE TABLE player (
+                account_id INTEGER PRIMARY KEY,
+                online_id TEXT NOT NULL,
+                status INTEGER NOT NULL DEFAULT 99,
+                last_updated_date TEXT
+            )'
+        );
+        $this->database->sqliteCreateFunction('NOW', static fn (): string => date('Y-m-d H:i:s'), 0);
+
+        $this->service = new PlayerScanPrivacyService(
+            $this->database,
+            new WorkerScanCoordinator($this->database),
+            static function (int $seconds): void {
+            },
+        );
+    }
+
+    public function testMarkAsPrivateByOnlineIdUpdatesStatusAndRemovesQueueEntry(): void
+    {
+        $this->database->exec(
+            "INSERT INTO player (account_id, online_id, status) VALUES (100, 'private-player', 99)"
+        );
+        $this->database->exec("INSERT INTO player_queue (online_id) VALUES ('private-player')");
+
+        $this->service->markAsPrivateByOnlineId('private-player');
+
+        $status = $this->database->query("SELECT status FROM player WHERE online_id = 'private-player'")->fetchColumn();
+        $queueCount = $this->database->query('SELECT COUNT(*) FROM player_queue')->fetchColumn();
+
+        $this->assertSame((string) PlayerStatus::PRIVATE_PROFILE->value, (string) $status);
+        $this->assertSame('0', (string) $queueCount);
+    }
+
+    public function testMarkAsPrivateByOnlineIdDoesNotOverrideFlaggedPlayers(): void
+    {
+        $this->database->exec(
+            "INSERT INTO player (account_id, online_id, status) VALUES (101, 'flagged-player', 1)"
+        );
+
+        $this->service->markAsPrivateByOnlineId('flagged-player');
+
+        $status = $this->database->query("SELECT status FROM player WHERE online_id = 'flagged-player'")->fetchColumn();
+
+        $this->assertSame((string) PlayerStatus::FLAGGED->value, (string) $status);
+    }
+
+    public function testMarkAsPrivateByAccountIdUpdatesStatusAndRemovesQueueEntry(): void
+    {
+        $this->database->exec(
+            "INSERT INTO player (account_id, online_id, status) VALUES (200, 'renamed-player', 99)"
+        );
+        $this->database->exec("INSERT INTO player_queue (online_id) VALUES ('queue-name')");
+
+        $this->service->markAsPrivateByAccountId(200, 'queue-name');
+
+        $status = $this->database->query('SELECT status FROM player WHERE account_id = 200')->fetchColumn();
+        $queueCount = $this->database->query('SELECT COUNT(*) FROM player_queue')->fetchColumn();
+
+        $this->assertSame((string) PlayerStatus::PRIVATE_PROFILE->value, (string) $status);
+        $this->assertSame('0', (string) $queueCount);
+    }
+
+    public function testResolveTrophySummaryLevelReturnsAccessibleLevel(): void
+    {
+        $user = new class {
+            public function trophySummary(): object
+            {
+                return new class {
+                    public function level(): int
+                    {
+                        return 42;
+                    }
+                };
+            }
+        };
+
+        $result = $this->service->resolveTrophySummaryLevel($user, 1);
+
+        $this->assertTrue($result->isAccessible());
+        $this->assertSame(42, $result->level);
+    }
+
+    public function testResolveTrophySummaryLevelMarksPrivateAfterRetryFailure(): void
+    {
+        $this->database->exec(
+            "INSERT INTO player (account_id, online_id, status) VALUES (300, 'hidden-player', 99)"
+        );
+        $this->database->exec("INSERT INTO player_queue (online_id) VALUES ('hidden-player')");
+
+        $user = new class {
+            public int $attempts = 0;
+
+            public function accountId(): int
+            {
+                return 300;
+            }
+
+            public function onlineId(): string
+            {
+                return 'hidden-player';
+            }
+
+            public function trophySummary(): object
+            {
+                $this->attempts++;
+
+                throw new RuntimeException('profile is private');
+            }
+        };
+
+        $result = $this->service->resolveTrophySummaryLevel($user, 1);
+
+        $this->assertTrue($result->isPrivateProfile());
+        $status = $this->database->query('SELECT status FROM player WHERE account_id = 300')->fetchColumn();
+        $queueCount = $this->database->query('SELECT COUNT(*) FROM player_queue')->fetchColumn();
+
+        $this->assertSame((string) PlayerStatus::PRIVATE_PROFILE->value, (string) $status);
+        $this->assertSame('0', (string) $queueCount);
+        $this->assertSame(2, $user->attempts);
+    }
+
+    public function testTrophySummaryAccessResultHelpers(): void
+    {
+        $accessible = PlayerScanTrophySummaryAccessResult::accessible(10);
+        $private = PlayerScanTrophySummaryAccessResult::privateProfile();
+        $abort = PlayerScanTrophySummaryAccessResult::abortScan();
+
+        $this->assertTrue($accessible->isAccessible());
+        $this->assertFalse($accessible->isPrivateProfile());
+        $this->assertFalse($accessible->shouldAbortScan());
+
+        $this->assertTrue($private->isPrivateProfile());
+        $this->assertFalse($private->isAccessible());
+        $this->assertFalse($private->shouldAbortScan());
+
+        $this->assertTrue($abort->shouldAbortScan());
+        $this->assertFalse($abort->isAccessible());
+        $this->assertFalse($abort->isPrivateProfile());
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanPrivacyService.php
+++ b/wwwroot/classes/Cron/PlayerScanPrivacyService.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../PlayerStatus.php';
+require_once __DIR__ . '/PlayerScanTrophySummaryAccessResult.php';
+
+/**
+ * Marks players as private and resolves trophy-summary access during scans.
+ *
+ * Encapsulates private-profile detection and persistence that were previously
+ * embedded in ThirtyMinuteCronJob and PlayerScanProfileSynchronizer.
+ */
+final class PlayerScanPrivacyService
+{
+    private readonly \Closure $sleeper;
+
+    public function __construct(
+        private readonly PDO $database,
+        private readonly WorkerScanCoordinator $workerScanCoordinator,
+        ?callable $sleeper = null,
+    ) {
+        $this->sleeper = \Closure::fromCallable($sleeper ?? static function (int $seconds): void {
+            sleep($seconds);
+        });
+    }
+
+    public function markAsPrivateByOnlineId(string $onlineId): void
+    {
+        $privateStatus = PlayerStatus::PRIVATE_PROFILE->value;
+
+        $query = $this->database->prepare(
+            'UPDATE player
+            SET `status` = :status, last_updated_date = NOW()
+            WHERE online_id = :online_id AND `status` != :flagged_status'
+        );
+        $query->bindValue(':status', $privateStatus, PDO::PARAM_INT);
+        $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
+        $query->bindValue(':flagged_status', PlayerStatus::FLAGGED->value, PDO::PARAM_INT);
+        $query->execute();
+
+        $query = $this->database->prepare('DELETE FROM player_queue WHERE online_id = :online_id');
+        $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    public function markAsPrivateByAccountId(int $accountId, string $queueOnlineId): void
+    {
+        $privateStatus = PlayerStatus::PRIVATE_PROFILE->value;
+
+        $query = $this->database->prepare(
+            'UPDATE player
+            SET `status` = :status, last_updated_date = NOW()
+            WHERE account_id = :account_id AND `status` != :flagged_status'
+        );
+        $query->bindValue(':status', $privateStatus, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':flagged_status', PlayerStatus::FLAGGED->value, PDO::PARAM_INT);
+        $query->execute();
+
+        $query = $this->database->prepare('DELETE FROM player_queue WHERE online_id = :online_id');
+        $query->bindValue(':online_id', $queueOnlineId, PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    public function resolveTrophySummaryLevel(object $user, int $workerId): PlayerScanTrophySummaryAccessResult
+    {
+        try {
+            return PlayerScanTrophySummaryAccessResult::accessible((int) $user->trophySummary()->level());
+        } catch (TypeError) {
+            $this->pauseBeforeRetryingScan($workerId, 'Encountered a problem while scanning. Waiting 1 minute before retrying.');
+
+            return PlayerScanTrophySummaryAccessResult::abortScan();
+        } catch (Exception) {
+            $this->workerScanCoordinator->setWaitingScanProgress(
+                $workerId,
+                'Profile scan failed, waiting 1 minute before confirming privacy.'
+            );
+            ($this->sleeper)(60);
+
+            try {
+                return PlayerScanTrophySummaryAccessResult::accessible((int) $user->trophySummary()->level());
+            } catch (TypeError) {
+                $this->pauseBeforeRetryingScan($workerId, 'Encountered a problem while scanning. Waiting 1 minute before retrying.');
+
+                return PlayerScanTrophySummaryAccessResult::abortScan();
+            } catch (Exception) {
+                $this->markAsPrivateByAccountId((int) $user->accountId(), (string) $user->onlineId());
+
+                return PlayerScanTrophySummaryAccessResult::privateProfile();
+            }
+        }
+    }
+
+    private function pauseBeforeRetryingScan(int $workerId, string $message): void
+    {
+        $this->workerScanCoordinator->setWaitingScanProgress($workerId, $message);
+        ($this->sleeper)(60);
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
 require_once __DIR__ . '/PlayerAvatarSynchronizer.php';
 require_once __DIR__ . '/../ImageHashCalculator.php';
+require_once __DIR__ . '/PlayerScanPrivacyService.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\PlayStation\Client;
@@ -20,16 +21,22 @@ final class PlayerScanProfileSynchronizer
     private const MAX_INVALID_API_RESPONSE_ATTEMPTS = 2;
 
     private readonly PlayerAvatarSynchronizer $avatarSynchronizer;
+    private readonly PlayerScanPrivacyService $privacyService;
 
     public function __construct(
         private readonly PDO $database,
         private readonly Psn100Logger $logger,
         private readonly WorkerScanCoordinator $workerScanCoordinator,
         ?PlayerAvatarSynchronizer $avatarSynchronizer = null,
+        ?PlayerScanPrivacyService $privacyService = null,
     ) {
         $this->avatarSynchronizer = $avatarSynchronizer ?? new PlayerAvatarSynchronizer(
             $database,
             new ImageHashCalculator(),
+        );
+        $this->privacyService = $privacyService ?? new PlayerScanPrivacyService(
+            $database,
+            $workerScanCoordinator,
         );
     }
 
@@ -161,7 +168,7 @@ final class PlayerScanProfileSynchronizer
                     $profile = $profileLookup['profile'] ?? null;
 
                     if (!is_array($profile)) {
-                        $this->markPlayerAsPrivate($originalOnlineId);
+                        $this->privacyService->markAsPrivateByOnlineId($originalOnlineId);
 
                         return PlayerScanProfileSyncResult::skipPlayer();
                     }
@@ -169,7 +176,7 @@ final class PlayerScanProfileSynchronizer
                     $profileAccountId = $profile['accountId'] ?? null;
 
                     if (!is_string($profileAccountId) || $profileAccountId === '') {
-                        $this->markPlayerAsPrivate($originalOnlineId);
+                        $this->privacyService->markAsPrivateByOnlineId($originalOnlineId);
 
                         return PlayerScanProfileSyncResult::skipPlayer();
                     }
@@ -211,7 +218,7 @@ final class PlayerScanProfileSynchronizer
                     }
                 } else {
                     if ($existingAccountId === null) {
-                        $this->markPlayerAsPrivate($originalOnlineId);
+                        $this->privacyService->markAsPrivateByOnlineId($originalOnlineId);
 
                         return PlayerScanProfileSyncResult::skipPlayer();
                     }
@@ -346,21 +353,6 @@ final class PlayerScanProfileSynchronizer
         $normalized = $this->normalizePlayerProfileResponse($profile);
 
         return is_array($normalized) ? $normalized : null;
-    }
-
-    private function markPlayerAsPrivate(string $onlineId): void
-    {
-        $query = $this->database->prepare(
-            'UPDATE player
-            SET `status` = 3, last_updated_date = NOW()
-            WHERE online_id = :online_id AND `status` != 1'
-        );
-        $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
-        $query->execute();
-
-        $query = $this->database->prepare('DELETE FROM player_queue WHERE online_id = :online_id');
-        $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
-        $query->execute();
     }
 
     private function updateQueuedOnlineId(int $workerId, string $previousOnlineId, string $newOnlineId): void

--- a/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Outcome of reading a PSN user's trophy summary level during a player scan.
+ */
+final class PlayerScanTrophySummaryAccessResult
+{
+    public const STATUS_ACCESSIBLE = 'accessible';
+    public const STATUS_PRIVATE = 'private';
+    public const STATUS_ABORT_SCAN = 'abort_scan';
+
+    private function __construct(
+        public readonly string $status,
+        public readonly int $level = 0,
+    ) {
+    }
+
+    public static function accessible(int $level): self
+    {
+        return new self(self::STATUS_ACCESSIBLE, $level);
+    }
+
+    public static function privateProfile(): self
+    {
+        return new self(self::STATUS_PRIVATE);
+    }
+
+    public static function abortScan(): self
+    {
+        return new self(self::STATUS_ABORT_SCAN);
+    }
+
+    public function isAccessible(): bool
+    {
+        return $this->status === self::STATUS_ACCESSIBLE;
+    }
+
+    public function isPrivateProfile(): bool
+    {
+        return $this->status === self::STATUS_PRIVATE;
+    }
+
+    public function shouldAbortScan(): bool
+    {
+        return $this->status === self::STATUS_ABORT_SCAN;
+    }
+}

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -24,6 +24,8 @@ require_once __DIR__ . '/PlayerScanStaleGameDeletionService.php';
 require_once __DIR__ . '/PlayerScanTitleCatalogSynchronizer.php';
 require_once __DIR__ . '/PlayerScanTitleCatalogSyncResult.php';
 require_once __DIR__ . '/PlayerScanTrophyProgressSynchronizer.php';
+require_once __DIR__ . '/PlayerScanPrivacyService.php';
+require_once __DIR__ . '/PlayerScanTrophySummaryAccessResult.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\Haste\Exception\UnauthorizedHttpException;
@@ -44,6 +46,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
     private readonly PlayerScanStaleGameDeletionService $staleGameDeletionService;
     private readonly PlayerScanTitleCatalogSynchronizer $titleCatalogSynchronizer;
     private readonly PlayerScanTrophyProgressSynchronizer $trophyProgressSynchronizer;
+    private readonly PlayerScanPrivacyService $privacyService;
 
     public function __construct(
         private readonly PDO $database,
@@ -63,6 +66,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         ?PlayerScanStaleGameDeletionService $staleGameDeletionService = null,
         ?PlayerScanTitleCatalogSynchronizer $titleCatalogSynchronizer = null,
         ?PlayerScanTrophyProgressSynchronizer $trophyProgressSynchronizer = null,
+        ?PlayerScanPrivacyService $privacyService = null,
     )
     {
         $this->automaticTrophyTitleMergeService = $automaticTrophyTitleMergeService
@@ -102,6 +106,10 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             $logger,
             $this->earnedTrophyPersister,
             $this->automaticTrophyTitleMergeService,
+        );
+        $this->privacyService = $privacyService ?? new PlayerScanPrivacyService(
+            $database,
+            $this->workerScanCoordinator,
         );
     }
 
@@ -385,60 +393,14 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                 break;
             }
 
-            $privateUser = false;
-            try {
-                $level = 0;
-                $level = $user->trophySummary()->level();
-            } catch (TypeError $e) {
-                // Rare error, wait 1 minute to not hammer Sony and try again.
-                $this->workerScanCoordinator->setWaitingScanProgress(
-                    (int) $worker['id'],
-                    'Encountered a problem while scanning. Waiting 1 minute before retrying.'
-                );
-                sleep(60 * 1);
+            $trophySummaryAccess = $this->privacyService->resolveTrophySummaryLevel($user, (int) $worker['id']);
+
+            if ($trophySummaryAccess->shouldAbortScan()) {
                 break;
-            } catch (Exception $e) {
-                // Potentially private profile, wait 1 minute and retry before updating the status.
-                $this->workerScanCoordinator->setWaitingScanProgress(
-                    (int) $worker['id'],
-                    'Profile scan failed, waiting 1 minute before confirming privacy.'
-                );
-                sleep(60 * 1);
-
-                try {
-                    $level = 0;
-                    $level = $user->trophySummary()->level();
-                } catch (TypeError $retryException) {
-                    // Rare error, wait 1 minute to not hammer Sony and try again.
-                    $this->workerScanCoordinator->setWaitingScanProgress(
-                        (int) $worker['id'],
-                        'Encountered a problem while scanning. Waiting 1 minute before retrying.'
-                    );
-                    sleep(60 * 1);
-                    break;
-                } catch (Exception $retryException) {
-                    // Profile seem to be private, set status to 3 to hide all trophies.
-                    $query = $this->database->prepare("UPDATE
-                            player
-                        SET
-                            status = 3,
-                            last_updated_date = NOW()
-                        WHERE
-                            account_id = :account_id
-                            AND status != 1
-                    ");
-                    $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
-                    $query->execute();
-
-                    // Delete user from the queue
-                    $query = $this->database->prepare("DELETE FROM player_queue
-                        WHERE  online_id = :online_id ");
-                    $query->bindValue(":online_id", $user->onlineId(), PDO::PARAM_STR);
-                    $query->execute();
-
-                    $privateUser = true;
-                }
             }
+
+            $privateUser = $trophySummaryAccess->isPrivateProfile();
+            $level = $trophySummaryAccess->isAccessible() ? $trophySummaryAccess->level : 0;
 
             try {
                 if (!$privateUser) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels private-profile detection and persistence out of `ThirtyMinuteCronJob` (749 → 710 lines) into a focused `PlayerScanPrivacyService`, consolidating duplicate logic that also lived in `PlayerScanProfileSynchronizer`.

This is the first in a series of incremental God-class refactors — one concern per PR.

## Changes

- **`PlayerScanPrivacyService`** — marks players private (by `online_id` or `account_id`), removes queue entries, and resolves trophy-summary access with retry/confirm logic
- **`PlayerScanTrophySummaryAccessResult`** — typed outcome (`accessible`, `private`, `abort_scan`) replacing the inline `$privateUser` flag + scattered `break`s
- **`ThirtyMinuteCronJob`** — delegates the ~50-line trophy-summary privacy block to the new service
- **`PlayerScanProfileSynchronizer`** — reuses the same service instead of its own `markPlayerAsPrivate()` helper
- Uses `PlayerStatus::PRIVATE_PROFILE` / `PlayerStatus::FLAGGED` instead of magic numbers
- Injectable `sleeper` closure for fast unit tests

## Test plan

- [x] `php tests/run.php` — all 732 tests pass
- [x] New `PlayerScanPrivacyServiceTest` covers marking private, flagged-player guard, trophy-summary access paths, and result helpers

## Follow-up PRs (remaining God classes)

1. `TrophyMergeService` — extract earned-trophy SQL (`copyMergedTrophies` / `copyTrophyEarned`)
2. Shared catalog refresh pipeline — unify `GameRescanService::updateTrophyTitle` and `PlayerScanTitleCatalogSynchronizer::synchronizeCatalog`
3. `PsnGameLookupService` — extract response parser
4. `TrophyStatusService` — extract recalculation SQL
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf38bdce-6aa6-47c2-9823-1f568d5eed3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf38bdce-6aa6-47c2-9823-1f568d5eed3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

