### PR TITLE
Phase 1: admin/cron .htaccess templates and cron HTTP guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,8 @@ the non-obvious steps to actually run the services.
 - The PHP built-in server does not read `.htaccess`. Cron scripts are still blocked
   over HTTP because `CronCliAccessGuard` runs in `init.php` and `CronJobBootstrapper`.
   Admin is intentionally left reachable in dev for login testing.
-- Cron jobs must be run via CLI, e.g. `php wwwroot/cron/hourly.php`.
+- Cron jobs must be run via CLI, e.g. `php wwwroot/cron/hourly.php`. Each script in
+  `wwwroot/cron/` loads `cron/bootstrap.php` first to reject HTTP execution.
 
 ### Tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,16 @@ the non-obvious steps to actually run the services.
   (param key is `q`); valid names match `^[\w\-]{3,16}$` and are inserted into
   `player_queue`. This is a quick way to exercise a real DB write.
 
+### `/admin` and `/cron` access control
+
+- Production Apache hosts should copy the templates in `wwwroot/admin/.htaccess.example`
+  and `wwwroot/cron/.htaccess.example` to `.htaccess` in those directories (adjust
+  `AuthUserFile` and the allowed cron IP before enabling).
+- The PHP built-in server does not read `.htaccess`. Cron scripts are still blocked
+  over HTTP because `CronCliAccessGuard` runs in `init.php` and `CronJobBootstrapper`.
+  Admin is intentionally left reachable in dev for login testing.
+- Cron jobs must be run via CLI, e.g. `php wwwroot/cron/hourly.php`.
+
 ### Tests
 
 - Run the full suite with `php tests/run.php` (custom runner, no PHPUnit). It does not

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ php -r "echo password_hash('your-password', PASSWORD_DEFAULT), PHP_EOL;"
 INSERT INTO admin_user (username, password_hash) VALUES ('admin', '$2y$10$...');
 ```
 
+### Protecting `/admin` and `/cron`
+
+Production should layer Apache rules on top of the application:
+
+- **`wwwroot/admin/.htaccess.example`** — HTTP Basic authentication in front of the admin UI.
+  Copy to `admin/.htaccess` and set `AuthUserFile` to your server password file.
+- **`wwwroot/cron/.htaccess.example`** — deny all web clients except the host that runs
+  scheduled jobs. Copy to `cron/.htaccess` and replace `127.0.0.1` with that server's IP.
+
+Cron entry scripts also refuse non-CLI execution in PHP (`CronCliAccessGuard`), which
+protects environments where `.htaccess` is not applied (for example the PHP built-in
+development server). Admin remains reachable in dev so you can exercise the login flow;
+use the Basic-auth template only on production Apache hosts.
+
 ## Merge Guideline Priorities
 1. Available > Delisted
 2. English language > Other language

--- a/tests/CronCliAccessGuardTest.php
+++ b/tests/CronCliAccessGuardTest.php
@@ -40,4 +40,24 @@ final class CronCliAccessGuardTest extends TestCase
 
         $this->assertTrue(true);
     }
+
+    public function testCronEntryScriptsRequireBootstrapGuard(): void
+    {
+        $entryScripts = glob(__DIR__ . '/../wwwroot/cron/*.php') ?: [];
+
+        foreach ($entryScripts as $scriptPath) {
+            if (str_ends_with($scriptPath, '/bootstrap.php')) {
+                continue;
+            }
+
+            $source = file_get_contents($scriptPath);
+            $this->assertTrue(is_string($source));
+
+            $this->assertStringContainsString(
+                "require_once __DIR__ . '/bootstrap.php'",
+                $source,
+                basename($scriptPath) . ' must load cron/bootstrap.php before other bootstrap logic.'
+            );
+        }
+    }
 }

--- a/tests/CronCliAccessGuardTest.php
+++ b/tests/CronCliAccessGuardTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/CronCliAccessGuard.php';
+
+final class CronCliAccessGuardTest extends TestCase
+{
+    public function testIsCronScriptRequestDetectsCronPaths(): void
+    {
+        $this->assertTrue(CronCliAccessGuard::isCronScriptRequest([
+            'SCRIPT_NAME' => '/cron/hourly.php',
+        ]));
+        $this->assertTrue(CronCliAccessGuard::isCronScriptRequest([
+            'PHP_SELF' => '/cron/30th_minute.php',
+        ]));
+    }
+
+    public function testIsCronScriptRequestIgnoresPublicPages(): void
+    {
+        $this->assertFalse(CronCliAccessGuard::isCronScriptRequest([
+            'SCRIPT_NAME' => '/index.php',
+        ]));
+        $this->assertFalse(CronCliAccessGuard::isCronScriptRequest([
+            'SCRIPT_NAME' => '/admin/login.php',
+        ]));
+        $this->assertFalse(CronCliAccessGuard::isCronScriptRequest([]));
+    }
+
+    public function testDenyWebCronScriptAccessDoesNothingInCli(): void
+    {
+        if (PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') {
+            $this->markTestSkipped('This assertion only applies under the CLI SAPI.');
+        }
+
+        CronCliAccessGuard::denyWebCronScriptAccess([
+            'SCRIPT_NAME' => '/cron/hourly.php',
+        ]);
+
+        $this->assertTrue(true);
+    }
+}

--- a/wwwroot/admin/.htaccess.example
+++ b/wwwroot/admin/.htaccess.example
@@ -1,0 +1,8 @@
+# Copy to .htaccess on the production server and adjust paths before enabling.
+# Apache 2.4+ (see cron/.htaccess.example for IP allowlisting used by cron jobs).
+
+AuthName "Admin"
+AuthType Basic
+AuthUserFile "/path/to/.htpasswds/admin/passwd"
+AuthGroupFile /dev/null
+Require valid-user

--- a/wwwroot/classes/Cron/CronCliAccessGuard.php
+++ b/wwwroot/classes/Cron/CronCliAccessGuard.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Ensures cron entry scripts cannot be executed over HTTP.
+ *
+ * Apache should also deny web access (see wwwroot/cron/.htaccess.example). This guard
+ * covers the PHP built-in server, misconfigured virtual hosts, and other SAPIs.
+ */
+final class CronCliAccessGuard
+{
+    public static function requireCliExecution(): void
+    {
+        if (self::isCli()) {
+            return;
+        }
+
+        self::respondForbidden();
+    }
+
+    /**
+     * @param array<string, mixed> $serverParameters
+     */
+    public static function denyWebCronScriptAccess(array $serverParameters = []): void
+    {
+        if (self::isCli()) {
+            return;
+        }
+
+        if (!self::isCronScriptRequest($serverParameters)) {
+            return;
+        }
+
+        self::respondForbidden();
+    }
+
+    /**
+     * @param array<string, mixed> $serverParameters
+     */
+    public static function isCronScriptRequest(array $serverParameters): bool
+    {
+        $scriptName = $serverParameters['SCRIPT_NAME'] ?? $serverParameters['PHP_SELF'] ?? '';
+
+        if (!is_string($scriptName) || $scriptName === '') {
+            return false;
+        }
+
+        return str_contains($scriptName, '/cron/');
+    }
+
+    private static function isCli(): bool
+    {
+        return PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg';
+    }
+
+    private static function respondForbidden(): never
+    {
+        if (!headers_sent()) {
+            http_response_code(403);
+            header('Content-Type: text/plain; charset=UTF-8');
+        }
+
+        echo 'Forbidden';
+        exit;
+    }
+}

--- a/wwwroot/classes/Cron/CronJobBootstrapper.php
+++ b/wwwroot/classes/Cron/CronJobBootstrapper.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CronCliAccessGuard.php';
 require_once __DIR__ . '/CronJobApplication.php';
 
 final class CronJobBootstrapper
@@ -25,6 +26,8 @@ final class CronJobBootstrapper
 
     public function bootstrap(bool $loadComposerAutoload = false): void
     {
+        CronCliAccessGuard::requireCliExecution();
+
         $this->application->configureEnvironment();
 
         if ($loadComposerAutoload) {

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CronCliAccessGuard.php';
 require_once __DIR__ . '/CronJobEntryPoint.php';
 require_once __DIR__ . '/CronJobCliArguments.php';
 require_once __DIR__ . '/../TrophyCalculator.php';
@@ -33,6 +34,8 @@ final class ThirtyMinuteCronJobApplication
 
     public function run(): void
     {
+        CronCliAccessGuard::requireCliExecution();
+
         $workerId = $this->cliArguments->getWorkerId();
         if ($workerId <= 0) {
             throw new InvalidArgumentException(sprintf(

--- a/wwwroot/cron/.htaccess.example
+++ b/wwwroot/cron/.htaccess.example
@@ -1,0 +1,11 @@
+# Copy to .htaccess on the production server and replace the placeholder IP with the
+# address of the host that runs scheduled cron jobs.
+#
+# Apache 2.4+:
+Require all denied
+Require ip 127.0.0.1
+#
+# Apache 2.2 (legacy) equivalent:
+# Order deny,allow
+# Deny from all
+# Allow from 127.0.0.1

--- a/wwwroot/cron/30th_minute.php
+++ b/wwwroot/cron/30th_minute.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/bootstrap.php';
 require_once dirname(__DIR__) . '/classes/Cron/ThirtyMinuteCronJobApplication.php';
 
 $application = ThirtyMinuteCronJobApplication::fromGlobals(

--- a/wwwroot/cron/5th_minute.php
+++ b/wwwroot/cron/5th_minute.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/bootstrap.php';
 require_once dirname(__DIR__) . '/classes/Cron/CronJobEntryPoint.php';
 require_once dirname(__DIR__) . '/classes/Cron/PlayerRankingCronJob.php';
 require_once dirname(__DIR__) . '/classes/Psn100Logger.php';

--- a/wwwroot/cron/bootstrap.php
+++ b/wwwroot/cron/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/classes/Cron/CronCliAccessGuard.php';
+
+CronCliAccessGuard::requireCliExecution();

--- a/wwwroot/cron/daily.php
+++ b/wwwroot/cron/daily.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/bootstrap.php';
 require_once dirname(__DIR__) . '/classes/Cron/CronJobEntryPoint.php';
 require_once dirname(__DIR__) . '/classes/Cron/DailyCronJob.php';
 

--- a/wwwroot/cron/hourly.php
+++ b/wwwroot/cron/hourly.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/bootstrap.php';
 require_once dirname(__DIR__) . '/classes/Cron/CronJobEntryPoint.php';
 require_once dirname(__DIR__) . '/classes/Cron/HourlyCronJob.php';
 

--- a/wwwroot/cron/weekly.php
+++ b/wwwroot/cron/weekly.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/bootstrap.php';
 require_once dirname(__DIR__) . '/classes/Cron/CronJobEntryPoint.php';
 require_once dirname(__DIR__) . '/classes/Cron/WeeklyCronJob.php';
 

--- a/wwwroot/init.php
+++ b/wwwroot/init.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Cron/CronCliAccessGuard.php';
+
+CronCliAccessGuard::denyWebCronScriptAccess($_SERVER ?? []);
+
 header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
 header("Pragma: no-cache");
 header("Expires: 0");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds production Apache configuration templates for `/admin` and `/cron`, plus a PHP guard that blocks cron scripts from running over HTTP when `.htaccess` is not applied (e.g. the PHP built-in dev server).

## Changes

- **`wwwroot/admin/.htaccess.example`** — HTTP Basic auth template with placeholder `AuthUserFile` path
- **`wwwroot/cron/.htaccess.example`** — deny-all except `127.0.0.1` placeholder (Apache 2.4 + legacy 2.2 notes); no production IP committed
- **`wwwroot/cron/bootstrap.php`** — shared CLI guard required by every cron entry script before any other logic
- **`CronCliAccessGuard`** — refuses non-CLI execution; also hooked from `CronJobBootstrapper`, `ThirtyMinuteCronJobApplication::run()`, and `init.php`
- **Docs** — README and AGENTS.md explain copying templates and cron CLI requirement
- **Tests** — `CronCliAccessGuardTest` (756 tests pass)

## Review feedback addressed

- `/cron/30th_minute.php` now returns `403 Forbidden` over HTTP (previously could 500 on missing worker args before the guard ran)

## Deployment

On production Apache:

1. Copy `admin/.htaccess.example` → `admin/.htaccess` and set `AuthUserFile`
2. Copy `cron/.htaccess.example` → `cron/.htaccess` and replace `127.0.0.1` with your cron host IP

Admin remains reachable in dev for login testing.

## Test plan

- [x] `php tests/run.php` — 756 tests passed
- [x] `curl http://127.0.0.1:8765/cron/hourly.php` → `403 Forbidden`
- [x] `curl http://127.0.0.1:8765/cron/30th_minute.php` → `403 Forbidden`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

