### PR TITLE
Phase 3: submission hardening, admin sessions, URL encoding, queue DOM safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,13 @@ the non-obvious steps to actually run the services.
 - Run the full suite with `php tests/run.php` (custom runner, no PHPUnit). It does not
   need MySQL — DB-backed tests use in-memory SQLite, so `php8.5-sqlite3` must be
   installed (it is, in the image).
+- Optional MySQL integration tests are skipped unless `PSN100_INTEGRATION_TEST_DB=1` and
+  `DB_HOST` / `DB_NAME` / `DB_USER` / `DB_PASSWORD` point at a reachable database.
+
+### Security headers
+
+- `init.php` sends `Content-Security-Policy-Report-Only` alongside existing security
+  headers. Enforcement is deferred until inline scripts/CDN usage are migrated.
 
 ### Composer
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ CSRF-protected `add_to_queue.php` response and stored in the visitor session. Po
 requests are limited to 60 per IP per minute; `scan_log_poll.php` is limited to 30 per
 IP per minute. Admin login locks an IP for 15 minutes after five failed attempts.
 
+### Security hardening (Phase 3)
+
+- Queue and report submissions return a friendly busy message (HTTP 503) when the MySQL
+  per-IP advisory lock cannot be acquired, instead of an uncaught 500.
+- Homepage queue polling renders structured `messageParts` with DOM APIs instead of
+  `innerHTML` for server responses.
+- Admin logout requires POST + CSRF and calls `session_destroy()`.
+- Worker refresh tokens can be edited from the admin Workers page (alongside NPSSO).
+- Player and game URLs use `rawurlencode()` consistently via `PlayerUrlBuilder`.
+- `Html::escape()` is the shared HTML-escaping helper for new code.
+- `Content-Security-Policy-Report-Only` is sent from `init.php` to collect violations
+  before enforcing a stricter policy.
+
+Optional MySQL integration tests (including IP lock acquisition) run when
+`PSN100_INTEGRATION_TEST_DB=1` and a reachable `DB_*` configuration are available.
+
 ## Merge Guideline Priorities
 1. Available > Delisted
 2. English language > Other language

--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -97,6 +97,7 @@ final class AdminAuthServiceTest extends TestCase
 
         $this->assertFalse($service->isAuthenticated());
         $this->assertSame(null, $service->getAuthenticatedUsername());
+        $this->assertSame(PHP_SESSION_NONE, session_status());
     }
 
     public function testLoginIsBlockedWhenIpAddressIsLocked(): void

--- a/tests/AdminWorkerPageTest.php
+++ b/tests/AdminWorkerPageTest.php
@@ -82,6 +82,21 @@ final class AdminWorkerPageTest extends TestCase
         $this->assertSame(null, $result->getErrorMessage());
     }
 
+    public function testHandleProcessesUpdateRefreshTokenRequests(): void
+    {
+        $this->database->exec("INSERT INTO setting (id, refresh_token, npsso, scanning, scan_start, scan_progress) VALUES (7, 'old-token', 'np', 'Worker', '2024-01-01 00:00:00', null)");
+
+        $service = new WorkerService($this->database, new FakeCommandExecutor(new CommandExecutionResult(0, '')));
+        $page = new WorkerPage($service);
+
+        $request = new AdminRequest('POST', ['action' => 'update_refresh_token', 'worker_id' => '7', 'refresh_token' => 'new-refresh-token-value']);
+        $result = $page->handle([], $request);
+
+        $this->assertSame('Worker refresh token updated successfully.', $result->getSuccessMessage());
+        $this->assertSame(null, $result->getErrorMessage());
+        $this->assertSame('new-refresh-token-value', $result->getWorkers()[0]->getRefreshToken());
+    }
+
     public function testHandleProcessesRestartAllWorkersFailure(): void
     {
         $this->database->exec("INSERT INTO setting (id, refresh_token, npsso, scanning, scan_start, scan_progress) VALUES (1, '', 'np', 'Worker', '2024-01-01 00:00:00', null)");

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Html.php';
+
+final class HtmlTest extends TestCase
+{
+    public function testEscapeUsesHtmlspecialcharsWithUtf8(): void
+    {
+        $this->assertSame('&lt;script&gt;', Html::escape('<script>'));
+    }
+}

--- a/tests/IpSubmissionLockExecutorIntegrationTest.php
+++ b/tests/IpSubmissionLockExecutorIntegrationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/IpSubmissionLockExecutor.php';
+
+final class IpSubmissionLockExecutorIntegrationTest extends TestCase
+{
+    private const string INTEGRATION_TEST_DB_ENV = 'PSN100_INTEGRATION_TEST_DB';
+
+    private ?PDO $database = null;
+
+    protected function tearDown(): void
+    {
+        $this->database = null;
+    }
+
+    public function testExecuteAcquiresAndReleasesMysqlLock(): void
+    {
+        $database = $this->createMysqlDatabase();
+        if ($database === null) {
+            return;
+        }
+
+        $executor = new IpSubmissionLockExecutor($database);
+        $result = $executor->execute('192.0.2.77', static fn (): string => 'locked');
+
+        $this->assertSame('locked', $result);
+    }
+
+    private function createMysqlDatabase(): ?PDO
+    {
+        if ($this->database instanceof PDO) {
+            return $this->database;
+        }
+
+        if (getenv(self::INTEGRATION_TEST_DB_ENV) !== '1') {
+            return null;
+        }
+
+        $host = getenv('DB_HOST') ?: '127.0.0.1';
+        $databaseName = getenv('DB_NAME') ?: 'psn100';
+        $user = getenv('DB_USER') ?: 'psn100';
+        $password = getenv('DB_PASSWORD') ?: 'psn100';
+
+        try {
+            $this->database = new PDO(
+                sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4', $host, $databaseName),
+                $user,
+                $password,
+                [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+            );
+        } catch (Throwable) {
+            return null;
+        }
+
+        return $this->database;
+    }
+}

--- a/tests/PlayerQueueHandlerTest.php
+++ b/tests/PlayerQueueHandlerTest.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponse.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueService.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueuePollTokenManager.php';
 require_once __DIR__ . '/../wwwroot/classes/SessionManager.php';
+require_once __DIR__ . '/../wwwroot/classes/IpSubmissionLockUnavailableException.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerScanProgress.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerScanStatus.php';
 
@@ -32,6 +33,8 @@ final class ConfigurablePlayerQueueServiceStub extends PlayerQueueService
     private bool $playerBeingScanned = false;
 
     private ?PlayerScanProgress $scanProgress = null;
+
+    private bool $throwLockUnavailable = false;
 
     public function __construct()
     {
@@ -68,8 +71,17 @@ final class ConfigurablePlayerQueueServiceStub extends PlayerQueueService
         return $this->isValidPlayerName;
     }
 
+    public function setThrowLockUnavailable(bool $throwLockUnavailable): void
+    {
+        $this->throwLockUnavailable = $throwLockUnavailable;
+    }
+
     public function addPlayerToQueue(string $playerName, string $ipAddress): bool
     {
+        if ($this->throwLockUnavailable) {
+            throw new IpSubmissionLockUnavailableException('Unable to acquire IP submission lock.');
+        }
+
         if ($this->hasReachedIpLimit && !$this->isPlayerInQueue($playerName)) {
             return false;
         }
@@ -368,6 +380,20 @@ final class PlayerQueueHandlerTest extends TestCase
         $this->assertStringContainsString('tagged as a cheater', $response->getMessage());
     }
 
+    public function testHandleAddToQueueRequestReturnsBusyResponseWhenLockUnavailable(): void
+    {
+        $service = new ConfigurablePlayerQueueServiceStub();
+        $service->setThrowLockUnavailable(true);
+        $handler = new PlayerQueueHandler($service);
+        $request = PlayerQueueRequest::fromArrays(['q' => 'QueueUser'], ['REMOTE_ADDR' => '192.0.2.40']);
+
+        $response = $handler->handleAddToQueueRequest($request);
+
+        $this->assertSame('error', $response->getStatus());
+        $this->assertSame(503, $response->getHttpStatusCode());
+        $this->assertStringContainsString('busy', strtolower($response->getMessage()));
+    }
+
     public function testHandleQueuePositionRequestReturnsQueuedForScanWhenPlayerBeingScanned(): void
     {
         $service = new ConfigurablePlayerQueueServiceStub();
@@ -388,8 +414,13 @@ final class PlayerQueueHandlerTest extends TestCase
         $this->assertSame('queued', $response->getStatus());
         $this->assertTrue($response->shouldPoll());
         $this->assertStringContainsString('is currently being scanned.', $response->getMessage());
-        $this->assertStringContainsString('Working on <strong>Game &lt;Title&gt;</strong> (3/10).', $response->getMessage());
-        $this->assertStringContainsString('class="progress mt-2"', $response->getMessage());
+        $this->assertStringContainsString('Working on Game <Title> (3/10)', $response->getMessage());
+
+        $parts = $response->getMessageParts();
+        $this->assertTrue(is_array($parts));
+        $progressParts = array_values(array_filter($parts, static fn (array $part): bool => ($part['type'] ?? '') === 'progress'));
+        $this->assertSame(1, count($progressParts));
+        $this->assertSame(30, $progressParts[0]['percentage'] ?? null);
     }
 
     public function testHandleQueuePositionRequestReturnsQueuePositionWhenAvailable(): void

--- a/tests/PlayerQueueResponseFactoryTest.php
+++ b/tests/PlayerQueueResponseFactoryTest.php
@@ -7,86 +7,45 @@ require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponse.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueService.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerScanProgress.php';
 
-/**
- * @extends PlayerQueueService
- */
-final class RecordingPlayerQueueServiceStub extends PlayerQueueService
-{
-    /** @var list<string> */
-    private array $escapedValues = [];
-
-    public function __construct()
-    {
-        // Parent constructor requires a PDO instance which is not needed for tests.
-    }
-
-    public function escapeHtml(string $value): string
-    {
-        $this->escapedValues[] = $value;
-
-        return htmlentities($value, ENT_QUOTES, 'UTF-8');
-    }
-
-    /**
-     * @return list<string>
-     */
-    public function getEscapedValues(): array
-    {
-        return $this->escapedValues;
-    }
-}
-
 final class PlayerQueueResponseFactoryTest extends TestCase
 {
-    public function testCreateCheaterResponseEscapesValuesAndIncludesDisputeLink(): void
+    public function testCreateCheaterResponseIncludesStructuredMessageParts(): void
     {
-        $service = new RecordingPlayerQueueServiceStub();
-        $factory = new PlayerQueueResponseFactory($service);
+        $factory = new PlayerQueueResponseFactory(new PlayerQueueService());
 
         $response = $factory->createCheaterResponse('Bad User', 'Account/123');
 
         $this->assertSame('error', $response->getStatus());
+        $this->assertStringContainsString("Player 'Bad User' is tagged as a cheater", $response->getMessage());
 
-        $message = $response->getMessage();
-        $this->assertStringContainsString("Player '<a class=\"link-underline link-underline-opacity-0 link-underline-opacity-100-hover\" href=\"/player/Bad%20User\">Bad User</a>' is tagged as a cheater and won't be scanned.", $message);
-        $this->assertStringContainsString('Dispute</a>?', $message);
-        $this->assertStringContainsString('https://github.com/Ragowit/psn100/issues?q=label%3Acheater%20Bad%20User%20OR%20Account%2F123', $message);
-
-        $this->assertSame(
-            [
-                'Bad User',
-                '/player/Bad%20User',
-                'https://github.com/Ragowit/psn100/issues?q=label%3Acheater%20Bad%20User%20OR%20Account%2F123',
-            ],
-            $service->getEscapedValues()
-        );
+        $parts = $response->getMessageParts();
+        $this->assertTrue(is_array($parts));
+        $this->assertSame('link', $parts[1]['type'] ?? null);
+        $this->assertSame('/player/Bad%20User', $parts[1]['href'] ?? null);
+        $this->assertSame('Bad User', $parts[1]['label'] ?? null);
+        $this->assertSame('Dispute', $parts[3]['label'] ?? null);
     }
 
-    public function testCreateQueuePositionResponseMarksQueuedAndEscapesValues(): void
+    public function testCreateQueuePositionResponseMarksQueuedWithStructuredParts(): void
     {
-        $service = new RecordingPlayerQueueServiceStub();
-        $factory = new PlayerQueueResponseFactory($service);
+        $factory = new PlayerQueueResponseFactory(new PlayerQueueService());
 
         $response = $factory->createQueuePositionResponse('Queue <User>', '<script>');
 
         $this->assertSame('queued', $response->getStatus());
         $this->assertTrue($response->shouldPoll());
+        $this->assertStringContainsString('currently in position <script>', $response->getMessage());
 
-        $message = $response->getMessage();
-        $this->assertStringContainsString('href="/player/Queue%20%3CUser%3E"', $message);
-        $this->assertStringContainsString('">Queue &lt;User&gt;</a> is in the update queue, currently in position &lt;script&gt;.', $message);
-        $this->assertStringContainsString('<div class="spinner-border" role="status">', $message);
-
-        $this->assertSame(
-            ['<script>', 'Queue <User>', '/player/Queue%20%3CUser%3E'],
-            $service->getEscapedValues()
-        );
+        $parts = $response->getMessageParts();
+        $this->assertSame('link', $parts[0]['type'] ?? null);
+        $this->assertSame('/player/Queue%20%3CUser%3E', $parts[0]['href'] ?? null);
+        $this->assertSame('Queue <User>', $parts[0]['label'] ?? null);
+        $this->assertSame('spinner', $parts[2]['type'] ?? null);
     }
 
     public function testCreateQueueLimitResponseReturnsErrorWithConfiguredLimitMessage(): void
     {
-        $service = new RecordingPlayerQueueServiceStub();
-        $factory = new PlayerQueueResponseFactory($service);
+        $factory = new PlayerQueueResponseFactory(new PlayerQueueService());
 
         $response = $factory->createQueueLimitResponse();
 
@@ -96,73 +55,51 @@ final class PlayerQueueResponseFactoryTest extends TestCase
             . ' players into the queue. Please wait a while.',
             $response->getMessage()
         );
-        $this->assertSame([], $service->getEscapedValues());
+        $this->assertSame(null, $response->getMessageParts());
     }
 
-    public function testCreateQueuedForAdditionResponseEscapesPlayerAndAddsSpinner(): void
+    public function testCreateQueuedForAdditionResponseIncludesSpinnerPart(): void
     {
-        $service = new RecordingPlayerQueueServiceStub();
-        $factory = new PlayerQueueResponseFactory($service);
+        $factory = new PlayerQueueResponseFactory(new PlayerQueueService());
 
         $response = $factory->createQueuedForAdditionResponse('Queue User');
 
         $this->assertSame('queued', $response->getStatus());
         $this->assertTrue($response->shouldPoll());
 
-        $message = $response->getMessage();
-        $this->assertStringContainsString('href="/player/Queue%20User"', $message);
-        $this->assertStringContainsString('">Queue User</a> is being added to the queue.', $message);
-        $this->assertStringContainsString('<div class="spinner-border" role="status">', $message);
-
-        $this->assertSame(
-            ['Queue User', '/player/Queue%20User'],
-            $service->getEscapedValues()
-        );
+        $parts = $response->getMessageParts();
+        $this->assertSame('Queue User', $parts[0]['label'] ?? null);
+        $this->assertSame('spinner', $parts[2]['type'] ?? null);
     }
 
-    public function testCreatePlayerNotFoundResponseReturnsErrorWithEscapedLink(): void
+    public function testCreatePlayerNotFoundResponseReturnsStructuredLinkParts(): void
     {
-        $service = new RecordingPlayerQueueServiceStub();
-        $factory = new PlayerQueueResponseFactory($service);
+        $factory = new PlayerQueueResponseFactory(new PlayerQueueService());
 
         $response = $factory->createPlayerNotFoundResponse('<Invalid>');
 
         $this->assertSame('error', $response->getStatus());
-
-        $message = $response->getMessage();
-        $this->assertStringContainsString('href="/player/%3CInvalid%3E"', $message);
-        $this->assertStringContainsString('">&lt;Invalid&gt;</a> was not found. Please check the spelling and try again.', $message);
-
-        $this->assertSame(
-            ['<Invalid>', '/player/%3CInvalid%3E'],
-            $service->getEscapedValues()
-        );
+        $parts = $response->getMessageParts();
+        $this->assertSame('/player/%3CInvalid%3E', $parts[0]['href'] ?? null);
+        $this->assertSame('<Invalid>', $parts[0]['label'] ?? null);
     }
 
-    public function testCreateQueueCompleteResponseReturnsCompleteStatusWithEscapedLink(): void
+    public function testCreateQueueCompleteResponseReturnsCompleteStatusWithLinkPart(): void
     {
-        $service = new RecordingPlayerQueueServiceStub();
-        $factory = new PlayerQueueResponseFactory($service);
+        $factory = new PlayerQueueResponseFactory(new PlayerQueueService());
 
         $response = $factory->createQueueCompleteResponse('Player One');
 
         $this->assertSame('complete', $response->getStatus());
         $this->assertFalse($response->shouldPoll());
-
-        $message = $response->getMessage();
-        $this->assertStringContainsString('href="/player/Player%20One"', $message);
-        $this->assertStringContainsString('">Player One</a> has been updated!', $message);
-
-        $this->assertSame(
-            ['Player One', '/player/Player%20One'],
-            $service->getEscapedValues()
-        );
+        $parts = $response->getMessageParts();
+        $this->assertSame('/player/Player%20One', $parts[0]['href'] ?? null);
+        $this->assertSame('Player One', $parts[0]['label'] ?? null);
     }
 
-    public function testCreateQueuedForScanResponseIncludesProgressDetails(): void
+    public function testCreateQueuedForScanResponseIncludesProgressPart(): void
     {
-        $service = new RecordingPlayerQueueServiceStub();
-        $factory = new PlayerQueueResponseFactory($service);
+        $factory = new PlayerQueueResponseFactory(new PlayerQueueService());
 
         $progress = PlayerScanProgress::fromArray([
             'current' => 5,
@@ -175,23 +112,18 @@ final class PlayerQueueResponseFactoryTest extends TestCase
 
         $this->assertSame('queued', $response->getStatus());
         $this->assertTrue($response->shouldPoll());
+        $this->assertStringContainsString('Working on Game <Title> (5/34)', $response->getMessage());
 
-        $message = $response->getMessage();
-        $this->assertStringContainsString('href="/player/Player%20%3CName%3E"', $message);
-        $this->assertStringContainsString('Working on <strong>Game &lt;Title&gt;</strong> (5/34).', $message);
-        $this->assertStringContainsString('class="progress mt-2"', $message);
-        $this->assertStringContainsString('spinner-border', $message);
-
-        $this->assertSame(
-            ['Player <Name>', '/player/Player%20%3CName%3E', 'Game <Title>'],
-            $service->getEscapedValues()
-        );
+        $parts = $response->getMessageParts();
+        $emphasisParts = array_values(array_filter($parts ?? [], static fn (array $part): bool => ($part['type'] ?? '') === 'emphasis'));
+        $progressParts = array_values(array_filter($parts ?? [], static fn (array $part): bool => ($part['type'] ?? '') === 'progress'));
+        $this->assertSame('Game <Title>', $emphasisParts[0]['value'] ?? null);
+        $this->assertSame(15, $progressParts[0]['percentage'] ?? null);
     }
 
     public function testCreateQueuedForScanResponseOmitsScanningPrefixForErrors(): void
     {
-        $service = new RecordingPlayerQueueServiceStub();
-        $factory = new PlayerQueueResponseFactory($service);
+        $factory = new PlayerQueueResponseFactory(new PlayerQueueService());
 
         $progress = PlayerScanProgress::fromArray([
             'current' => null,
@@ -203,23 +135,13 @@ final class PlayerQueueResponseFactoryTest extends TestCase
         $response = $factory->createQueuedForScanResponse('dragonrider', $progress);
 
         $this->assertSame('queued', $response->getStatus());
-        $this->assertTrue($response->shouldPoll());
-
-        $message = $response->getMessage();
-        $this->assertStringContainsString('dragonrider</a> is currently being scanned.', $message);
-        $this->assertFalse(str_contains($message, 'Currently scanning Profile scan failed'), 'Should not prefix error messages with "Currently scanning".');
-        $this->assertStringContainsString('Profile scan failed, waiting 1 minute before confirming privacy.', $message);
-
-        $this->assertSame(
-            ['dragonrider', '/player/dragonrider', 'Profile scan failed, waiting 1 minute before confirming privacy'],
-            $service->getEscapedValues()
-        );
+        $this->assertStringContainsString('dragonrider is currently being scanned.', $response->getMessage());
+        $this->assertStringContainsString('Profile scan failed, waiting 1 minute before confirming privacy.', $response->getMessage());
     }
 
     public function testCreateQueuedForScanResponseUsesActionVerbsForProgressTitle(): void
     {
-        $service = new RecordingPlayerQueueServiceStub();
-        $factory = new PlayerQueueResponseFactory($service);
+        $factory = new PlayerQueueResponseFactory(new PlayerQueueService());
 
         $progress = PlayerScanProgress::fromArray([
             'current' => null,
@@ -231,15 +153,16 @@ final class PlayerQueueResponseFactoryTest extends TestCase
         $response = $factory->createQueuedForScanResponse('Ragowit', $progress);
 
         $this->assertSame('queued', $response->getStatus());
-        $this->assertTrue($response->shouldPoll());
+        $this->assertStringContainsString('Updating avatar.', $response->getMessage());
+    }
 
-        $message = $response->getMessage();
-        $this->assertStringContainsString('is currently being scanned.', $message);
-        $this->assertStringContainsString('Updating avatar.', $message);
+    public function testCreateBusyResponseUsesHttpStatus503(): void
+    {
+        $factory = new PlayerQueueResponseFactory(new PlayerQueueService());
 
-        $this->assertSame(
-            ['Ragowit', '/player/Ragowit', 'updating avatar'],
-            $service->getEscapedValues()
-        );
+        $response = $factory->createBusyResponse();
+
+        $this->assertSame('error', $response->getStatus());
+        $this->assertSame(503, $response->getHttpStatusCode());
     }
 }

--- a/tests/PlayerQueueResponseTest.php
+++ b/tests/PlayerQueueResponseTest.php
@@ -69,6 +69,35 @@ final class PlayerQueueResponseTest extends TestCase
         $this->assertSame($response->toArray(), $response->jsonSerialize());
     }
 
+    public function testBusyResponseUsesHttpStatus503(): void
+    {
+        $response = PlayerQueueResponse::busy('Server busy.');
+
+        $this->assertSame('error', $response->getStatus());
+        $this->assertSame(503, $response->getHttpStatusCode());
+        $this->assertFalse($response->shouldPoll());
+    }
+
+    public function testQueuedResponseIncludesMessagePartsInPayload(): void
+    {
+        $parts = [
+            ['type' => 'text', 'value' => 'Hello'],
+            ['type' => 'spinner'],
+        ];
+        $response = PlayerQueueResponse::queued('Hello', $parts);
+
+        $this->assertSame($parts, $response->getMessageParts());
+        $this->assertSame(
+            [
+                'status' => 'queued',
+                'message' => 'Hello',
+                'shouldPoll' => true,
+                'messageParts' => $parts,
+            ],
+            $response->toArray()
+        );
+    }
+
     public function testErrorResponseIncludesShouldPollFalse(): void
     {
         $response = PlayerQueueResponse::error('An error occurred');

--- a/tests/PlayerReportServiceTest.php
+++ b/tests/PlayerReportServiceTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerReportService.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerReportResult.php';
+require_once __DIR__ . '/../wwwroot/classes/IpSubmissionLockExecutor.php';
+require_once __DIR__ . '/../wwwroot/classes/IpSubmissionLockUnavailableException.php';
 
 final class PlayerReportServiceTest extends TestCase
 {
@@ -131,6 +133,16 @@ final class PlayerReportServiceTest extends TestCase
         }
     }
 
+    public function testSubmitReportReturnsBusyMessageWhenLockIsUnavailable(): void
+    {
+        $service = new PlayerReportService($this->pdo, new UnavailableIpSubmissionLockExecutor());
+        $result = $service->submitReport(123, '198.51.100.10', 'Cheating behavior');
+
+        $this->assertFalse($result->isSuccess());
+        $this->assertStringContainsString('busy', strtolower($result->getMessage()));
+        $this->assertSame(0, (int) $this->pdo->query('SELECT COUNT(*) FROM player_report')->fetchColumn());
+    }
+
     public function testSubmitReportPerformsDuplicateCheckInsideIpLock(): void
     {
         $source = file_get_contents(__DIR__ . '/../wwwroot/classes/PlayerReportService.php');
@@ -146,5 +158,18 @@ final class PlayerReportServiceTest extends TestCase
         $this->assertTrue($lockPos !== false);
         $this->assertTrue($duplicatePos !== false);
         $this->assertTrue($duplicatePos > $lockPos);
+    }
+}
+
+final class UnavailableIpSubmissionLockExecutor extends IpSubmissionLockExecutor
+{
+    public function __construct()
+    {
+        parent::__construct(new PDO('sqlite::memory:'));
+    }
+
+    public function execute(string $ipAddress, callable $callback): mixed
+    {
+        throw new IpSubmissionLockUnavailableException('Unable to acquire IP submission lock.');
     }
 }

--- a/tests/PlayerUrlBuilderTest.php
+++ b/tests/PlayerUrlBuilderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerUrlBuilder.php';
+
+final class PlayerUrlBuilderTest extends TestCase
+{
+    public function testPlayerPathEncodesOnlineId(): void
+    {
+        $this->assertSame('/player/Queue%20%3CUser%3E', PlayerUrlBuilder::playerPath('Queue <User>'));
+    }
+
+    public function testPlayerReportPathAppendsReportSegment(): void
+    {
+        $this->assertSame('/player/Bad%20User/report', PlayerUrlBuilder::playerReportPath('Bad User'));
+    }
+
+    public function testGamePathOmitsPlayerWhenNotProvided(): void
+    {
+        $this->assertSame('/game/42-example-game', PlayerUrlBuilder::gamePath('42-example-game'));
+    }
+
+    public function testGamePathEncodesPlayerSegment(): void
+    {
+        $this->assertSame(
+            '/game/42-example-game/Player%20One',
+            PlayerUrlBuilder::gamePath('42-example-game', 'Player One')
+        );
+    }
+}

--- a/wwwroot/admin/index.php
+++ b/wwwroot/admin/index.php
@@ -20,7 +20,10 @@ $navigationItems = $navigation->getItems();
     <body>
         <div class="p-4">
             <p>
-                <a href="/admin/logout.php">Log out</a>
+                <form method="post" action="/admin/logout.php" class="d-inline">
+                    <?php AdminBootstrap::renderCsrfField(); ?>
+                    <button type="submit" class="btn btn-link p-0 align-baseline">Log out</button>
+                </form>
                 <?php
                 $authenticatedUsername = AdminBootstrap::createAuthService()->getAuthenticatedUsername();
                 if ($authenticatedUsername !== null) {

--- a/wwwroot/admin/logout.php
+++ b/wwwroot/admin/logout.php
@@ -8,6 +8,14 @@ require_once __DIR__ . '/../classes/Admin/AdminBootstrap.php';
 
 SessionManager::ensureStarted();
 
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+    http_response_code(405);
+    echo 'Method not allowed.';
+    exit;
+}
+
+AdminBootstrap::requireValidPostCsrfToken();
+
 $authService = AdminBootstrap::createAuthService();
 $authService->logout();
 

--- a/wwwroot/admin/workers.php
+++ b/wwwroot/admin/workers.php
@@ -82,6 +82,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                         <?php } ?>
                                     </a>
                                 </th>
+                                <th scope="col" style="width: 18rem;">Refresh Token</th>
                                 <th scope="col" style="width: 18rem;">NPSSO</th>
                                 <th scope="col" style="width: 16rem;">Scanning</th>
                                 <th scope="col" style="width: 16rem;">
@@ -107,6 +108,21 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                 ?>
                                 <tr>
                                     <td class="text-nowrap">#<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?></td>
+                                    <td>
+                                        <form method="post" class="d-flex gap-2 align-items-center" autocomplete="off">
+                    <?php AdminBootstrap::renderCsrfField(); ?>
+                                            <input type="hidden" name="action" value="update_refresh_token">
+                                            <input type="hidden" name="worker_id" value="<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
+                                            <input
+                                                type="text"
+                                                name="refresh_token"
+                                                class="form-control form-control-sm"
+                                                value="<?= htmlspecialchars($worker->getRefreshToken(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                maxlength="36"
+                                            >
+                                            <button type="submit" class="btn btn-sm btn-primary">Save</button>
+                                        </form>
+                                    </td>
                                     <td>
                                         <form method="post" class="d-flex gap-2 align-items-center" autocomplete="off">
                     <?php AdminBootstrap::renderCsrfField(); ?>

--- a/wwwroot/classes/Admin/AdminAuthService.php
+++ b/wwwroot/classes/Admin/AdminAuthService.php
@@ -75,5 +75,9 @@ final class AdminAuthService
     public function logout(): void
     {
         unset($_SESSION[self::SESSION_AUTHENTICATED_KEY], $_SESSION[self::SESSION_USERNAME_KEY]);
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
     }
 }

--- a/wwwroot/classes/Admin/AdminBootstrap.php
+++ b/wwwroot/classes/Admin/AdminBootstrap.php
@@ -74,6 +74,11 @@ final class AdminBootstrap
         return is_string($method) && strtoupper($method) === 'POST';
     }
 
+    public static function requireValidPostCsrfToken(): void
+    {
+        self::validateCsrfToken();
+    }
+
     private static function validateCsrfToken(): void
     {
         $submittedToken = $_POST['_csrf_token'] ?? '';

--- a/wwwroot/classes/Admin/WorkerPage.php
+++ b/wwwroot/classes/Admin/WorkerPage.php
@@ -57,6 +57,7 @@ final class WorkerPage
 
         return match ($action) {
             'update_npsso' => $this->processUpdateNpsso($request),
+            'update_refresh_token' => $this->processUpdateRefreshToken($request),
             'restart_worker' => $this->processRestartWorker($request),
             'restart_all_workers' => $this->processRestartAllWorkers(),
             default => [null, 'Unsupported action requested.'],
@@ -95,6 +96,40 @@ final class WorkerPage
         }
 
         return [null, 'Unable to update NPSSO. Please verify the worker still exists.'];
+    }
+
+    /**
+     * @return array{0: ?string, 1: ?string}
+     */
+    private function processUpdateRefreshToken(AdminRequest $request): array
+    {
+        $workerId = $request->getPostPositiveInt('worker_id');
+
+        if ($workerId === null) {
+            return [null, 'Invalid worker selected.'];
+        }
+
+        $refreshToken = $request->getPostString('refresh_token');
+
+        if ($refreshToken === '') {
+            return [null, 'The refresh token cannot be empty.'];
+        }
+
+        if (strlen($refreshToken) > 36) {
+            return [null, 'The refresh token must be 36 characters or fewer.'];
+        }
+
+        try {
+            $updated = $this->workerService->updateWorkerRefreshToken($workerId, $refreshToken);
+        } catch (Throwable $exception) {
+            return [null, 'An unexpected error occurred while updating the refresh token.'];
+        }
+
+        if ($updated) {
+            return ['Worker refresh token updated successfully.', null];
+        }
+
+        return [null, 'Unable to update refresh token. Please verify the worker still exists.'];
     }
 
     /**

--- a/wwwroot/classes/Html.php
+++ b/wwwroot/classes/Html.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+final class Html
+{
+    public static function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+}

--- a/wwwroot/classes/IpSubmissionLockExecutor.php
+++ b/wwwroot/classes/IpSubmissionLockExecutor.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-final class IpSubmissionLockExecutor
+require_once __DIR__ . '/IpSubmissionLockUnavailableException.php';
+
+class IpSubmissionLockExecutor
 {
     private const string LOCK_NAME_PREFIX = 'psn100:ip:';
 
@@ -30,7 +32,7 @@ final class IpSubmissionLockExecutor
 
         $lockAcquired = (int) ($lockStatement->fetchColumn() ?? 0) === 1;
         if (!$lockAcquired) {
-            throw new RuntimeException('Unable to acquire IP submission lock.');
+            throw new IpSubmissionLockUnavailableException('Unable to acquire IP submission lock.');
         }
 
         try {

--- a/wwwroot/classes/IpSubmissionLockUnavailableException.php
+++ b/wwwroot/classes/IpSubmissionLockUnavailableException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+final class IpSubmissionLockUnavailableException extends RuntimeException
+{
+}

--- a/wwwroot/classes/PlayerGamesPageContext.php
+++ b/wwwroot/classes/PlayerGamesPageContext.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/SearchQueryHelper.php';
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/PlayerSummaryService.php';
 require_once __DIR__ . '/PlayerStatus.php';
+require_once __DIR__ . '/PlayerUrlBuilder.php';
 
 final class PlayerGamesPageContext
 {
@@ -218,7 +219,7 @@ final class PlayerGamesPageContext
         $metaData = (new PageMetaData())
             ->withTitle($this->buildTitle($playerData))
             ->withImage('https://psn100.net/img/avatar/' . $this->extractString($playerData['avatar_url'] ?? ''))
-            ->withUrl('https://psn100.net/player/' . $this->extractString($playerData['online_id'] ?? ''));
+            ->withUrl('https://psn100.net' . PlayerUrlBuilder::playerPath($this->extractString($playerData['online_id'] ?? '')));
 
         $status = self::extractPlayerStatus($playerData);
 

--- a/wwwroot/classes/PlayerQueueHandler.php
+++ b/wwwroot/classes/PlayerQueueHandler.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/PlayerQueueResponse.php';
 require_once __DIR__ . '/PlayerQueueResponseFactory.php';
 require_once __DIR__ . '/PlayerQueuePollTokenManager.php';
 require_once __DIR__ . '/IpRateLimitService.php';
+require_once __DIR__ . '/IpSubmissionLockUnavailableException.php';
 
 class PlayerQueueHandler
 {
@@ -41,8 +42,12 @@ class PlayerQueueHandler
             return $this->responseFactory->createInvalidNameResponse();
         }
 
-        if (!$this->service->addPlayerToQueue($playerName, $ipAddress)) {
-            return $this->responseFactory->createQueueLimitResponse();
+        try {
+            if (!$this->service->addPlayerToQueue($playerName, $ipAddress)) {
+                return $this->responseFactory->createQueueLimitResponse();
+            }
+        } catch (IpSubmissionLockUnavailableException) {
+            return $this->responseFactory->createBusyResponse();
         }
 
         $response = $this->responseFactory->createQueuedForAdditionResponse($playerName);

--- a/wwwroot/classes/PlayerQueueMessageBuilder.php
+++ b/wwwroot/classes/PlayerQueueMessageBuilder.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayerUrlBuilder.php';
+require_once __DIR__ . '/PlayerStatusNotice.php';
+
+final class PlayerQueueMessageBuilder
+{
+    /** @var list<array<string, mixed>> */
+    private array $parts = [];
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function text(string $value): self
+    {
+        if ($value !== '') {
+            $this->parts[] = [
+                'type' => 'text',
+                'value' => $value,
+            ];
+        }
+
+        return $this;
+    }
+
+    public function playerLink(string $playerName): self
+    {
+        $this->parts[] = [
+            'type' => 'link',
+            'href' => PlayerUrlBuilder::playerPath($playerName),
+            'label' => $playerName,
+        ];
+
+        return $this;
+    }
+
+    public function link(string $href, string $label): self
+    {
+        $this->parts[] = [
+            'type' => 'link',
+            'href' => $href,
+            'label' => $label,
+        ];
+
+        return $this;
+    }
+
+    public function emphasis(string $value): self
+    {
+        if ($value !== '') {
+            $this->parts[] = [
+                'type' => 'emphasis',
+                'value' => $value,
+            ];
+        }
+
+        return $this;
+    }
+
+    public function spinner(): self
+    {
+        $this->parts[] = ['type' => 'spinner'];
+
+        return $this;
+    }
+
+    public function progress(int $percentage, ?string $title = null, ?string $summary = null): self
+    {
+        $part = [
+            'type' => 'progress',
+            'percentage' => $percentage,
+        ];
+
+        if ($title !== null && $title !== '') {
+            $part['title'] = $title;
+        }
+
+        if ($summary !== null && $summary !== '') {
+            $part['summary'] = $summary;
+        }
+
+        $this->parts[] = $part;
+
+        return $this;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function build(): array
+    {
+        return $this->parts;
+    }
+
+    public function toPlainText(): string
+    {
+        $text = '';
+
+        foreach ($this->parts as $part) {
+            $type = $part['type'] ?? '';
+
+            if ($type === 'text' || $type === 'emphasis') {
+                $text .= (string) ($part['value'] ?? '');
+            } elseif ($type === 'link') {
+                $text .= (string) ($part['label'] ?? '');
+            } elseif ($type === 'progress') {
+                // Progress bars are rendered separately in the client.
+            }
+        }
+
+        return trim($text);
+    }
+}

--- a/wwwroot/classes/PlayerQueueResponse.php
+++ b/wwwroot/classes/PlayerQueueResponse.php
@@ -6,31 +6,46 @@ require_once __DIR__ . '/PlayerQueueStatus.php';
 
 readonly class PlayerQueueResponse implements \JsonSerializable
 {
+    /**
+     * @param list<array<string, mixed>>|null $messageParts
+     */
     private function __construct(
         private PlayerQueueStatus $status,
         private string $message,
+        private ?array $messageParts = null,
         private ?string $pollToken = null,
         private int $httpStatusCode = 200,
     ) {}
 
-    public static function queued(string $message): self
+    /**
+     * @param list<array<string, mixed>>|null $messageParts
+     */
+    public static function queued(string $message, ?array $messageParts = null): self
     {
-        return new self(PlayerQueueStatus::QUEUED, $message);
+        return new self(PlayerQueueStatus::QUEUED, $message, $messageParts);
     }
 
-    public static function complete(string $message): self
+    /**
+     * @param list<array<string, mixed>>|null $messageParts
+     */
+    public static function complete(string $message, ?array $messageParts = null): self
     {
-        return new self(PlayerQueueStatus::COMPLETE, $message);
+        return new self(PlayerQueueStatus::COMPLETE, $message, $messageParts);
     }
 
-    public static function error(string $message): self
+    public static function error(string $message, ?array $messageParts = null): self
     {
-        return new self(PlayerQueueStatus::ERROR, $message);
+        return new self(PlayerQueueStatus::ERROR, $message, $messageParts);
+    }
+
+    public static function busy(string $message): self
+    {
+        return new self(PlayerQueueStatus::ERROR, $message, null, null, 503);
     }
 
     public static function rateLimited(string $message): self
     {
-        return new self(PlayerQueueStatus::ERROR, $message, null, 429);
+        return new self(PlayerQueueStatus::ERROR, $message, null, null, 429);
     }
 
     public function withPollToken(string $pollToken): self
@@ -38,6 +53,7 @@ readonly class PlayerQueueResponse implements \JsonSerializable
         return new self(
             $this->status,
             $this->message,
+            $this->messageParts,
             $pollToken,
             $this->httpStatusCode,
         );
@@ -58,6 +74,14 @@ readonly class PlayerQueueResponse implements \JsonSerializable
         return $this->message;
     }
 
+    /**
+     * @return list<array<string, mixed>>|null
+     */
+    public function getMessageParts(): ?array
+    {
+        return $this->messageParts;
+    }
+
     public function getPollToken(): ?string
     {
         return $this->pollToken;
@@ -74,7 +98,7 @@ readonly class PlayerQueueResponse implements \JsonSerializable
     }
 
     /**
-     * @return array<string, string|bool>
+     * @return array<string, mixed>
      */
     public function toArray(): array
     {
@@ -83,6 +107,10 @@ readonly class PlayerQueueResponse implements \JsonSerializable
             'message' => $this->getMessage(),
             'shouldPoll' => $this->shouldPoll(),
         ];
+
+        if ($this->messageParts !== null) {
+            $payload['messageParts'] = $this->messageParts;
+        }
 
         if ($this->pollToken !== null) {
             $payload['pollToken'] = $this->pollToken;

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -6,12 +6,16 @@ require_once __DIR__ . '/PlayerQueueService.php';
 require_once __DIR__ . '/PlayerQueueResponse.php';
 require_once __DIR__ . '/PlayerStatusNotice.php';
 require_once __DIR__ . '/PlayerScanProgress.php';
+require_once __DIR__ . '/PlayerQueueMessageBuilder.php';
+require_once __DIR__ . '/PlayerUrlBuilder.php';
 
 final class PlayerQueueResponseFactory
 {
     private const string EMPTY_NAME_MESSAGE = "PSN name can't be empty.";
 
     private const string INVALID_NAME_MESSAGE = "PSN name must contain between three and 16 characters, and can consist of letters, numbers, hyphens (-) and underscores (_).";
+
+    private const string BUSY_MESSAGE = 'The server is busy processing another request. Please try again in a moment.';
 
     public function __construct(private readonly PlayerQueueService $service)
     {
@@ -32,14 +36,31 @@ final class PlayerQueueResponseFactory
         return PlayerQueueResponse::error($this->createQueueLimitMessage());
     }
 
+    public function createBusyResponse(): PlayerQueueResponse
+    {
+        return PlayerQueueResponse::busy(self::BUSY_MESSAGE);
+    }
+
     public function createCheaterResponse(string $playerName, ?string $accountId): PlayerQueueResponse
     {
-        return PlayerQueueResponse::error($this->createCheaterMessage($playerName, $accountId));
+        $messageParts = PlayerQueueMessageBuilder::create()
+            ->text("Player '")
+            ->playerLink($playerName)
+            ->text("' is tagged as a cheater and won't be scanned. ")
+            ->link(PlayerStatusNotice::createDisputeUrl($playerName, $accountId), 'Dispute')
+            ->text('?')
+            ->build();
+
+        return PlayerQueueResponse::error($this->buildPlainText($messageParts), $messageParts);
     }
 
     public function createQueuedForAdditionResponse(string $playerName): PlayerQueueResponse
     {
-        $message = $this->createPlayerLink($playerName) . ' is being added to the queue.';
+        $message = PlayerQueueMessageBuilder::create()
+            ->playerLink($playerName)
+            ->text(' is being added to the queue.')
+            ->spinner()
+            ->build();
 
         return $this->createQueuedResponse($message);
     }
@@ -48,97 +69,122 @@ final class PlayerQueueResponseFactory
         string $playerName,
         ?PlayerScanProgress $scanProgress = null
     ): PlayerQueueResponse {
-        $message = $this->createPlayerLink($playerName) . ' is currently being scanned.';
+        $builder = PlayerQueueMessageBuilder::create()
+            ->playerLink($playerName)
+            ->text(' is currently being scanned.');
 
         if ($scanProgress !== null) {
-            $message .= $this->createScanProgressMessage($scanProgress);
+            $this->appendScanProgressParts($builder, $scanProgress);
         }
 
-        return $this->createQueuedResponse($message);
+        $builder->spinner();
+
+        return $this->createQueuedResponse($builder->build());
     }
 
     public function createQueuePositionResponse(string $playerName, int|string $position): PlayerQueueResponse
     {
-        $positionText = $this->service->escapeHtml((string) $position);
-        $message = $this->createPlayerLink($playerName)
-            . ' is in the update queue, currently in position '
-            . $positionText . '.';
+        $message = PlayerQueueMessageBuilder::create()
+            ->playerLink($playerName)
+            ->text(' is in the update queue, currently in position ' . (string) $position . '.')
+            ->spinner()
+            ->build();
 
         return $this->createQueuedResponse($message);
     }
 
     public function createQueueCompleteResponse(string $playerName): PlayerQueueResponse
     {
-        $playerLink = $this->createPlayerLink($playerName);
+        $message = PlayerQueueMessageBuilder::create()
+            ->playerLink($playerName)
+            ->text(' has been updated!')
+            ->build();
 
-        return PlayerQueueResponse::complete($playerLink . ' has been updated!');
+        return PlayerQueueResponse::complete($this->buildPlainText($message), $message);
     }
 
     public function createPlayerNotFoundResponse(string $playerName): PlayerQueueResponse
     {
-        $playerLink = $this->createPlayerLink($playerName);
+        $message = PlayerQueueMessageBuilder::create()
+            ->playerLink($playerName)
+            ->text(' was not found. Please check the spelling and try again.')
+            ->build();
 
-        return PlayerQueueResponse::error($playerLink . ' was not found. Please check the spelling and try again.');
+        return PlayerQueueResponse::error($this->buildPlainText($message), $message);
     }
 
-    private function createQueuedResponse(string $message): PlayerQueueResponse
+    /**
+     * @param list<array<string, mixed>> $messageParts
+     */
+    private function createQueuedResponse(array $messageParts): PlayerQueueResponse
     {
-        return PlayerQueueResponse::queued($this->createSpinnerMessage($message));
+        return PlayerQueueResponse::queued($this->buildPlainText($messageParts), $messageParts);
     }
 
-    private function createPlayerLink(string $playerName): string
+  /**
+   * @param list<array<string, mixed>> $messageParts
+   */
+    private function buildPlainText(array $messageParts): string
     {
-        $escapedPlayerName = $this->service->escapeHtml($playerName);
-        $playerUrl = '/player/' . rawurlencode($playerName);
-        $escapedPlayerUrl = $this->service->escapeHtml($playerUrl);
+        $builder = PlayerQueueMessageBuilder::create();
 
-        return '<a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="'
-            . $escapedPlayerUrl . '">' . $escapedPlayerName . '</a>';
-    }
+        foreach ($messageParts as $part) {
+            $type = $part['type'] ?? '';
 
-    private function createSpinnerMessage(string $message): string
-    {
-        return $message
-            . "\n<div class=\"spinner-border\" role=\"status\">\n    <span class=\"visually-hidden\">Loading...</span>\n</div>";
-    }
-
-    private function createScanProgressMessage(PlayerScanProgress $progress): string
-    {
-        $parts = [];
-
-        $title = $progress->getTitle();
-        if ($title !== null) {
-            $progressTitle = $this->formatProgressTitle($title);
-
-            if ($progressTitle !== '') {
-                $parts[] = $progressTitle;
+            if ($type === 'text') {
+                $builder->text((string) ($part['value'] ?? ''));
+            } elseif ($type === 'link') {
+                $builder->link(
+                    (string) ($part['href'] ?? ''),
+                    (string) ($part['label'] ?? '')
+                );
+            } elseif ($type === 'emphasis') {
+                $builder->emphasis((string) ($part['value'] ?? ''));
+            } elseif ($type === 'progress') {
+                $builder->progress(
+                    (int) ($part['percentage'] ?? 0),
+                    isset($part['title']) ? (string) $part['title'] : null,
+                    isset($part['summary']) ? (string) $part['summary'] : null,
+                );
             }
         }
 
+        return $builder->toPlainText();
+    }
+
+    private function appendScanProgressParts(PlayerQueueMessageBuilder $builder, PlayerScanProgress $progress): void
+    {
+        $title = $progress->getTitle();
         $summary = $progress->getProgressSummary();
-        if ($summary !== null) {
-            $parts[] = $summary;
-        }
-
-        if ($parts === []) {
-            return '';
-        }
-
-        $message = ' ' . implode(' ', $parts) . '.';
-
         $percentage = $progress->getPercentage();
+        $formattedTitle = $title !== null ? $this->formatProgressTitle($title) : '';
+
+        if ($formattedTitle !== '') {
+            if (
+                $title !== null
+                && !$this->isErrorProgressTitle($title)
+                && preg_match('/^(Updating|Fetching)\b/i', $title) !== 1
+            ) {
+                $normalizedTitle = preg_replace('/\s+for\s+[^.]+\.?$/i', '', trim($title)) ?? '';
+                $normalizedTitle = rtrim($normalizedTitle, " .\t\n\r\0\v");
+                $builder->text(' Working on ');
+                $builder->emphasis($normalizedTitle);
+            } else {
+                $builder->text(' ' . $formattedTitle);
+            }
+        }
+
+        if ($summary !== null) {
+            $builder->text(' ' . $summary);
+        }
+
+        if ($formattedTitle !== '' || $summary !== null) {
+            $builder->text('.');
+        }
 
         if ($percentage !== null) {
-            $message .= sprintf(
-                '<div class="progress mt-2" role="progressbar" aria-valuenow="%d" aria-valuemin="0" aria-valuemax="100">'
-                . '<div class="progress-bar bg-primary" style="width: %d%%;"></div>'
-                . '</div>',
-                $percentage,
-                $percentage
-            );
+            $builder->progress($percentage, $formattedTitle !== '' ? $formattedTitle : null, $summary);
         }
-
-        return $message;
     }
 
     private function formatProgressTitle(string $title): string
@@ -151,32 +197,19 @@ final class PlayerQueueResponseFactory
         }
 
         if (preg_match('/^(Updating|Fetching)\b/i', $normalizedTitle) === 1) {
-            $actionText = strtolower($normalizedTitle);
-            $escapedActionText = $this->service->escapeHtml($actionText);
-
-            return ucfirst($escapedActionText);
+            return ucfirst(strtolower($normalizedTitle));
         }
 
         if ($this->isErrorProgressTitle($normalizedTitle)) {
-            return $this->service->escapeHtml($normalizedTitle);
+            return $normalizedTitle;
         }
 
-        return 'Working on <strong>' . $this->service->escapeHtml($normalizedTitle) . '</strong>';
+        return 'Working on ' . $normalizedTitle;
     }
 
     private function isErrorProgressTitle(string $title): bool
     {
         return preg_match('/\\b(failed|error|problem|unable|denied|unavailable|timeout)\\b/i', $title) === 1;
-    }
-
-    private function createCheaterMessage(string $playerName, ?string $accountId): string
-    {
-        $playerLink = $this->createPlayerLink($playerName);
-        $disputeUrl = PlayerStatusNotice::createDisputeUrl($playerName, $accountId);
-        $disputeLink = '<a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="'
-            . $this->service->escapeHtml($disputeUrl) . '">Dispute</a>';
-
-        return "Player '{$playerLink}' is tagged as a cheater and won't be scanned. {$disputeLink}?";
     }
 
     private function createQueueLimitMessage(): string

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 require_once __DIR__ . '/PlayerScanProgress.php';
 require_once __DIR__ . '/PlayerScanStatus.php';
 require_once __DIR__ . '/IpSubmissionLockExecutor.php';
+require_once __DIR__ . '/IpSubmissionLockUnavailableException.php';
+require_once __DIR__ . '/Html.php';
 
 class PlayerQueueService
 {
@@ -208,7 +210,7 @@ class PlayerQueueService
 
     public function escapeHtml(string $value): string
     {
-        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        return Html::escape($value);
     }
 
     public function isPlayerBeingScanned(string $playerName): bool

--- a/wwwroot/classes/PlayerReportService.php
+++ b/wwwroot/classes/PlayerReportService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerReportResult.php';
 require_once __DIR__ . '/IpSubmissionLockExecutor.php';
+require_once __DIR__ . '/IpSubmissionLockUnavailableException.php';
 
 class PlayerReportService
 {
@@ -31,30 +32,36 @@ class PlayerReportService
             );
         }
 
-        $outcome = $this->getIpSubmissionLockExecutor()->execute(
-            $ipAddress,
-            function () use ($accountId, $ipAddress, $explanation): string {
-                if ($this->hasExistingReport($accountId, $ipAddress)) {
-                    return self::SUBMIT_OUTCOME_DUPLICATE;
-                }
-
-                if ($this->getReportCountForIp($ipAddress) >= self::MAX_PENDING_REPORTS_PER_IP) {
-                    return self::SUBMIT_OUTCOME_LIMIT;
-                }
-
-                try {
-                    $this->insertReport($accountId, $ipAddress, $explanation);
-                } catch (PDOException $exception) {
-                    if ($this->isDuplicateReportException($exception)) {
+        try {
+            $outcome = $this->getIpSubmissionLockExecutor()->execute(
+                $ipAddress,
+                function () use ($accountId, $ipAddress, $explanation): string {
+                    if ($this->hasExistingReport($accountId, $ipAddress)) {
                         return self::SUBMIT_OUTCOME_DUPLICATE;
                     }
 
-                    throw $exception;
-                }
+                    if ($this->getReportCountForIp($ipAddress) >= self::MAX_PENDING_REPORTS_PER_IP) {
+                        return self::SUBMIT_OUTCOME_LIMIT;
+                    }
 
-                return self::SUBMIT_OUTCOME_SUCCESS;
-            }
-        );
+                    try {
+                        $this->insertReport($accountId, $ipAddress, $explanation);
+                    } catch (PDOException $exception) {
+                        if ($this->isDuplicateReportException($exception)) {
+                            return self::SUBMIT_OUTCOME_DUPLICATE;
+                        }
+
+                        throw $exception;
+                    }
+
+                    return self::SUBMIT_OUTCOME_SUCCESS;
+                }
+            );
+        } catch (IpSubmissionLockUnavailableException) {
+            return PlayerReportResult::error(
+                'The server is busy processing another request. Please try again in a moment.'
+            );
+        }
 
         return match ($outcome) {
             self::SUBMIT_OUTCOME_SUCCESS => PlayerReportResult::success('Player reported successfully.'),

--- a/wwwroot/classes/PlayerUrlBuilder.php
+++ b/wwwroot/classes/PlayerUrlBuilder.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+final class PlayerUrlBuilder
+{
+    public static function playerPath(string $onlineId): string
+    {
+        return '/player/' . rawurlencode($onlineId);
+    }
+
+    public static function playerReportPath(string $onlineId): string
+    {
+        return self::playerPath($onlineId) . '/report';
+    }
+
+    public static function gamePlayerPath(string $gameSlug, string $onlineId): string
+    {
+        return '/game/' . $gameSlug . '/' . rawurlencode($onlineId);
+    }
+
+    public static function gamePath(string $gameSlug, ?string $onlineId = null): string
+    {
+        if ($onlineId === null || $onlineId === '') {
+            return '/game/' . $gameSlug;
+        }
+
+        return self::gamePlayerPath($gameSlug, $onlineId);
+    }
+}

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/classes/GamePage.php';
 require_once __DIR__ . '/classes/GameTrophyFilter.php';
 require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
+require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
 if (!isset($gameId)) {
     header("Location: /game/", true, 303);
@@ -32,6 +33,8 @@ try {
 }
 
 $game = $gamePage->getGame();
+$gameSlug = $game->getId() . '-' . $utility->slugify($game->getName());
+$encodedGamePlayer = isset($player) ? '/' . rawurlencode((string) $player) : '';
 $gameHeaderData = $gamePage->getGameHeaderData();
 $sort = $gamePage->getSort();
 $accountId = $gamePage->getPlayerAccountId();
@@ -55,10 +58,10 @@ require_once("header.php");
 
             <div class="col-12 col-lg-6 mb-3 text-center">
                 <div class="btn-group">
-                    <a class="btn btn-primary active" href="/game/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Trophies</a>
-                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Leaderboard</a>
-                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Recent Players</a>
-                    <a class="btn btn-outline-primary" href="/game-history/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">History</a>
+                    <a class="btn btn-primary active" href="/game/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Trophies</a>
+                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Leaderboard</a>
+                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Recent Players</a>
+                    <a class="btn btn-outline-primary" href="/game-history/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">History</a>
                 </div>
             </div>
 

--- a/wwwroot/game_history.php
+++ b/wwwroot/game_history.php
@@ -27,6 +27,8 @@ try {
 }
 
 $game = $gameHistoryPage->getGame();
+$gameSlug = $game->getId() . '-' . $utility->slugify($game->getName());
+$encodedGamePlayer = isset($player) ? '/' . rawurlencode((string) $player) : '';
 $gameHeaderData = $gameHistoryPage->getGameHeaderData();
 $historyEntries = $gameHistoryPage->getHistoryEntries();
 $metaData = $gameHistoryPage->createMetaData();
@@ -91,10 +93,10 @@ require_once 'header.php';
 
             <div class="col-12 col-lg-6 mb-3 text-center">
                 <div class="btn-group">
-                    <a class="btn btn-outline-primary" href="/game/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= isset($player) ? '/' . $player : ''; ?>">Trophies</a>
-                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= isset($player) ? '/' . $player : ''; ?>">Leaderboard</a>
-                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= isset($player) ? '/' . $player : ''; ?>">Recent Players</a>
-                    <a class="btn btn-primary active" href="/game-history/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= isset($player) ? '/' . $player : ''; ?>">History</a>
+                    <a class="btn btn-outline-primary" href="/game/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Trophies</a>
+                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Leaderboard</a>
+                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Recent Players</a>
+                    <a class="btn btn-primary active" href="/game-history/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">History</a>
                 </div>
             </div>
 

--- a/wwwroot/game_leaderboard.php
+++ b/wwwroot/game_leaderboard.php
@@ -27,6 +27,7 @@ $totalPagesCount = $pageContext->getTotalPagesCount();
 $rows = $pageContext->getRows();
 $accountId = $pageContext->getPlayerAccountId();
 $gameSlug = $pageContext->getGameSlug();
+$encodedGamePlayer = isset($player) ? '/' . rawurlencode((string) $player) : '';
 
 $title = $pageContext->getTitle();
 require_once("header.php");
@@ -44,10 +45,10 @@ require_once("header.php");
 
             <div class="col-6 text-center">
                 <div class="btn-group">
-                    <a class="btn btn-outline-primary" href="/game/<?= $gameSlug; ?><?= (isset($player) ? '/' . $player : ''); ?>">Trophies</a>
-                    <a class="btn btn-primary active" href="/game-leaderboard/<?= $gameSlug; ?><?= (isset($player) ? '/' . $player : ''); ?>">Leaderboard</a>
-                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= $gameSlug; ?><?= (isset($player) ? '/' . $player : ''); ?>">Recent Players</a>
-                    <a class="btn btn-outline-primary" href="/game-history/<?= $gameSlug; ?><?= (isset($player) ? '/' . $player : ''); ?>">History</a>
+                    <a class="btn btn-outline-primary" href="/game/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Trophies</a>
+                    <a class="btn btn-primary active" href="/game-leaderboard/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Leaderboard</a>
+                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Recent Players</a>
+                    <a class="btn btn-outline-primary" href="/game-history/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">History</a>
                 </div>
             </div>
 

--- a/wwwroot/game_recent_players.php
+++ b/wwwroot/game_recent_players.php
@@ -23,6 +23,7 @@ $recentPlayers = $pageContext->getRecentPlayers();
 $accountId = $pageContext->getPlayerAccountId();
 $gamePlayer = $pageContext->getGamePlayer();
 $gameSlug = $pageContext->getGameSlug();
+$encodedGamePlayer = isset($player) ? '/' . rawurlencode((string) $player) : '';
 
 $title = $pageContext->getTitle();
 require_once("header.php");
@@ -41,10 +42,10 @@ require_once("header.php");
 
             <div class="col-6 text-center">
                 <div class="btn-group">
-                    <a class="btn btn-outline-primary" href="/game/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Trophies</a>
-                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Leaderboard</a>
-                    <a class="btn btn-primary active" href="/game-recent-players/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">Recent Players</a>
-                    <a class="btn btn-outline-primary" href="/game-history/<?= $game->getId() . '-' . $utility->slugify($game->getName()); ?><?= (isset($player) ? '/' . $player : ''); ?>">History</a>
+                    <a class="btn btn-outline-primary" href="/game/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Trophies</a>
+                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Leaderboard</a>
+                    <a class="btn btn-primary active" href="/game-recent-players/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Recent Players</a>
+                    <a class="btn btn-outline-primary" href="/game-history/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">History</a>
                 </div>
             </div>
 

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -321,19 +321,7 @@ class PlayerQueueManager {
         const request = new XMLHttpRequest();
 
         request.onreadystatechange = () => {
-            if (request.readyState === XMLHttpRequest.DONE) {
-                if (request.status >= 200 && request.status < 300) {
-                    const response = this.parseResponse(request.responseText);
-
-                    if (response !== null) {
-                        onSuccess(response);
-                    } else {
-                        this.handleError();
-                    }
-                } else {
-                    this.handleError();
-                }
-            }
+            this.handleCompletedRequest(request, onSuccess);
         };
 
         request.onerror = () => this.handleError();
@@ -348,19 +336,7 @@ class PlayerQueueManager {
         const request = new XMLHttpRequest();
 
         request.onreadystatechange = () => {
-            if (request.readyState === XMLHttpRequest.DONE) {
-                if (request.status >= 200 && request.status < 300) {
-                    const response = this.parseResponse(request.responseText);
-
-                    if (response !== null) {
-                        onSuccess(response);
-                    } else {
-                        this.handleError();
-                    }
-                } else {
-                    this.handleError();
-                }
-            }
+            this.handleCompletedRequest(request, onSuccess);
         };
 
         request.onerror = () => this.handleError();
@@ -368,6 +344,32 @@ class PlayerQueueManager {
         request.open('GET', url, true);
         request.setRequestHeader('Accept', 'application/json');
         request.send();
+    }
+
+    handleCompletedRequest(request, onSuccess) {
+        if (request.readyState !== XMLHttpRequest.DONE) {
+            return;
+        }
+
+        const response = this.parseResponse(request.responseText);
+
+        if (response !== null) {
+            if (request.status >= 200 && request.status < 300) {
+                onSuccess(response);
+                return;
+            }
+
+            this.updateQueueResult(response);
+            this.stopPolling(true);
+            return;
+        }
+
+        if (request.status >= 200 && request.status < 300) {
+            this.handleError();
+            return;
+        }
+
+        this.handleError();
     }
 
     parseResponse(responseText) {

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -270,7 +270,7 @@ class PlayerQueueManager {
         });
 
         this.sendPostRequest('add_to_queue.php', body, (response) => {
-            this.updateQueueResult(response.message);
+            this.updateQueueResult(response);
 
             if (typeof response.pollToken === 'string' && response.pollToken !== '') {
                 this.pollToken = response.pollToken;
@@ -298,7 +298,7 @@ class PlayerQueueManager {
         }
 
         this.sendRequest(url.toString(), (response) => {
-            this.updateQueueResult(response.message);
+            this.updateQueueResult(response);
 
             if (!response.shouldPoll) {
                 this.stopPolling(true);
@@ -386,19 +386,86 @@ class PlayerQueueManager {
             const shouldPoll = typeof data.shouldPoll === 'boolean' ? data.shouldPoll : false;
             const status = typeof data.status === 'string' ? data.status : 'error';
             const pollToken = typeof data.pollToken === 'string' ? data.pollToken : '';
+            const messageParts = Array.isArray(data.messageParts) ? data.messageParts : [];
 
-            return { message, shouldPoll, status, pollToken };
+            return { message, shouldPoll, status, pollToken, messageParts };
         } catch (error) {
             return null;
         }
     }
 
-    updateQueueResult(message) {
-        if (this.messageElement) {
-            this.messageElement.innerHTML = message;
+    updateQueueResult(response) {
+        if (!this.messageElement) {
+            return;
+        }
+
+        if (response && Array.isArray(response.messageParts) && response.messageParts.length > 0) {
+            this.renderMessageParts(response.messageParts);
+        } else {
+            this.messageElement.textContent = response?.message ?? '';
         }
 
         this.showQueueResult();
+    }
+
+    renderMessageParts(parts) {
+        this.messageElement.replaceChildren();
+
+        parts.forEach((part) => {
+            if (!part || typeof part !== 'object') {
+                return;
+            }
+
+            switch (part.type) {
+                case 'text':
+                    this.messageElement.appendChild(document.createTextNode(part.value ?? ''));
+                    break;
+                case 'link': {
+                    const anchor = document.createElement('a');
+                    anchor.className = 'link-underline link-underline-opacity-0 link-underline-opacity-100-hover';
+                    anchor.href = typeof part.href === 'string' ? part.href : '#';
+                    anchor.textContent = part.label ?? '';
+                    this.messageElement.appendChild(anchor);
+                    break;
+                }
+                case 'emphasis': {
+                    const emphasis = document.createElement('strong');
+                    emphasis.textContent = part.value ?? '';
+                    this.messageElement.appendChild(emphasis);
+                    break;
+                }
+                case 'spinner': {
+                    this.messageElement.appendChild(document.createElement('br'));
+                    const spinner = document.createElement('div');
+                    spinner.className = 'spinner-border';
+                    spinner.setAttribute('role', 'status');
+                    const hidden = document.createElement('span');
+                    hidden.className = 'visually-hidden';
+                    hidden.textContent = 'Loading...';
+                    spinner.appendChild(hidden);
+                    this.messageElement.appendChild(spinner);
+                    break;
+                }
+                case 'progress': {
+                    const progress = document.createElement('div');
+                    progress.className = 'progress mt-2';
+                    progress.setAttribute('role', 'progressbar');
+                    const percentage = Number(part.percentage ?? 0);
+                    progress.setAttribute('aria-valuenow', String(percentage));
+                    progress.setAttribute('aria-valuemin', '0');
+                    progress.setAttribute('aria-valuemax', '100');
+
+                    const bar = document.createElement('div');
+                    bar.className = 'progress-bar bg-primary';
+                    bar.style.width = `${percentage}%`;
+                    progress.appendChild(bar);
+                    this.messageElement.appendChild(progress);
+                    break;
+                }
+                default:
+                    break;
+            }
+        });
     }
 
     showQueueResult() {
@@ -408,7 +475,10 @@ class PlayerQueueManager {
     }
 
     handleError() {
-        this.updateQueueResult('An error occurred while contacting the server. Please try again later.');
+        this.updateQueueResult({
+            message: 'An error occurred while contacting the server. Please try again later.',
+            messageParts: [],
+        });
         this.stopPolling(true);
     }
 }

--- a/wwwroot/init.php
+++ b/wwwroot/init.php
@@ -12,6 +12,17 @@ header("Expires: 0");
 header('X-Content-Type-Options: nosniff');
 header('Referrer-Policy: strict-origin-when-cross-origin');
 header('X-Frame-Options: SAMEORIGIN');
+header(
+    "Content-Security-Policy-Report-Only: default-src 'self'; "
+    . "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://code.jquery.com https://cdnjs.cloudflare.com; "
+    . "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+    . "img-src 'self' data: https:; "
+    . "font-src 'self' https://cdn.jsdelivr.net; "
+    . "connect-src 'self'; "
+    . "frame-ancestors 'self'; "
+    . "base-uri 'self'; "
+    . "form-action 'self'"
+);
 
 require_once __DIR__ . '/classes/ApplicationBootstrapper.php';
 

--- a/wwwroot/leaderboard_in_game_rarity.php
+++ b/wwwroot/leaderboard_in_game_rarity.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once 'classes/Leaderboard/InGameRarityLeaderboardPageContext.php';
+require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
 $leaderboardPageContext = InGameRarityLeaderboardPageContext::fromGlobals($database, $utility, $_GET ?? []);
 $title = $leaderboardPageContext->getTitle();
@@ -68,7 +69,7 @@ $shouldShowCountryRank = $leaderboardPageContext->shouldShowCountryRank();
                                             </div>
 
                                             <div>
-                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/player/<?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
+                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars(PlayerUrlBuilder::playerPath($row->getOnlineId()), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
                                             </div>
 
                                             <div class="ms-auto">

--- a/wwwroot/leaderboard_main.php
+++ b/wwwroot/leaderboard_main.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once 'classes/Leaderboard/TrophyLeaderboardPageContext.php';
+require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
 $trophyLeaderboardPageContext = TrophyLeaderboardPageContext::fromGlobals($database, $utility, $_GET ?? []);
 $title = $trophyLeaderboardPageContext->getTitle();
@@ -73,7 +74,7 @@ $filterParameters = $trophyLeaderboardPageContext->getFilterQueryParameters();
                                             </div>
 
                                             <div>
-                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/player/<?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
+                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars(PlayerUrlBuilder::playerPath($row->getOnlineId()), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
                                             </div>
 
                                             <div class="ms-auto">

--- a/wwwroot/leaderboard_rarity.php
+++ b/wwwroot/leaderboard_rarity.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once 'classes/Leaderboard/RarityLeaderboardPageContext.php';
+require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
 $rarityLeaderboardPageContext = RarityLeaderboardPageContext::fromGlobals($database, $utility, $_GET ?? []);
 $title = $rarityLeaderboardPageContext->getTitle();
@@ -68,7 +69,7 @@ $shouldShowCountryRank = $rarityLeaderboardPageContext->shouldShowCountryRank();
                                             </div>
 
                                             <div>
-                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/player/<?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
+                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars(PlayerUrlBuilder::playerPath($row->getOnlineId()), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
                                             </div>
 
                                             <div class="ms-auto">

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerGamesPageContext.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
 require_once __DIR__ . '/classes/PlayerStatusNotice.php';
+require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -47,7 +48,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="/player/<?= htmlspecialchars($playerOnlineId, ENT_QUOTES, 'UTF-8'); ?>/report">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= htmlspecialchars(PlayerUrlBuilder::playerReportPath($playerOnlineId), ENT_QUOTES, 'UTF-8'); ?>">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">
@@ -147,7 +148,7 @@ require_once("header.php");
 
                                                 <div class="vstack">
                                                     <span>
-                                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= $playerGame->getId() ."-". $utility->slugify($playerGame->getName()); ?>/<?= htmlspecialchars($playerOnlineId, ENT_QUOTES, 'UTF-8'); ?>">
+                                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars(PlayerUrlBuilder::gamePlayerPath($playerGame->getId() . '-' . $utility->slugify($playerGame->getName()), $playerOnlineId), ENT_QUOTES, 'UTF-8'); ?>">
                                                             <?= htmlentities($playerGame->getName()); ?>
                                                         </a>
                                                     </span>

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerAdvisorPageContext.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
+require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -48,7 +49,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="/player/<?= htmlspecialchars($playerOnlineId, ENT_QUOTES, 'UTF-8'); ?>/report">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= htmlspecialchars(PlayerUrlBuilder::playerReportPath($playerOnlineId), ENT_QUOTES, 'UTF-8'); ?>">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerLogPageContext.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
 require_once __DIR__ . '/classes/PlayerStatusNotice.php';
+require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -47,7 +48,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="/player/<?= $player["online_id"]; ?>/report">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= htmlspecialchars(PlayerUrlBuilder::playerReportPath($player['online_id']), ENT_QUOTES, 'UTF-8'); ?>">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">
@@ -100,8 +101,8 @@ require_once("header.php");
                                     $rowClassAttribute = $trophy->requiresWarning() ? ' class="table-warning"' : '';
                                     $gameSlug = $trophy->getGameSlug($utility);
                                     $trophySlug = $trophy->getTrophySlug($utility);
-                                    $gameUrl = '/game/' . $gameSlug . '/' . $player['online_id'];
-                                    $trophyUrl = '/trophy/' . $trophySlug . '/' . $player['online_id'];
+                                    $gameUrl = PlayerUrlBuilder::gamePlayerPath($gameSlug, $player['online_id']);
+                                    $trophyUrl = '/trophy/' . $trophySlug . '/' . rawurlencode($player['online_id']);
                                     $badgeElementId = $trophy->getEarnedBadgeElementId();
                                     $progressDisplay = $trophy->getProgressDisplay();
                                     $rewardName = $trophy->getRewardName();

--- a/wwwroot/player_random.php
+++ b/wwwroot/player_random.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerRandomGamesPageContext.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
-require_once __DIR__ . '/classes/PlayerStatusNotice.php';
+require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -46,7 +46,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="/player/<?= $player["online_id"]; ?>/report">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= htmlspecialchars(PlayerUrlBuilder::playerReportPath($player['online_id']), ENT_QUOTES, 'UTF-8'); ?>">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">

--- a/wwwroot/player_random.php
+++ b/wwwroot/player_random.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerRandomGamesPageContext.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
+require_once __DIR__ . '/classes/PlayerStatusNotice.php';
 require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);

--- a/wwwroot/player_report.php
+++ b/wwwroot/player_report.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
 require_once __DIR__ . '/classes/PlayerNavigation.php';
 require_once __DIR__ . '/classes/CsrfTokenManager.php';
+require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -42,7 +43,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="/player/<?= htmlspecialchars($playerOnlineId, ENT_QUOTES, 'UTF-8'); ?>/report">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= htmlspecialchars(PlayerUrlBuilder::playerReportPath($playerOnlineId), ENT_QUOTES, 'UTF-8'); ?>">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">

--- a/wwwroot/player_timeline.php
+++ b/wwwroot/player_timeline.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerTimelineLayout.php';
 require_once __DIR__ . '/classes/PlayerTimelinePageContext.php';
 require_once __DIR__ . '/classes/PlayerStatusNotice.php';
+require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
 $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null);
 $accountId = $playerPageAccessGuard->requireAccountId();
@@ -42,7 +43,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="/player/<?= $player["online_id"]; ?>/report">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= htmlspecialchars(PlayerUrlBuilder::playerReportPath($player['online_id']), ENT_QUOTES, 'UTF-8'); ?>">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 3 hardens public submission paths, admin session handling, URL encoding, and the homepage queue UI.

## Changes

### IP submission lock graceful degradation
- `IpSubmissionLockUnavailableException` when MySQL `GET_LOCK` fails
- Queue adds return HTTP 503 with a friendly busy message
- Player reports return a friendly error instead of an uncaught 500

### Queue polling DOM safety
- `PlayerQueueMessageBuilder` produces structured `messageParts` in JSON
- Homepage `QueueManager` renders parts with `createElement` / `textContent` (no `innerHTML` for poll responses)
- Plain-text `message` retained as fallback

### Admin session integrity
- Logout requires POST + CSRF (`admin/index.php` form, `admin/logout.php`)
- `AdminAuthService::logout()` calls `session_destroy()`

### Worker admin UI
- Refresh token column + update form on Workers page (max 36 chars)

### URL encoding
- New `PlayerUrlBuilder` helper (`playerPath`, `playerReportPath`, `gamePath`, etc.)
- Fixed raw or `htmlspecialchars`-encoded player IDs in player pages, leaderboards, and game nav links

### Shared escaping + CSP
- `Html::escape()` helper; `PlayerQueueService::escapeHtml()` delegates to it
- `Content-Security-Policy-Report-Only` header in `init.php` (enforcement deferred)

### Tests & docs
- 784 tests pass (including lock-busy, messageParts, URL builder, refresh-token admin, optional MySQL lock integration test)
- README / AGENTS updated for Phase 3

## Review feedback addressed

| Issue | Fix |
|-------|-----|
| P2: Missing `PlayerStatusNotice` include on `player_random.php` | Restored require alongside `PlayerUrlBuilder` (`3a15f1fd`) |
| P2: HTTP 503 busy response not shown in queue UI | Parse JSON on non-2xx XHR responses and display server message (`dfe7f1cb`) |

## Test plan

- [x] `php tests/run.php` — 784 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

