### PR TITLE
Extract GameHistoryChangeFilter from GameHistoryPage

### DIFF
--- a/tests/GameHistoryChangeFilterTest.php
+++ b/tests/GameHistoryChangeFilterTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/GameHistoryChangeFilter.php';
+
+final class GameHistoryChangeFilterTest extends TestCase
+{
+    public function testFilterReturnsEmptyArrayForEmptyInput(): void
+    {
+        $filter = new GameHistoryChangeFilter();
+
+        $this->assertSame([], $filter->filter([]));
+    }
+
+    public function testFilterOmitsUnchangedRowsAndHighlightsDifferences(): void
+    {
+        $filter = new GameHistoryChangeFilter();
+
+        $entries = [
+            [
+                'historyId' => 4,
+                'discoveredAt' => new DateTimeImmutable('2024-04-01 00:00:00'),
+                'title' => ['detail' => null, 'icon_url' => null, 'set_version' => '01.10'],
+                'groups' => [
+                    ['group_id' => 'default', 'name' => 'Base', 'detail' => 'Base detail', 'icon_url' => 'group-a.png'],
+                    ['group_id' => '001', 'name' => 'Expansion', 'detail' => 'Expansion detail', 'icon_url' => '.png'],
+                ],
+                'trophies' => [
+                    ['group_id' => 'default', 'order_id' => 1, 'name' => 'First Trophy', 'detail' => 'Earn it', 'icon_url' => 'trophy-a.png', 'progress_target_value' => null, 'is_unobtainable' => false],
+                    ['group_id' => '001', 'order_id' => 5, 'name' => 'Challenger', 'detail' => 'Reach level 5', 'icon_url' => '.png', 'progress_target_value' => 100, 'is_unobtainable' => true],
+                ],
+            ],
+            [
+                'historyId' => 3,
+                'discoveredAt' => new DateTimeImmutable('2024-03-05 00:00:00'),
+                'title' => ['detail' => null, 'icon_url' => null, 'set_version' => '01.10'],
+                'groups' => [
+                    ['group_id' => 'default', 'name' => 'Base', 'detail' => 'Base detail', 'icon_url' => 'group-a.png'],
+                    ['group_id' => '001', 'name' => 'Expansion', 'detail' => 'Expansion detail', 'icon_url' => '.png'],
+                ],
+                'trophies' => [
+                    ['group_id' => 'default', 'order_id' => 1, 'name' => 'First Trophy', 'detail' => 'Earn it', 'icon_url' => 'trophy-a.png', 'progress_target_value' => null, 'is_unobtainable' => false],
+                    ['group_id' => '001', 'order_id' => 5, 'name' => 'Challenger', 'detail' => 'Reach level 5', 'icon_url' => '.png', 'progress_target_value' => 100, 'is_unobtainable' => true],
+                ],
+            ],
+            [
+                'historyId' => 2,
+                'discoveredAt' => new DateTimeImmutable('2024-02-01 00:00:00'),
+                'title' => ['detail' => null, 'icon_url' => null, 'set_version' => '01.05'],
+                'groups' => [
+                    ['group_id' => 'default', 'name' => 'Base', 'detail' => 'Base detail', 'icon_url' => 'group-a.png'],
+                    ['group_id' => '001', 'name' => 'Expansion', 'detail' => 'Expansion detail', 'icon_url' => '.png'],
+                ],
+                'trophies' => [
+                    ['group_id' => 'default', 'order_id' => 1, 'name' => 'First Trophy', 'detail' => 'Earn it', 'icon_url' => 'trophy-a.png', 'progress_target_value' => null, 'is_unobtainable' => false],
+                    ['group_id' => '001', 'order_id' => 5, 'name' => 'Challenger', 'detail' => 'Reach level 5', 'icon_url' => '.png', 'progress_target_value' => 50, 'is_unobtainable' => true],
+                ],
+            ],
+            [
+                'historyId' => 1,
+                'discoveredAt' => new DateTimeImmutable('2024-01-01 00:00:00'),
+                'title' => ['detail' => 'Initial detail', 'icon_url' => 'icon-a.png', 'set_version' => '01.00'],
+                'groups' => [
+                    ['group_id' => 'default', 'name' => 'Base', 'detail' => 'Base detail', 'icon_url' => 'group-a.png'],
+                ],
+                'trophies' => [
+                    ['group_id' => 'default', 'order_id' => 1, 'name' => 'First Trophy', 'detail' => 'Earn it', 'icon_url' => 'trophy-a.png', 'progress_target_value' => null, 'is_unobtainable' => false],
+                ],
+            ],
+        ];
+
+        $filtered = $filter->filter($entries);
+
+        $this->assertCount(3, $filtered);
+        $this->assertSame([3, 2, 1], array_column($filtered, 'historyId'));
+
+        $latestEntry = $filtered[0];
+        $this->assertTrue($latestEntry['hasTitleChanges']);
+        $this->assertTrue($latestEntry['titleHighlights']['set_version']);
+        $this->assertFalse($latestEntry['titleHighlights']['detail']);
+        $this->assertSame([
+            'set_version' => [
+                'previous' => '01.05',
+                'current' => '01.10',
+            ],
+        ], $latestEntry['titleFieldDiffs']);
+        $this->assertSame([], $latestEntry['groups']);
+        $this->assertCount(1, $latestEntry['trophies']);
+        $this->assertTrue($latestEntry['trophies'][0]['changedFields']['progress_target_value']);
+
+        $midEntry = $filtered[1];
+        $this->assertTrue($midEntry['hasTitleChanges']);
+        $this->assertTrue($midEntry['titleHighlights']['set_version']);
+        $this->assertSame([
+            'set_version' => [
+                'previous' => '01.00',
+                'current' => '01.05',
+            ],
+        ], $midEntry['titleFieldDiffs']);
+        $this->assertCount(1, $midEntry['groups']);
+        $this->assertTrue($midEntry['groups'][0]['isNewRow']);
+        $this->assertCount(1, $midEntry['trophies']);
+        $this->assertTrue($midEntry['trophies'][0]['isNewRow']);
+        $this->assertTrue($midEntry['trophies'][0]['is_unobtainable']);
+
+        $earliestEntry = $filtered[2];
+        $this->assertTrue($earliestEntry['hasTitleChanges']);
+        $this->assertTrue($earliestEntry['titleHighlights']['icon_url']);
+        $this->assertTrue($earliestEntry['titleHighlights']['detail']);
+        $this->assertSame([
+            'detail' => [
+                'previous' => null,
+                'current' => 'Initial detail',
+            ],
+            'icon_url' => [
+                'previous' => null,
+                'current' => 'icon-a.png',
+            ],
+            'set_version' => [
+                'previous' => null,
+                'current' => '01.00',
+            ],
+        ], $earliestEntry['titleFieldDiffs']);
+        $this->assertCount(1, $earliestEntry['groups']);
+        $this->assertTrue($earliestEntry['groups'][0]['isNewRow']);
+        $this->assertCount(1, $earliestEntry['trophies']);
+        $this->assertTrue($earliestEntry['trophies'][0]['isNewRow']);
+        $this->assertFalse($earliestEntry['trophies'][0]['is_unobtainable']);
+    }
+}

--- a/wwwroot/classes/GameHistoryChangeFilter.php
+++ b/wwwroot/classes/GameHistoryChangeFilter.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Filters raw game history rows down to entries with meaningful changes and
+ * annotates each row with field-level diff metadata for rendering.
+ */
+final class GameHistoryChangeFilter
+{
+    /**
+     * @param array<int, array{
+     *     historyId: int,
+     *     discoveredAt: DateTimeImmutable,
+     *     title: ?array{detail: ?string, icon_url: ?string, set_version: ?string},
+     *     groups: array<int, array{group_id: string, name: ?string, detail: ?string, icon_url: ?string}>,
+     *     trophies: array<int, array{group_id: string, order_id: int, name: ?string, detail: ?string, icon_url: ?string, progress_target_value: ?int, is_unobtainable: bool}>
+     * }> $entries
+     * @return array<int, array{
+     *     historyId: int,
+     *     discoveredAt: DateTimeImmutable,
+     *     title: ?array{detail: ?string, icon_url: ?string, set_version: ?string},
+     *     titleHighlights: array{detail: bool, icon_url: bool, set_version: bool},
+     *     titleFieldDiffs?: array<string, array{previous: mixed, current: mixed}>,
+     *     hasTitleChanges: bool,
+     *     isTitleNewRow: bool,
+     *     groups: array<int, array{
+     *         group_id: string,
+     *         name: ?string,
+     *         detail: ?string,
+     *         icon_url: ?string,
+     *         changedFields: array{name: bool, detail: bool, icon_url: bool},
+     *         fieldDiffs?: array<string, array{previous: mixed, current: mixed}>,
+     *         isNewRow: bool
+     *     }>,
+     *     trophies: array<int, array{
+     *         group_id: string,
+     *         order_id: int,
+     *         name: ?string,
+     *         detail: ?string,
+     *         icon_url: ?string,
+     *         progress_target_value: ?int,
+     *         is_unobtainable: bool,
+     *         changedFields: array{name: bool, detail: bool, icon_url: bool, progress_target_value: bool},
+     *         fieldDiffs?: array<string, array{previous: mixed, current: mixed}>,
+     *         isNewRow: bool
+     *     }>
+     * }>
+     */
+    public function filter(array $entries): array
+    {
+        if ($entries === []) {
+            return [];
+        }
+
+        $previousTitle = [
+            'detail' => null,
+            'icon_url' => null,
+            'set_version' => null,
+        ];
+
+        /** @var array<string, array{name: ?string, detail: ?string, icon_url: ?string}> $previousGroups */
+        $previousGroups = [];
+
+        /** @var array<string, array{name: ?string, detail: ?string, icon_url: ?string, progress_target_value: ?int}> $previousTrophies */
+        $previousTrophies = [];
+
+        $processedEntries = [];
+
+        $chronologicalEntries = array_reverse($entries);
+
+        foreach ($chronologicalEntries as $entry) {
+            $titleChange = $entry['title'];
+            $titleHighlights = [
+                'detail' => false,
+                'icon_url' => false,
+                'set_version' => false,
+            ];
+            $hasTitleChanges = false;
+
+            $titleFieldDiffs = [];
+            $isTitleNewRow = $titleChange !== null
+                && $previousTitle['detail'] === null
+                && $previousTitle['icon_url'] === null
+                && $previousTitle['set_version'] === null;
+
+            if ($titleChange !== null) {
+                $titleHighlights['detail'] = $this->isNewNonEmptyString($titleChange['detail'] ?? null, $previousTitle['detail']);
+                $titleHighlights['icon_url'] = $this->isNewNonEmptyString($titleChange['icon_url'] ?? null, $previousTitle['icon_url']);
+                $titleHighlights['set_version'] = $this->isNewNonEmptyString($titleChange['set_version'] ?? null, $previousTitle['set_version']);
+
+                $hasTitleChanges = in_array(true, $titleHighlights, true);
+
+                foreach (['detail', 'icon_url', 'set_version'] as $field) {
+                    if ($titleHighlights[$field]) {
+                        $currentValue = $this->normalizeString($titleChange[$field] ?? null);
+                        $titleFieldDiffs[$field] = [
+                            'previous' => $previousTitle[$field] ?? null,
+                            'current' => $currentValue,
+                        ];
+                    }
+                }
+            }
+
+            $filteredGroups = [];
+            foreach ($entry['groups'] as $groupChange) {
+                $groupId = $groupChange['group_id'];
+                $previousGroup = $previousGroups[$groupId] ?? ['name' => null, 'detail' => null, 'icon_url' => null];
+
+                $changedFields = [
+                    'name' => $this->isNewNonEmptyString($groupChange['name'] ?? null, $previousGroup['name']),
+                    'detail' => $this->isNewNonEmptyString($groupChange['detail'] ?? null, $previousGroup['detail']),
+                    'icon_url' => $this->isNewNonEmptyString($groupChange['icon_url'] ?? null, $previousGroup['icon_url']),
+                ];
+
+                $isNewRow = !array_key_exists($groupId, $previousGroups);
+
+                if ($isNewRow) {
+                    foreach (array_keys($changedFields) as $field) {
+                        if ($this->hasNonEmptyString($groupChange[$field] ?? null)) {
+                            $changedFields[$field] = true;
+                        }
+                    }
+                }
+
+                $hasRowChanges = $isNewRow || in_array(true, $changedFields, true);
+
+                if ($hasRowChanges) {
+                    $fieldDiffs = [];
+
+                    foreach ($changedFields as $field => $hasChanged) {
+                        if ($hasChanged || $isNewRow) {
+                            $fieldDiffs[$field] = [
+                                'previous' => $previousGroup[$field] ?? null,
+                                'current' => $this->normalizeString($groupChange[$field] ?? null),
+                            ];
+                        }
+                    }
+
+                    if ($fieldDiffs !== []) {
+                        $groupChange['fieldDiffs'] = $fieldDiffs;
+                    }
+
+                    $groupChange['changedFields'] = $changedFields;
+                    $groupChange['isNewRow'] = $isNewRow;
+                    $filteredGroups[] = $groupChange;
+                }
+
+                $previousGroups[$groupId] = [
+                    'name' => $this->normalizeString($groupChange['name'] ?? null),
+                    'detail' => $this->normalizeString($groupChange['detail'] ?? null),
+                    'icon_url' => $this->normalizeString($groupChange['icon_url'] ?? null),
+                ];
+            }
+
+            $filteredTrophies = [];
+            foreach ($entry['trophies'] as $trophyChange) {
+                $trophyKey = $trophyChange['group_id'] . ':' . $trophyChange['order_id'];
+                $previousTrophy = $previousTrophies[$trophyKey] ?? [
+                    'name' => null,
+                    'detail' => null,
+                    'icon_url' => null,
+                    'progress_target_value' => null,
+                ];
+
+                $changedFields = [
+                    'name' => $this->isNewNonEmptyString($trophyChange['name'] ?? null, $previousTrophy['name']),
+                    'detail' => $this->isNewNonEmptyString($trophyChange['detail'] ?? null, $previousTrophy['detail']),
+                    'icon_url' => $this->isNewNonEmptyString($trophyChange['icon_url'] ?? null, $previousTrophy['icon_url']),
+                    'progress_target_value' => $this->isNewInt($trophyChange['progress_target_value'] ?? null, $previousTrophy['progress_target_value']),
+                ];
+
+                $isNewRow = !array_key_exists($trophyKey, $previousTrophies);
+
+                if ($isNewRow) {
+                    foreach (array_keys($changedFields) as $field) {
+                        if ($field === 'progress_target_value') {
+                            if ($trophyChange['progress_target_value'] !== null) {
+                                $changedFields[$field] = true;
+                            }
+                        } else {
+                            if ($this->hasNonEmptyString($trophyChange[$field] ?? null)) {
+                                $changedFields[$field] = true;
+                            }
+                        }
+                    }
+                }
+
+                $hasRowChanges = $isNewRow || in_array(true, $changedFields, true);
+
+                if ($hasRowChanges) {
+                    $fieldDiffs = [];
+
+                    foreach ($changedFields as $field => $hasChanged) {
+                        if ($hasChanged || $isNewRow) {
+                            if ($field === 'progress_target_value') {
+                                $currentValue = $trophyChange['progress_target_value'] ?? null;
+                                $previousValue = $previousTrophy['progress_target_value'] ?? null;
+                            } else {
+                                $currentValue = $this->normalizeString($trophyChange[$field] ?? null);
+                                $previousValue = $previousTrophy[$field] ?? null;
+                            }
+
+                            $fieldDiffs[$field] = [
+                                'previous' => $previousValue,
+                                'current' => $currentValue,
+                            ];
+                        }
+                    }
+
+                    if ($fieldDiffs !== []) {
+                        $trophyChange['fieldDiffs'] = $fieldDiffs;
+                    }
+
+                    $trophyChange['changedFields'] = $changedFields;
+                    $trophyChange['isNewRow'] = $isNewRow;
+                    $filteredTrophies[] = $trophyChange;
+                }
+
+                $previousTrophies[$trophyKey] = [
+                    'name' => $this->normalizeString($trophyChange['name'] ?? null),
+                    'detail' => $this->normalizeString($trophyChange['detail'] ?? null),
+                    'icon_url' => $this->normalizeString($trophyChange['icon_url'] ?? null),
+                    'progress_target_value' => $trophyChange['progress_target_value'] ?? null,
+                ];
+            }
+
+            $entryHasChanges = $hasTitleChanges || $filteredGroups !== [] || $filteredTrophies !== [];
+
+            if ($entryHasChanges) {
+                $entry['titleHighlights'] = $titleHighlights;
+                if ($titleFieldDiffs !== []) {
+                    $entry['titleFieldDiffs'] = $titleFieldDiffs;
+                }
+                $entry['hasTitleChanges'] = $hasTitleChanges;
+                $entry['isTitleNewRow'] = $isTitleNewRow;
+                $entry['groups'] = $filteredGroups;
+                $entry['trophies'] = $filteredTrophies;
+
+                $processedEntries[] = $entry;
+            }
+
+            if ($titleChange !== null) {
+                $previousTitle = [
+                    'detail' => $this->normalizeString($titleChange['detail'] ?? null),
+                    'icon_url' => $this->normalizeString($titleChange['icon_url'] ?? null),
+                    'set_version' => $this->normalizeString($titleChange['set_version'] ?? null),
+                ];
+            }
+        }
+
+        return array_reverse($processedEntries);
+    }
+
+    private function normalizeString(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return $value === '' ? null : $value;
+    }
+
+    private function hasNonEmptyString(?string $value): bool
+    {
+        return $this->normalizeString($value) !== null;
+    }
+
+    private function isNewNonEmptyString(?string $value, ?string $previous): bool
+    {
+        $normalized = $this->normalizeString($value);
+
+        if ($normalized === null) {
+            return false;
+        }
+
+        return $normalized !== $previous;
+    }
+
+    private function isNewInt(?int $value, ?int $previous): bool
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        return $value !== $previous;
+    }
+}

--- a/wwwroot/classes/GameHistoryPage.php
+++ b/wwwroot/classes/GameHistoryPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/GameService.php';
 require_once __DIR__ . '/GameHistoryService.php';
+require_once __DIR__ . '/GameHistoryChangeFilter.php';
 require_once __DIR__ . '/GameHeaderService.php';
 require_once __DIR__ . '/GameNotFoundException.php';
 require_once __DIR__ . '/Game/GameDetails.php';
@@ -18,6 +19,8 @@ final class GameHistoryPage
     private GameHistoryService $historyService;
 
     private GameHeaderService $gameHeaderService;
+
+    private GameHistoryChangeFilter $historyChangeFilter;
 
     private Utility $utility;
 
@@ -64,11 +67,13 @@ final class GameHistoryPage
         GameHistoryService $historyService,
         GameHeaderService $gameHeaderService,
         Utility $utility,
-        int $gameId
+        int $gameId,
+        ?GameHistoryChangeFilter $historyChangeFilter = null
     ) {
         $this->gameService = $gameService;
         $this->historyService = $historyService;
         $this->gameHeaderService = $gameHeaderService;
+        $this->historyChangeFilter = $historyChangeFilter ?? new GameHistoryChangeFilter();
         $this->utility = $utility;
 
         $this->game = $this->loadGame($gameId);
@@ -109,288 +114,10 @@ final class GameHistoryPage
     {
         if ($this->historyEntries === null) {
             $history = $this->historyService->getHistoryForGame($this->game->getId());
-            $this->historyEntries = $this->filterHistoryEntries($history);
+            $this->historyEntries = $this->historyChangeFilter->filter($history);
         }
 
         return $this->historyEntries;
-    }
-
-    /**
-     * @param array<int, array{
-     *     historyId: int,
-     *     discoveredAt: DateTimeImmutable,
-     *     title: ?array{detail: ?string, icon_url: ?string, set_version: ?string},
-     *     groups: array<int, array{group_id: string, name: ?string, detail: ?string, icon_url: ?string}>,
-     *     trophies: array<int, array{group_id: string, order_id: int, name: ?string, detail: ?string, icon_url: ?string, progress_target_value: ?int, is_unobtainable: bool}>
-     * }> $entries
-     * @return array<int, array{
-     *     historyId: int,
-     *     discoveredAt: DateTimeImmutable,
-     *     title: ?array{detail: ?string, icon_url: ?string, set_version: ?string},
-     *     titleHighlights: array{detail: bool, icon_url: bool, set_version: bool},
-     *     titleFieldDiffs?: array<string, array{previous: mixed, current: mixed}>,
-     *     hasTitleChanges: bool,
-     *     isTitleNewRow: bool,
-     *     groups: array<int, array{
-     *         group_id: string,
-     *         name: ?string,
-     *         detail: ?string,
-     *         icon_url: ?string,
-     *         changedFields: array{name: bool, detail: bool, icon_url: bool},
-     *         fieldDiffs?: array<string, array{previous: mixed, current: mixed}>,
-     *         isNewRow: bool
-     *     }>,
-     *     trophies: array<int, array{
-     *         group_id: string,
-     *         order_id: int,
-     *         name: ?string,
-     *         detail: ?string,
-     *         icon_url: ?string,
-     *         progress_target_value: ?int,
-     *         is_unobtainable: bool,
-     *         changedFields: array{name: bool, detail: bool, icon_url: bool, progress_target_value: bool},
-     *         fieldDiffs?: array<string, array{previous: mixed, current: mixed}>,
-     *         isNewRow: bool
-     *     }>
-     * }>
-     */
-    private function filterHistoryEntries(array $entries): array
-    {
-        if ($entries === []) {
-            return [];
-        }
-
-        $previousTitle = [
-            'detail' => null,
-            'icon_url' => null,
-            'set_version' => null,
-        ];
-
-        /** @var array<string, array{name: ?string, detail: ?string, icon_url: ?string}> $previousGroups */
-        $previousGroups = [];
-
-        /** @var array<string, array{name: ?string, detail: ?string, icon_url: ?string, progress_target_value: ?int}> $previousTrophies */
-        $previousTrophies = [];
-
-        $processedEntries = [];
-
-        $chronologicalEntries = array_reverse($entries);
-
-        foreach ($chronologicalEntries as $entry) {
-            $titleChange = $entry['title'];
-            $titleHighlights = [
-                'detail' => false,
-                'icon_url' => false,
-                'set_version' => false,
-            ];
-            $hasTitleChanges = false;
-
-            $titleFieldDiffs = [];
-            $isTitleNewRow = $titleChange !== null
-                && $previousTitle['detail'] === null
-                && $previousTitle['icon_url'] === null
-                && $previousTitle['set_version'] === null;
-
-            if ($titleChange !== null) {
-                $titleHighlights['detail'] = $this->isNewNonEmptyString($titleChange['detail'] ?? null, $previousTitle['detail']);
-                $titleHighlights['icon_url'] = $this->isNewNonEmptyString($titleChange['icon_url'] ?? null, $previousTitle['icon_url']);
-                $titleHighlights['set_version'] = $this->isNewNonEmptyString($titleChange['set_version'] ?? null, $previousTitle['set_version']);
-
-                $hasTitleChanges = in_array(true, $titleHighlights, true);
-
-                foreach (['detail', 'icon_url', 'set_version'] as $field) {
-                    if ($titleHighlights[$field]) {
-                        $currentValue = $this->normalizeString($titleChange[$field] ?? null);
-                        $titleFieldDiffs[$field] = [
-                            'previous' => $previousTitle[$field] ?? null,
-                            'current' => $currentValue,
-                        ];
-                    }
-                }
-            }
-
-            $filteredGroups = [];
-            foreach ($entry['groups'] as $groupChange) {
-                $groupId = $groupChange['group_id'];
-                $previousGroup = $previousGroups[$groupId] ?? ['name' => null, 'detail' => null, 'icon_url' => null];
-
-                $changedFields = [
-                    'name' => $this->isNewNonEmptyString($groupChange['name'] ?? null, $previousGroup['name']),
-                    'detail' => $this->isNewNonEmptyString($groupChange['detail'] ?? null, $previousGroup['detail']),
-                    'icon_url' => $this->isNewNonEmptyString($groupChange['icon_url'] ?? null, $previousGroup['icon_url']),
-                ];
-
-                $isNewRow = !array_key_exists($groupId, $previousGroups);
-
-                if ($isNewRow) {
-                    foreach (array_keys($changedFields) as $field) {
-                        if ($this->hasNonEmptyString($groupChange[$field] ?? null)) {
-                            $changedFields[$field] = true;
-                        }
-                    }
-                }
-
-                $hasRowChanges = $isNewRow || in_array(true, $changedFields, true);
-
-                if ($hasRowChanges) {
-                    $fieldDiffs = [];
-
-                    foreach ($changedFields as $field => $hasChanged) {
-                        if ($hasChanged || $isNewRow) {
-                            $fieldDiffs[$field] = [
-                                'previous' => $previousGroup[$field] ?? null,
-                                'current' => $this->normalizeString($groupChange[$field] ?? null),
-                            ];
-                        }
-                    }
-
-                    if ($fieldDiffs !== []) {
-                        $groupChange['fieldDiffs'] = $fieldDiffs;
-                    }
-
-                    $groupChange['changedFields'] = $changedFields;
-                    $groupChange['isNewRow'] = $isNewRow;
-                    $filteredGroups[] = $groupChange;
-                }
-
-                $previousGroups[$groupId] = [
-                    'name' => $this->normalizeString($groupChange['name'] ?? null),
-                    'detail' => $this->normalizeString($groupChange['detail'] ?? null),
-                    'icon_url' => $this->normalizeString($groupChange['icon_url'] ?? null),
-                ];
-            }
-
-            $filteredTrophies = [];
-            foreach ($entry['trophies'] as $trophyChange) {
-                $trophyKey = $trophyChange['group_id'] . ':' . $trophyChange['order_id'];
-                $previousTrophy = $previousTrophies[$trophyKey] ?? [
-                    'name' => null,
-                    'detail' => null,
-                    'icon_url' => null,
-                    'progress_target_value' => null,
-                ];
-
-                $changedFields = [
-                    'name' => $this->isNewNonEmptyString($trophyChange['name'] ?? null, $previousTrophy['name']),
-                    'detail' => $this->isNewNonEmptyString($trophyChange['detail'] ?? null, $previousTrophy['detail']),
-                    'icon_url' => $this->isNewNonEmptyString($trophyChange['icon_url'] ?? null, $previousTrophy['icon_url']),
-                    'progress_target_value' => $this->isNewInt($trophyChange['progress_target_value'] ?? null, $previousTrophy['progress_target_value']),
-                ];
-
-                $isNewRow = !array_key_exists($trophyKey, $previousTrophies);
-
-                if ($isNewRow) {
-                    foreach (array_keys($changedFields) as $field) {
-                        if ($field === 'progress_target_value') {
-                            if ($trophyChange['progress_target_value'] !== null) {
-                                $changedFields[$field] = true;
-                            }
-                        } else {
-                            if ($this->hasNonEmptyString($trophyChange[$field] ?? null)) {
-                                $changedFields[$field] = true;
-                            }
-                        }
-                    }
-                }
-
-                $hasRowChanges = $isNewRow || in_array(true, $changedFields, true);
-
-                if ($hasRowChanges) {
-                    $fieldDiffs = [];
-
-                    foreach ($changedFields as $field => $hasChanged) {
-                        if ($hasChanged || $isNewRow) {
-                            if ($field === 'progress_target_value') {
-                                $currentValue = $trophyChange['progress_target_value'] ?? null;
-                                $previousValue = $previousTrophy['progress_target_value'] ?? null;
-                            } else {
-                                $currentValue = $this->normalizeString($trophyChange[$field] ?? null);
-                                $previousValue = $previousTrophy[$field] ?? null;
-                            }
-
-                            $fieldDiffs[$field] = [
-                                'previous' => $previousValue,
-                                'current' => $currentValue,
-                            ];
-                        }
-                    }
-
-                    if ($fieldDiffs !== []) {
-                        $trophyChange['fieldDiffs'] = $fieldDiffs;
-                    }
-
-                    $trophyChange['changedFields'] = $changedFields;
-                    $trophyChange['isNewRow'] = $isNewRow;
-                    $filteredTrophies[] = $trophyChange;
-                }
-
-                $previousTrophies[$trophyKey] = [
-                    'name' => $this->normalizeString($trophyChange['name'] ?? null),
-                    'detail' => $this->normalizeString($trophyChange['detail'] ?? null),
-                    'icon_url' => $this->normalizeString($trophyChange['icon_url'] ?? null),
-                    'progress_target_value' => $trophyChange['progress_target_value'] ?? null,
-                ];
-            }
-
-            $entryHasChanges = $hasTitleChanges || $filteredGroups !== [] || $filteredTrophies !== [];
-
-            if ($entryHasChanges) {
-                $entry['titleHighlights'] = $titleHighlights;
-                if ($titleFieldDiffs !== []) {
-                    $entry['titleFieldDiffs'] = $titleFieldDiffs;
-                }
-                $entry['hasTitleChanges'] = $hasTitleChanges;
-                $entry['isTitleNewRow'] = $isTitleNewRow;
-                $entry['groups'] = $filteredGroups;
-                $entry['trophies'] = $filteredTrophies;
-
-                $processedEntries[] = $entry;
-            }
-
-            if ($titleChange !== null) {
-                $previousTitle = [
-                    'detail' => $this->normalizeString($titleChange['detail'] ?? null),
-                    'icon_url' => $this->normalizeString($titleChange['icon_url'] ?? null),
-                    'set_version' => $this->normalizeString($titleChange['set_version'] ?? null),
-                ];
-            }
-        }
-
-        return array_reverse($processedEntries);
-    }
-
-    private function normalizeString(?string $value): ?string
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        return $value === '' ? null : $value;
-    }
-
-    private function hasNonEmptyString(?string $value): bool
-    {
-        return $this->normalizeString($value) !== null;
-    }
-
-    private function isNewNonEmptyString(?string $value, ?string $previous): bool
-    {
-        $normalized = $this->normalizeString($value);
-
-        if ($normalized === null) {
-            return false;
-        }
-
-        return $normalized !== $previous;
-    }
-
-    private function isNewInt(?int $value, ?int $previous): bool
-    {
-        if ($value === null) {
-            return false;
-        }
-
-        return $value !== $previous;
     }
 
     public function createMetaData(): PageMetaData


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels the chronological diff/filter logic out of `GameHistoryPage` into a new `GameHistoryChangeFilter` class. This mirrors the existing `GameHistoryRenderer` split and is the first step in reducing God-class responsibilities across the codebase.

## Problem

`GameHistoryPage` mixed page assembly (game loading, metadata, slugs) with ~200 lines of domain logic for filtering history entries, computing field diffs, and detecting new rows.

## Change

- Add `GameHistoryChangeFilter` with a single `filter()` entry point and the helper methods that were private on the page class.
- `GameHistoryPage` delegates filtering via an injectable dependency (defaults to a new instance).
- Add `GameHistoryChangeFilterTest` with direct unit coverage of the filter behavior.

## Testing

- `php tests/run.php` — all 734 tests pass.

## Follow-ups (separate PRs)

Other God-class candidates identified for incremental extraction:

1. `ThirtyMinuteCronJob::run()` — per-player scan loop
2. `GameRescanService::updateTrophyTitle()` — shared catalog refresh with cron path
3. `TrophyMergeService` — earned-row copy SQL (`copyTrophyEarned`, `copyMergedTrophies`)
4. `PlayerScanTitleCatalogSynchronizer::synchronizeCatalog()` — title vs group/trophy phases
5. `PsnGameLookupService` — response parsing helpers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cecabb63-f6b8-4bc0-a1b7-38fdca7163eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cecabb63-f6b8-4bc0-a1b7-38fdca7163eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

