### PR TITLE
Phase 5: migrate player pages to Html::escape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,9 @@ the non-obvious steps to actually run the services.
   `/js/admin-report-delete.js`; admin log bulk actions use
   `/js/admin-log-bulk-actions.js`; admin game merge UI uses `/js/admin-merge-form.js`;
   admin game rescan UI uses `/js/admin-rescan-form.js`.
+- Player page templates (`player.php`, `player_header.php`, `player_log.php`,
+  `player_advisor.php`, `player_random.php`, `player_report.php`) and
+  `PlayerHeaderViewModel` use `Html::escape()` for output escaping.
 
 ### Composer
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ IP per minute. Admin login locks an IP for 15 minutes after five failed attempts
 - Bootstrap 5.3.8 and Popper 2.11.8 are self-hosted under `wwwroot/lib/` via
   `BootstrapAssets`, removing `cdn.jsdelivr.net` from templates and the CSP
   Report-Only allowlist.
+- Player page templates and `PlayerHeaderViewModel` now use `Html::escape()` instead
+  of `htmlentities()`.
 
 Optional MySQL integration tests (including IP lock acquisition) run when
 `PSN100_INTEGRATION_TEST_DB=1` and a reachable `DB_*` configuration are available.

--- a/wwwroot/classes/PlayerHeaderViewModel.php
+++ b/wwwroot/classes/PlayerHeaderViewModel.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Html.php';
+
 require_once __DIR__ . '/PlayerSummary.php';
 require_once __DIR__ . '/Utility.php';
 require_once __DIR__ . '/PlayerLeaderboardRank.php';
@@ -23,7 +25,7 @@ final readonly class PlayerHeaderViewModel
     {
         $aboutMe = (string) ($this->player['about_me'] ?? '');
 
-        $escapedAboutMe = htmlentities($aboutMe, ENT_QUOTES, 'UTF-8');
+        $escapedAboutMe = Html::escape($aboutMe);
 
         return str_replace(["\r\n", "\r", "\n"], '&#10;', $escapedAboutMe);
     }

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerGamesPageContext.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
@@ -58,7 +60,7 @@ require_once("header.php");
             <div class="col-12 col-lg-3 mb-3">
                 <form>
                     <div class="input-group d-flex justify-content-end">
-                        <input type="text" name="search" class="form-control rounded-start" placeholder="Game..." value="<?= htmlentities($playerSearch, ENT_QUOTES, 'UTF-8'); ?>" aria-label="Text input to search for a game within the player">
+                        <input type="text" name="search" class="form-control rounded-start" placeholder="Game..." value="<?= Html::escape($playerSearch); ?>" aria-label="Text input to search for a game within the player">
 
                         <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Filter</button>
                         <ul class="dropdown-menu p-2">
@@ -144,12 +146,12 @@ require_once("header.php");
                                     <tr<?= $rowAttributes; ?>>
                                         <td scope="row">
                                             <div class="hstack gap-3">
-                                                <img src="/img/title/<?= htmlspecialchars($playerGame->getIconFileName(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($playerGame->getName()); ?>" width="100" />
+                                                <img src="/img/title/<?= htmlspecialchars($playerGame->getIconFileName(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($playerGame->getName()); ?>" width="100" />
 
                                                 <div class="vstack">
                                                     <span>
                                                         <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars(PlayerUrlBuilder::gamePlayerPath($playerGame->getId() . '-' . $utility->slugify($playerGame->getName()), $playerOnlineId), ENT_QUOTES, 'UTF-8'); ?>">
-                                                            <?= htmlentities($playerGame->getName()); ?>
+                                                            <?= Html::escape($playerGame->getName()); ?>
                                                         </a>
                                                     </span>
 
@@ -170,7 +172,7 @@ require_once("header.php");
                                         <td class="align-middle text-center">
                                             <?php
                                             foreach ($playerGame->getPlatforms() as $platform) {
-                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1 mb-1\">" . htmlentities($platform) . "</span> ";
+                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1 mb-1\">" . Html::escape($platform) . "</span> ";
                                             }
                                             ?>
                                         </td>

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerAdvisorPageContext.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
@@ -104,7 +106,7 @@ require_once("header.php");
                                     <tr>
                                         <td scope="row" class="text-center align-middle">
                                             <a href="/game/<?= htmlspecialchars($gameLink, ENT_QUOTES, 'UTF-8'); ?>">
-                                                <?php $gameName = htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>
+                                                <?php $gameName = Html::escape($trophy->getGameName()); ?>
                                                 <img src="/img/title/<?= htmlspecialchars($trophy->getGameIconUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= $gameName; ?>" title="<?= $gameName; ?>" style="width: 10rem;" />
                                             </a>
                                         </td>
@@ -112,7 +114,7 @@ require_once("header.php");
                                             <div class="hstack gap-3">
                                                 <div class="d-flex align-items-center justify-content-center">
                                                     <a href="/trophy/<?= htmlspecialchars($trophyLink, ENT_QUOTES, 'UTF-8'); ?>">
-                                                        <?php $trophyName = htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>
+                                                        <?php $trophyName = Html::escape($trophy->getTrophyName()); ?>
                                                         <img src="/img/trophy/<?= htmlspecialchars($trophy->getTrophyIconUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= $trophyName; ?>" title="<?= $trophyName; ?>" style="width: 5rem;" />
                                                     </a>
                                                 </div>
@@ -124,14 +126,14 @@ require_once("header.php");
                                                                 <b><?= $trophyName; ?></b>
                                                             </a>
                                                         </span>
-                                                        <?= nl2br(htmlentities($trophy->getTrophyDetail(), ENT_QUOTES, 'UTF-8')); ?>
+                                                        <?= nl2br(Html::escape($trophy->getTrophyDetail())); ?>
                                                         <?php
                                                         if ($progressLabel !== null) {
                                                             echo '<br><b>' . htmlspecialchars($progressLabel, ENT_QUOTES, 'UTF-8') . '</b>';
                                                         }
 
                                                         if ($trophy->hasReward()) {
-                                                            $rewardName = htmlentities((string) $trophy->getRewardName(), ENT_QUOTES, 'UTF-8');
+                                                            $rewardName = Html::escape((string) $trophy->getRewardName());
                                                             $rewardImage = htmlspecialchars((string) $trophy->getRewardImageUrl(), ENT_QUOTES, 'UTF-8');
                                                             echo "<br>Reward: <a href='/img/reward/{$rewardImage}'>{$rewardName}</a>";
                                                         }
@@ -144,7 +146,7 @@ require_once("header.php");
                                             <div class="vstack gap-1">
                                                 <?php
                                                 foreach ($trophy->getPlatforms() as $platform) {
-                                                    echo '<span class="badge rounded-pill text-bg-primary p-2">' . htmlentities($platform, ENT_QUOTES, 'UTF-8') . '</span> ';
+                                                    echo '<span class="badge rounded-pill text-bg-primary p-2">' . Html::escape($platform) . '</span> ';
                                                 }
                                                 ?>
                                             </div>

--- a/wwwroot/player_header.php
+++ b/wwwroot/player_header.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/PlayerHeaderViewModel.php';
 
 $playerHeaderViewModel = new PlayerHeaderViewModel($player, $playerSummary, $utility);
@@ -50,7 +52,7 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
 
             <!-- Country -->
             <div class="ms-auto">
-                <?php $countryName = htmlentities($playerHeaderViewModel->getCountryName(), ENT_QUOTES, 'UTF-8'); ?>
+                <?php $countryName = Html::escape($playerHeaderViewModel->getCountryName()); ?>
                 <img src="/img/country/<?= htmlspecialchars($playerHeaderViewModel->getCountryCode(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
             </div>
         </div>

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerLogPageContext.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
@@ -111,14 +113,14 @@ require_once("header.php");
                                     <tr<?= $rowClassAttribute; ?>>
                                         <td scope="row" class="text-center align-middle">
                                             <a href="<?= htmlspecialchars($gameUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                                                <img src="/img/title/<?= htmlspecialchars($trophy->getGameIconRelativePath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 10rem;" />
+                                                <img src="/img/title/<?= htmlspecialchars($trophy->getGameIconRelativePath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($trophy->getGameName()); ?>" title="<?= Html::escape($trophy->getGameName()); ?>" style="width: 10rem;" />
                                             </a>
                                         </td>
                                         <td class="align-middle">
                                             <div class="hstack gap-3">
                                                 <div class="d-flex align-items-center justify-content-center">
                                                     <a href="<?= htmlspecialchars($trophyUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                                                        <img src="/img/trophy/<?= htmlspecialchars($trophy->getTrophyIconRelativePath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 5rem;" />
+                                                        <img src="/img/trophy/<?= htmlspecialchars($trophy->getTrophyIconRelativePath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($trophy->getTrophyName()); ?>" title="<?= Html::escape($trophy->getTrophyName()); ?>" style="width: 5rem;" />
                                                     </a>
                                                 </div>
 
@@ -126,13 +128,13 @@ require_once("header.php");
                                                     <div class="vstack">
                                                         <span>
                                                             <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($trophyUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                                                                <b><?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?></b>
+                                                                <b><?= Html::escape($trophy->getTrophyName()); ?></b>
                                                             </a>
                                                         </span>
-                                                        <?= nl2br(htmlentities($trophy->getTrophyDetail(), ENT_QUOTES, 'UTF-8')); ?>
+                                                        <?= nl2br(Html::escape($trophy->getTrophyDetail())); ?>
                                                         <?php
                                                         if ($progressDisplay !== null) {
-                                                            echo '<br><b>' . htmlentities($progressDisplay, ENT_QUOTES, 'UTF-8') . '</b>';
+                                                            echo '<br><b>' . Html::escape($progressDisplay) . '</b>';
                                                         }
 
                                                         if ($rewardName !== null && $rewardImageUrl !== null) {
@@ -190,7 +192,7 @@ require_once("header.php");
                                             </div>
                                         </td>
                                         <td class="text-center align-middle">
-                                            <img src="/img/trophy-<?= htmlspecialchars($trophy->getTrophyType(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= htmlentities(ucfirst($trophy->getTrophyType()), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities(ucfirst($trophy->getTrophyType()), ENT_QUOTES, 'UTF-8'); ?>" height="50" />
+                                            <img src="/img/trophy-<?= htmlspecialchars($trophy->getTrophyType(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= Html::escape(ucfirst($trophy->getTrophyType())); ?>" title="<?= Html::escape(ucfirst($trophy->getTrophyType())); ?>" height="50" />
                                         </td>
                                     </tr>
                                     <?php

--- a/wwwroot/player_random.php
+++ b/wwwroot/player_random.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerRandomGamesPageContext.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
@@ -80,11 +82,11 @@ require_once("header.php");
                                 <div class="card">
                                     <div class="d-flex justify-content-center align-items-center" style="min-height: 11.5rem;">
                                         <a href="/game/<?= htmlspecialchars($gameLink, ENT_QUOTES, 'UTF-8'); ?>">
-                                            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= htmlspecialchars($game->getIconUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($game->getName()); ?>">
+                                            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= htmlspecialchars($game->getIconUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($game->getName()); ?>">
                                             <div class="card-img-overlay d-flex align-items-end p-2">
                                                 <?php
                                                 foreach ($game->getPlatforms() as $platform) {
-                                                    echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">" . htmlentities($platform) . "</span> ";
+                                                    echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">" . Html::escape($platform) . "</span> ";
                                                 }
                                                 ?>
                                             </div>
@@ -101,7 +103,7 @@ require_once("header.php");
                             <!-- name -->
                             <div class="text-center">
                                 <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= htmlspecialchars($gameLink, ENT_QUOTES, 'UTF-8'); ?>">
-                                    <?= htmlentities($game->getName()); ?>
+                                    <?= Html::escape($game->getName()); ?>
                                 </a>
                             </div>
 

--- a/wwwroot/player_report.php
+++ b/wwwroot/player_report.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerReportHandler.php';
 require_once __DIR__ . '/classes/PlayerReportPage.php';
@@ -80,7 +82,7 @@ require_once("header.php");
                             <li>Include the game and trophy name and why it's wrong.</li>
                             <li>"This player is banned on X and/or Y!" isn't going to help, we need specific details on what trophy and why it's wrong.</li>
                         </ul>
-                        <textarea class="form-control" id="explanation" name="explanation" maxlength="256" rows="7" aria-describedby="explanationHelp"><?= htmlentities($explanation, ENT_QUOTES, 'UTF-8'); ?></textarea>
+                        <textarea class="form-control" id="explanation" name="explanation" maxlength="256" rows="7" aria-describedby="explanationHelp"><?= Html::escape($explanation); ?></textarea>
                         <div id="explanationHelp" class="form-text">Or use <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="https://github.com/Ragowit/psn100/issues">issues</a> to include images and get feedback on your report (requires GitHub login).</div>
                     </div>
                     <button type="submit" class="btn btn-primary">Submit</button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replace `htmlentities()` with `Html::escape()` across player page templates and `PlayerHeaderViewModel`.
- `Html::escape()` uses `ENT_QUOTES | ENT_SUBSTITUTE`, matching the stricter escaping already used in class-layer code.

## Files

- `player.php`, `player_header.php`, `player_log.php`, `player_advisor.php`, `player_random.php`, `player_report.php`
- `classes/PlayerHeaderViewModel.php` (`getAboutMe()`)

## Test plan

- [x] `php tests/run.php` — 790 tests passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

