### PR TITLE
Phase 5: migrate admin pages to Html::escape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,8 @@ the non-obvious steps to actually run the services.
   `PlayerHeaderViewModel` use `Html::escape()` for output escaping.
 - Game page templates (`game.php`, `game_header.php`, `game_history.php`, `games.php`,
   `trophy.php`, `trophies.php`, `home.php`) and `TrophyPage` use `Html::escape()`.
+- Admin templates load `Html.php` via `admin/bootstrap.php`; admin request handlers
+  (`GameDetailPage`, `CheaterRequestHandler`, etc.) use `Html::escape()`.
 
 ### Composer
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ IP per minute. Admin login locks an IP for 15 minutes after five failed attempts
   of `htmlentities()`.
 - Game page templates (`game.php`, `game_header.php`, `game_history.php`, `games.php`,
   `trophy.php`, `trophies.php`, `home.php`) and `TrophyPage` use `Html::escape()`.
+- Admin templates and admin request handlers use `Html::escape()` instead of
+  `htmlentities()`.
 
 Optional MySQL integration tests (including IP lock acquisition) run when
 `PSN100_INTEGRATION_TEST_DB=1` and a reachable `DB_*` configuration are available.

--- a/wwwroot/admin/bootstrap.php
+++ b/wwwroot/admin/bootstrap.php
@@ -5,5 +5,6 @@ declare(strict_types=1);
 require_once __DIR__ . '/../init.php';
 require_once __DIR__ . '/../classes/Admin/AdminBootstrap.php';
 require_once __DIR__ . '/../classes/BootstrapAssets.php';
+require_once __DIR__ . '/../classes/Html.php';
 
 AdminBootstrap::requireAuthenticatedAdminPage();

--- a/wwwroot/admin/detail.php
+++ b/wwwroot/admin/detail.php
@@ -38,9 +38,9 @@ $requestedNpCommunicationId = isset($_GET['np_communication_id']) ? (string) $_G
             <a href="/admin/">Back</a><br><br>
             <form method="get" autocomplete="off">
                 Game ID:<br>
-                <input type="number" name="game" value="<?= htmlentities($requestedGameId, ENT_QUOTES, 'UTF-8'); ?>"><br>
+                <input type="number" name="game" value="<?= Html::escape($requestedGameId); ?>"><br>
                 NP Communication ID:<br>
-                <input type="text" name="np_communication_id" style="width: 300px;" value="<?= htmlentities($requestedNpCommunicationId, ENT_QUOTES, 'UTF-8'); ?>"><br>
+                <input type="text" name="np_communication_id" style="width: 300px;" value="<?= Html::escape($requestedNpCommunicationId); ?>"><br>
                 <small>Examples: NPWR10853_00, MERGE_048500</small><br>
                 <input type="submit" value="Fetch">
             </form>
@@ -52,8 +52,8 @@ $requestedNpCommunicationId = isset($_GET['np_communication_id']) ? (string) $_G
                 ?>
                 <p>
                     Game page:
-                    <a href="<?= htmlentities($gameUrl, ENT_QUOTES, 'UTF-8'); ?>" target="_blank" rel="noopener">
-                        <?= htmlentities($gameUrl, ENT_QUOTES, 'UTF-8'); ?>
+                    <a href="<?= Html::escape($gameUrl); ?>" target="_blank" rel="noopener">
+                        <?= Html::escape($gameUrl); ?>
                     </a>
                 </p>
                 <form method="post" autocomplete="off">
@@ -61,9 +61,9 @@ $requestedNpCommunicationId = isset($_GET['np_communication_id']) ? (string) $_G
                     <input type="hidden" name="action" value="update-detail">
                     <input type="hidden" name="game" value="<?= $gameDetail->getId(); ?>"><br>
                     Name:<br>
-                    <input type="text" name="name" style="width: 859px;" value="<?= htmlentities($gameDetail->getName(), ENT_QUOTES, 'UTF-8'); ?>"><br>
+                    <input type="text" name="name" style="width: 859px;" value="<?= Html::escape($gameDetail->getName()); ?>"><br>
                     Icon URL:<br>
-                    <input type="text" name="icon_url" style="width: 859px;" value="<?= htmlentities($gameDetail->getIconUrl(), ENT_QUOTES, 'UTF-8'); ?>"><br>
+                    <input type="text" name="icon_url" style="width: 859px;" value="<?= Html::escape($gameDetail->getIconUrl()); ?>"><br>
                     <?php
                     $selectedPlatforms = [];
                     foreach (explode(',', $gameDetail->getPlatform()) as $platformValue) {
@@ -88,25 +88,25 @@ $requestedNpCommunicationId = isset($_GET['np_communication_id']) ? (string) $_G
                                     type="checkbox"
                                     id="platform-<?= $lowerCasePlatform; ?>"
                                     name="platform[]"
-                                    value="<?= htmlentities($platformOption, ENT_QUOTES, 'UTF-8'); ?>"
+                                    value="<?= Html::escape($platformOption); ?>"
                                     <?= $isChecked; ?>
                                 >
                                 <label class="form-check-label" for="platform-<?= $lowerCasePlatform; ?>">
-                                    <?= htmlentities($platformOption, ENT_QUOTES, 'UTF-8'); ?>
+                                    <?= Html::escape($platformOption); ?>
                                 </label>
                             </div>
                         <?php } ?>
                     </fieldset>
                     Set Version:<br>
-                    <input type="text" name="set_version" style="width: 859px;" value="<?= htmlentities($gameDetail->getSetVersion(), ENT_QUOTES, 'UTF-8'); ?>"><br>
+                    <input type="text" name="set_version" style="width: 859px;" value="<?= Html::escape($gameDetail->getSetVersion()); ?>"><br>
                     Region:<br>
-                    <input type="text" name="region" style="width: 859px;" value="<?= htmlentities((string) ($gameDetail->getRegion() ?? ''), ENT_QUOTES, 'UTF-8'); ?>"><br>
+                    <input type="text" name="region" style="width: 859px;" value="<?= Html::escape((string) ($gameDetail->getRegion() ?? '')); ?>"><br>
                     NP Communication ID:<br>
-                    <input type="text" name="np_communication_id" style="width: 859px;" value="<?= htmlentities((string) ($gameDetail->getNpCommunicationId() ?? ''), ENT_QUOTES, 'UTF-8'); ?>" readonly><br>
+                    <input type="text" name="np_communication_id" style="width: 859px;" value="<?= Html::escape((string) ($gameDetail->getNpCommunicationId() ?? '')); ?>" readonly><br>
                     PSNProfiles ID:<br>
-                    <input type="text" name="psnprofiles_id" style="width: 859px;" value="<?= htmlentities((string) ($gameDetail->getPsnprofilesId() ?? ''), ENT_QUOTES, 'UTF-8'); ?>"><br>
+                    <input type="text" name="psnprofiles_id" style="width: 859px;" value="<?= Html::escape((string) ($gameDetail->getPsnprofilesId() ?? '')); ?>"><br>
                     Obsolete Game IDs:<br>
-                    <input type="text" name="obsolete_ids" style="width: 859px;" value="<?= htmlentities((string) ($gameDetail->getObsoleteIds() ?? ''), ENT_QUOTES, 'UTF-8'); ?>"><br>
+                    <input type="text" name="obsolete_ids" style="width: 859px;" value="<?= Html::escape((string) ($gameDetail->getObsoleteIds() ?? '')); ?>"><br>
                     <small>Comma separated trophy_title.id values.</small><br>
                     Message:<br>
                     <textarea name="message" rows="6" cols="120"><?= GameMessageSanitizer::escapeTextareaContent($gameDetail->getMessage()); ?></textarea><br><br>
@@ -114,8 +114,8 @@ $requestedNpCommunicationId = isset($_GET['np_communication_id']) ? (string) $_G
                     <select id="status" name="status" class="form-select" style="max-width: 300px;">
                         <?php foreach ($statusOptions as $value => $label) { ?>
                             <?php $selected = $gameDetail->getStatus()->value === $value ? 'selected' : ''; ?>
-                            <option value="<?= htmlentities((string) $value, ENT_QUOTES, 'UTF-8'); ?>" <?= $selected; ?>>
-                                <?= htmlentities($label, ENT_QUOTES, 'UTF-8'); ?>
+                            <option value="<?= Html::escape((string) $value); ?>" <?= $selected; ?>>
+                                <?= Html::escape($label); ?>
                             </option>
                         <?php } ?>
                     </select><br><br>

--- a/wwwroot/admin/psn-game-lookup.php
+++ b/wwwroot/admin/psn-game-lookup.php
@@ -32,18 +32,18 @@ $errorMessage = $handledRequest->getErrorMessage();
                 <div class="mb-2">
                     <label for="gameId" class="form-label">PSN100 Game ID</label>
                     <div class="input-group">
-                        <input type="text" class="form-control" id="gameId" name="gameId" value="<?= htmlentities($gameId, ENT_QUOTES, 'UTF-8'); ?>" placeholder="e.g. 12345" autocomplete="off" inputmode="numeric">
+                        <input type="text" class="form-control" id="gameId" name="gameId" value="<?= Html::escape($gameId); ?>" placeholder="e.g. 12345" autocomplete="off" inputmode="numeric">
                         <button class="btn btn-primary" type="submit">Lookup</button>
                     </div>
                 </div>
             </form>
             <?php if ($errorMessage !== null) { ?>
                 <div class="alert alert-warning" role="alert">
-                    <?= htmlentities($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
+                    <?= Html::escape($errorMessage); ?>
                 </div>
             <?php } elseif ($normalizedGameId !== '' && $result === null) { ?>
                 <div class="alert alert-info" role="alert">
-                    No trophy data was returned for game ID "<?= htmlentities($normalizedGameId, ENT_QUOTES, 'UTF-8'); ?>".
+                    No trophy data was returned for game ID "<?= Html::escape($normalizedGameId); ?>".
                 </div>
             <?php } ?>
             <?php if (is_array($result)) { ?>
@@ -51,7 +51,7 @@ $errorMessage = $handledRequest->getErrorMessage();
                     <div class="card-body">
                         <pre class="mb-0 text-white-50"><?php
                             $json = json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-                            echo htmlentities($json === false ? 'Unable to encode response.' : $json, ENT_QUOTES, 'UTF-8');
+                            echo Html::escape($json === false ? 'Unable to encode response.' : $json);
                         ?></pre>
                     </div>
                 </div>

--- a/wwwroot/admin/psn-player-lookup.php
+++ b/wwwroot/admin/psn-player-lookup.php
@@ -49,18 +49,18 @@ if (is_array($earnedTrophies)) {
                 <div class="mb-2">
                     <label for="onlineId" class="form-label">Online ID</label>
                     <div class="input-group">
-                        <input type="text" class="form-control" id="onlineId" name="onlineId" value="<?= htmlentities($onlineId, ENT_QUOTES, 'UTF-8'); ?>" maxlength="16" placeholder="PSN online ID" autocomplete="off">
+                        <input type="text" class="form-control" id="onlineId" name="onlineId" value="<?= Html::escape($onlineId); ?>" maxlength="16" placeholder="PSN online ID" autocomplete="off">
                         <button class="btn btn-primary" type="submit">Lookup</button>
                     </div>
                 </div>
             </form>
             <?php if ($errorMessage !== null) { ?>
                 <div class="alert alert-warning" role="alert">
-                    <?= htmlentities($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
+                    <?= Html::escape($errorMessage); ?>
                 </div>
             <?php } elseif ($normalizedOnlineId !== '' && $result === null) { ?>
                 <div class="alert alert-info" role="alert">
-                    No profile data was returned for "<?= htmlentities($normalizedOnlineId, ENT_QUOTES, 'UTF-8'); ?>".
+                    No profile data was returned for "<?= Html::escape($normalizedOnlineId); ?>".
                 </div>
             <?php } ?>
             <?php if ($decodedNpId !== null || $npCountry !== null) { ?>
@@ -69,11 +69,11 @@ if (is_array($earnedTrophies)) {
                         <dl class="row mb-0">
                             <?php if ($decodedNpId !== null) { ?>
                                 <dt class="col-sm-3">Decoded NP ID</dt>
-                                <dd class="col-sm-9"><code><?= htmlentities($decodedNpId, ENT_QUOTES, 'UTF-8'); ?></code></dd>
+                                <dd class="col-sm-9"><code><?= Html::escape($decodedNpId); ?></code></dd>
                             <?php } ?>
                             <?php if ($npCountry !== null) { ?>
                                 <dt class="col-sm-3">Country</dt>
-                                <dd class="col-sm-9"><?= htmlentities($npCountry, ENT_QUOTES, 'UTF-8'); ?></dd>
+                                <dd class="col-sm-9"><?= Html::escape($npCountry); ?></dd>
                             <?php } ?>
                         </dl>
                     </div>
@@ -105,7 +105,7 @@ if (is_array($earnedTrophies)) {
                     <div class="card-body">
                         <pre class="mb-0 text-white-50"><?php
                             $json = json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-                            echo htmlentities($json === false ? 'Unable to encode response.' : $json, ENT_QUOTES, 'UTF-8');
+                            echo Html::escape($json === false ? 'Unable to encode response.' : $json);
                         ?></pre>
                     </div>
                 </div>

--- a/wwwroot/admin/psn-trophy-title-compare.php
+++ b/wwwroot/admin/psn-trophy-title-compare.php
@@ -36,7 +36,7 @@ $errorMessage = $handledRequest->getErrorMessage();
                 <div class="mb-2">
                     <label for="accountId" class="form-label">Account ID</label>
                     <div class="input-group">
-                        <input type="text" class="form-control" id="accountId" name="accountId" value="<?= htmlentities($accountId, ENT_QUOTES, 'UTF-8'); ?>" placeholder="e.g. 1234567890123456789" autocomplete="off" inputmode="numeric">
+                        <input type="text" class="form-control" id="accountId" name="accountId" value="<?= Html::escape($accountId); ?>" placeholder="e.g. 1234567890123456789" autocomplete="off" inputmode="numeric">
                         <button class="btn btn-primary" type="submit">Fetch</button>
                     </div>
                 </div>
@@ -53,11 +53,11 @@ $errorMessage = $handledRequest->getErrorMessage();
             </form>
             <?php if ($errorMessage !== null) { ?>
                 <div class="alert alert-warning" role="alert">
-                    <?= htmlentities($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
+                    <?= Html::escape($errorMessage); ?>
                 </div>
             <?php } elseif ($normalizedAccountId !== '' && $result === null) { ?>
                 <div class="alert alert-info" role="alert">
-                    No data was returned for account ID "<?= htmlentities($normalizedAccountId, ENT_QUOTES, 'UTF-8'); ?>".
+                    No data was returned for account ID "<?= Html::escape($normalizedAccountId); ?>".
                 </div>
             <?php } ?>
             <?php if (is_array($result)) { ?>
@@ -68,15 +68,15 @@ $errorMessage = $handledRequest->getErrorMessage();
                                 <h2 class="h5"><?= $normalizedSource === PsnTrophyTitleComparisonService::SOURCE_DIRECT ? 'Direct endpoint' : 'tustin/psn-php'; ?></h2>
                                 <dl class="row mb-0">
                                     <dt class="col-sm-5">Titles fetched</dt>
-                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['result']['count'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <dd class="col-sm-7"><?= Html::escape((string) ($result['result']['count'] ?? 0)); ?></dd>
                                     <?php if ($normalizedSource === PsnTrophyTitleComparisonService::SOURCE_DIRECT) { ?>
                                         <dt class="col-sm-5">Pages fetched</dt>
-                                        <dd class="col-sm-7"><?= htmlentities((string) ($result['result']['pagesFetched'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                        <dd class="col-sm-7"><?= Html::escape((string) ($result['result']['pagesFetched'] ?? 0)); ?></dd>
                                         <dt class="col-sm-5">Total item count</dt>
-                                        <dd class="col-sm-7"><?= htmlentities((string) ($result['result']['totalItemCount'] ?? 'n/a'), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                        <dd class="col-sm-7"><?= Html::escape((string) ($result['result']['totalItemCount'] ?? 'n/a')); ?></dd>
                                     <?php } ?>
                                     <dt class="col-sm-5">Duration (ms)</dt>
-                                    <dd class="col-sm-7"><?= htmlentities((string) ($result['result']['durationMs'] ?? 0), ENT_QUOTES, 'UTF-8'); ?></dd>
+                                    <dd class="col-sm-7"><?= Html::escape((string) ($result['result']['durationMs'] ?? 0)); ?></dd>
                                 </dl>
                             </div>
                         </div>

--- a/wwwroot/admin/psnp-plus.php
+++ b/wwwroot/admin/psnp-plus.php
@@ -54,13 +54,13 @@ try {
 
             <?php foreach ($successMessages as $successMessage) { ?>
                 <div class="alert alert-success" role="alert">
-                    <?= htmlentities($successMessage, ENT_QUOTES, 'UTF-8'); ?>
+                    <?= Html::escape($successMessage); ?>
                 </div>
             <?php } ?>
 
             <?php foreach ($errorMessages as $errorMessage) { ?>
                 <div class="alert alert-danger" role="alert">
-                    <?= htmlentities($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
+                    <?= Html::escape($errorMessage); ?>
                 </div>
             <?php } ?>
 
@@ -69,7 +69,7 @@ try {
                     <div class="mb-3">
                         <?php foreach ($psnpPlusReport->getMissingGames() as $missingGame) { ?>
                             <p>
-                                PSNProfiles ID <a href="<?= htmlentities($missingGame->getPsnprofilesUrl(), ENT_QUOTES, 'UTF-8'); ?>" target="_blank" rel="noopener"><?= htmlentities((string) $missingGame->getPsnprofilesId(), ENT_QUOTES, 'UTF-8'); ?></a> not in our database.
+                                PSNProfiles ID <a href="<?= Html::escape($missingGame->getPsnprofilesUrl()); ?>" target="_blank" rel="noopener"><?= Html::escape((string) $missingGame->getPsnprofilesId()); ?></a> not in our database.
                             </p>
                         <?php } ?>
                     </div>
@@ -79,16 +79,16 @@ try {
                     <div class="mb-3">
                         <strong>
                             <a href="../game/<?= $difference->getGameId(); ?>" target="_blank" rel="noopener">
-                                <?= htmlentities($difference->getGameName(), ENT_QUOTES, 'UTF-8'); ?>
+                                <?= Html::escape($difference->getGameName()); ?>
                             </a>
                         </strong><br>
 
                         <?php if ($difference->hasUnobtainable()) { ?>
-                            <a href="unobtainable.php?status=1&amp;trophy=<?= $difference->getUnobtainableTrophyIdQuery(); ?>">Unobtainable</a>: <?= htmlentities($difference->getUnobtainableOrderList(), ENT_QUOTES, 'UTF-8'); ?><br>
+                            <a href="unobtainable.php?status=1&amp;trophy=<?= $difference->getUnobtainableTrophyIdQuery(); ?>">Unobtainable</a>: <?= Html::escape($difference->getUnobtainableOrderList()); ?><br>
                         <?php } ?>
 
                         <?php if ($difference->hasObtainable()) { ?>
-                            <a href="unobtainable.php?status=0&amp;trophy=<?= $difference->getObtainableTrophyIdQuery(); ?>">Obtainable</a>: <?= htmlentities($difference->getObtainableOrderList(), ENT_QUOTES, 'UTF-8'); ?><br>
+                            <a href="unobtainable.php?status=0&amp;trophy=<?= $difference->getObtainableTrophyIdQuery(); ?>">Obtainable</a>: <?= Html::escape($difference->getObtainableOrderList()); ?><br>
                         <?php } ?>
                     </div>
                 <?php } ?>
@@ -99,12 +99,12 @@ try {
                     <div class="mb-3">
                         <strong>
                             <a href="../game/<?= $fixedGame->getGameId(); ?>" target="_blank" rel="noopener">
-                                <?= htmlentities($fixedGame->getGameName(), ENT_QUOTES, 'UTF-8'); ?>
+                                <?= Html::escape($fixedGame->getGameName()); ?>
                             </a>
                         </strong><br>
 
                         <?php if ($fixedGame->hasTrophies()) { ?>
-                            <a href="unobtainable.php?status=0&amp;trophy=<?= $fixedGame->getTrophyIdQuery(); ?>">Obtainable</a>: <?= htmlentities($fixedGame->getTrophyIdList(), ENT_QUOTES, 'UTF-8'); ?><br>
+                            <a href="unobtainable.php?status=0&amp;trophy=<?= $fixedGame->getTrophyIdQuery(); ?>">Obtainable</a>: <?= Html::escape($fixedGame->getTrophyIdList()); ?><br>
                         <?php } ?>
                     </div>
                 <?php } ?>

--- a/wwwroot/admin/report.php
+++ b/wwwroot/admin/report.php
@@ -29,21 +29,21 @@ $errorMessage = $pageResult->getErrorMessage();
             <a href="/admin/">Back</a><br><br>
             <?php if ($successMessage !== null) { ?>
                 <div class="alert alert-success" role="alert">
-                    <?= htmlentities($successMessage, ENT_QUOTES, 'UTF-8'); ?>
+                    <?= Html::escape($successMessage); ?>
                 </div>
             <?php } ?>
             <?php if ($errorMessage !== null) { ?>
                 <div class="alert alert-warning" role="alert">
-                    <?= htmlentities($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
+                    <?= Html::escape($errorMessage); ?>
                 </div>
             <?php } ?>
             <?php foreach ($reportedPlayers as $reportedPlayer) { ?>
                 <div class="mb-3">
-                    <a href="/player/<?= htmlentities($reportedPlayer->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>">
-                        <?= htmlentities($reportedPlayer->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>
+                    <a href="/player/<?= Html::escape($reportedPlayer->getOnlineId()); ?>">
+                        <?= Html::escape($reportedPlayer->getOnlineId()); ?>
                     </a>
                     <div class="mt-2">
-                        <?= nl2br(htmlentities($reportedPlayer->getExplanation(), ENT_QUOTES, 'UTF-8')); ?>
+                        <?= nl2br(Html::escape($reportedPlayer->getExplanation())); ?>
                     </div>
                     <div class="mt-2">
                         <form method="post" class="d-inline js-report-delete-form">

--- a/wwwroot/classes/Admin/CheaterRequestHandler.php
+++ b/wwwroot/classes/Admin/CheaterRequestHandler.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../Html.php';
+
 require_once __DIR__ . '/AdminRequest.php';
 require_once __DIR__ . '/CheaterRequestResult.php';
 require_once __DIR__ . '/CheaterService.php';
@@ -45,6 +47,6 @@ class CheaterRequestHandler
 
     private function escapeHtml(string $value): string
     {
-        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+        return Html::escape($value);
     }
 }

--- a/wwwroot/classes/Admin/GameCopyHandler.php
+++ b/wwwroot/classes/Admin/GameCopyHandler.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../Html.php';
+
 class GameCopyHandler
 {
     public function __construct(private readonly GameCopyService $gameCopyService)
@@ -77,6 +79,6 @@ class GameCopyHandler
 
     private function escape(string $value): string
     {
-        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+        return Html::escape($value);
     }
 }

--- a/wwwroot/classes/Admin/GameDetailPage.php
+++ b/wwwroot/classes/Admin/GameDetailPage.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../Html.php';
+
 require_once __DIR__ . '/GameDetailService.php';
 require_once __DIR__ . '/GameDetailPageResult.php';
 require_once __DIR__ . '/../GameStatusService.php';
@@ -92,7 +94,7 @@ class GameDetailPage
                 }
             }
         } catch (Throwable $exception) {
-            $error = '<p>' . htmlentities($exception->getMessage(), ENT_QUOTES, 'UTF-8') . '</p>';
+            $error = '<p>' . Html::escape($exception->getMessage()) . '</p>';
         }
 
         return new GameDetailPageResult($gameDetail, $success, $error);
@@ -131,7 +133,7 @@ class GameDetailPage
                 $statusText = $this->gameStatusService->updateGameStatus($gameId, $status);
                 $successMessages[] = $this->formatStatusSuccessMessage($gameId, $statusText);
             } catch (InvalidArgumentException $exception) {
-                $error = '<p>' . htmlentities($exception->getMessage(), ENT_QUOTES, 'UTF-8') . '</p>';
+                $error = '<p>' . Html::escape($exception->getMessage()) . '</p>';
             } catch (Throwable $exception) {
                 $error = '<p>Failed to update game status. Please try again.</p>';
             }
@@ -165,7 +167,7 @@ class GameDetailPage
         try {
             $statusText = $this->gameStatusService->updateGameStatus($gameId, $status);
         } catch (InvalidArgumentException $exception) {
-            $message = htmlentities($exception->getMessage(), ENT_QUOTES, 'UTF-8');
+            $message = Html::escape($exception->getMessage());
 
             return [
                 $this->gameDetailService->getGameDetail($gameId),
@@ -371,7 +373,7 @@ class GameDetailPage
 
     private function formatStatusSuccessMessage(int $gameId, string $statusText): string
     {
-        $escapedStatus = htmlentities($statusText, ENT_QUOTES, 'UTF-8');
+        $escapedStatus = Html::escape($statusText);
 
         return sprintf(
             '<p>Game %d is now set as %s. All affected players will be updated soon, and ranks updated the next whole hour.</p>',

--- a/wwwroot/classes/Admin/GameResetRequestHandler.php
+++ b/wwwroot/classes/Admin/GameResetRequestHandler.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../Html.php';
+
 require_once __DIR__ . '/AdminRequest.php';
 require_once __DIR__ . '/GameResetRequestResult.php';
 require_once __DIR__ . '/../GameResetService.php';
@@ -46,6 +48,6 @@ class GameResetRequestHandler
 
     private function escape(string $value): string
     {
-        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+        return Html::escape($value);
     }
 }

--- a/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
+++ b/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../Html.php';
+
 require_once __DIR__ . '/TrophyMergeProgressListener.php';
 
 class TrophyMergeRequestHandler
@@ -145,6 +147,6 @@ class TrophyMergeRequestHandler
 
     private function escape(string $value): string
     {
-        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+        return Html::escape($value);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replace `htmlentities()` with `Html::escape()` across remaining admin templates and admin request-handler classes.
- Load `Html.php` from `admin/bootstrap.php` so all authenticated admin pages have access.

## Files

**Templates:** `report.php`, `psnp-plus.php`, `psn-trophy-title-compare.php`, `psn-player-lookup.php`, `psn-game-lookup.php`, `detail.php`

**Classes:** `GameDetailPage`, `CheaterRequestHandler`, `GameCopyHandler`, `GameResetRequestHandler`, `TrophyMergeRequestHandler`

## Notes

This completes the view-layer `htmlentities` → `Html::escape` migration for public and admin pages. The only remaining `htmlentities()` call in application code is a test stub in `PlayerQueueHandlerTest`.

## Test plan

- [x] `php tests/run.php` — 790 tests passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

