### PR TITLE
Extract PSN trophy API payload inspection from PsnGameLookupService

### DIFF
--- a/tests/PsnTrophyApiPayloadInspectorTest.php
+++ b/tests/PsnTrophyApiPayloadInspectorTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PsnTrophyApiPayloadInspector.php';
+
+final class PsnTrophyApiPayloadInspectorTest extends TestCase
+{
+    private PsnTrophyApiPayloadInspector $inspector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->inspector = new PsnTrophyApiPayloadInspector();
+    }
+
+    public function testNormalizeReturnsArrayPayloadUnchanged(): void
+    {
+        $payload = ['trophies' => [['trophyId' => 1]]];
+
+        $this->assertSame($payload, $this->inspector->normalize($payload));
+    }
+
+    public function testNormalizeConvertsObjectPayloadToArray(): void
+    {
+        $payload = (object) [
+            'trophies' => [
+                (object) ['trophyId' => 1],
+            ],
+        ];
+
+        $normalized = $this->inspector->normalize($payload);
+
+        $this->assertSame([['trophyId' => 1]], $normalized['trophies']);
+    }
+
+    public function testExtractNpCommunicationIdsFromTrophyIconUrl(): void
+    {
+        $detected = $this->inspector->extractNpCommunicationIds([
+            'trophies' => [
+                [
+                    'trophyGroupId' => 'all',
+                    'trophyIconUrl' => 'https://image.api.playstation.com/trophy/np/NPWR99999_00_HASH/ICON.PNG',
+                ],
+            ],
+        ]);
+
+        $this->assertSame(['NPWR99999_00'], $detected);
+    }
+
+    public function testExtractNpCommunicationIdsFromTopLevelAndNestedFields(): void
+    {
+        $detected = $this->inspector->extractNpCommunicationIds([
+            'npCommunicationId' => 'NPWR12345_00',
+            'trophies' => [
+                [
+                    'np_communication_id' => 'NPWR12345_00',
+                ],
+            ],
+            'trophyGroups' => [
+                [
+                    'npCommunicationId' => 'NPWR12345_00',
+                    'trophies' => [
+                        [
+                            'trophyIconUrl' => 'https://image.api.playstation.com/trophy/np/NPWR12345_00_HASH/ICON.PNG',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(['NPWR12345_00'], $detected);
+    }
+
+    public function testAssertMatchesRequestedAllowsMatchingIds(): void
+    {
+        $this->inspector->assertMatchesRequested('NPWR12345_00', [
+            'npCommunicationId' => 'NPWR12345_00',
+        ], 'all/trophies');
+
+        $this->assertTrue(true);
+    }
+
+    public function testAssertMatchesRequestedAllowsPayloadWithNoDetectableIds(): void
+    {
+        $this->inspector->assertMatchesRequested('NPWR12345_00', [
+            'trophies' => [
+                ['trophyGroupId' => 'all', 'trophyId' => 1],
+            ],
+        ], 'all/trophies');
+
+        $this->assertTrue(true);
+    }
+
+    public function testAssertMatchesRequestedThrowsForMismatchedId(): void
+    {
+        try {
+            $this->inspector->assertMatchesRequested('NPWR12345_00', [
+                'trophies' => [
+                    [
+                        'trophyGroupId' => 'all',
+                        'trophyIconUrl' => 'https://image.api.playstation.com/trophy/np/NPWR99999_00_HASH/ICON.PNG',
+                    ],
+                ],
+            ], 'all/trophies');
+            $this->fail('Expected PsnGameLookupException to be thrown for mismatched payload ID.');
+        } catch (PsnGameLookupException $exception) {
+            $this->assertStringContainsString(
+                'PSN response integrity check failed for endpoint "all/trophies"',
+                $exception->getMessage()
+            );
+            $this->assertStringContainsString('NPWR12345_00', $exception->getMessage());
+            $this->assertStringContainsString('NPWR99999_00', $exception->getMessage());
+        }
+    }
+
+    public function testAssertMatchesRequestedThrowsForConflictingIdsInPayload(): void
+    {
+        try {
+            $this->inspector->assertMatchesRequested('NPWR12345_00', [
+                'npCommunicationId' => 'NPWR12345_00',
+                'trophies' => [
+                    [
+                        'trophyGroupId' => 'all',
+                        'trophyId' => 1,
+                        'npCommunicationId' => 'NPWR99999_00',
+                    ],
+                ],
+            ], 'all/trophies');
+            $this->fail('Expected PsnGameLookupException when payload contains conflicting npCommunicationIds.');
+        } catch (PsnGameLookupException $exception) {
+            $this->assertStringContainsString(
+                'PSN response integrity check failed for endpoint "all/trophies"',
+                $exception->getMessage()
+            );
+            $this->assertStringContainsString('NPWR12345_00', $exception->getMessage());
+            $this->assertStringContainsString('NPWR99999_00', $exception->getMessage());
+        }
+    }
+
+    public function testAssertMatchesRequestedThrowsForMismatchedTrophyGroupsId(): void
+    {
+        try {
+            $this->inspector->assertMatchesRequested('NPWR12345_00', [
+                'trophyGroups' => [
+                    [
+                        'trophyGroupId' => 'all',
+                        'npCommunicationId' => 'NPWR99999_00',
+                    ],
+                ],
+            ], 'trophyGroups');
+            $this->fail('Expected PsnGameLookupException to be thrown for mismatched trophyGroups payload ID.');
+        } catch (PsnGameLookupException $exception) {
+            $this->assertStringContainsString(
+                'PSN response integrity check failed for endpoint "trophyGroups"',
+                $exception->getMessage()
+            );
+            $this->assertStringContainsString('NPWR12345_00', $exception->getMessage());
+            $this->assertStringContainsString('NPWR99999_00', $exception->getMessage());
+        }
+    }
+
+    public function testAssertMatchesRequestedThrowsForConflictingNestedTrophyGroupIds(): void
+    {
+        try {
+            $this->inspector->assertMatchesRequested('NPWR12345_00', [
+                'trophyGroups' => [
+                    [
+                        'npCommunicationId' => 'NPWR12345_00',
+                        'trophies' => [
+                            [
+                                'trophyGroupId' => 'all',
+                                'trophyId' => 2,
+                                'trophyIconUrl' => 'https://image.api.playstation.com/trophy/np/NPWR99999_00_HASH/ICON.PNG',
+                            ],
+                        ],
+                    ],
+                ],
+            ], 'trophyGroups');
+            $this->fail('Expected PsnGameLookupException when trophyGroups contains conflicting nested IDs.');
+        } catch (PsnGameLookupException $exception) {
+            $this->assertStringContainsString(
+                'PSN response integrity check failed for endpoint "trophyGroups"',
+                $exception->getMessage()
+            );
+            $this->assertStringContainsString('NPWR12345_00', $exception->getMessage());
+            $this->assertStringContainsString('NPWR99999_00', $exception->getMessage());
+        }
+    }
+}

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/WorkerService.php';
 require_once __DIR__ . '/Worker.php';
 require_once __DIR__ . '/PlayStationWorkerAuthenticator.php';
 require_once __DIR__ . '/PsnGameLookupException.php';
+require_once __DIR__ . '/PsnTrophyApiPayloadInspector.php';
 require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
 
 use Tustin\PlayStation\Client;
@@ -13,6 +14,7 @@ use Tustin\PlayStation\Client;
 final class PsnGameLookupService
 {
     private readonly PlayStationWorkerAuthenticator $workerAuthenticator;
+    private readonly PsnTrophyApiPayloadInspector $payloadInspector;
 
     public function __construct(
         private readonly PDO $database,
@@ -20,12 +22,14 @@ final class PsnGameLookupService
         ?callable $clientFactory = null,
         ?callable $refreshTokenSaver = null,
         ?PlayStationWorkerAuthenticator $workerAuthenticator = null,
+        ?PsnTrophyApiPayloadInspector $payloadInspector = null,
     ) {
         $this->workerAuthenticator = $workerAuthenticator ?? new PlayStationWorkerAuthenticator(
             $workerFetcher,
             $clientFactory,
             $refreshTokenSaver,
         );
+        $this->payloadInspector = $payloadInspector ?? new PsnTrophyApiPayloadInspector();
     }
 
     public static function fromDatabase(PDO $database): self
@@ -90,8 +94,8 @@ final class PsnGameLookupService
                 ),
                 $preferredNpServiceName
             );
-            $normalizedResponse = $this->normalizeResponse($trophyRequestResult['payload']);
-            $this->assertPayloadMatchesRequestedNpCommunicationId(
+            $normalizedResponse = $this->payloadInspector->normalize($trophyRequestResult['payload']);
+            $this->payloadInspector->assertMatchesRequested(
                 $normalizedNpCommunicationId,
                 $normalizedResponse,
                 'all/trophies'
@@ -109,8 +113,8 @@ final class PsnGameLookupService
                     null,
                     $trophyRequestResult['query']
                 );
-                $normalizedGroupResponse = $this->normalizeResponse($trophyGroupRequestResult['payload']);
-                $this->assertPayloadMatchesRequestedNpCommunicationId(
+                $normalizedGroupResponse = $this->payloadInspector->normalize($trophyGroupRequestResult['payload']);
+                $this->payloadInspector->assertMatchesRequested(
                     $normalizedNpCommunicationId,
                     $normalizedGroupResponse,
                     'trophyGroups'
@@ -138,8 +142,8 @@ final class PsnGameLookupService
                     null,
                     $fallbackQuery
                 );
-                $normalizedResponse = $this->normalizeResponse($trophyRequestResult['payload']);
-                $this->assertPayloadMatchesRequestedNpCommunicationId(
+                $normalizedResponse = $this->payloadInspector->normalize($trophyRequestResult['payload']);
+                $this->payloadInspector->assertMatchesRequested(
                     $normalizedNpCommunicationId,
                     $normalizedResponse,
                     'all/trophies'
@@ -151,8 +155,8 @@ final class PsnGameLookupService
                     null,
                     $fallbackQuery
                 );
-                $normalizedGroupResponse = $this->normalizeResponse($trophyGroupRequestResult['payload']);
-                $this->assertPayloadMatchesRequestedNpCommunicationId(
+                $normalizedGroupResponse = $this->payloadInspector->normalize($trophyGroupRequestResult['payload']);
+                $this->payloadInspector->assertMatchesRequested(
                     $normalizedNpCommunicationId,
                     $normalizedGroupResponse,
                     'trophyGroups'
@@ -453,181 +457,4 @@ final class PsnGameLookupService
         return null;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    private function normalizeResponse(mixed $response): array
-    {
-        if (is_array($response)) {
-            return $response;
-        }
-
-        if (is_object($response)) {
-            try {
-                $encoded = json_encode($response, JSON_THROW_ON_ERROR);
-                $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
-
-                if (is_array($decoded)) {
-                    return $decoded;
-                }
-            } catch (JsonException) {
-            }
-
-            return get_object_vars($response);
-        }
-
-        return [];
-    }
-
-    /**
-     * @param array<string, mixed> $payload
-     */
-    private function extractNpCommunicationIdsFromPayload(array $payload): array
-    {
-        $detected = [];
-        $seen = [];
-
-        $this->addNpCommunicationIdCandidates(
-            $this->extractNpCommunicationIdFromArray($payload),
-            $detected,
-            $seen
-        );
-
-        $this->addNpCommunicationIdCandidates(
-            $this->extractNpCommunicationIdFromTrophies($payload['trophies'] ?? null),
-            $detected,
-            $seen
-        );
-
-        $trophyGroups = $payload['trophyGroups'] ?? null;
-        if (!is_array($trophyGroups)) {
-            return $detected;
-        }
-
-        foreach ($trophyGroups as $trophyGroup) {
-            if (!is_array($trophyGroup)) {
-                continue;
-            }
-
-            $this->addNpCommunicationIdCandidates(
-                $this->extractNpCommunicationIdFromArray($trophyGroup),
-                $detected,
-                $seen
-            );
-
-            $this->addNpCommunicationIdCandidates(
-                $this->extractNpCommunicationIdFromTrophies($trophyGroup['trophies'] ?? null),
-                $detected,
-                $seen
-            );
-        }
-
-        return $detected;
-    }
-
-    private function extractNpCommunicationIdFromTrophies(mixed $trophies): array
-    {
-        if (!is_array($trophies) || $trophies === []) {
-            return [];
-        }
-
-        $detected = [];
-        $seen = [];
-
-        foreach ($trophies as $trophy) {
-            if (!is_array($trophy)) {
-                continue;
-            }
-
-            $this->addNpCommunicationIdCandidates(
-                $this->extractNpCommunicationIdFromArray($trophy),
-                $detected,
-                $seen
-            );
-
-            $trophyIconUrl = $trophy['trophyIconUrl'] ?? null;
-            if (!is_string($trophyIconUrl) || trim($trophyIconUrl) === '') {
-                continue;
-            }
-
-            if (preg_match('/\/(NP[A-Z0-9]{2}[0-9]{5}_[0-9]{2})_/i', $trophyIconUrl, $matches) !== 1) {
-                continue;
-            }
-
-            $this->addNpCommunicationIdCandidates($matches[1], $detected, $seen);
-        }
-
-        return $detected;
-    }
-
-    /**
-     * @param list<string>|string|null $candidates
-     * @param list<string>             $detected
-     * @param array<string, true>      $seen
-     */
-    private function addNpCommunicationIdCandidates(array|string|null $candidates, array &$detected, array &$seen): void
-    {
-        if ($candidates === null) {
-            return;
-        }
-
-        if (is_string($candidates)) {
-            $candidates = [$candidates];
-        }
-
-        foreach ($candidates as $candidate) {
-            if (!is_string($candidate) || trim($candidate) === '') {
-                continue;
-            }
-
-            $normalizedCandidate = strtoupper(trim($candidate));
-            if (isset($seen[$normalizedCandidate])) {
-                continue;
-            }
-
-            $detected[] = $normalizedCandidate;
-            $seen[$normalizedCandidate] = true;
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $payload
-     */
-    private function extractNpCommunicationIdFromArray(array $payload): ?string
-    {
-        $topLevelCandidateKeys = ['npCommunicationId', 'np_communication_id'];
-        foreach ($topLevelCandidateKeys as $candidateKey) {
-            $candidate = $payload[$candidateKey] ?? null;
-            if (is_string($candidate) && trim($candidate) !== '') {
-                return $candidate;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<string, mixed> $payload
-     */
-    private function assertPayloadMatchesRequestedNpCommunicationId(string $requested, array $payload, string $endpointLabel): void
-    {
-        $detected = $this->extractNpCommunicationIdsFromPayload($payload);
-        if ($detected === []) {
-            return;
-        }
-
-        $normalizedRequested = strtoupper(trim($requested));
-        foreach ($detected as $normalizedDetected) {
-            if ($normalizedDetected === $normalizedRequested) {
-                continue;
-            }
-
-            throw new PsnGameLookupException(sprintf(
-                'PSN response integrity check failed for endpoint "%s": requested npCommunicationId "%s" but received "%s".',
-                $endpointLabel,
-                $normalizedRequested,
-                $normalizedDetected
-            ));
-        }
-    }
 }

--- a/wwwroot/classes/Admin/PsnTrophyApiPayloadInspector.php
+++ b/wwwroot/classes/Admin/PsnTrophyApiPayloadInspector.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PsnGameLookupException.php';
+
+/**
+ * Normalizes PSN trophy API payloads and validates npCommunicationId integrity.
+ */
+final class PsnTrophyApiPayloadInspector
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function normalize(mixed $response): array
+    {
+        if (is_array($response)) {
+            return $response;
+        }
+
+        if (is_object($response)) {
+            try {
+                $encoded = json_encode($response, JSON_THROW_ON_ERROR);
+                $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
+
+                if (is_array($decoded)) {
+                    return $decoded;
+                }
+            } catch (JsonException) {
+            }
+
+            return get_object_vars($response);
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return list<string>
+     */
+    public function extractNpCommunicationIds(array $payload): array
+    {
+        $detected = [];
+        $seen = [];
+
+        $this->addNpCommunicationIdCandidates(
+            $this->extractNpCommunicationIdFromArray($payload),
+            $detected,
+            $seen
+        );
+
+        $this->addNpCommunicationIdCandidates(
+            $this->extractNpCommunicationIdFromTrophies($payload['trophies'] ?? null),
+            $detected,
+            $seen
+        );
+
+        $trophyGroups = $payload['trophyGroups'] ?? null;
+        if (!is_array($trophyGroups)) {
+            return $detected;
+        }
+
+        foreach ($trophyGroups as $trophyGroup) {
+            if (!is_array($trophyGroup)) {
+                continue;
+            }
+
+            $this->addNpCommunicationIdCandidates(
+                $this->extractNpCommunicationIdFromArray($trophyGroup),
+                $detected,
+                $seen
+            );
+
+            $this->addNpCommunicationIdCandidates(
+                $this->extractNpCommunicationIdFromTrophies($trophyGroup['trophies'] ?? null),
+                $detected,
+                $seen
+            );
+        }
+
+        return $detected;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function assertMatchesRequested(string $requested, array $payload, string $endpointLabel): void
+    {
+        $detected = $this->extractNpCommunicationIds($payload);
+        if ($detected === []) {
+            return;
+        }
+
+        $normalizedRequested = strtoupper(trim($requested));
+        foreach ($detected as $normalizedDetected) {
+            if ($normalizedDetected === $normalizedRequested) {
+                continue;
+            }
+
+            throw new PsnGameLookupException(sprintf(
+                'PSN response integrity check failed for endpoint "%s": requested npCommunicationId "%s" but received "%s".',
+                $endpointLabel,
+                $normalizedRequested,
+                $normalizedDetected
+            ));
+        }
+    }
+
+    private function extractNpCommunicationIdFromTrophies(mixed $trophies): array
+    {
+        if (!is_array($trophies) || $trophies === []) {
+            return [];
+        }
+
+        $detected = [];
+        $seen = [];
+
+        foreach ($trophies as $trophy) {
+            if (!is_array($trophy)) {
+                continue;
+            }
+
+            $this->addNpCommunicationIdCandidates(
+                $this->extractNpCommunicationIdFromArray($trophy),
+                $detected,
+                $seen
+            );
+
+            $trophyIconUrl = $trophy['trophyIconUrl'] ?? null;
+            if (!is_string($trophyIconUrl) || trim($trophyIconUrl) === '') {
+                continue;
+            }
+
+            if (preg_match('/\/(NP[A-Z0-9]{2}[0-9]{5}_[0-9]{2})_/i', $trophyIconUrl, $matches) !== 1) {
+                continue;
+            }
+
+            $this->addNpCommunicationIdCandidates($matches[1], $detected, $seen);
+        }
+
+        return $detected;
+    }
+
+    /**
+     * @param list<string>|string|null $candidates
+     * @param list<string>             $detected
+     * @param array<string, true>      $seen
+     */
+    private function addNpCommunicationIdCandidates(array|string|null $candidates, array &$detected, array &$seen): void
+    {
+        if ($candidates === null) {
+            return;
+        }
+
+        if (is_string($candidates)) {
+            $candidates = [$candidates];
+        }
+
+        foreach ($candidates as $candidate) {
+            if (!is_string($candidate) || trim($candidate) === '') {
+                continue;
+            }
+
+            $normalizedCandidate = strtoupper(trim($candidate));
+            if (isset($seen[$normalizedCandidate])) {
+                continue;
+            }
+
+            $detected[] = $normalizedCandidate;
+            $seen[$normalizedCandidate] = true;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function extractNpCommunicationIdFromArray(array $payload): ?string
+    {
+        $topLevelCandidateKeys = ['npCommunicationId', 'np_communication_id'];
+        foreach ($topLevelCandidateKeys as $candidateKey) {
+            $candidate = $payload[$candidateKey] ?? null;
+            if (is_string($candidate) && trim($candidate) !== '') {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`PsnGameLookupService` (~633 lines) mixed HTTP orchestration with PSN trophy API payload parsing and integrity validation. This PR peels off the latter into a dedicated `PsnTrophyApiPayloadInspector`, following the same pattern as the earlier `PsnHttpExceptionClassifier` extraction.

## Changes

- Add `PsnTrophyApiPayloadInspector` with:
  - `normalize()` — convert object/array API responses to arrays
  - `extractNpCommunicationIds()` — detect IDs from payload fields and trophy icon URLs
  - `assertMatchesRequested()` — reject responses whose IDs don't match the request
- Inject the inspector into `PsnGameLookupService` (optional constructor param, defaults to a new instance)
- Add `PsnTrophyApiPayloadInspectorTest` with focused unit tests for the extracted concern

`PsnGameLookupService` drops from ~633 to ~460 lines. Existing integration tests in `PsnGameLookupServiceTest` continue to pass unchanged.

## Follow-up candidates (separate PRs)

1. Extract trophy group assembly (`buildTrophyGroups`, `groupTrophiesByGroupId`) from `PsnGameLookupService`
2. Share `PsnTrophyApiPayloadInspector::normalize()` with `PsnTrophyTitleComparisonService`
3. Converge `GameRescanService::updateTrophyTitle()` with `PlayerScanTitleCatalogSynchronizer` catalog sync
4. Extract bulk recalculation SQL from `TrophyStatusService` into `TrophyStatusRecalculator`

## Test plan

- [x] `php tests/run.php` — all 744 tests pass
- [x] New `PsnTrophyApiPayloadInspectorTest` covers normalization, ID extraction, and integrity assertions
- [x] Existing `PsnGameLookupServiceTest` integrity/retry cases still pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c45dcbe-d89b-4651-bab0-3552568a26c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c45dcbe-d89b-4651-bab0-3552568a26c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

