### PR TITLE
Extract trophy ID input parsing from TrophyStatusService

### DIFF
--- a/tests/TrophyStatusInputParserTest.php
+++ b/tests/TrophyStatusInputParserTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyStatusInputParser.php';
+
+final class TrophyStatusInputParserTest extends TestCase
+{
+    public function testParseTrophyIdsAcceptsCommaSeparatedValues(): void
+    {
+        $parser = new TrophyStatusInputParser(new TrophyStatusInputParserPDO());
+
+        $this->assertSame([1, 2, 3], $parser->parseTrophyIds('1,2,3'));
+    }
+
+    public function testParseTrophyIdsAcceptsWhitespaceSeparatedValues(): void
+    {
+        $parser = new TrophyStatusInputParser(new TrophyStatusInputParserPDO());
+
+        $this->assertSame([10, 20, 30], $parser->parseTrophyIds("10\n20 30"));
+    }
+
+    public function testParseTrophyIdsDeduplicatesValues(): void
+    {
+        $parser = new TrophyStatusInputParser(new TrophyStatusInputParserPDO());
+
+        $this->assertSame([5, 6], $parser->parseTrophyIds('5,6,5,6'));
+    }
+
+    public function testParseTrophyIdsTrimsSurroundingWhitespace(): void
+    {
+        $parser = new TrophyStatusInputParser(new TrophyStatusInputParserPDO());
+
+        $this->assertSame([42], $parser->parseTrophyIds('  42  '));
+    }
+
+    public function testParseTrophyIdsRejectsNonNumericValues(): void
+    {
+        $parser = new TrophyStatusInputParser(new TrophyStatusInputParserPDO());
+
+        try {
+            $parser->parseTrophyIds('1,abc');
+            $this->fail('Expected InvalidArgumentException for non-numeric trophy ID.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('Invalid trophy ID: abc', $exception->getMessage());
+        }
+    }
+
+    public function testParseTrophyIdsRejectsEmptyInput(): void
+    {
+        $parser = new TrophyStatusInputParser(new TrophyStatusInputParserPDO());
+
+        try {
+            $parser->parseTrophyIds('   ');
+            $this->fail('Expected InvalidArgumentException for empty trophy input.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('No trophies were provided.', $exception->getMessage());
+        }
+    }
+
+    public function testGetTrophyIdsForGameReturnsUniqueIds(): void
+    {
+        $database = new TrophyStatusInputParserPDO();
+        $database->trophyIdsForGame = ['7', '8', '7'];
+        $parser = new TrophyStatusInputParser($database);
+
+        $this->assertSame([7, 8], $parser->getTrophyIdsForGame(99));
+    }
+
+    public function testGetTrophyIdsForGameRejectsMissingTrophies(): void
+    {
+        $database = new TrophyStatusInputParserPDO();
+        $database->trophyIdsForGame = [];
+        $parser = new TrophyStatusInputParser($database);
+
+        try {
+            $parser->getTrophyIdsForGame(99);
+            $this->fail('Expected InvalidArgumentException when no trophies exist for the game.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('No trophies found for the selected game.', $exception->getMessage());
+        }
+    }
+}
+
+final class TrophyStatusInputParserPDO extends PDO
+{
+    /** @var list<string> */
+    public array $trophyIdsForGame = [];
+
+    public function __construct()
+    {
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement
+    {
+        return new TrophyStatusInputParserStatement($this->trophyIdsForGame);
+    }
+}
+
+final class TrophyStatusInputParserStatement extends PDOStatement
+{
+    /**
+     * @param list<string> $trophyIdsForGame
+     */
+    public function __construct(private array $trophyIdsForGame)
+    {
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args): array
+    {
+        return $this->trophyIdsForGame;
+    }
+}

--- a/wwwroot/admin/unobtainable.php
+++ b/wwwroot/admin/unobtainable.php
@@ -11,11 +11,13 @@ ExecutionEnvironmentConfigurator::create()
     ->configure();
 
 require_once __DIR__ . '/bootstrap.php';
+require_once("../classes/Admin/TrophyStatusInputParser.php");
 require_once("../classes/Admin/TrophyStatusService.php");
 require_once("../classes/Admin/TrophyStatusPage.php");
 
+$trophyStatusInputParser = new TrophyStatusInputParser($database);
 $trophyStatusService = new TrophyStatusService($database);
-$trophyStatusPage = new TrophyStatusPage($trophyStatusService);
+$trophyStatusPage = new TrophyStatusPage($trophyStatusInputParser, $trophyStatusService);
 
 $requestMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 $postData = $_POST ?? [];

--- a/wwwroot/classes/Admin/TrophyStatusInputParser.php
+++ b/wwwroot/classes/Admin/TrophyStatusInputParser.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Resolves admin trophy-status form input into trophy IDs.
+ */
+final class TrophyStatusInputParser
+{
+    public function __construct(private readonly PDO $database)
+    {
+    }
+
+    /**
+     * @return int[]
+     */
+    public function parseTrophyIds(string $input): array
+    {
+        $values = preg_split('/[\s,]+/', trim($input));
+        $ids = [];
+
+        foreach ($values as $value) {
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            if (!ctype_digit($value)) {
+                throw new InvalidArgumentException('Invalid trophy ID: ' . $value);
+            }
+
+            $ids[] = (int) $value;
+        }
+
+        $ids = array_values(array_unique($ids));
+
+        if (count($ids) === 0) {
+            throw new InvalidArgumentException('No trophies were provided.');
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getTrophyIdsForGame(int $gameId): array
+    {
+        $query = $this->database->prepare(
+            'SELECT id FROM trophy WHERE np_communication_id = (SELECT np_communication_id FROM trophy_title WHERE id = :id)'
+        );
+        $query->bindValue(':id', $gameId, PDO::PARAM_INT);
+        $query->execute();
+
+        $trophies = $query->fetchAll(PDO::FETCH_COLUMN);
+
+        if ($trophies === false || count($trophies) === 0) {
+            throw new InvalidArgumentException('No trophies found for the selected game.');
+        }
+
+        $ids = array_map('intval', $trophies);
+
+        return array_values(array_unique($ids));
+    }
+}

--- a/wwwroot/classes/Admin/TrophyStatusPage.php
+++ b/wwwroot/classes/Admin/TrophyStatusPage.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/TrophyStatusInputParser.php';
 require_once __DIR__ . '/TrophyStatusService.php';
 
 class TrophyStatusPageResult
@@ -42,10 +43,15 @@ class TrophyStatusPageResult
 
 class TrophyStatusPage
 {
+    private TrophyStatusInputParser $trophyStatusInputParser;
+
     private TrophyStatusService $trophyStatusService;
 
-    public function __construct(TrophyStatusService $trophyStatusService)
-    {
+    public function __construct(
+        TrophyStatusInputParser $trophyStatusInputParser,
+        TrophyStatusService $trophyStatusService,
+    ) {
+        $this->trophyStatusInputParser = $trophyStatusInputParser;
         $this->trophyStatusService = $trophyStatusService;
     }
 
@@ -76,11 +82,11 @@ class TrophyStatusPage
                     }
 
                     $gameId = (int) $gameValue;
-                    $trophyIds = $this->trophyStatusService->getTrophyIdsForGame($gameId);
+                    $trophyIds = $this->trophyStatusInputParser->getTrophyIdsForGame($gameId);
                     $trophyInput = implode(',', array_map('strval', $trophyIds));
                 } else {
                     $trophyInput = (string) ($postData['trophy'] ?? '');
-                    $trophyIds = $this->trophyStatusService->parseTrophyIds($trophyInput);
+                    $trophyIds = $this->trophyStatusInputParser->parseTrophyIds($trophyInput);
                 }
 
                 $result = $this->trophyStatusService->updateTrophies($trophyIds, $status);

--- a/wwwroot/classes/Admin/TrophyStatusService.php
+++ b/wwwroot/classes/Admin/TrophyStatusService.php
@@ -55,57 +55,6 @@ class TrophyStatusService
     }
 
     /**
-     * @return int[]
-     */
-    public function parseTrophyIds(string $input): array
-    {
-        $values = preg_split('/[\s,]+/', trim($input));
-        $ids = [];
-
-        foreach ($values as $value) {
-            if ($value === null || $value === '') {
-                continue;
-            }
-
-            if (!ctype_digit($value)) {
-                throw new InvalidArgumentException('Invalid trophy ID: ' . $value);
-            }
-
-            $ids[] = (int) $value;
-        }
-
-        $ids = array_values(array_unique($ids));
-
-        if (count($ids) === 0) {
-            throw new InvalidArgumentException('No trophies were provided.');
-        }
-
-        return $ids;
-    }
-
-    /**
-     * @return int[]
-     */
-    public function getTrophyIdsForGame(int $gameId): array
-    {
-        $query = $this->database->prepare(
-            'SELECT id FROM trophy WHERE np_communication_id = (SELECT np_communication_id FROM trophy_title WHERE id = :id)'
-        );
-        $query->bindValue(':id', $gameId, PDO::PARAM_INT);
-        $query->execute();
-
-        $trophies = $query->fetchAll(PDO::FETCH_COLUMN);
-
-        if ($trophies === false || count($trophies) === 0) {
-            throw new InvalidArgumentException('No trophies found for the selected game.');
-        }
-
-        $ids = array_map('intval', $trophies);
-
-        return array_values(array_unique($ids));
-    }
-
-    /**
      * @param int[] $trophyIds
      */
     public function updateTrophies(array $trophyIds, int $status): TrophyStatusUpdateResult


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels admin form input resolution out of `TrophyStatusService` into a dedicated `TrophyStatusInputParser` class. This is the first incremental step toward shrinking that god class — input parsing is now isolated from the heavy SQL recalculation logic.

## Changes

- Added `TrophyStatusInputParser` with `parseTrophyIds()` and `getTrophyIdsForGame()`
- `TrophyStatusService` now focuses solely on status updates and downstream recalculation
- `TrophyStatusPage` and `unobtainable.php` wire the parser separately
- Added 8 unit tests covering parsing edge cases (whitespace, deduplication, validation, game lookup)

## Follow-up candidates (future PRs)

`TrophyStatusService` still bundles several concerns that can be peeled off one at a time:

1. **Recalculation SQL** — extract `recalculateGroup()` / `recalculateTitle()` into a `TrophyObtainabilityRecalculator`
2. **Result presentation** — move `TrophyStatusUpdateResult::toHtml()` out of the service layer
3. **Temp table management** — extract `createImpactedAccountsTempTable()` alongside the recalculator

Other god classes identified for future work:

- `ThirtyMinuteCronJob` (~603 lines) — per-title API validation/retry logic
- `GameRescanService` (~621 lines) — duplicated catalog refresh in `updateTrophyTitle()`
- `PlayerScanTitleCatalogSynchronizer` (~445 lines) — group-level sync loop
- `AutomaticTrophyTitleMergeService` (~434 lines) — trophy comparison/matching rules

## Test plan

- [x] `php tests/run.php` — all 752 tests pass
- [x] New `TrophyStatusInputParserTest` covers parsing and validation paths
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb009bf6-c8c6-443c-8c56-6b22d04efd1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb009bf6-c8c6-443c-8c56-6b22d04efd1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

