### PR TITLE
Extract TrophyMergeEarnedCopier from TrophyMergeService

### DIFF
--- a/tests/TrophyMergeServiceCopyMergedTrophiesTest.php
+++ b/tests/TrophyMergeServiceCopyMergedTrophiesTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../wwwroot/classes/TrophyMergeService.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMergeEarnedCopier.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyMergeProgressListener.php';
 
 final class TrophyMergeServiceCopyMergedTrophiesTest extends TestCase
@@ -10,12 +10,10 @@ final class TrophyMergeServiceCopyMergedTrophiesTest extends TestCase
     public function testCopyMergedTrophiesBulkCopiesEarnedProgressWithMergeSourceCte(): void
     {
         $pdo = new RecordingPDO(2);
-        $service = new TrophyMergeService($pdo);
+        $copier = new TrophyMergeEarnedCopier($pdo);
         $progress = new RecordingProgressListener();
 
-        $reflection = new ReflectionMethod(TrophyMergeService::class, 'copyMergedTrophies');
-        $reflection->setAccessible(true);
-        $reflection->invoke($service, 'NP_CHILD', $progress);
+        $copier->copyMergedTrophies('NP_CHILD', $progress);
 
         $this->assertSame(1, $pdo->insertExecutions, 'Expected a single bulk insert operation.');
         $this->assertSame(1, $pdo->updateExecutions, 'Expected a single synchronization update.');

--- a/wwwroot/classes/TrophyMergeEarnedCopier.php
+++ b/wwwroot/classes/TrophyMergeEarnedCopier.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Admin/TrophyMergeProgressListener.php';
+
+/**
+ * Copies player trophy-earned progress from child titles into merge parents.
+ *
+ * Previously embedded in TrophyMergeService.
+ */
+final class TrophyMergeEarnedCopier
+{
+    public function __construct(private readonly PDO $database)
+    {
+    }
+
+    public function copyTrophyMapping(
+        string $childNpCommunicationId,
+        string $childGroupId,
+        int $childOrderId,
+        string $parentNpCommunicationId,
+        string $parentGroupId,
+        int $parentOrderId
+    ): void {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy_earned(
+                np_communication_id,
+                group_id,
+                order_id,
+                account_id,
+                earned_date,
+                progress,
+                earned
+            )
+            SELECT
+                new.np_communication_id,
+                new.group_id,
+                new.order_id,
+                new.account_id,
+                new.earned_date,
+                new.progress,
+                new.earned
+            FROM (
+                SELECT
+                    :parent_np_communication_id AS np_communication_id,
+                    :parent_group_id AS group_id,
+                    :parent_order_id AS order_id,
+                    child.account_id AS account_id,
+                    CASE
+                        WHEN existing.earned_date IS NULL THEN child.earned_date
+                        WHEN child.earned_date IS NULL THEN existing.earned_date
+                        WHEN child.earned_date < existing.earned_date THEN child.earned_date
+                        ELSE existing.earned_date
+                    END AS earned_date,
+                    CASE
+                        WHEN existing.progress IS NULL THEN child.progress
+                        WHEN child.progress IS NULL THEN existing.progress
+                        WHEN child.progress > existing.progress THEN child.progress
+                        ELSE existing.progress
+                    END AS progress,
+                    CASE
+                        WHEN child.earned = 1 THEN 1
+                        WHEN existing.earned = 1 THEN 1
+                        ELSE COALESCE(existing.earned, 0)
+                    END AS earned
+                FROM
+                    trophy_earned AS child
+                LEFT JOIN trophy_earned AS existing ON existing.np_communication_id = :parent_np_communication_id
+                    AND existing.group_id = :parent_group_id
+                    AND existing.order_id = :parent_order_id
+                    AND existing.account_id = child.account_id
+                WHERE
+                    child.np_communication_id = :child_np_communication_id
+                    AND child.order_id = :child_order_id
+            ) AS new
+            ON DUPLICATE KEY
+            UPDATE
+                earned_date = new.earned_date,
+                progress = new.progress,
+                earned = new.earned
+SQL
+        );
+        $query->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':child_order_id', $childOrderId, PDO::PARAM_INT);
+        $query->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':parent_group_id', $parentGroupId, PDO::PARAM_STR);
+        $query->bindValue(':parent_order_id', $parentOrderId, PDO::PARAM_INT);
+        $query->execute();
+    }
+
+    public function copyMergedTrophies(
+        string $childNpCommunicationId,
+        ?TrophyMergeProgressListener $progressListener = null
+    ): void {
+        $countQuery = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                COUNT(*)
+            FROM
+                trophy_merge
+            WHERE
+                child_np_communication_id = :child_np_communication_id
+SQL
+        );
+        $countQuery->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $countQuery->execute();
+
+        $total = (int) $countQuery->fetchColumn();
+
+        if ($total === 0) {
+            $this->notifyProgress($progressListener, 73, 'No merged trophies to copy.');
+
+            return;
+        }
+
+        $this->notifyProgress(
+            $progressListener,
+            73,
+            sprintf('Found %d merged trophies to copy…', $total)
+        );
+
+        $mergeSourceCte = <<<'SQL'
+            WITH merge_source AS (
+                SELECT
+                    tm.parent_np_communication_id,
+                    tm.parent_group_id,
+                    tm.parent_order_id,
+                    child.account_id,
+                    child.earned_date,
+                    child.progress,
+                    child.earned
+                FROM trophy_merge AS tm
+                JOIN trophy_earned AS child ON child.np_communication_id = tm.child_np_communication_id
+                    AND child.group_id = tm.child_group_id
+                    AND child.order_id = tm.child_order_id
+                WHERE tm.child_np_communication_id = :child_np_communication_id
+            )
+        SQL;
+
+        $insertMissingParentEarned = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy_earned (
+                np_communication_id,
+                group_id,
+                order_id,
+                account_id,
+                earned_date,
+                progress,
+                earned
+            )
+        SQL
+            . "\n" . $mergeSourceCte . "\n"
+            . <<<'SQL'
+            SELECT
+                source.parent_np_communication_id,
+                source.parent_group_id,
+                source.parent_order_id,
+                source.account_id,
+                source.earned_date,
+                source.progress,
+                source.earned
+            FROM merge_source AS source
+            LEFT JOIN trophy_earned AS parent ON parent.np_communication_id = source.parent_np_communication_id
+                AND parent.group_id = source.parent_group_id
+                AND parent.order_id = source.parent_order_id
+                AND parent.account_id = source.account_id
+            WHERE parent.account_id IS NULL
+SQL
+        );
+        $insertMissingParentEarned->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $insertMissingParentEarned->execute();
+
+        $synchronizeExistingEarned = $this->database->prepare(
+            $mergeSourceCte . <<<'SQL'
+            UPDATE trophy_earned AS parent
+            JOIN merge_source AS source ON source.parent_np_communication_id = parent.np_communication_id
+                AND source.parent_group_id = parent.group_id
+                AND source.parent_order_id = parent.order_id
+                AND source.account_id = parent.account_id
+            SET
+                parent.earned_date = CASE
+                    WHEN parent.earned_date IS NULL THEN source.earned_date
+                    WHEN source.earned_date IS NULL THEN parent.earned_date
+                    WHEN source.earned_date < parent.earned_date THEN source.earned_date
+                    ELSE parent.earned_date
+                END,
+                parent.progress = CASE
+                    WHEN parent.progress IS NULL THEN source.progress
+                    WHEN source.progress IS NULL THEN parent.progress
+                    WHEN source.progress > parent.progress THEN source.progress
+                    ELSE parent.progress
+                END,
+                parent.earned = CASE
+                    WHEN source.earned = 1 THEN 1
+                    ELSE parent.earned
+                END
+SQL
+        );
+        $synchronizeExistingEarned->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $synchronizeExistingEarned->execute();
+
+        $this->notifyProgress(
+            $progressListener,
+            75,
+            sprintf('Copying merged trophies… (%d/%d)', $total, $total)
+        );
+    }
+
+    private function notifyProgress(?TrophyMergeProgressListener $listener, int $percent, string $message): void
+    {
+        if ($listener === null) {
+            return;
+        }
+
+        $listener->onProgress($percent, $message);
+    }
+}

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/Admin/GameCopyService.php';
 require_once __DIR__ . '/Admin/TrophyMergeProgressListener.php';
 require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
+require_once __DIR__ . '/TrophyMergeEarnedCopier.php';
 require_once __DIR__ . '/TrophyMergeMappingService.php';
 require_once __DIR__ . '/TrophyMergePlayerProgressUpdater.php';
 require_once __DIR__ . '/TrophyTitleCloneService.php';
@@ -17,16 +18,22 @@ class TrophyMergeService
 
     private NestedDatabaseTransactionRunner $transactionRunner;
 
+    private ?TrophyMergeEarnedCopier $earnedCopier = null;
+
     private ?TrophyMergeMappingService $mappingService = null;
 
     private ?TrophyMergePlayerProgressUpdater $playerProgressUpdater = null;
 
     private ?TrophyTitleCloneService $cloneService = null;
 
-    public function __construct(PDO $database, ?NestedDatabaseTransactionRunner $transactionRunner = null)
-    {
+    public function __construct(
+        PDO $database,
+        ?NestedDatabaseTransactionRunner $transactionRunner = null,
+        ?TrophyMergeEarnedCopier $earnedCopier = null
+    ) {
         $this->database = $database;
         $this->transactionRunner = $transactionRunner ?? new NestedDatabaseTransactionRunner($database);
+        $this->earnedCopier = $earnedCopier;
     }
 
     public function mergeSpecificTrophies(int $parentTrophyId, array $childTrophyIds): string
@@ -67,7 +74,7 @@ class TrophyMergeService
 
                 $childGameId = $this->getGameIdByTrophyId($childTrophyId);
 
-                $this->copyTrophyEarned(
+                $this->earnedCopier()->copyTrophyMapping(
                     $childTrophy['np_communication_id'],
                     $childTrophy['group_id'],
                     (int) $childTrophy['order_id'],
@@ -140,7 +147,7 @@ class TrophyMergeService
             $this->notifyProgress($progressListener, 65, 'Child game marked as merged.');
             $this->notifyProgress($progressListener, 70, 'Preparing to copy merged trophies…');
             $this->notifyProgress($progressListener, 72, 'Copying merged trophies…');
-            $this->copyMergedTrophies($childNpCommunicationId, $progressListener);
+            $this->earnedCopier()->copyMergedTrophies($childNpCommunicationId, $progressListener);
             $this->notifyProgress($progressListener, 75, 'Merged trophies copied.');
             $this->notifyProgress($progressListener, 80, 'Updating player trophy groups…');
             $this->updateTrophyGroupPlayer($childGameId);
@@ -238,79 +245,9 @@ SQL
         return (int) $childGameId;
     }
 
-    private function copyTrophyEarned(
-        string $childNpCommunicationId,
-        string $childGroupId,
-        int $childOrderId,
-        string $parentNpCommunicationId,
-        string $parentGroupId,
-        int $parentOrderId
-    ): void {
-        $query = $this->database->prepare(
-            <<<'SQL'
-            INSERT INTO trophy_earned(
-                np_communication_id,
-                group_id,
-                order_id,
-                account_id,
-                earned_date,
-                progress,
-                earned
-            )
-            SELECT
-                new.np_communication_id,
-                new.group_id,
-                new.order_id,
-                new.account_id,
-                new.earned_date,
-                new.progress,
-                new.earned
-            FROM (
-                SELECT
-                    :parent_np_communication_id AS np_communication_id,
-                    :parent_group_id AS group_id,
-                    :parent_order_id AS order_id,
-                    child.account_id AS account_id,
-                    CASE
-                        WHEN existing.earned_date IS NULL THEN child.earned_date
-                        WHEN child.earned_date IS NULL THEN existing.earned_date
-                        WHEN child.earned_date < existing.earned_date THEN child.earned_date
-                        ELSE existing.earned_date
-                    END AS earned_date,
-                    CASE
-                        WHEN existing.progress IS NULL THEN child.progress
-                        WHEN child.progress IS NULL THEN existing.progress
-                        WHEN child.progress > existing.progress THEN child.progress
-                        ELSE existing.progress
-                    END AS progress,
-                    CASE
-                        WHEN child.earned = 1 THEN 1
-                        WHEN existing.earned = 1 THEN 1
-                        ELSE COALESCE(existing.earned, 0)
-                    END AS earned
-                FROM
-                    trophy_earned AS child
-                LEFT JOIN trophy_earned AS existing ON existing.np_communication_id = :parent_np_communication_id
-                    AND existing.group_id = :parent_group_id
-                    AND existing.order_id = :parent_order_id
-                    AND existing.account_id = child.account_id
-                WHERE
-                    child.np_communication_id = :child_np_communication_id
-                    AND child.order_id = :child_order_id
-            ) AS new
-            ON DUPLICATE KEY
-            UPDATE
-                earned_date = new.earned_date,
-                progress = new.progress,
-                earned = new.earned
-SQL
-        );
-        $query->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-        $query->bindValue(':child_order_id', $childOrderId, PDO::PARAM_INT);
-        $query->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
-        $query->bindValue(':parent_group_id', $parentGroupId, PDO::PARAM_STR);
-        $query->bindValue(':parent_order_id', $parentOrderId, PDO::PARAM_INT);
-        $query->execute();
+    private function earnedCopier(): TrophyMergeEarnedCopier
+    {
+        return $this->earnedCopier ??= new TrophyMergeEarnedCopier($this->database);
     }
 
     private function updateTrophyGroupPlayer(int $childGameId): void
@@ -415,122 +352,6 @@ SQL
             $query->bindValue(':np_communication_id', (string) $npCommunicationId, PDO::PARAM_STR);
             $query->execute();
         });
-    }
-
-    private function copyMergedTrophies(string $childNpCommunicationId, ?TrophyMergeProgressListener $progressListener = null): void
-    {
-        $countQuery = $this->database->prepare(
-            <<<'SQL'
-            SELECT
-                COUNT(*)
-            FROM
-                trophy_merge
-            WHERE
-                child_np_communication_id = :child_np_communication_id
-SQL
-        );
-        $countQuery->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-        $countQuery->execute();
-
-        $total = (int) $countQuery->fetchColumn();
-
-        if ($total === 0) {
-            $this->notifyProgress($progressListener, 73, 'No merged trophies to copy.');
-
-            return;
-        }
-
-        $this->notifyProgress(
-            $progressListener,
-            73,
-            sprintf('Found %d merged trophies to copy…', $total)
-        );
-
-        $mergeSourceCte = <<<'SQL'
-            WITH merge_source AS (
-                SELECT
-                    tm.parent_np_communication_id,
-                    tm.parent_group_id,
-                    tm.parent_order_id,
-                    child.account_id,
-                    child.earned_date,
-                    child.progress,
-                    child.earned
-                FROM trophy_merge AS tm
-                JOIN trophy_earned AS child ON child.np_communication_id = tm.child_np_communication_id
-                    AND child.group_id = tm.child_group_id
-                    AND child.order_id = tm.child_order_id
-                WHERE tm.child_np_communication_id = :child_np_communication_id
-            )
-        SQL;
-
-        $insertMissingParentEarned = $this->database->prepare(
-            <<<'SQL'
-            INSERT INTO trophy_earned (
-                np_communication_id,
-                group_id,
-                order_id,
-                account_id,
-                earned_date,
-                progress,
-                earned
-            )
-        SQL
-            . "\n" . $mergeSourceCte . "\n"
-            . <<<'SQL'
-            SELECT
-                source.parent_np_communication_id,
-                source.parent_group_id,
-                source.parent_order_id,
-                source.account_id,
-                source.earned_date,
-                source.progress,
-                source.earned
-            FROM merge_source AS source
-            LEFT JOIN trophy_earned AS parent ON parent.np_communication_id = source.parent_np_communication_id
-                AND parent.group_id = source.parent_group_id
-                AND parent.order_id = source.parent_order_id
-                AND parent.account_id = source.account_id
-            WHERE parent.account_id IS NULL
-SQL
-        );
-        $insertMissingParentEarned->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-        $insertMissingParentEarned->execute();
-
-        $synchronizeExistingEarned = $this->database->prepare(
-            $mergeSourceCte . <<<'SQL'
-            UPDATE trophy_earned AS parent
-            JOIN merge_source AS source ON source.parent_np_communication_id = parent.np_communication_id
-                AND source.parent_group_id = parent.group_id
-                AND source.parent_order_id = parent.order_id
-                AND source.account_id = parent.account_id
-            SET
-                parent.earned_date = CASE
-                    WHEN parent.earned_date IS NULL THEN source.earned_date
-                    WHEN source.earned_date IS NULL THEN parent.earned_date
-                    WHEN source.earned_date < parent.earned_date THEN source.earned_date
-                    ELSE parent.earned_date
-                END,
-                parent.progress = CASE
-                    WHEN parent.progress IS NULL THEN source.progress
-                    WHEN source.progress IS NULL THEN parent.progress
-                    WHEN source.progress > parent.progress THEN source.progress
-                    ELSE parent.progress
-                END,
-                parent.earned = CASE
-                    WHEN source.earned = 1 THEN 1
-                    ELSE parent.earned
-                END
-SQL
-        );
-        $synchronizeExistingEarned->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-        $synchronizeExistingEarned->execute();
-
-        $this->notifyProgress(
-            $progressListener,
-            75,
-            sprintf('Copying merged trophies… (%d/%d)', $total, $total)
-        );
     }
 
     private function updateParentRelationship(string $childNpCommunicationId, string $parentNpCommunicationId): void


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels one concern off `TrophyMergeService` (~724 lines): **player trophy-earned progress copying** during merges.

New `TrophyMergeEarnedCopier` owns:
- `copyTrophyMapping()` — single child→parent trophy earned upsert (used by `mergeSpecificTrophies`)
- `copyMergedTrophies()` — bulk CTE-based sync of all mapped trophies (used by `mergeGames`)

`TrophyMergeService` now delegates via lazy injection, matching the existing `TrophyMergeMappingService` / `TrophyMergePlayerProgressUpdater` decomposition.

## Motivation

`TrophyMergeService` mixed orchestration, transactions, mapping, earned-progress SQL, platform updates, and changelog logging. This is the smallest, clearest first extraction: pure SQL persistence with existing test coverage.

## Follow-up candidates (separate PRs)

1. `PsnTrophyApiResponseNormalizer` from `PsnGameLookupService` (~633 lines)
2. `PlayerScanGameLoop` from `ThirtyMinuteCronJob` (~711 lines)
3. `GameRescanCatalogUpdater` from `GameRescanService` (~721 lines)

## Test plan

- [x] `php tests/run.php` — all 734 tests pass
- [x] `TrophyMergeServiceCopyMergedTrophiesTest` updated to exercise `TrophyMergeEarnedCopier` directly (no reflection)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4d2333c-498d-423b-bce4-1f9f40731510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4d2333c-498d-423b-bce4-1f9f40731510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

