### PR TITLE
Phase 5: remove unused jQuery from public footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ IP per minute. Admin login locks an IP for 15 minutes after five failed attempts
 - Class-layer HTML escaping migrated to `Html::escape()` in changelog, game header,
   history, and message sanitizer code paths.
 
+### Security hardening (Phase 5)
+
+- Removed unused jQuery from the public footer and dropped `code.jquery.com` from the
+  CSP Report-Only allowlist.
+
 Optional MySQL integration tests (including IP lock acquisition) run when
 `PSN100_INTEGRATION_TEST_DB=1` and a reachable `DB_*` configuration are available.
 

--- a/wwwroot/footer.php
+++ b/wwwroot/footer.php
@@ -11,8 +11,7 @@ $footerRenderer = new FooterRenderer();
 echo $footerRenderer->render($footerViewModel);
 ?>
         
-        <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-        <script src="https://code.jquery.com/jquery-3.7.1.slim.min.js"></script>
+        <!-- Popper.js, then Bootstrap JS -->
         <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js" integrity="sha384-G/EV+4j2dNv+tEPo3++6LCgdCROaejBqfUeNjuKAiuXbjrxilcCdDz6ZAVfHWe1Y" crossorigin="anonymous"></script>
     </body>

--- a/wwwroot/init.php
+++ b/wwwroot/init.php
@@ -14,7 +14,7 @@ header('Referrer-Policy: strict-origin-when-cross-origin');
 header('X-Frame-Options: SAMEORIGIN');
 header(
     "Content-Security-Policy-Report-Only: default-src 'self'; "
-    . "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://code.jquery.com https://cdnjs.cloudflare.com; "
+    . "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; "
     . "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
     . "img-src 'self' data: https:; "
     . "font-src 'self' https://cdn.jsdelivr.net; "


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Phase 5 starts by reducing third-party script surface before CSP enforcement and CDN self-hosting.

`footer.php` loaded jQuery Slim from `code.jquery.com` on every public page, but nothing in the codebase uses `$()` or `jQuery`.

## Fix

- Remove the unused jQuery `<script>` tag from `footer.php`.
- Drop `https://code.jquery.com` from the CSP Report-Only `script-src` allowlist in `init.php`.

Popper and Bootstrap JS remain unchanged.

## Testing

- `php tests/run.php` (787 tests passing)
- Confirmed no `jQuery` / `$()` usage anywhere in the repository
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

