### PR TITLE
Phase 5: extract admin report delete confirmation JS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,8 @@ the non-obvious steps to actually run the services.
 - Date localization uses `/js/localized-date-formatter.js`; changelog grouping uses
   `/js/changelog-date-grouping.js`; homepage queue polling uses
   `/js/player-queue-manager.js`; about-page scan log polling uses
-  `/js/scan-log-renderer.js`.
+  `/js/scan-log-renderer.js`; admin reported-player deletes use
+  `/js/admin-report-delete.js`.
 
 ### Composer
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ IP per minute. Admin login locks an IP for 15 minutes after five failed attempts
   `player-queue-manager.js`, removing the large inline script from `home.php`.
 - About-page scan log polling moved to `scan-log-renderer.js` with row-entry
   animation styles in `scan-log-renderer.css`.
+- Admin reported-players delete confirmation moved to `admin-report-delete.js`.
 
 Optional MySQL integration tests (including IP lock acquisition) run when
 `PSN100_INTEGRATION_TEST_DB=1` and a reachable `DB_*` configuration are available.

--- a/wwwroot/admin/report.php
+++ b/wwwroot/admin/report.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/bootstrap.php';
+require_once '../classes/StaticAsset.php';
 require_once '../classes/Admin/PlayerReportAdminService.php';
 require_once '../classes/Admin/PlayerReportAdminPage.php';
 
@@ -21,6 +22,7 @@ $errorMessage = $pageResult->getErrorMessage();
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
         <title>Admin ~ Reported Players</title>
+        <script src="<?= htmlspecialchars(StaticAsset::url('/js/admin-report-delete.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
     </head>
     <body>
         <div class="p-4">
@@ -54,14 +56,5 @@ $errorMessage = $pageResult->getErrorMessage();
                 <hr>
             <?php } ?>
         </div>
-        <script>
-            document.querySelectorAll('.js-report-delete-form').forEach((form) => {
-                form.addEventListener('submit', (event) => {
-                    if (!window.confirm('Are you sure you want to delete this report?')) {
-                        event.preventDefault();
-                    }
-                });
-            });
-        </script>
     </body>
 </html>

--- a/wwwroot/js/admin-report-delete.js
+++ b/wwwroot/js/admin-report-delete.js
@@ -1,0 +1,15 @@
+function initializeReportDeleteForms() {
+    document.querySelectorAll('.js-report-delete-form').forEach((form) => {
+        form.addEventListener('submit', (event) => {
+            if (!window.confirm('Are you sure you want to delete this report?')) {
+                event.preventDefault();
+            }
+        });
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeReportDeleteForms);
+} else {
+    initializeReportDeleteForms();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Phase 5 continues extracting inline JavaScript ahead of CSP enforcement. `admin/report.php` contained an inline script that wired delete confirmations on reported-player forms.

## Fix

- Add `wwwroot/js/admin-report-delete.js` with the delete-form confirm handler and DOM-ready initialization.
- Load the script from `admin/report.php` via `StaticAsset::url()` with cache-busting.
- Remove the inline `<script>` block.

## Testing

- `php tests/run.php` (787 tests passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

