### PR TITLE
Phase 5: migrate game pages to Html::escape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,8 @@ the non-obvious steps to actually run the services.
 - Player page templates (`player.php`, `player_header.php`, `player_log.php`,
   `player_advisor.php`, `player_random.php`, `player_report.php`) and
   `PlayerHeaderViewModel` use `Html::escape()` for output escaping.
+- Game page templates (`game.php`, `game_header.php`, `game_history.php`, `games.php`,
+  `trophy.php`, `trophies.php`, `home.php`) and `TrophyPage` use `Html::escape()`.
 
 ### Composer
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ IP per minute. Admin login locks an IP for 15 minutes after five failed attempts
   Report-Only allowlist.
 - Player page templates and `PlayerHeaderViewModel` now use `Html::escape()` instead
   of `htmlentities()`.
+- Game page templates (`game.php`, `game_header.php`, `game_history.php`, `games.php`,
+  `trophy.php`, `trophies.php`, `home.php`) and `TrophyPage` use `Html::escape()`.
 
 Optional MySQL integration tests (including IP lock acquisition) run when
 `PSN100_INTEGRATION_TEST_DB=1` and a reachable `DB_*` configuration are available.

--- a/wwwroot/classes/TrophyPage.php
+++ b/wwwroot/classes/TrophyPage.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Html.php';
+
 require_once __DIR__ . '/PageMetaData.php';
 require_once __DIR__ . '/TrophyService.php';
 require_once __DIR__ . '/TrophyRarityFormatter.php';
@@ -83,7 +85,7 @@ class TrophyPage
         $trophyName = $trophy->getName();
         $metaData = (new PageMetaData())
             ->withTitle($trophyName . ' Trophy')
-            ->withDescription(htmlentities($trophy->getDetail(), ENT_QUOTES, 'UTF-8'))
+            ->withDescription(Html::escape($trophy->getDetail()))
             ->withImage('https://psn100.net/img/trophy/' . $trophy->getIconFileName())
             ->withUrl('https://psn100.net/trophy/' . $trophy->getTrophySlug($utility));
 

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/GamePage.php';
 require_once __DIR__ . '/classes/GameTrophyFilter.php';
 require_once __DIR__ . '/classes/TrophyRarityFormatter.php';
@@ -125,12 +127,12 @@ require_once("header.php");
                                     <th scope="col" colspan="5" class="bg-dark-subtle">
                                         <div class="hstack gap-3">
                                             <div>
-                                                <img class="card-img object-fit-cover" style="height: 7rem;" src="/img/group/<?= htmlspecialchars($trophyGroup->getIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophyGroup->getName()); ?>">
+                                                <img class="card-img object-fit-cover" style="height: 7rem;" src="/img/group/<?= htmlspecialchars($trophyGroup->getIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($trophyGroup->getName()); ?>">
                                             </div>
                                             
                                             <div>
-                                                <b><?= htmlentities($trophyGroup->getName()); ?></b><br>
-                                                <?= nl2br(htmlentities($trophyGroup->getDetail(), ENT_QUOTES, 'UTF-8')); ?>
+                                                <b><?= Html::escape($trophyGroup->getName()); ?></b><br>
+                                                <?= nl2br(Html::escape($trophyGroup->getDetail())); ?>
                                             </div>
 
                                             <div class="ms-auto">
@@ -228,7 +230,7 @@ require_once("header.php");
                                                     class="card-img object-fit-scale"
                                                     style="height: 5rem;"
                                                     src="/img/trophy/<?= htmlspecialchars($trophyRow->getIconPath(), ENT_QUOTES, 'UTF-8'); ?>"
-                                                    alt="<?= htmlentities($trophyRow->getName()); ?>"
+                                                    alt="<?= Html::escape($trophyRow->getName()); ?>"
                                                 >
                                             </div>
                                         </td>
@@ -240,10 +242,10 @@ require_once("header.php");
                                                         class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover"
                                                         href="<?= htmlspecialchars($trophyLink, ENT_QUOTES, 'UTF-8'); ?>"
                                                     >
-                                                        <b><?= htmlentities($trophyRow->getName()); ?></b>
+                                                        <b><?= Html::escape($trophyRow->getName()); ?></b>
                                                     </a>
                                                 </span>
-                                                <?= nl2br(htmlentities($trophyRow->getDetail(), ENT_QUOTES, 'UTF-8')); ?>
+                                                <?= nl2br(Html::escape($trophyRow->getDetail())); ?>
                                                 <?php
                                                 $progressDisplay = $trophyRow->getProgressDisplay();
                                                 if ($progressDisplay !== null) {

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/Game/GamePlayerProgress.php';
 require_once __DIR__ . '/classes/GameMessageSanitizer.php';
 
@@ -23,7 +25,7 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
             ?>
             <div class="col-12">
                 <div class="alert alert-warning" role="alert">
-                    This game has been merged into <a href="/game/<?= $parentLink; ?>"><?= htmlentities($parentGame->getName()); ?></a>. Earned trophies in this entry will not be accounted for on any leaderboard.
+                    This game has been merged into <a href="/game/<?= $parentLink; ?>"><?= Html::escape($parentGame->getName()); ?></a>. Earned trophies in this entry will not be accounted for on any leaderboard.
                 </div>
             </div>
             <?php
@@ -64,8 +66,8 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
 
             $replacementLinks[] = sprintf(
                 '<a href="%s">%s</a>',
-                htmlentities($replacementLink, ENT_QUOTES, 'UTF-8'),
-                htmlentities($replacement->getName(), ENT_QUOTES, 'UTF-8')
+                Html::escape($replacementLink),
+                Html::escape($replacement->getName())
             );
         }
 
@@ -136,14 +138,14 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
                     : '../missing-ps4-game.png')
                 : $gameIconUrl;
             ?>
-            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= htmlspecialchars($iconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($game->getName()); ?>">
+            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= htmlspecialchars($iconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($game->getName()); ?>">
         </div>
 
         <div class="col-12 col-lg-6">
             <div class="vstack gap-3">
                 <div class="hstack">
                     <div>
-                        <h1><?= htmlentities($game->getName()); ?></h1>
+                        <h1><?= Html::escape($game->getName()); ?></h1>
                     </div>
 
                     <?php
@@ -167,12 +169,12 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
                                     ?>
                                     <li class="dropdown-item">
                                         <a class="dropdown-item" href="/game/<?= $stackLink; ?>">
-                                            <?= htmlentities($stack->getName()); ?>
-                                            <span class="badge rounded-pill text-bg-primary"><?= htmlentities($stack->getPlatform()); ?></span>
+                                            <?= Html::escape($stack->getName()); ?>
+                                            <span class="badge rounded-pill text-bg-primary"><?= Html::escape($stack->getPlatform()); ?></span>
                                             <?php
                                             if ($region !== null) {
                                                 ?>
-                                                <span class="badge rounded-pill text-bg-primary"><?= htmlentities($region); ?></span>
+                                                <span class="badge rounded-pill text-bg-primary"><?= Html::escape($region); ?></span>
                                                 <?php
                                             }
                                             ?>
@@ -200,8 +202,8 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
                     <?php
                     $region = $game->getRegion();
                     ?>
-                    Version: <?= htmlentities($game->getSetVersion(), ENT_QUOTES, 'UTF-8'); ?>
-                    <?= ($region === null ? '' : " <span class=\"badge rounded-pill text-bg-primary\">" . htmlentities($region, ENT_QUOTES, 'UTF-8') . '</span>') ?>
+                    Version: <?= Html::escape($game->getSetVersion()); ?>
+                    <?= ($region === null ? '' : " <span class=\"badge rounded-pill text-bg-primary\">" . Html::escape($region) . '</span>') ?>
                 </div>
 
                 <div>

--- a/wwwroot/game_history.php
+++ b/wwwroot/game_history.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/GameHistoryPage.php';
 require_once __DIR__ . '/classes/GameHistoryRenderer.php';
 
@@ -123,7 +125,7 @@ require_once 'header.php';
                                 $titleFieldDiffs = $entry['titleFieldDiffs'] ?? [];
                                 ?>
                                 <span class="fw-semibold">
-                                    Version <?= htmlentities($setVersion ?? 'Unknown', ENT_QUOTES, 'UTF-8'); ?>
+                                    Version <?= Html::escape($setVersion ?? 'Unknown'); ?>
                                     <?php if ($titleHighlights['set_version'] ?? false) { ?>
                                         <span class="badge text-bg-success ms-2">New</span>
                                     <?php } ?>
@@ -131,7 +133,7 @@ require_once 'header.php';
                             </div>
                             <?php $discoveredAt = $entry['discoveredAt']; ?>
                             <time class="text-body-secondary small js-localized-datetime" datetime="<?= htmlspecialchars($discoveredAt->format(DATE_ATOM), ENT_QUOTES, 'UTF-8'); ?>" data-show-timezone="1">
-                                <?= htmlentities($discoveredAt->format('Y-m-d H:i:s'), ENT_QUOTES, 'UTF-8'); ?> UTC
+                                <?= Html::escape($discoveredAt->format('Y-m-d H:i:s')); ?> UTC
                             </time>
                         </div>
                         <div class="card-body">
@@ -173,7 +175,7 @@ require_once 'header.php';
                                                     ?>
                                                     <tr class="<?= $groupIsNewRow ? 'table-success' : ''; ?>">
                                                         <td>
-                                                            <span class="badge text-bg-secondary"><?= htmlentities($groupChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span>
+                                                            <span class="badge text-bg-secondary"><?= Html::escape($groupChange['group_id']); ?></span>
                                                         </td>
                                                         <td>
                                                             <?php if ($groupIsNewRow) { ?>
@@ -235,7 +237,7 @@ require_once 'header.php';
                                                     ?>
                                                     <tr class="<?= $trophyIsNewRow ? 'table-success' : ''; ?>">
                                                         <td class="<?= ($trophyChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
-                                                            <span class="badge text-bg-secondary"><?= htmlentities($trophyChange['group_id'], ENT_QUOTES, 'UTF-8'); ?></span>
+                                                            <span class="badge text-bg-secondary"><?= Html::escape($trophyChange['group_id']); ?></span>
                                                         </td>
                                                         <td class="<?= ($trophyChange['isNewRow'] ?? false) ? 'table-success' : ''; ?>">
                                                             <?php if ($trophyChange['is_unobtainable'] ?? false) { ?>

--- a/wwwroot/games.php
+++ b/wwwroot/games.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/GameListFilter.php';
 require_once __DIR__ . '/classes/GameListService.php';
 require_once __DIR__ . '/classes/GameListPage.php';
@@ -33,8 +35,8 @@ require_once("header.php");
             <form>
                 <div class="input-group d-flex justify-content-end">
                     <input type="hidden" name="page" value="<?= $gameListPage->getCurrentPage(); ?>">
-                    <input type="hidden" name="search" value="<?= htmlentities($filter->getSearch(), ENT_QUOTES, 'UTF-8'); ?>">
-                    <input type="text" name="player" class="form-control rounded-start" maxlength="16" placeholder="View as player..." value="<?= htmlentities($filter->getPlayer() ?? '', ENT_QUOTES, 'UTF-8'); ?>" aria-label="Text input to show completed games for specified player">
+                    <input type="hidden" name="search" value="<?= Html::escape($filter->getSearch()); ?>">
+                    <input type="text" name="player" class="form-control rounded-start" maxlength="16" placeholder="View as player..." value="<?= Html::escape($filter->getPlayer() ?? ''); ?>" aria-label="Text input to show completed games for specified player">
 
                     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Filter</button>
                     <ul class="dropdown-menu p-2">
@@ -152,11 +154,11 @@ require_once("header.php");
                             <div class="card">
                                 <div class="d-flex justify-content-center align-items-center" style="min-height: 11.5rem;">
                                     <a href="/game/<?= $gameLink; ?>">
-                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= htmlspecialchars($iconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($game->getName()); ?>">
+                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= htmlspecialchars($iconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($game->getName()); ?>">
                                         <div class="card-img-overlay d-flex align-items-end p-2">
                                             <?php
                                             foreach ($platforms as $platform) {
-                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">" . htmlentities($platform) . "</span> ";
+                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">" . Html::escape($platform) . "</span> ";
                                             }
                                             ?>
                                         </div>
@@ -173,7 +175,7 @@ require_once("header.php");
                         <!-- name -->
                         <div class="text-center">
                             <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= $gameLink; ?>">
-                                <?= htmlentities($game->getName()); ?>
+                                <?= Html::escape($game->getName()); ?>
                             </a>
                         </div>
 

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once 'classes/HomepageController.php';
 require_once 'classes/HomepagePopularGamesFilter.php';
 
@@ -55,11 +57,11 @@ require_once("header.php");
                                             <div class="card">
                                                 <div class="d-flex justify-content-center align-items-center" style="min-height: 11.5rem;">
                                                     <a href="<?= $gameUrl; ?>">
-                                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="<?= $game->getIconPath(); ?>" alt="<?= htmlentities($game->getName()); ?>">
+                                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="<?= $game->getIconPath(); ?>" alt="<?= Html::escape($game->getName()); ?>">
                                                         <div class="card-img-overlay d-flex align-items-end p-2">
                                                             <?php
                                                             foreach ($game->getPlatforms() as $platform) {
-                                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">" . htmlentities($platform) . "</span> ";
+                                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">" . Html::escape($platform) . "</span> ";
                                                             }
                                                             ?>
                                                         </div>
@@ -76,7 +78,7 @@ require_once("header.php");
                                         <!-- name -->
                                         <div class="text-center">
                                             <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= $gameUrl; ?>">
-                                                <?= htmlentities($game->getName()); ?>
+                                                <?= Html::escape($game->getName()); ?>
                                             </a>
                                         </div>
                                     </div>
@@ -106,11 +108,11 @@ require_once("header.php");
                                             <div class="card">
                                                 <div class="d-flex justify-content-center align-items-center" style="min-height: 11.5rem;">
                                                     <a href="<?= $dlcUrl; ?>">
-                                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="<?= $dlc->getIconPath(); ?>" alt="<?= htmlentities($dlc->getGroupName()); ?>">
+                                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="<?= $dlc->getIconPath(); ?>" alt="<?= Html::escape($dlc->getGroupName()); ?>">
                                                         <div class="card-img-overlay d-flex align-items-end p-2">
                                                             <?php
                                                             foreach ($dlc->getPlatforms() as $platform) {
-                                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">" . htmlentities($platform) . "</span> ";
+                                                                echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">" . Html::escape($platform) . "</span> ";
                                                             }
                                                             ?>
                                                         </div>
@@ -127,7 +129,7 @@ require_once("header.php");
                                         <!-- name -->
                                         <div class="text-center">
                                             <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= $dlcUrl; ?>">
-                                                <small><?= htmlentities($dlc->getName()); ?></small><br><?= htmlentities($dlc->getGroupName()); ?>
+                                                <small><?= Html::escape($dlc->getName()); ?></small><br><?= Html::escape($dlc->getGroupName()); ?>
                                             </a>
                                         </div>
                                     </div>
@@ -153,8 +155,8 @@ require_once("header.php");
                                     <?php
                                     foreach (HomepagePopularGamesFilter::getPlatformOptions() as $platformValue => $platformLabel) {
                                         ?>
-                                        <option value="<?= htmlentities($platformValue, ENT_QUOTES, 'UTF-8'); ?>"<?= ($popularGamesFilter->isPlatformSelected($platformValue) ? ' selected' : ''); ?>>
-                                            <?= htmlentities($platformLabel); ?>
+                                        <option value="<?= Html::escape($platformValue); ?>"<?= ($popularGamesFilter->isPlatformSelected($platformValue) ? ' selected' : ''); ?>>
+                                            <?= Html::escape($platformLabel); ?>
                                         </option>
                                         <?php
                                     }
@@ -181,7 +183,7 @@ require_once("header.php");
                             <div class="card">
                                 <div class="d-flex justify-content-center align-items-center" style="height: 7rem;">
                                     <a href="<?= $gameUrl; ?>">
-                                        <img class="card-img object-fit-cover" style="height: 7rem;" src="<?= $game->getIconPath(); ?>" alt="<?= htmlentities($game->getName()); ?>">
+                                        <img class="card-img object-fit-cover" style="height: 7rem;" src="<?= $game->getIconPath(); ?>" alt="<?= Html::escape($game->getName()); ?>">
                                     </a>
                                 </div>
                             </div>
@@ -193,7 +195,7 @@ require_once("header.php");
                                 <div class="row">
                                     <div class="col">
                                         <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= $gameUrl; ?>">
-                                            <?= htmlentities($game->getName()); ?>
+                                            <?= Html::escape($game->getName()); ?>
                                         </a>
                                     </div>
                                 </div>
@@ -201,7 +203,7 @@ require_once("header.php");
                                     <div class="col">
                                         <?php
                                         foreach ($game->getPlatforms() as $platform) {
-                                            echo "<span class=\"badge rounded-pill text-bg-primary p-2 mt-2\">" . htmlentities($platform) . "</span> ";
+                                            echo "<span class=\"badge rounded-pill text-bg-primary p-2 mt-2\">" . Html::escape($platform) . "</span> ";
                                         }
                                         ?>
                                     </div>

--- a/wwwroot/trophies.php
+++ b/wwwroot/trophies.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/TrophyListFilter.php';
 require_once __DIR__ . '/classes/TrophyListPage.php';
 require_once __DIR__ . '/classes/TrophyListService.php';
@@ -48,14 +50,14 @@ require_once('header.php');
                                 <tr>
                                     <td scope="row" class="text-center align-middle">
                                         <a href="<?= $gameUrl; ?>">
-                                            <img src="/img/title/<?= htmlspecialchars($trophy->getGameIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 10rem;" />
+                                            <img src="/img/title/<?= htmlspecialchars($trophy->getGameIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($trophy->getGameName()); ?>" title="<?= Html::escape($trophy->getGameName()); ?>" style="width: 10rem;" />
                                         </a>
                                     </td>
                                     <td class="align-middle">
                                         <div class="hstack gap-3">
                                             <div class="d-flex align-items-center justify-content-center">
                                                 <a href="<?= $trophyUrl; ?>">
-                                                    <img src="/img/trophy/<?= htmlspecialchars($trophy->getTrophyIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlentities($trophy->getTrophyName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 5rem;" />
+                                                    <img src="/img/trophy/<?= htmlspecialchars($trophy->getTrophyIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($trophy->getTrophyName()); ?>" title="<?= Html::escape($trophy->getTrophyName()); ?>" style="width: 5rem;" />
                                                 </a>
                                             </div>
 
@@ -63,10 +65,10 @@ require_once('header.php');
                                                 <div class="vstack">
                                                     <span>
                                                         <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= $trophyUrl; ?>">
-                                                            <b><?= htmlentities($trophy->getTrophyName()); ?></b>
+                                                            <b><?= Html::escape($trophy->getTrophyName()); ?></b>
                                                         </a>
                                                     </span>
-                                                    <?= nl2br(htmlentities($trophy->getTrophyDetail(), ENT_QUOTES, 'UTF-8')); ?>
+                                                    <?= nl2br(Html::escape($trophy->getTrophyDetail())); ?>
                                                     <?php
                                                     $progressTargetValue = $trophy->getProgressTargetValue();
                                                     if ($progressTargetValue !== null) {
@@ -90,7 +92,7 @@ require_once('header.php');
                                             <?php
                                             foreach ($trophy->getPlatforms() as $platform) {
                                                 echo '<span class="badge rounded-pill text-bg-primary p-2">'
-                                                    . htmlentities($platform, ENT_QUOTES, 'UTF-8') . '</span> ';
+                                                    . Html::escape($platform) . '</span> ';
                                             }
                                             ?>
                                         </div>

--- a/wwwroot/trophy.php
+++ b/wwwroot/trophy.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once 'classes/TrophyPage.php';
 require_once 'classes/TrophyRarityFormatter.php';
 
@@ -76,7 +78,7 @@ require_once("header.php");
                                             <div class="vstack gap-1">
                                                 <div class="hstack gap-3">
                                                     <div>
-                                                        <b><?= htmlentities($trophy->getName()); ?></b>
+                                                        <b><?= Html::escape($trophy->getName()); ?></b>
                                                     </div>
 
                                                     <?php
@@ -100,7 +102,7 @@ require_once("header.php");
                                                 </div>
 
                                                 <div>
-                                                    <?= nl2br(htmlentities($trophy->getDetail(), ENT_QUOTES, "UTF-8")); ?>
+                                                    <?= nl2br(Html::escape($trophy->getDetail())); ?>
                                                     <?php
                                                     $progressTargetValue = $trophy->getProgressTargetValue();
                                                     if ($progressTargetValue !== null) {
@@ -124,11 +126,11 @@ require_once("header.php");
                                                     <div class="hstack gap-1">
                                                         <?php
                                                         foreach ($trophy->getPlatforms() as $platform) {
-                                                            echo "<span class=\"badge rounded-pill text-bg-primary p-2\">" . htmlentities($platform) . "</span> ";
+                                                            echo "<span class=\"badge rounded-pill text-bg-primary p-2\">" . Html::escape($platform) . "</span> ";
                                                         }
                                                         ?>
 
-                                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($trophy->getGameLink($utility, $playerOnlineId), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlentities($trophy->getGameName()); ?></a>
+                                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($trophy->getGameLink($utility, $playerOnlineId), ENT_QUOTES, 'UTF-8'); ?>"><?= Html::escape($trophy->getGameName()); ?></a>
                                                     </div>
                                                 </div>
                                             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replace `htmlentities()` with `Html::escape()` across game-related public templates and `TrophyPage`.
- Covers game detail, header, history, browse list, trophy detail/list pages, and the homepage game cards.

## Files

- `game.php`, `game_header.php`, `game_history.php`, `games.php`, `trophy.php`, `trophies.php`, `home.php`
- `classes/TrophyPage.php` (meta description)

## Test plan

- [x] `php tests/run.php` — 790 tests passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

