### PR TITLE
Show date and time only on admin log and workers pages

### DIFF
--- a/wwwroot/admin/log.php
+++ b/wwwroot/admin/log.php
@@ -97,8 +97,8 @@ if ($pageResult->getTotalPages() > 1) {
                                         <td class="text-nowrap">#<?= htmlspecialchars((string) $entry->getId(), ENT_QUOTES, 'UTF-8'); ?></td>
                                         <td>
                                             <?php $time = $entry->getTime(); ?>
-                                            <time class="small text-body-secondary js-localized-datetime" datetime="<?= htmlspecialchars($time->format(DATE_ATOM), ENT_QUOTES, 'UTF-8'); ?>" data-show-timezone="1">
-                                                <?= htmlspecialchars($time->format('Y-m-d H:i:s T'), ENT_QUOTES, 'UTF-8'); ?>
+                                            <time class="small text-body-secondary js-localized-datetime" datetime="<?= htmlspecialchars($time->format(DATE_ATOM), ENT_QUOTES, 'UTF-8'); ?>">
+                                                <?= htmlspecialchars($time->format('Y-m-d H:i:s'), ENT_QUOTES, 'UTF-8'); ?>
                                             </time>
                                         </td>
                                         <td><?= $entry->getFormattedMessage(); ?></td>

--- a/wwwroot/admin/workers.php
+++ b/wwwroot/admin/workers.php
@@ -153,9 +153,8 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                         <time
                                             class="js-localized-datetime"
                                             datetime="<?= htmlspecialchars($scanStart->format(DATE_ATOM), ENT_QUOTES, 'UTF-8'); ?>"
-                                            data-show-timezone="1"
                                         >
-                                            <?= htmlspecialchars($scanStart->format('Y-m-d H:i:s T'), ENT_QUOTES, 'UTF-8'); ?>
+                                            <?= htmlspecialchars($scanStart->format('Y-m-d H:i:s'), ENT_QUOTES, 'UTF-8'); ?>
                                         </time>
                                     </td>
                                     <td>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Admin log and workers pages used `data-show-timezone="1"`, which made `localized-date-formatter.js` append the browser timezone name (e.g. `Europe/Stockholm`) after each timestamp.

## Fix

Remove `data-show-timezone` from both admin templates and use `Y-m-d H:i:s` for the no-JS fallback. Localized output is now `2026-07-08 14:01:54` only.

## Testing

- `php tests/run.php` (787 tests passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

