### PR TITLE
Fix missing localized dates after Phase 4

### DIFF
--- a/tests/StaticAssetTest.php
+++ b/tests/StaticAssetTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/StaticAsset.php';
+
+final class StaticAssetTest extends TestCase
+{
+    public function testUrlAppendsFileModificationTimeForExistingAsset(): void
+    {
+        $url = StaticAsset::url('/js/localized-date-formatter.js');
+
+        $this->assertStringContainsString('/js/localized-date-formatter.js?v=', $url);
+        $this->assertTrue((bool) preg_match('/\?v=\d+$/', $url));
+    }
+
+    public function testUrlReturnsPathUnchangedWhenAssetIsMissing(): void
+    {
+        $this->assertSame('/js/does-not-exist.js', StaticAsset::url('/js/does-not-exist.js'));
+    }
+}

--- a/wwwroot/admin/log.php
+++ b/wwwroot/admin/log.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/bootstrap.php';
+require_once '../classes/StaticAsset.php';
 require_once '../classes/Admin/LogEntry.php';
 require_once '../classes/Admin/LogEntryFormatter.php';
 require_once '../classes/Admin/LogService.php';
@@ -33,7 +34,7 @@ if ($pageResult->getTotalPages() > 1) {
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
         <title>Admin ~ Logs</title>
-        <script src="/js/localized-date-formatter.js" defer></script>
+        <script src="<?= htmlspecialchars(StaticAsset::url('/js/localized-date-formatter.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
     </head>
     <body>
         <div class="container py-4">

--- a/wwwroot/admin/workers.php
+++ b/wwwroot/admin/workers.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/bootstrap.php';
+require_once '../classes/StaticAsset.php';
 require_once '../classes/Admin/AdminRequest.php';
 require_once '../classes/Admin/WorkerService.php';
 require_once '../classes/Admin/WorkerPage.php';
@@ -38,7 +39,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
             crossorigin="anonymous"
         >
         <title>Admin ~ Workers</title>
-        <script src="/js/localized-date-formatter.js" defer></script>
+        <script src="<?= htmlspecialchars(StaticAsset::url('/js/localized-date-formatter.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
     </head>
     <body>
         <div class="container py-4">

--- a/wwwroot/classes/StaticAsset.php
+++ b/wwwroot/classes/StaticAsset.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+final class StaticAsset
+{
+    public static function url(string $webPath): string
+    {
+        $webPath = '/' . ltrim($webPath, '/');
+        $fullPath = dirname(__DIR__) . $webPath;
+
+        if (!is_file($fullPath)) {
+            return $webPath;
+        }
+
+        return $webPath . '?v=' . filemtime($fullPath);
+    }
+}

--- a/wwwroot/header.php
+++ b/wwwroot/header.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/classes/PageMetaData.php';
 require_once __DIR__ . '/classes/PageMetaDataRenderer.php';
 require_once __DIR__ . '/classes/SessionManager.php';
 require_once __DIR__ . '/classes/CsrfTokenManager.php';
+require_once __DIR__ . '/classes/StaticAsset.php';
 
 SessionManager::ensureStarted();
 $publicCsrfToken = htmlspecialchars(CsrfTokenManager::getToken('public'), ENT_QUOTES, 'UTF-8');
@@ -161,7 +162,7 @@ if (isset($metaData) && $metaData instanceof PageMetaData) {
             }
         </style>
 
-        <script src="/js/localized-date-formatter.js" defer></script>
+        <script src="<?= htmlspecialchars(StaticAsset::url('/js/localized-date-formatter.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
 
         <title><?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?></title>
     </head>

--- a/wwwroot/js/localized-date-formatter.js
+++ b/wwwroot/js/localized-date-formatter.js
@@ -102,6 +102,12 @@ class LocalizedDateFormatter {
 
 window.LocalizedDateFormatter = LocalizedDateFormatter;
 
-document.addEventListener('DOMContentLoaded', () => {
+function initializeLocalizedDates() {
     LocalizedDateFormatter.initializeAll();
-});
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeLocalizedDates);
+} else {
+    initializeLocalizedDates();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After Phase 4 merged, dates disappeared across multiple pages:

- Player profile game rows
- Game earned-trophy dates
- Game leaderboard
- Game recent players
- Trophy achiever tables

Phase 4 removed the per-page inline `LocalizedDateFormatter` init scripts and moved initialization into `localized-date-formatter.js`. Production is still serving the pre-Phase 4 script (no auto-init), so the new empty `<span>` / `<td>` markers never get formatted.

## Fix

- Make `localized-date-formatter.js` initialize immediately when the document is already parsed (not only on `DOMContentLoaded`).
- Add `StaticAsset::url()` cache-busting via `filemtime` for the formatter script in `header.php`, `admin/log.php`, and `admin/workers.php`, so deploys reliably fetch the updated JS instead of a cached old copy.

## Testing

- `php tests/run.php` (787 tests passing)
- Simulated formatter init with `document.readyState === 'complete'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

