### PR TITLE
Phase 2: queue poll tokens, JSON rate limits, admin login lockout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,9 @@ the non-obvious steps to actually run the services.
   Admin is intentionally left reachable in dev for login testing.
 - Cron jobs must be run via CLI, e.g. `php wwwroot/cron/hourly.php`. Each script in
   `wwwroot/cron/` loads `cron/bootstrap.php` first to reject HTTP execution.
+- Queue polling and admin login abuse controls use `ip_rate_limit` and
+  `admin_login_throttle` tables (see `database/psn100.sql`). Import the schema on
+  fresh VMs; existing production DBs need those tables added before deploying Phase 2.
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ protects environments where `.htaccess` is not applied (for example the PHP buil
 development server). Admin remains reachable in dev so you can exercise the login flow;
 use the Basic-auth template only on production Apache hosts.
 
+### Abuse resistance (queue polling, scan log, admin login)
+
+Existing deployments need the new tables from `database/psn100.sql`:
+
+- `ip_rate_limit` — fixed-window IP rate limits for public JSON endpoints
+- `admin_login_throttle` — failed admin login tracking and temporary lockouts
+
+Queue status polling (`check_queue_position.php`) requires a `poll_token` issued by the
+CSRF-protected `add_to_queue.php` response and stored in the visitor session. Poll
+requests are limited to 60 per IP per minute; `scan_log_poll.php` is limited to 30 per
+IP per minute. Admin login locks an IP for 15 minutes after five failed attempts.
+
 ## Merge Guideline Priorities
 1. Available > Delisted
 2. English language > Other language

--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -29,6 +29,31 @@ CREATE TABLE `admin_user` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `admin_login_throttle`
+--
+
+CREATE TABLE `admin_login_throttle` (
+  `ip_address` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+  `failure_count` smallint UNSIGNED NOT NULL DEFAULT '0',
+  `locked_until` timestamp NULL DEFAULT NULL,
+  `last_attempt_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `ip_rate_limit`
+--
+
+CREATE TABLE `ip_rate_limit` (
+  `bucket_key` varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+  `window_start` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `request_count` int UNSIGNED NOT NULL DEFAULT '1'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `log`
 --
 
@@ -429,6 +454,18 @@ CREATE TABLE `trophy_title_player` (
 --
 ALTER TABLE `admin_user`
   ADD PRIMARY KEY (`username`);
+
+--
+-- Indexes for table `admin_login_throttle`
+--
+ALTER TABLE `admin_login_throttle`
+  ADD PRIMARY KEY (`ip_address`);
+
+--
+-- Indexes for table `ip_rate_limit`
+--
+ALTER TABLE `ip_rate_limit`
+  ADD PRIMARY KEY (`bucket_key`);
 
 --
 -- Indexes for table `log`

--- a/tests/AboutPageScanLogControllerTest.php
+++ b/tests/AboutPageScanLogControllerTest.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/../wwwroot/classes/AboutPagePlayer.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPagePlayerArraySerializer.php';
 require_once __DIR__ . '/../wwwroot/classes/Utility.php';
 require_once __DIR__ . '/../wwwroot/classes/JsonResponseEmitter.php';
+require_once __DIR__ . '/../wwwroot/classes/IpRateLimitService.php';
 
 final class FakeAboutPageService extends AboutPageService
 {
@@ -119,6 +120,50 @@ final class AboutPageScanLogControllerTest extends TestCase
         ob_end_clean();
 
         $this->assertSame(5, $service->getCapturedLimit());
+    }
+
+    public function testHandleRespondsWithErrorWhenRateLimitExceeded(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE ip_rate_limit (
+                bucket_key TEXT PRIMARY KEY,
+                window_start TEXT NOT NULL,
+                request_count INTEGER NOT NULL
+            )
+            SQL
+        );
+
+        $utility = new Utility();
+        $players = [
+            new AboutPagePlayer($utility, 'SoloPlayer', 'gb', 'avatar3.png', '2024-01-03 08:30:00', 75, '90', 0, 0, 1, 1, 5),
+        ];
+        $summary = new AboutPageScanSummary(3, 1);
+        $service = new FakeAboutPageService($summary, $players);
+        $controller = new AboutPageScanLogController(
+            $service,
+            new JsonResponseEmitter(),
+            new IpRateLimitService($pdo)
+        );
+
+        for ($index = 0; $index < 30; $index++) {
+            header_remove();
+            ob_start();
+            $controller->handle([], ['REMOTE_ADDR' => '192.0.2.50']);
+            ob_end_clean();
+        }
+
+        header_remove();
+        ob_start();
+        $controller->handle([], ['REMOTE_ADDR' => '192.0.2.50']);
+        $output = ob_get_clean();
+
+        $this->assertSame(429, http_response_code());
+        $decodedOutput = json_decode((string) $output, true);
+        $this->assertTrue(is_array($decodedOutput));
+        $this->assertSame('error', $decodedOutput['status'] ?? null);
     }
 
     public function testHandleRespondsWithErrorWhenExceptionThrown(): void

--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/Admin/AdminAuthService.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/AdminLoginThrottleService.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/AdminUserRepository.php';
 require_once __DIR__ . '/../wwwroot/classes/SessionManager.php';
 
@@ -29,11 +30,23 @@ final class AdminAuthServiceTest extends TestCase
                 username TEXT PRIMARY KEY,
                 password_hash TEXT NOT NULL,
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-            )
+            );
+
+            CREATE TABLE admin_login_throttle (
+                ip_address TEXT PRIMARY KEY,
+                failure_count INTEGER NOT NULL,
+                locked_until TEXT NULL,
+                last_attempt_at TEXT NOT NULL
+            );
             SQL
         );
 
         $this->repository = new AdminUserRepository($this->pdo);
+    }
+
+    private function createAuthService(): AdminAuthService
+    {
+        return new AdminAuthService($this->repository, new AdminLoginThrottleService($this->pdo));
     }
 
     protected function tearDown(): void
@@ -47,9 +60,9 @@ final class AdminAuthServiceTest extends TestCase
     public function testLoginSucceedsWithDatabaseCredentials(): void
     {
         $this->insertAdmin('admin-user', password_hash('secret-password', PASSWORD_DEFAULT));
-        $service = new AdminAuthService($this->repository);
+        $service = $this->createAuthService();
 
-        $this->assertTrue($service->login('admin-user', 'secret-password'));
+        $this->assertTrue($service->login('admin-user', 'secret-password', '192.0.2.30'));
         $this->assertTrue($service->isAuthenticated());
         $this->assertSame('admin-user', $service->getAuthenticatedUsername());
     }
@@ -57,15 +70,15 @@ final class AdminAuthServiceTest extends TestCase
     public function testLoginFailsWithInvalidCredentials(): void
     {
         $this->insertAdmin('admin-user', password_hash('secret-password', PASSWORD_DEFAULT));
-        $service = new AdminAuthService($this->repository);
+        $service = $this->createAuthService();
 
-        $this->assertFalse($service->login('admin-user', 'wrong-password'));
+        $this->assertFalse($service->login('admin-user', 'wrong-password', '192.0.2.31'));
         $this->assertFalse($service->isAuthenticated());
     }
 
     public function testIsConfiguredRequiresAtLeastOneAdminUser(): void
     {
-        $service = new AdminAuthService($this->repository);
+        $service = $this->createAuthService();
 
         $this->assertFalse($service->isConfigured());
 
@@ -77,13 +90,28 @@ final class AdminAuthServiceTest extends TestCase
     public function testLogoutClearsAuthenticationState(): void
     {
         $this->insertAdmin('admin-user', password_hash('secret-password', PASSWORD_DEFAULT));
-        $service = new AdminAuthService($this->repository);
-        $service->login('admin-user', 'secret-password');
+        $service = $this->createAuthService();
+        $service->login('admin-user', 'secret-password', '192.0.2.32');
 
         $service->logout();
 
         $this->assertFalse($service->isAuthenticated());
         $this->assertSame(null, $service->getAuthenticatedUsername());
+    }
+
+    public function testLoginIsBlockedWhenIpAddressIsLocked(): void
+    {
+        $this->insertAdmin('admin-user', password_hash('secret-password', PASSWORD_DEFAULT));
+        $service = $this->createAuthService();
+        $ipAddress = '192.0.2.33';
+
+        for ($index = 0; $index < AdminLoginThrottleService::MAX_FAILURES; $index++) {
+            $service->login('admin-user', 'wrong-password', $ipAddress);
+        }
+
+        $this->assertTrue($service->isLoginLocked($ipAddress));
+        $this->assertFalse($service->login('admin-user', 'secret-password', $ipAddress));
+        $this->assertFalse($service->isAuthenticated());
     }
 
     private function insertAdmin(string $username, string $passwordHash): void

--- a/tests/AdminLoginThrottleServiceTest.php
+++ b/tests/AdminLoginThrottleServiceTest.php
@@ -41,6 +41,27 @@ final class AdminLoginThrottleServiceTest extends TestCase
         $this->assertTrue($this->service->getLockoutRemainingSeconds($ipAddress) > 0);
     }
 
+    public function testDoesNotLockUntilFifthFailure(): void
+    {
+        $ipAddress = '192.0.2.22';
+        $statement = $this->pdo->prepare(
+            <<<'SQL'
+            INSERT INTO admin_login_throttle (ip_address, failure_count, locked_until, last_attempt_at)
+            VALUES (:ip_address, :failure_count, NULL, :last_attempt_at)
+            SQL
+        );
+        $statement->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
+        $statement->bindValue(':failure_count', AdminLoginThrottleService::MAX_FAILURES - 2, PDO::PARAM_INT);
+        $statement->bindValue(':last_attempt_at', '2026-01-01 00:00:00', PDO::PARAM_STR);
+        $statement->execute();
+
+        $this->service->recordFailure($ipAddress);
+        $this->assertFalse($this->service->isLocked($ipAddress));
+
+        $this->service->recordFailure($ipAddress);
+        $this->assertTrue($this->service->isLocked($ipAddress));
+    }
+
     public function testRecordSuccessClearsThrottleState(): void
     {
         $ipAddress = '192.0.2.21';

--- a/tests/AdminLoginThrottleServiceTest.php
+++ b/tests/AdminLoginThrottleServiceTest.php
@@ -62,6 +62,37 @@ final class AdminLoginThrottleServiceTest extends TestCase
         $this->assertTrue($this->service->isLocked($ipAddress));
     }
 
+    public function testResetsFailureCountAfterLockoutExpires(): void
+    {
+        $ipAddress = '192.0.2.23';
+
+        for ($index = 0; $index < AdminLoginThrottleService::MAX_FAILURES; $index++) {
+            $this->service->recordFailure($ipAddress);
+        }
+
+        $this->assertTrue($this->service->isLocked($ipAddress));
+
+        $statement = $this->pdo->prepare(
+            'UPDATE admin_login_throttle SET locked_until = :locked_until WHERE ip_address = :ip_address'
+        );
+        $statement->bindValue(':locked_until', '2020-01-01 00:00:00', PDO::PARAM_STR);
+        $statement->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
+        $statement->execute();
+
+        $this->assertFalse($this->service->isLocked($ipAddress));
+
+        $this->service->recordFailure($ipAddress);
+        $this->assertFalse($this->service->isLocked($ipAddress));
+
+        for ($index = 0; $index < AdminLoginThrottleService::MAX_FAILURES - 2; $index++) {
+            $this->service->recordFailure($ipAddress);
+            $this->assertFalse($this->service->isLocked($ipAddress));
+        }
+
+        $this->service->recordFailure($ipAddress);
+        $this->assertTrue($this->service->isLocked($ipAddress));
+    }
+
     public function testRecordSuccessClearsThrottleState(): void
     {
         $ipAddress = '192.0.2.21';

--- a/tests/AdminLoginThrottleServiceTest.php
+++ b/tests/AdminLoginThrottleServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/AdminLoginThrottleService.php';
+
+final class AdminLoginThrottleServiceTest extends TestCase
+{
+    private PDO $pdo;
+
+    private AdminLoginThrottleService $service;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec(
+            <<<'SQL'
+            CREATE TABLE admin_login_throttle (
+                ip_address TEXT PRIMARY KEY,
+                failure_count INTEGER NOT NULL,
+                locked_until TEXT NULL,
+                last_attempt_at TEXT NOT NULL
+            )
+            SQL
+        );
+
+        $this->service = new AdminLoginThrottleService($this->pdo);
+    }
+
+    public function testLocksOutAfterMaxFailures(): void
+    {
+        $ipAddress = '192.0.2.20';
+
+        for ($index = 0; $index < AdminLoginThrottleService::MAX_FAILURES; $index++) {
+            $this->service->recordFailure($ipAddress);
+        }
+
+        $this->assertTrue($this->service->isLocked($ipAddress));
+        $this->assertTrue($this->service->getLockoutRemainingSeconds($ipAddress) > 0);
+    }
+
+    public function testRecordSuccessClearsThrottleState(): void
+    {
+        $ipAddress = '192.0.2.21';
+
+        for ($index = 0; $index < AdminLoginThrottleService::MAX_FAILURES; $index++) {
+            $this->service->recordFailure($ipAddress);
+        }
+
+        $this->service->recordSuccess($ipAddress);
+
+        $this->assertFalse($this->service->isLocked($ipAddress));
+        $this->assertSame(0, $this->service->getLockoutRemainingSeconds($ipAddress));
+    }
+}

--- a/tests/IpRateLimitServiceTest.php
+++ b/tests/IpRateLimitServiceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/IpRateLimitService.php';
+
+final class IpRateLimitServiceTest extends TestCase
+{
+    private PDO $pdo;
+
+    private IpRateLimitService $service;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec(
+            <<<'SQL'
+            CREATE TABLE ip_rate_limit (
+                bucket_key TEXT PRIMARY KEY,
+                window_start TEXT NOT NULL,
+                request_count INTEGER NOT NULL
+            )
+            SQL
+        );
+
+        $this->service = new IpRateLimitService($this->pdo);
+    }
+
+    public function testCheckAndRecordAllowsRequestsWithinLimit(): void
+    {
+        for ($index = 0; $index < 60; $index++) {
+            $this->assertTrue(
+                $this->service->checkAndRecord('192.0.2.10', IpRateLimitService::BUCKET_QUEUE_POLL)
+            );
+        }
+    }
+
+    public function testCheckAndRecordBlocksRequestsAboveLimit(): void
+    {
+        for ($index = 0; $index < 60; $index++) {
+            $this->service->checkAndRecord('192.0.2.11', IpRateLimitService::BUCKET_QUEUE_POLL);
+        }
+
+        $this->assertFalse(
+            $this->service->checkAndRecord('192.0.2.11', IpRateLimitService::BUCKET_QUEUE_POLL)
+        );
+    }
+
+    public function testDifferentBucketsTrackSeparately(): void
+    {
+        for ($index = 0; $index < 30; $index++) {
+            $this->service->checkAndRecord('192.0.2.12', IpRateLimitService::BUCKET_SCAN_LOG_POLL);
+        }
+
+        $this->assertFalse(
+            $this->service->checkAndRecord('192.0.2.12', IpRateLimitService::BUCKET_SCAN_LOG_POLL)
+        );
+        $this->assertTrue(
+            $this->service->checkAndRecord('192.0.2.12', IpRateLimitService::BUCKET_QUEUE_POLL)
+        );
+    }
+}

--- a/tests/PlayerQueueControllerTest.php
+++ b/tests/PlayerQueueControllerTest.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/../wwwroot/classes/PlayerQueueController.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueHandler.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueRequest.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponse.php';
+require_once __DIR__ . '/../wwwroot/classes/IpRateLimitService.php';
 
 final class PlayerQueueHandlerSpy extends PlayerQueueHandler
 {
@@ -32,6 +33,12 @@ final class PlayerQueueHandlerSpy extends PlayerQueueHandler
     public function getHandledMethod(): ?string
     {
         return $this->handledMethod;
+    }
+
+    public function resetCapturedState(): void
+    {
+        $this->capturedRequest = null;
+        $this->handledMethod = null;
     }
 
     public function handleAddToQueueRequest(PlayerQueueRequest $request): PlayerQueueResponse
@@ -101,5 +108,34 @@ final class PlayerQueueControllerTest extends TestCase
         $this->assertTrue($capturedRequest instanceof PlayerQueueRequest);
         $this->assertSame('QueueUser', $capturedRequest->getPlayerName());
         $this->assertSame('198.51.100.23', $capturedRequest->getIpAddress());
+    }
+
+    public function testHandleQueuePositionReturnsRateLimitedResponseWhenIpLimitExceeded(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE ip_rate_limit (
+                bucket_key TEXT PRIMARY KEY,
+                window_start TEXT NOT NULL,
+                request_count INTEGER NOT NULL
+            )
+            SQL
+        );
+
+        $rateLimitService = new IpRateLimitService($pdo);
+        $handler = new PlayerQueueHandlerSpy(PlayerQueueResponse::complete('unused'));
+        $controller = new PlayerQueueController($handler, $rateLimitService);
+
+        for ($index = 0; $index < 60; $index++) {
+            $controller->handleQueuePosition(['q' => 'QueueUser', 'poll_token' => 'token'], ['REMOTE_ADDR' => '192.0.2.44']);
+        }
+
+        $handler->resetCapturedState();
+        $result = $controller->handleQueuePosition(['q' => 'QueueUser', 'poll_token' => 'token'], ['REMOTE_ADDR' => '192.0.2.44']);
+
+        $this->assertSame(429, $result->getHttpStatusCode());
+        $this->assertSame(null, $handler->getHandledMethod());
     }
 }

--- a/tests/PlayerQueueHandlerTest.php
+++ b/tests/PlayerQueueHandlerTest.php
@@ -8,6 +8,8 @@ require_once __DIR__ . '/../wwwroot/classes/PlayerQueueRequest.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponseFactory.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponse.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueService.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerQueuePollTokenManager.php';
+require_once __DIR__ . '/../wwwroot/classes/SessionManager.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerScanProgress.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerScanStatus.php';
 
@@ -177,6 +179,40 @@ final class ConfigurablePlayerQueueServiceStub extends PlayerQueueService
 
 final class PlayerQueueHandlerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+
+        session_start();
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            $_SESSION = [];
+            session_destroy();
+        }
+    }
+
+    private function createPollToken(string $playerName): string
+    {
+        return (new PlayerQueuePollTokenManager())->issue($playerName);
+    }
+
+    private function createQueuePositionRequest(string $playerName, string $ipAddress): PlayerQueueRequest
+    {
+        return PlayerQueueRequest::fromArrays(
+            [
+                'q' => $playerName,
+                'poll_token' => $this->createPollToken($playerName),
+            ],
+            ['REMOTE_ADDR' => $ipAddress]
+        );
+    }
+
     public function testHandleAddToQueueRequestReturnsErrorForEmptyName(): void
     {
         $service = new ConfigurablePlayerQueueServiceStub();
@@ -262,12 +298,28 @@ final class PlayerQueueHandlerTest extends TestCase
 
         $this->assertSame('queued', $response->getStatus());
         $this->assertTrue($response->shouldPoll());
+        $this->assertTrue($response->getPollToken() !== null);
         $this->assertStringContainsString('is being added to the queue', $response->getMessage());
         $this->assertSame(
             [
                 ['playerName' => 'ValidUser', 'ipAddress' => '192.168.0.1'],
             ],
             $service->getQueuedPlayers()
+        );
+    }
+
+    public function testHandleQueuePositionRequestReturnsErrorWhenPollTokenMissing(): void
+    {
+        $service = new ConfigurablePlayerQueueServiceStub();
+        $handler = new PlayerQueueHandler($service, new PlayerQueueResponseFactory($service));
+        $request = PlayerQueueRequest::fromArrays(['q' => 'QueueUser'], ['REMOTE_ADDR' => '10.0.0.7']);
+
+        $response = $handler->handleQueuePositionRequest($request);
+
+        $this->assertSame('error', $response->getStatus());
+        $this->assertSame(
+            'Your session has expired. Please reload the page and try again.',
+            $response->getMessage()
         );
     }
 
@@ -288,7 +340,7 @@ final class PlayerQueueHandlerTest extends TestCase
         $service = new ConfigurablePlayerQueueServiceStub();
         $service->setIsValidPlayerName(false);
         $handler = new PlayerQueueHandler($service, new PlayerQueueResponseFactory($service));
-        $request = PlayerQueueRequest::fromArrays(['q' => 'invalid name'], ['REMOTE_ADDR' => '10.0.0.4']);
+        $request = $this->createQueuePositionRequest('invalid name', '10.0.0.4');
 
         $response = $handler->handleQueuePositionRequest($request);
 
@@ -308,7 +360,7 @@ final class PlayerQueueHandlerTest extends TestCase
             'status' => PlayerQueueService::CHEATER_STATUS,
         ]);
         $handler = new PlayerQueueHandler($service, new PlayerQueueResponseFactory($service));
-        $request = PlayerQueueRequest::fromArrays(['q' => 'Cheater'], ['REMOTE_ADDR' => '10.0.0.5']);
+        $request = $this->createQueuePositionRequest('Cheater', '10.0.0.5');
 
         $response = $handler->handleQueuePositionRequest($request);
 
@@ -329,7 +381,7 @@ final class PlayerQueueHandlerTest extends TestCase
             'title' => 'Game <Title>',
         ]);
         $handler = new PlayerQueueHandler($service, new PlayerQueueResponseFactory($service));
-        $request = PlayerQueueRequest::fromArrays(['q' => 'ScanningUser'], ['REMOTE_ADDR' => '10.0.0.6']);
+        $request = $this->createQueuePositionRequest('ScanningUser', '10.0.0.6');
 
         $response = $handler->handleQueuePositionRequest($request);
 
@@ -349,7 +401,7 @@ final class PlayerQueueHandlerTest extends TestCase
         ]);
         $service->setQueuePosition(5);
         $handler = new PlayerQueueHandler($service, new PlayerQueueResponseFactory($service));
-        $request = PlayerQueueRequest::fromArrays(['q' => 'QueueUser'], ['REMOTE_ADDR' => '10.0.0.7']);
+        $request = $this->createQueuePositionRequest('QueueUser', '10.0.0.7');
 
         $response = $handler->handleQueuePositionRequest($request);
 
@@ -362,7 +414,7 @@ final class PlayerQueueHandlerTest extends TestCase
     {
         $service = new ConfigurablePlayerQueueServiceStub();
         $handler = new PlayerQueueHandler($service, new PlayerQueueResponseFactory($service));
-        $request = PlayerQueueRequest::fromArrays(['q' => 'UnknownUser'], ['REMOTE_ADDR' => '10.0.0.8']);
+        $request = $this->createQueuePositionRequest('UnknownUser', '10.0.0.8');
 
         $response = $handler->handleQueuePositionRequest($request);
 
@@ -378,7 +430,7 @@ final class PlayerQueueHandlerTest extends TestCase
             'status' => null,
         ]);
         $handler = new PlayerQueueHandler($service, new PlayerQueueResponseFactory($service));
-        $request = PlayerQueueRequest::fromArrays(['q' => 'FinishedUser'], ['REMOTE_ADDR' => '10.0.0.9']);
+        $request = $this->createQueuePositionRequest('FinishedUser', '10.0.0.9');
 
         $response = $handler->handleQueuePositionRequest($request);
 

--- a/tests/PlayerQueuePollTokenManagerTest.php
+++ b/tests/PlayerQueuePollTokenManagerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerQueuePollTokenManager.php';
+require_once __DIR__ . '/../wwwroot/classes/SessionManager.php';
+
+final class PlayerQueuePollTokenManagerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+
+        session_start();
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            $_SESSION = [];
+            session_destroy();
+        }
+    }
+
+    public function testIssueAndValidateMatchingToken(): void
+    {
+        $manager = new PlayerQueuePollTokenManager();
+        $token = $manager->issue('ExamplePlayer');
+
+        $this->assertTrue($token !== '');
+        $this->assertTrue($manager->validate('ExamplePlayer', $token));
+    }
+
+    public function testValidateRejectsMissingOrMismatchedToken(): void
+    {
+        $manager = new PlayerQueuePollTokenManager();
+        $manager->issue('ExamplePlayer');
+
+        $this->assertFalse($manager->validate('ExamplePlayer', ''));
+        $this->assertFalse($manager->validate('ExamplePlayer', 'invalid-token'));
+        $this->assertFalse($manager->validate('OtherPlayer', 'invalid-token'));
+    }
+}

--- a/tests/PlayerQueueRequestTest.php
+++ b/tests/PlayerQueueRequestTest.php
@@ -6,6 +6,16 @@ require_once __DIR__ . '/../wwwroot/classes/PlayerQueueRequest.php';
 
 final class PlayerQueueRequestTest extends TestCase
 {
+    public function testFromArraysReadsPollToken(): void
+    {
+        $request = PlayerQueueRequest::fromArrays(
+            ['q' => 'ExamplePlayer', 'poll_token' => ' poll-token '],
+            ['REMOTE_ADDR' => '127.0.0.1']
+        );
+
+        $this->assertSame('poll-token', $request->getPollToken());
+    }
+
     public function testFromArraysTrimsAndNormalizesValues(): void
     {
         $request = PlayerQueueRequest::fromArrays(

--- a/tests/PlayerQueueResponseTest.php
+++ b/tests/PlayerQueueResponseTest.php
@@ -7,6 +7,30 @@ require_once __DIR__ . '/../wwwroot/classes/PlayerQueueStatus.php';
 
 final class PlayerQueueResponseTest extends TestCase
 {
+    public function testRateLimitedResponseUsesHttpStatus429(): void
+    {
+        $response = PlayerQueueResponse::rateLimited('Too many requests.');
+
+        $this->assertSame('error', $response->getStatus());
+        $this->assertSame(429, $response->getHttpStatusCode());
+        $this->assertFalse($response->shouldPoll());
+    }
+
+    public function testQueuedResponseCanIncludePollToken(): void
+    {
+        $response = PlayerQueueResponse::queued('Queued for processing')->withPollToken('poll-token');
+
+        $this->assertSame(
+            [
+                'status' => 'queued',
+                'message' => 'Queued for processing',
+                'shouldPoll' => true,
+                'pollToken' => 'poll-token',
+            ],
+            $response->toArray()
+        );
+    }
+
     public function testQueuedResponseIncludesShouldPollTrue(): void
     {
         $response = PlayerQueueResponse::queued('Queued for processing');

--- a/wwwroot/admin/login.php
+++ b/wwwroot/admin/login.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../init.php';
+require_once __DIR__ . '/../classes/IpAddressResolver.php';
 require_once __DIR__ . '/../classes/SessionManager.php';
 require_once __DIR__ . '/../classes/CsrfTokenManager.php';
 require_once __DIR__ . '/../classes/Admin/AdminBootstrap.php';
@@ -27,10 +28,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     $username = is_string($_POST['username'] ?? null) ? trim($_POST['username']) : '';
     $password = is_string($_POST['password'] ?? null) ? (string) $_POST['password'] : '';
+    $ipAddress = IpAddressResolver::resolveFromServer($_SERVER ?? []);
 
     if (!$authService->isConfigured()) {
         $errorMessage = 'Admin access is not configured. Add at least one row to the admin_user table.';
-    } elseif ($authService->login($username, $password)) {
+    } elseif ($authService->isLoginLocked($ipAddress)) {
+        $remainingMinutes = (int) ceil($authService->getLoginLockoutRemainingSeconds($ipAddress) / 60);
+        $errorMessage = sprintf(
+            'Too many failed login attempts. Please try again in %d minute%s.',
+            max($remainingMinutes, 1),
+            $remainingMinutes === 1 ? '' : 's'
+        );
+    } elseif ($authService->login($username, $password, $ipAddress)) {
         header('Location: /admin/', true, 303);
         exit;
     } else {

--- a/wwwroot/check_queue_position.php
+++ b/wwwroot/check_queue_position.php
@@ -3,10 +3,7 @@
 declare(strict_types=1);
 
 require_once 'init.php';
-require_once 'classes/SessionManager.php';
 require_once 'classes/PlayerQueueEndpoint.php';
-
-SessionManager::ensureStarted();
 
 $endpoint = PlayerQueueEndpoint::fromDatabase($database);
 $endpoint->handleQueuePosition($_GET ?? [], $_SERVER ?? []);

--- a/wwwroot/check_queue_position.php
+++ b/wwwroot/check_queue_position.php
@@ -3,7 +3,10 @@
 declare(strict_types=1);
 
 require_once 'init.php';
+require_once 'classes/SessionManager.php';
 require_once 'classes/PlayerQueueEndpoint.php';
+
+SessionManager::ensureStarted();
 
 $endpoint = PlayerQueueEndpoint::fromDatabase($database);
 $endpoint->handleQueuePosition($_GET ?? [], $_SERVER ?? []);

--- a/wwwroot/classes/AboutPageScanLogController.php
+++ b/wwwroot/classes/AboutPageScanLogController.php
@@ -6,6 +6,8 @@ require_once __DIR__ . '/AboutPageService.php';
 require_once __DIR__ . '/AboutPageScanSummary.php';
 require_once __DIR__ . '/AboutPagePlayerArraySerializer.php';
 require_once __DIR__ . '/JsonResponseEmitter.php';
+require_once __DIR__ . '/IpRateLimitService.php';
+require_once __DIR__ . '/IpAddressResolver.php';
 
 final class AboutPageScanLogController
 {
@@ -15,6 +17,7 @@ final class AboutPageScanLogController
 
     private AboutPageService $aboutPageService;
     private JsonResponseEmitter $jsonResponder;
+    private ?IpRateLimitService $rateLimitService;
     private int $defaultLimit;
     private int $minLimit;
     private int $maxLimit;
@@ -22,27 +25,50 @@ final class AboutPageScanLogController
     public function __construct(
         AboutPageService $aboutPageService,
         JsonResponseEmitter $jsonResponder,
+        ?IpRateLimitService $rateLimitService = null,
         int $defaultLimit = self::DEFAULT_LIMIT,
         int $minLimit = self::MIN_LIMIT,
         int $maxLimit = self::MAX_LIMIT
     ) {
         $this->aboutPageService = $aboutPageService;
         $this->jsonResponder = $jsonResponder;
+        $this->rateLimitService = $rateLimitService;
         $this->defaultLimit = $defaultLimit;
         $this->minLimit = $minLimit;
         $this->maxLimit = $maxLimit;
     }
 
-    public static function create(AboutPageService $aboutPageService, JsonResponseEmitter $jsonResponder): self
-    {
-        return new self($aboutPageService, $jsonResponder);
+    public static function create(
+        AboutPageService $aboutPageService,
+        JsonResponseEmitter $jsonResponder,
+        ?IpRateLimitService $rateLimitService = null,
+    ): self {
+        return new self($aboutPageService, $jsonResponder, $rateLimitService);
     }
 
     /**
      * @param array<string, mixed> $queryParameters
+     * @param array<string, mixed> $serverParameters
      */
-    public function handle(array $queryParameters = []): void
+    public function handle(array $queryParameters = [], array $serverParameters = []): void
     {
+        if ($this->rateLimitService !== null) {
+            $ipAddress = IpAddressResolver::resolveFromServer($serverParameters);
+            if (
+                !$this->rateLimitService->checkAndRecord(
+                    $ipAddress,
+                    IpRateLimitService::BUCKET_SCAN_LOG_POLL
+                )
+            ) {
+                $this->jsonResponder->respond([
+                    'status' => 'error',
+                    'message' => 'Too many scan log requests. Please wait a moment and try again.',
+                ], 429);
+
+                return;
+            }
+        }
+
         $limit = $this->resolveLimit($queryParameters['limit'] ?? null);
 
         try {

--- a/wwwroot/classes/Admin/AdminAuthService.php
+++ b/wwwroot/classes/Admin/AdminAuthService.php
@@ -2,14 +2,18 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/AdminLoginThrottleService.php';
+
 final class AdminAuthService
 {
     private const string SESSION_AUTHENTICATED_KEY = 'admin_authenticated';
 
     private const string SESSION_USERNAME_KEY = 'admin_username';
 
-    public function __construct(private readonly AdminUserRepository $adminUserRepository)
-    {
+    public function __construct(
+        private readonly AdminUserRepository $adminUserRepository,
+        private readonly ?AdminLoginThrottleService $loginThrottle = null,
+    ) {
     }
 
     public function isConfigured(): bool
@@ -33,10 +37,32 @@ final class AdminAuthService
         return is_string($username) && $username !== '' ? $username : null;
     }
 
-    public function login(string $username, string $password): bool
+    public function isLoginLocked(string $ipAddress): bool
     {
-        if (!$this->adminUserRepository->verifyCredentials($username, $password)) {
+        return $this->loginThrottle?->isLocked($ipAddress) ?? false;
+    }
+
+    public function getLoginLockoutRemainingSeconds(string $ipAddress): int
+    {
+        return $this->loginThrottle?->getLockoutRemainingSeconds($ipAddress) ?? 0;
+    }
+
+    public function login(string $username, string $password, string $ipAddress = ''): bool
+    {
+        if ($ipAddress !== '' && $this->isLoginLocked($ipAddress)) {
             return false;
+        }
+
+        if (!$this->adminUserRepository->verifyCredentials($username, $password)) {
+            if ($ipAddress !== '') {
+                $this->loginThrottle?->recordFailure($ipAddress);
+            }
+
+            return false;
+        }
+
+        if ($ipAddress !== '') {
+            $this->loginThrottle?->recordSuccess($ipAddress);
         }
 
         $_SESSION[self::SESSION_AUTHENTICATED_KEY] = true;

--- a/wwwroot/classes/Admin/AdminBootstrap.php
+++ b/wwwroot/classes/Admin/AdminBootstrap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../CsrfTokenManager.php';
 require_once __DIR__ . '/../SessionManager.php';
 require_once __DIR__ . '/AdminAuthService.php';
+require_once __DIR__ . '/AdminLoginThrottleService.php';
 require_once __DIR__ . '/AdminUserRepository.php';
 
 final class AdminBootstrap
@@ -31,7 +32,12 @@ final class AdminBootstrap
 
     public static function createAuthService(): AdminAuthService
     {
-        return new AdminAuthService(new AdminUserRepository(self::requireDatabase()));
+        $database = self::requireDatabase();
+
+        return new AdminAuthService(
+            new AdminUserRepository($database),
+            new AdminLoginThrottleService($database),
+        );
     }
 
     public static function getCsrfToken(): string

--- a/wwwroot/classes/Admin/AdminLoginThrottleService.php
+++ b/wwwroot/classes/Admin/AdminLoginThrottleService.php
@@ -44,24 +44,15 @@ final class AdminLoginThrottleService
             return;
         }
 
-        $row = $this->fetchRow($ipAddress);
-        $now = $this->formatTimestamp($this->clock());
-        $failureCount = $row === null ? 1 : (int) ($row['failure_count'] ?? 0) + 1;
-        $lockedUntil = null;
+        $lastAttemptAt = $this->formatTimestamp($this->clock());
 
-        if ($failureCount >= self::MAX_FAILURES) {
-            $lockedUntil = $this->formatTimestamp(
-                $this->clock()->modify('+' . self::LOCK_SECONDS . ' seconds')
-            );
-        }
-
-        if ($row === null) {
-            $this->insertRow($ipAddress, $failureCount, $lockedUntil, $now);
+        if ($this->isSqlite()) {
+            $this->recordFailureSqlite($ipAddress, $lastAttemptAt);
 
             return;
         }
 
-        $this->updateRow($ipAddress, $failureCount, $lockedUntil, $now);
+        $this->recordFailureMysql($ipAddress, $lastAttemptAt);
     }
 
     public function recordSuccess(string $ipAddress): void
@@ -77,9 +68,9 @@ final class AdminLoginThrottleService
         $statement->execute();
     }
 
-    /**
-     * @return array<string, mixed>|null
-     */
+  /**
+   * @return array<string, mixed>|null
+   */
     private function fetchRow(string $ipAddress): ?array
     {
         $statement = $this->database->prepare(
@@ -102,58 +93,59 @@ final class AdminLoginThrottleService
         return is_array($row) ? $row : null;
     }
 
-    private function insertRow(
-        string $ipAddress,
-        int $failureCount,
-        ?string $lockedUntil,
-        string $lastAttemptAt,
-    ): void {
+    private function recordFailureMysql(string $ipAddress, string $lastAttemptAt): void
+    {
         $statement = $this->database->prepare(
             <<<'SQL'
             INSERT INTO admin_login_throttle (ip_address, failure_count, locked_until, last_attempt_at)
-            VALUES (:ip_address, :failure_count, :locked_until, :last_attempt_at)
+            VALUES (:ip_address, 1, NULL, :last_attempt_at)
+            AS new_values
+            ON DUPLICATE KEY UPDATE
+                failure_count = admin_login_throttle.failure_count + 1,
+                last_attempt_at = new_values.last_attempt_at,
+                locked_until = IF(
+                    admin_login_throttle.failure_count + 1 >= :max_failures,
+                    CURRENT_TIMESTAMP + INTERVAL :lock_seconds SECOND,
+                    admin_login_throttle.locked_until
+                )
             SQL
         );
         $statement->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
-        $statement->bindValue(':failure_count', $failureCount, PDO::PARAM_INT);
-        $this->bindNullableTimestamp($statement, ':locked_until', $lockedUntil);
         $statement->bindValue(':last_attempt_at', $lastAttemptAt, PDO::PARAM_STR);
+        $statement->bindValue(':max_failures', self::MAX_FAILURES, PDO::PARAM_INT);
+        $statement->bindValue(':lock_seconds', self::LOCK_SECONDS, PDO::PARAM_INT);
         $statement->execute();
     }
 
-    private function updateRow(
-        string $ipAddress,
-        int $failureCount,
-        ?string $lockedUntil,
-        string $lastAttemptAt,
-    ): void {
+    private function recordFailureSqlite(string $ipAddress, string $lastAttemptAt): void
+    {
+        $lockedUntil = $this->formatTimestamp(
+            $this->clock()->modify('+' . self::LOCK_SECONDS . ' seconds')
+        );
+
         $statement = $this->database->prepare(
             <<<'SQL'
-            UPDATE admin_login_throttle
-            SET
-                failure_count = :failure_count,
-                locked_until = :locked_until,
-                last_attempt_at = :last_attempt_at
-            WHERE
-                ip_address = :ip_address
+            INSERT INTO admin_login_throttle (ip_address, failure_count, locked_until, last_attempt_at)
+            VALUES (:ip_address, 1, NULL, :last_attempt_at)
+            ON CONFLICT(ip_address) DO UPDATE SET
+                failure_count = failure_count + 1,
+                last_attempt_at = excluded.last_attempt_at,
+                locked_until = CASE
+                    WHEN failure_count + 1 >= :max_failures THEN :locked_until
+                    ELSE locked_until
+                END
             SQL
         );
         $statement->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
-        $statement->bindValue(':failure_count', $failureCount, PDO::PARAM_INT);
-        $this->bindNullableTimestamp($statement, ':locked_until', $lockedUntil);
         $statement->bindValue(':last_attempt_at', $lastAttemptAt, PDO::PARAM_STR);
+        $statement->bindValue(':max_failures', self::MAX_FAILURES, PDO::PARAM_INT);
+        $statement->bindValue(':locked_until', $lockedUntil, PDO::PARAM_STR);
         $statement->execute();
     }
 
-    private function bindNullableTimestamp(PDOStatement $statement, string $parameter, ?string $value): void
+    private function isSqlite(): bool
     {
-        if ($value === null) {
-            $statement->bindValue($parameter, null, PDO::PARAM_NULL);
-
-            return;
-        }
-
-        $statement->bindValue($parameter, $value, PDO::PARAM_STR);
+        return $this->database->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite';
     }
 
     private function parseTimestamp(mixed $value): ?DateTimeImmutable

--- a/wwwroot/classes/Admin/AdminLoginThrottleService.php
+++ b/wwwroot/classes/Admin/AdminLoginThrottleService.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+final class AdminLoginThrottleService
+{
+    public const int MAX_FAILURES = 5;
+
+    public const int LOCK_SECONDS = 900;
+
+    public function __construct(private readonly PDO $database)
+    {
+    }
+
+    public function isLocked(string $ipAddress): bool
+    {
+        return $this->getLockoutRemainingSeconds($ipAddress) > 0;
+    }
+
+    public function getLockoutRemainingSeconds(string $ipAddress): int
+    {
+        if ($ipAddress === '') {
+            return 0;
+        }
+
+        $row = $this->fetchRow($ipAddress);
+        if ($row === null) {
+            return 0;
+        }
+
+        $lockedUntil = $this->parseTimestamp($row['locked_until'] ?? null);
+        if ($lockedUntil === null) {
+            return 0;
+        }
+
+        $remaining = $lockedUntil->getTimestamp() - $this->clock()->getTimestamp();
+
+        return $remaining > 0 ? $remaining : 0;
+    }
+
+    public function recordFailure(string $ipAddress): void
+    {
+        if ($ipAddress === '') {
+            return;
+        }
+
+        $row = $this->fetchRow($ipAddress);
+        $now = $this->formatTimestamp($this->clock());
+        $failureCount = $row === null ? 1 : (int) ($row['failure_count'] ?? 0) + 1;
+        $lockedUntil = null;
+
+        if ($failureCount >= self::MAX_FAILURES) {
+            $lockedUntil = $this->formatTimestamp(
+                $this->clock()->modify('+' . self::LOCK_SECONDS . ' seconds')
+            );
+        }
+
+        if ($row === null) {
+            $this->insertRow($ipAddress, $failureCount, $lockedUntil, $now);
+
+            return;
+        }
+
+        $this->updateRow($ipAddress, $failureCount, $lockedUntil, $now);
+    }
+
+    public function recordSuccess(string $ipAddress): void
+    {
+        if ($ipAddress === '') {
+            return;
+        }
+
+        $statement = $this->database->prepare(
+            'DELETE FROM admin_login_throttle WHERE ip_address = :ip_address'
+        );
+        $statement->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
+        $statement->execute();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function fetchRow(string $ipAddress): ?array
+    {
+        $statement = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                failure_count,
+                locked_until
+            FROM
+                admin_login_throttle
+            WHERE
+                ip_address = :ip_address
+            LIMIT 1
+            SQL
+        );
+        $statement->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
+        $statement->execute();
+
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+
+        return is_array($row) ? $row : null;
+    }
+
+    private function insertRow(
+        string $ipAddress,
+        int $failureCount,
+        ?string $lockedUntil,
+        string $lastAttemptAt,
+    ): void {
+        $statement = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO admin_login_throttle (ip_address, failure_count, locked_until, last_attempt_at)
+            VALUES (:ip_address, :failure_count, :locked_until, :last_attempt_at)
+            SQL
+        );
+        $statement->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
+        $statement->bindValue(':failure_count', $failureCount, PDO::PARAM_INT);
+        $this->bindNullableTimestamp($statement, ':locked_until', $lockedUntil);
+        $statement->bindValue(':last_attempt_at', $lastAttemptAt, PDO::PARAM_STR);
+        $statement->execute();
+    }
+
+    private function updateRow(
+        string $ipAddress,
+        int $failureCount,
+        ?string $lockedUntil,
+        string $lastAttemptAt,
+    ): void {
+        $statement = $this->database->prepare(
+            <<<'SQL'
+            UPDATE admin_login_throttle
+            SET
+                failure_count = :failure_count,
+                locked_until = :locked_until,
+                last_attempt_at = :last_attempt_at
+            WHERE
+                ip_address = :ip_address
+            SQL
+        );
+        $statement->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
+        $statement->bindValue(':failure_count', $failureCount, PDO::PARAM_INT);
+        $this->bindNullableTimestamp($statement, ':locked_until', $lockedUntil);
+        $statement->bindValue(':last_attempt_at', $lastAttemptAt, PDO::PARAM_STR);
+        $statement->execute();
+    }
+
+    private function bindNullableTimestamp(PDOStatement $statement, string $parameter, ?string $value): void
+    {
+        if ($value === null) {
+            $statement->bindValue($parameter, null, PDO::PARAM_NULL);
+
+            return;
+        }
+
+        $statement->bindValue($parameter, $value, PDO::PARAM_STR);
+    }
+
+    private function parseTimestamp(mixed $value): ?DateTimeImmutable
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    private function formatTimestamp(DateTimeImmutable $timestamp): string
+    {
+        return $timestamp->format('Y-m-d H:i:s');
+    }
+
+    private function clock(): DateTimeImmutable
+    {
+        return new DateTimeImmutable('now');
+    }
+}

--- a/wwwroot/classes/Admin/AdminLoginThrottleService.php
+++ b/wwwroot/classes/Admin/AdminLoginThrottleService.php
@@ -101,10 +101,10 @@ final class AdminLoginThrottleService
             VALUES (:ip_address, 1, NULL, :last_attempt_at)
             AS new_values
             ON DUPLICATE KEY UPDATE
-                failure_count = admin_login_throttle.failure_count + 1,
+                failure_count = (@new_failure_count := admin_login_throttle.failure_count + 1),
                 last_attempt_at = new_values.last_attempt_at,
                 locked_until = IF(
-                    admin_login_throttle.failure_count + 1 >= :max_failures,
+                    @new_failure_count >= :max_failures,
                     CURRENT_TIMESTAMP + INTERVAL :lock_seconds SECOND,
                     admin_login_throttle.locked_until
                 )

--- a/wwwroot/classes/Admin/AdminLoginThrottleService.php
+++ b/wwwroot/classes/Admin/AdminLoginThrottleService.php
@@ -46,13 +46,31 @@ final class AdminLoginThrottleService
 
         $lastAttemptAt = $this->formatTimestamp($this->clock());
 
-        if ($this->isSqlite()) {
-            $this->recordFailureSqlite($ipAddress, $lastAttemptAt);
-
-            return;
+        $startedTransaction = false;
+        if (!$this->database->inTransaction()) {
+            $this->database->beginTransaction();
+            $startedTransaction = true;
         }
 
-        $this->recordFailureMysql($ipAddress, $lastAttemptAt);
+        try {
+            $this->clearExpiredLockout($ipAddress, $lastAttemptAt);
+
+            if ($this->isSqlite()) {
+                $this->recordFailureSqlite($ipAddress, $lastAttemptAt);
+            } else {
+                $this->recordFailureMysql($ipAddress, $lastAttemptAt);
+            }
+
+            if ($startedTransaction) {
+                $this->database->commit();
+            }
+        } catch (Throwable $exception) {
+            if ($startedTransaction && $this->database->inTransaction()) {
+                $this->database->rollBack();
+            }
+
+            throw $exception;
+        }
     }
 
     public function recordSuccess(string $ipAddress): void
@@ -91,6 +109,22 @@ final class AdminLoginThrottleService
         $row = $statement->fetch(PDO::FETCH_ASSOC);
 
         return is_array($row) ? $row : null;
+    }
+
+    private function clearExpiredLockout(string $ipAddress, string $now): void
+    {
+        $statement = $this->database->prepare(
+            <<<'SQL'
+            DELETE FROM admin_login_throttle
+            WHERE
+                ip_address = :ip_address
+                AND locked_until IS NOT NULL
+                AND locked_until <= :now
+            SQL
+        );
+        $statement->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);
+        $statement->bindValue(':now', $now, PDO::PARAM_STR);
+        $statement->execute();
     }
 
     private function recordFailureMysql(string $ipAddress, string $lastAttemptAt): void

--- a/wwwroot/classes/IpRateLimitService.php
+++ b/wwwroot/classes/IpRateLimitService.php
@@ -49,46 +49,39 @@ final class IpRateLimitService
 
     public function recordRequest(string $ipAddress, string $bucket): void
     {
-        if ($ipAddress === '') {
-            return;
-        }
-
-        [$maxRequests, $windowSeconds] = $this->resolveLimits($bucket);
-        $bucketKey = $this->buildBucketKey($ipAddress, $bucket);
-        $row = $this->fetchBucketRow($bucketKey);
-        $now = $this->formatTimestamp($this->clock());
-
-        if ($row === null) {
-            $this->insertBucketRow($bucketKey, $now, 1);
-
-            return;
-        }
-
-        $windowStart = $this->parseTimestamp($row['window_start'] ?? null);
-        $requestCount = (int) ($row['request_count'] ?? 0);
-
-        if ($windowStart === null || $this->hasWindowExpired($windowStart, $windowSeconds)) {
-            $this->updateBucketRow($bucketKey, $now, 1);
-
-            return;
-        }
-
-        if ($requestCount >= $maxRequests) {
-            return;
-        }
-
-        $this->updateBucketRow($bucketKey, $this->formatTimestamp($windowStart), $requestCount + 1);
+        $this->checkAndRecord($ipAddress, $bucket);
     }
 
     public function checkAndRecord(string $ipAddress, string $bucket): bool
     {
-        if (!$this->isAllowed($ipAddress, $bucket)) {
-            return false;
+        if ($ipAddress === '') {
+            return true;
         }
 
-        $this->recordRequest($ipAddress, $bucket);
+        [$maxRequests, $windowSeconds] = $this->resolveLimits($bucket);
+        $bucketKey = $this->buildBucketKey($ipAddress, $bucket);
 
-        return true;
+        $startedTransaction = false;
+        if (!$this->database->inTransaction()) {
+            $this->database->beginTransaction();
+            $startedTransaction = true;
+        }
+
+        try {
+            $allowed = $this->consumeSlotIfAvailable($bucketKey, $maxRequests, $windowSeconds);
+
+            if ($startedTransaction) {
+                $this->database->commit();
+            }
+
+            return $allowed;
+        } catch (Throwable $exception) {
+            if ($startedTransaction && $this->database->inTransaction()) {
+                $this->database->rollBack();
+            }
+
+            throw $exception;
+        }
     }
 
     /**
@@ -112,6 +105,47 @@ final class IpRateLimitService
     private function buildBucketKey(string $ipAddress, string $bucket): string
     {
         return hash('sha256', $bucket . '|' . $ipAddress);
+    }
+
+    private function consumeSlotIfAvailable(string $bucketKey, int $maxRequests, int $windowSeconds): bool
+    {
+        $row = $this->fetchBucketRowForUpdate($bucketKey);
+        $now = $this->clock();
+
+        if ($row === null) {
+            try {
+                $this->insertBucketRow($bucketKey, $this->formatTimestamp($now), 1);
+
+                return true;
+            } catch (PDOException $exception) {
+                if (!$this->isDuplicateKeyException($exception)) {
+                    throw $exception;
+                }
+
+                $row = $this->fetchBucketRowForUpdate($bucketKey);
+            }
+        }
+
+        if ($row === null) {
+            return false;
+        }
+
+        $windowStart = $this->parseTimestamp($row['window_start'] ?? null);
+        $requestCount = (int) ($row['request_count'] ?? 0);
+
+        if ($windowStart === null || $this->hasWindowExpired($windowStart, $windowSeconds, $now)) {
+            $this->updateBucketRow($bucketKey, $this->formatTimestamp($now), 1);
+
+            return true;
+        }
+
+        if ($requestCount >= $maxRequests) {
+            return false;
+        }
+
+        $this->updateBucketRow($bucketKey, $this->formatTimestamp($windowStart), $requestCount + 1);
+
+        return true;
     }
 
     /**
@@ -139,6 +173,36 @@ final class IpRateLimitService
         return is_array($row) ? $row : null;
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function fetchBucketRowForUpdate(string $bucketKey): ?array
+    {
+        if ($this->isSqlite()) {
+            return $this->fetchBucketRow($bucketKey);
+        }
+
+        $statement = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                window_start,
+                request_count
+            FROM
+                ip_rate_limit
+            WHERE
+                bucket_key = :bucket_key
+            LIMIT 1
+            FOR UPDATE
+            SQL
+        );
+        $statement->bindValue(':bucket_key', $bucketKey, PDO::PARAM_STR);
+        $statement->execute();
+
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+
+        return is_array($row) ? $row : null;
+    }
+
     private function insertBucketRow(string $bucketKey, string $windowStart, int $requestCount): void
     {
         $statement = $this->database->prepare(
@@ -155,32 +219,14 @@ final class IpRateLimitService
 
     private function updateBucketRow(string $bucketKey, string $windowStart, int $requestCount): void
     {
-        if ($this->database->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
-            $statement = $this->database->prepare(
-                <<<'SQL'
-                UPDATE ip_rate_limit
-                SET
-                    window_start = :window_start,
-                    request_count = :request_count
-                WHERE
-                    bucket_key = :bucket_key
-                SQL
-            );
-            $statement->bindValue(':bucket_key', $bucketKey, PDO::PARAM_STR);
-            $statement->bindValue(':window_start', $windowStart, PDO::PARAM_STR);
-            $statement->bindValue(':request_count', $requestCount, PDO::PARAM_INT);
-            $statement->execute();
-
-            return;
-        }
-
         $statement = $this->database->prepare(
             <<<'SQL'
-            INSERT INTO ip_rate_limit (bucket_key, window_start, request_count)
-            VALUES (:bucket_key, :window_start, :request_count) AS new_values
-            ON DUPLICATE KEY UPDATE
-                window_start = new_values.window_start,
-                request_count = new_values.request_count
+            UPDATE ip_rate_limit
+            SET
+                window_start = :window_start,
+                request_count = :request_count
+            WHERE
+                bucket_key = :bucket_key
             SQL
         );
         $statement->bindValue(':bucket_key', $bucketKey, PDO::PARAM_STR);
@@ -189,9 +235,31 @@ final class IpRateLimitService
         $statement->execute();
     }
 
-    private function hasWindowExpired(DateTimeImmutable $windowStart, int $windowSeconds): bool
+    private function hasWindowExpired(
+        DateTimeImmutable $windowStart,
+        int $windowSeconds,
+        ?DateTimeImmutable $now = null,
+    ): bool {
+        $now ??= $this->clock();
+
+        return $now->getTimestamp() - $windowStart->getTimestamp() >= $windowSeconds;
+    }
+
+    private function isDuplicateKeyException(PDOException $exception): bool
     {
-        return $this->clock()->getTimestamp() - $windowStart->getTimestamp() >= $windowSeconds;
+        if ($exception->getCode() === '23000') {
+            return true;
+        }
+
+        $message = $exception->getMessage();
+
+        return str_contains($message, 'UNIQUE constraint failed')
+            || str_contains($message, 'Duplicate entry');
+    }
+
+    private function isSqlite(): bool
+    {
+        return $this->database->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite';
     }
 
     private function parseTimestamp(mixed $value): ?DateTimeImmutable

--- a/wwwroot/classes/IpRateLimitService.php
+++ b/wwwroot/classes/IpRateLimitService.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixed-window IP rate limiting backed by the ip_rate_limit table.
+ */
+final class IpRateLimitService
+{
+    public const string BUCKET_QUEUE_POLL = 'queue_poll';
+
+    public const string BUCKET_SCAN_LOG_POLL = 'scan_log_poll';
+
+    private const int QUEUE_POLL_MAX_REQUESTS = 60;
+
+    private const int QUEUE_POLL_WINDOW_SECONDS = 60;
+
+    private const int SCAN_LOG_POLL_MAX_REQUESTS = 30;
+
+    private const int SCAN_LOG_POLL_WINDOW_SECONDS = 60;
+
+    public function __construct(private readonly PDO $database)
+    {
+    }
+
+    public function isAllowed(string $ipAddress, string $bucket): bool
+    {
+        if ($ipAddress === '') {
+            return true;
+        }
+
+        [$maxRequests, $windowSeconds] = $this->resolveLimits($bucket);
+        $bucketKey = $this->buildBucketKey($ipAddress, $bucket);
+        $row = $this->fetchBucketRow($bucketKey);
+
+        if ($row === null) {
+            return true;
+        }
+
+        $windowStart = $this->parseTimestamp($row['window_start'] ?? null);
+        $requestCount = (int) ($row['request_count'] ?? 0);
+
+        if ($windowStart === null || $this->hasWindowExpired($windowStart, $windowSeconds)) {
+            return true;
+        }
+
+        return $requestCount < $maxRequests;
+    }
+
+    public function recordRequest(string $ipAddress, string $bucket): void
+    {
+        if ($ipAddress === '') {
+            return;
+        }
+
+        [$maxRequests, $windowSeconds] = $this->resolveLimits($bucket);
+        $bucketKey = $this->buildBucketKey($ipAddress, $bucket);
+        $row = $this->fetchBucketRow($bucketKey);
+        $now = $this->formatTimestamp($this->clock());
+
+        if ($row === null) {
+            $this->insertBucketRow($bucketKey, $now, 1);
+
+            return;
+        }
+
+        $windowStart = $this->parseTimestamp($row['window_start'] ?? null);
+        $requestCount = (int) ($row['request_count'] ?? 0);
+
+        if ($windowStart === null || $this->hasWindowExpired($windowStart, $windowSeconds)) {
+            $this->updateBucketRow($bucketKey, $now, 1);
+
+            return;
+        }
+
+        if ($requestCount >= $maxRequests) {
+            return;
+        }
+
+        $this->updateBucketRow($bucketKey, $this->formatTimestamp($windowStart), $requestCount + 1);
+    }
+
+    public function checkAndRecord(string $ipAddress, string $bucket): bool
+    {
+        if (!$this->isAllowed($ipAddress, $bucket)) {
+            return false;
+        }
+
+        $this->recordRequest($ipAddress, $bucket);
+
+        return true;
+    }
+
+    /**
+     * @return array{0: int, 1: int}
+     */
+    private function resolveLimits(string $bucket): array
+    {
+        return match ($bucket) {
+            self::BUCKET_SCAN_LOG_POLL => [
+                self::SCAN_LOG_POLL_MAX_REQUESTS,
+                self::SCAN_LOG_POLL_WINDOW_SECONDS,
+            ],
+            self::BUCKET_QUEUE_POLL => [
+                self::QUEUE_POLL_MAX_REQUESTS,
+                self::QUEUE_POLL_WINDOW_SECONDS,
+            ],
+            default => throw new InvalidArgumentException(sprintf('Unknown rate-limit bucket "%s".', $bucket)),
+        };
+    }
+
+    private function buildBucketKey(string $ipAddress, string $bucket): string
+    {
+        return hash('sha256', $bucket . '|' . $ipAddress);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function fetchBucketRow(string $bucketKey): ?array
+    {
+        $statement = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                window_start,
+                request_count
+            FROM
+                ip_rate_limit
+            WHERE
+                bucket_key = :bucket_key
+            LIMIT 1
+            SQL
+        );
+        $statement->bindValue(':bucket_key', $bucketKey, PDO::PARAM_STR);
+        $statement->execute();
+
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+
+        return is_array($row) ? $row : null;
+    }
+
+    private function insertBucketRow(string $bucketKey, string $windowStart, int $requestCount): void
+    {
+        $statement = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO ip_rate_limit (bucket_key, window_start, request_count)
+            VALUES (:bucket_key, :window_start, :request_count)
+            SQL
+        );
+        $statement->bindValue(':bucket_key', $bucketKey, PDO::PARAM_STR);
+        $statement->bindValue(':window_start', $windowStart, PDO::PARAM_STR);
+        $statement->bindValue(':request_count', $requestCount, PDO::PARAM_INT);
+        $statement->execute();
+    }
+
+    private function updateBucketRow(string $bucketKey, string $windowStart, int $requestCount): void
+    {
+        if ($this->database->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            $statement = $this->database->prepare(
+                <<<'SQL'
+                UPDATE ip_rate_limit
+                SET
+                    window_start = :window_start,
+                    request_count = :request_count
+                WHERE
+                    bucket_key = :bucket_key
+                SQL
+            );
+            $statement->bindValue(':bucket_key', $bucketKey, PDO::PARAM_STR);
+            $statement->bindValue(':window_start', $windowStart, PDO::PARAM_STR);
+            $statement->bindValue(':request_count', $requestCount, PDO::PARAM_INT);
+            $statement->execute();
+
+            return;
+        }
+
+        $statement = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO ip_rate_limit (bucket_key, window_start, request_count)
+            VALUES (:bucket_key, :window_start, :request_count) AS new_values
+            ON DUPLICATE KEY UPDATE
+                window_start = new_values.window_start,
+                request_count = new_values.request_count
+            SQL
+        );
+        $statement->bindValue(':bucket_key', $bucketKey, PDO::PARAM_STR);
+        $statement->bindValue(':window_start', $windowStart, PDO::PARAM_STR);
+        $statement->bindValue(':request_count', $requestCount, PDO::PARAM_INT);
+        $statement->execute();
+    }
+
+    private function hasWindowExpired(DateTimeImmutable $windowStart, int $windowSeconds): bool
+    {
+        return $this->clock()->getTimestamp() - $windowStart->getTimestamp() >= $windowSeconds;
+    }
+
+    private function parseTimestamp(mixed $value): ?DateTimeImmutable
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    private function formatTimestamp(DateTimeImmutable $timestamp): string
+    {
+        return $timestamp->format('Y-m-d H:i:s');
+    }
+
+    private function clock(): DateTimeImmutable
+    {
+        return new DateTimeImmutable('now');
+    }
+}

--- a/wwwroot/classes/PlayerQueueController.php
+++ b/wwwroot/classes/PlayerQueueController.php
@@ -7,18 +7,27 @@ require_once __DIR__ . '/PlayerQueueService.php';
 require_once __DIR__ . '/PlayerQueueRequest.php';
 require_once __DIR__ . '/PlayerQueueHandler.php';
 require_once __DIR__ . '/PlayerQueueResponseFactory.php';
+require_once __DIR__ . '/PlayerQueuePollTokenManager.php';
+require_once __DIR__ . '/IpRateLimitService.php';
 
 class PlayerQueueController
 {
-    public function __construct(private readonly PlayerQueueHandler $handler) {}
+    public function __construct(
+        private readonly PlayerQueueHandler $handler,
+        private readonly ?IpRateLimitService $rateLimitService = null,
+    ) {}
 
-    public static function create(Database $database): self
-    {
+    public static function create(
+        Database $database,
+        ?PlayerQueuePollTokenManager $pollTokenManager = null,
+        ?IpRateLimitService $rateLimitService = null,
+    ): self {
         $service = new PlayerQueueService($database);
         $responseFactory = new PlayerQueueResponseFactory($service);
-        $handler = new PlayerQueueHandler($service, $responseFactory);
+        $handler = new PlayerQueueHandler($service, $responseFactory, $pollTokenManager);
+        $rateLimiter = $rateLimitService ?? new IpRateLimitService($database);
 
-        return new self($handler);
+        return new self($handler, $rateLimiter);
     }
 
     public function handleAddToQueue(array $requestData, array $serverData): PlayerQueueResponse
@@ -31,6 +40,18 @@ class PlayerQueueController
     public function handleQueuePosition(array $requestData, array $serverData): PlayerQueueResponse
     {
         $request = PlayerQueueRequest::fromArrays($requestData, $serverData);
+
+        if (
+            $this->rateLimitService !== null
+            && !$this->rateLimitService->checkAndRecord(
+                $request->getIpAddress(),
+                IpRateLimitService::BUCKET_QUEUE_POLL
+            )
+        ) {
+            return PlayerQueueResponse::rateLimited(
+                'Too many queue status requests. Please wait a moment and try again.'
+            );
+        }
 
         return $this->handler->handleQueuePositionRequest($request);
     }

--- a/wwwroot/classes/PlayerQueueEndpoint.php
+++ b/wwwroot/classes/PlayerQueueEndpoint.php
@@ -36,13 +36,13 @@ class PlayerQueueEndpoint
     {
         $response = $this->controller->handleAddToQueue($requestData, $serverData);
 
-        $this->jsonResponder->respond($response);
+        $this->jsonResponder->respond($response->toArray(), $response->getHttpStatusCode());
     }
 
     public function handleQueuePosition(array $requestData, array $serverData): void
     {
         $response = $this->controller->handleQueuePosition($requestData, $serverData);
 
-        $this->jsonResponder->respond($response);
+        $this->jsonResponder->respond($response->toArray(), $response->getHttpStatusCode());
     }
 }

--- a/wwwroot/classes/PlayerQueueHandler.php
+++ b/wwwroot/classes/PlayerQueueHandler.php
@@ -5,16 +5,22 @@ declare(strict_types=1);
 require_once __DIR__ . '/PlayerQueueRequest.php';
 require_once __DIR__ . '/PlayerQueueResponse.php';
 require_once __DIR__ . '/PlayerQueueResponseFactory.php';
+require_once __DIR__ . '/PlayerQueuePollTokenManager.php';
+require_once __DIR__ . '/IpRateLimitService.php';
 
 class PlayerQueueHandler
 {
     private readonly PlayerQueueResponseFactory $responseFactory;
 
+    private readonly PlayerQueuePollTokenManager $pollTokenManager;
+
     public function __construct(
         private readonly PlayerQueueService $service,
         ?PlayerQueueResponseFactory $responseFactory = null,
+        ?PlayerQueuePollTokenManager $pollTokenManager = null,
     ) {
         $this->responseFactory = $responseFactory ?? new PlayerQueueResponseFactory($service);
+        $this->pollTokenManager = $pollTokenManager ?? new PlayerQueuePollTokenManager();
     }
 
     public function handleAddToQueueRequest(PlayerQueueRequest $request): PlayerQueueResponse
@@ -39,7 +45,13 @@ class PlayerQueueHandler
             return $this->responseFactory->createQueueLimitResponse();
         }
 
-        return $this->responseFactory->createQueuedForAdditionResponse($playerName);
+        $response = $this->responseFactory->createQueuedForAdditionResponse($playerName);
+
+        if ($response->shouldPoll()) {
+            return $response->withPollToken($this->pollTokenManager->issue($playerName));
+        }
+
+        return $response;
     }
 
     public function handleQueuePositionRequest(PlayerQueueRequest $request): PlayerQueueResponse
@@ -52,6 +64,12 @@ class PlayerQueueHandler
 
         if (!$this->service->isValidPlayerName($playerName)) {
             return $this->responseFactory->createInvalidNameResponse();
+        }
+
+        if (!$this->pollTokenManager->validate($playerName, $request->getPollToken())) {
+            return PlayerQueueResponse::error(
+                'Your session has expired. Please reload the page and try again.'
+            );
         }
 
         $playerData = $this->service->getPlayerStatusData($playerName);

--- a/wwwroot/classes/PlayerQueuePollTokenManager.php
+++ b/wwwroot/classes/PlayerQueuePollTokenManager.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/SessionManager.php';
+
+final class PlayerQueuePollTokenManager
+{
+    private const string SESSION_KEY = 'queue_poll_tokens';
+
+    private const int TOKEN_TTL_SECONDS = 3600;
+
+    public function issue(string $playerName): string
+    {
+        SessionManager::ensureStarted();
+
+        $token = bin2hex(random_bytes(32));
+        $tokens = $this->readTokens();
+        $this->purgeExpired($tokens);
+        $tokens[$playerName] = [
+            'token' => $token,
+            'expires' => $this->clock()->getTimestamp() + self::TOKEN_TTL_SECONDS,
+        ];
+        $_SESSION[self::SESSION_KEY] = $tokens;
+
+        return $token;
+    }
+
+    public function validate(string $playerName, string $submittedToken): bool
+    {
+        if ($playerName === '' || $submittedToken === '') {
+            return false;
+        }
+
+        SessionManager::ensureStarted();
+
+        $tokens = $this->readTokens();
+        $this->purgeExpired($tokens);
+        $_SESSION[self::SESSION_KEY] = $tokens;
+
+        $entry = $tokens[$playerName] ?? null;
+        if (!is_array($entry)) {
+            return false;
+        }
+
+        $storedToken = $entry['token'] ?? '';
+        if (!is_string($storedToken) || $storedToken === '') {
+            return false;
+        }
+
+        return hash_equals($storedToken, $submittedToken);
+    }
+
+    /**
+     * @return array<string, array{token: string, expires: int}>
+     */
+    private function readTokens(): array
+    {
+        $tokens = $_SESSION[self::SESSION_KEY] ?? [];
+
+        return is_array($tokens) ? $tokens : [];
+    }
+
+    /**
+     * @param array<string, array{token?: string, expires?: int}> $tokens
+     */
+    private function purgeExpired(array &$tokens): void
+    {
+        $now = $this->clock()->getTimestamp();
+
+        foreach ($tokens as $playerName => $entry) {
+            $expires = is_array($entry) ? (int) ($entry['expires'] ?? 0) : 0;
+
+            if ($expires <= $now) {
+                unset($tokens[$playerName]);
+            }
+        }
+    }
+
+    private function clock(): DateTimeImmutable
+    {
+        return new DateTimeImmutable('now');
+    }
+}

--- a/wwwroot/classes/PlayerQueueRequest.php
+++ b/wwwroot/classes/PlayerQueueRequest.php
@@ -9,14 +9,16 @@ readonly class PlayerQueueRequest
     private function __construct(
         private string $playerName,
         private string $ipAddress,
+        private string $pollToken,
     ) {}
 
     public static function fromArrays(array $requestData, array $serverData): self
     {
         $playerName = self::sanitizeValue($requestData['q'] ?? '');
         $ipAddress = IpAddressResolver::resolveFromServer($serverData);
+        $pollToken = self::sanitizeValue($requestData['poll_token'] ?? $requestData['pollToken'] ?? '');
 
-        return new self($playerName, $ipAddress);
+        return new self($playerName, $ipAddress, $pollToken);
     }
 
     public function getPlayerName(): string
@@ -27,6 +29,11 @@ readonly class PlayerQueueRequest
     public function getIpAddress(): string
     {
         return $this->ipAddress;
+    }
+
+    public function getPollToken(): string
+    {
+        return $this->pollToken;
     }
 
     public function isPlayerNameEmpty(): bool

--- a/wwwroot/classes/PlayerQueueResponse.php
+++ b/wwwroot/classes/PlayerQueueResponse.php
@@ -9,6 +9,8 @@ readonly class PlayerQueueResponse implements \JsonSerializable
     private function __construct(
         private PlayerQueueStatus $status,
         private string $message,
+        private ?string $pollToken = null,
+        private int $httpStatusCode = 200,
     ) {}
 
     public static function queued(string $message): self
@@ -26,6 +28,21 @@ readonly class PlayerQueueResponse implements \JsonSerializable
         return new self(PlayerQueueStatus::ERROR, $message);
     }
 
+    public static function rateLimited(string $message): self
+    {
+        return new self(PlayerQueueStatus::ERROR, $message, null, 429);
+    }
+
+    public function withPollToken(string $pollToken): self
+    {
+        return new self(
+            $this->status,
+            $this->message,
+            $pollToken,
+            $this->httpStatusCode,
+        );
+    }
+
     public function getStatusEnum(): PlayerQueueStatus
     {
         return $this->status;
@@ -41,6 +58,16 @@ readonly class PlayerQueueResponse implements \JsonSerializable
         return $this->message;
     }
 
+    public function getPollToken(): ?string
+    {
+        return $this->pollToken;
+    }
+
+    public function getHttpStatusCode(): int
+    {
+        return $this->httpStatusCode;
+    }
+
     public function shouldPoll(): bool
     {
         return $this->status === PlayerQueueStatus::QUEUED;
@@ -51,11 +78,17 @@ readonly class PlayerQueueResponse implements \JsonSerializable
      */
     public function toArray(): array
     {
-        return [
+        $payload = [
             'status' => $this->getStatus(),
             'message' => $this->getMessage(),
             'shouldPoll' => $this->shouldPoll(),
         ];
+
+        if ($this->pollToken !== null) {
+            $payload['pollToken'] = $this->pollToken;
+        }
+
+        return $payload;
     }
 
     #[\Override]

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -241,6 +241,7 @@ class PlayerQueueManager {
         this.messageElement = document.getElementById(messageElementId);
         this.pollInterval = pollInterval;
         this.timerId = null;
+        this.pollToken = null;
     }
 
     initialize() {
@@ -271,6 +272,10 @@ class PlayerQueueManager {
         this.sendPostRequest('add_to_queue.php', body, (response) => {
             this.updateQueueResult(response.message);
 
+            if (typeof response.pollToken === 'string' && response.pollToken !== '') {
+                this.pollToken = response.pollToken;
+            }
+
             if (response.shouldPoll) {
                 this.startPolling(player);
             } else {
@@ -285,9 +290,14 @@ class PlayerQueueManager {
     }
 
     checkQueuePosition(player) {
-        const url = `check_queue_position.php?q=${encodeURIComponent(player)}`;
+        const url = new URL('check_queue_position.php', window.location.href);
+        url.searchParams.set('q', player);
 
-        this.sendRequest(url, (response) => {
+        if (typeof this.pollToken === 'string' && this.pollToken !== '') {
+            url.searchParams.set('poll_token', this.pollToken);
+        }
+
+        this.sendRequest(url.toString(), (response) => {
             this.updateQueueResult(response.message);
 
             if (!response.shouldPoll) {
@@ -301,6 +311,8 @@ class PlayerQueueManager {
             window.clearInterval(this.timerId);
             this.timerId = null;
         }
+
+        this.pollToken = null;
     }
 
     sendPostRequest(url, body, onSuccess) {
@@ -371,8 +383,9 @@ class PlayerQueueManager {
             const message = typeof data.message === 'string' ? data.message : '';
             const shouldPoll = typeof data.shouldPoll === 'boolean' ? data.shouldPoll : false;
             const status = typeof data.status === 'string' ? data.status : 'error';
+            const pollToken = typeof data.pollToken === 'string' ? data.pollToken : '';
 
-            return { message, shouldPoll, status };
+            return { message, shouldPoll, status, pollToken };
         } catch (error) {
             return null;
         }

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -279,7 +279,7 @@ class PlayerQueueManager {
             if (response.shouldPoll) {
                 this.startPolling(player);
             } else {
-                this.stopPolling();
+                this.stopPolling(true);
             }
         });
     }
@@ -301,18 +301,20 @@ class PlayerQueueManager {
             this.updateQueueResult(response.message);
 
             if (!response.shouldPoll) {
-                this.stopPolling();
+                this.stopPolling(true);
             }
         });
     }
 
-    stopPolling() {
+    stopPolling(clearPollToken = false) {
         if (this.timerId !== null) {
             window.clearInterval(this.timerId);
             this.timerId = null;
         }
 
-        this.pollToken = null;
+        if (clearPollToken) {
+            this.pollToken = null;
+        }
     }
 
     sendPostRequest(url, body, onSuccess) {
@@ -407,7 +409,7 @@ class PlayerQueueManager {
 
     handleError() {
         this.updateQueueResult('An error occurred while contacting the server. Please try again later.');
-        this.stopPolling();
+        this.stopPolling(true);
     }
 }
 

--- a/wwwroot/scan_log_poll.php
+++ b/wwwroot/scan_log_poll.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 require_once __DIR__ . '/init.php';
 require_once __DIR__ . '/classes/AboutPageService.php';
 require_once __DIR__ . '/classes/JsonResponseEmitter.php';
+require_once __DIR__ . '/classes/IpRateLimitService.php';
 require_once __DIR__ . '/classes/AboutPageScanLogController.php';
 
 $aboutPageService = new AboutPageService($database, $utility);
 $jsonResponder = new JsonResponseEmitter();
-$controller = AboutPageScanLogController::create($aboutPageService, $jsonResponder);
+$rateLimitService = new IpRateLimitService($database);
+$controller = AboutPageScanLogController::create($aboutPageService, $jsonResponder, $rateLimitService);
 
-$controller->handle($_GET ?? []);
+$controller->handle($_GET ?? [], $_SERVER ?? []);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Phase 2 abuse resistance: authenticated queue polling, IP rate limits on public JSON endpoints, and admin login lockout after repeated failures.

## Changes

### Queue polling (`check_queue_position.php`)
- Issues a session-backed `pollToken` from `add_to_queue.php` when a player is queued
- Homepage queue manager stores and sends `poll_token` on poll requests
- Blocks unauthenticated PSN-name enumeration without a prior CSRF-protected queue submission
- `stopPolling(true)` only clears the poll token when polling ends/errors (not when restarting the interval)
- Rate limit runs before any PHP session is started on poll requests

### IP rate limits
- New `IpRateLimitService` with `ip_rate_limit` table
- Atomic check-and-increment via transaction + `SELECT ... FOR UPDATE` (MySQL) / transaction (SQLite)
- `check_queue_position.php`: 60 requests / IP / minute (HTTP 429)
- `scan_log_poll.php`: 30 requests / IP / minute (HTTP 429)

### Admin login lockout
- New `AdminLoginThrottleService` with `admin_login_throttle` table
- Atomic failure counting via single-statement upsert (`ON DUPLICATE KEY UPDATE` / `ON CONFLICT`)
- Locks an IP for 15 minutes after 5 failed attempts
- Expired lockout rows are cleared before counting new failures

### Schema
- Adds `ip_rate_limit` and `admin_login_throttle` to `database/psn100.sql`
- **Existing production DBs must create these tables before deploy**

## Review feedback addressed

| Issue | Fix |
|-------|-----|
| P1: `stopPolling()` cleared poll token when restarting polling | `stopPolling(clearPollToken = false)` (`21c9be91`) |
| P2: Rate-limit race under concurrent requests | `checkAndRecord()` with `FOR UPDATE` + duplicate-key retry (`b1dd06a7`) |
| P2: Login-throttle race under concurrent failures | Atomic upsert increments `failure_count` in SQL (`b1dd06a7`) |
| P2: MySQL lockout triggered one attempt early | `@new_failure_count` user variable (`ff07b7d9`) |
| P2: Session churn on rate-limited queue polls | Removed eager session start from `check_queue_position.php` (`289f01bf`) |
| P2: Stale failure count after lockout expires | Delete expired rows before incrementing (`289f01bf`) |

## Test plan

- [x] `php tests/run.php` — 772 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

