### PR TITLE
Phase 5: enforce Content-Security-Policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,9 +91,8 @@ the non-obvious steps to actually run the services.
 
 ### Security headers
 
-- `init.php` sends `Content-Security-Policy-Report-Only` alongside existing security
-  headers. Public and admin page scripts are now externalized; Bootstrap and Popper are
-  self-hosted under `wwwroot/lib/`; CSP enforcement is the next Phase 5 step.
+- `init.php` sends an enforced `Content-Security-Policy` header (via
+  `ContentSecurityPolicy`) alongside existing security headers.
 - Date localization uses `/js/localized-date-formatter.js`; changelog grouping uses
   `/js/changelog-date-grouping.js`; homepage queue polling uses
   `/js/player-queue-manager.js`; about-page scan log polling uses

--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ IP per minute. Admin login locks an IP for 15 minutes after five failed attempts
 - Worker refresh tokens can be edited from the admin Workers page (alongside NPSSO).
 - Player and game URLs use `rawurlencode()` consistently via `PlayerUrlBuilder`.
 - `Html::escape()` is the shared HTML-escaping helper for new code.
-- `Content-Security-Policy-Report-Only` is sent from `init.php` to collect violations
-  before enforcing a stricter policy.
+- `Content-Security-Policy` is enforced from `init.php` via `ContentSecurityPolicy`.
 
 ### Security hardening (Phase 4)
 
@@ -129,6 +128,8 @@ IP per minute. Admin login locks an IP for 15 minutes after five failed attempts
   `trophy.php`, `trophies.php`, `home.php`) and `TrophyPage` use `Html::escape()`.
 - Admin templates and admin request handlers use `Html::escape()` instead of
   `htmlentities()`.
+- CSP is enforced (no longer Report-Only); policy values live in
+  `ContentSecurityPolicy`.
 
 Optional MySQL integration tests (including IP lock acquisition) run when
 `PSN100_INTEGRATION_TEST_DB=1` and a reachable `DB_*` configuration are available.

--- a/tests/ContentSecurityPolicyTest.php
+++ b/tests/ContentSecurityPolicyTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/ContentSecurityPolicy.php';
+
+final class ContentSecurityPolicyTest extends TestCase
+{
+    public function testHeaderNameIsEnforcedPolicy(): void
+    {
+        $this->assertSame('Content-Security-Policy', ContentSecurityPolicy::HEADER_NAME);
+    }
+
+    public function testValueAllowsSelfHostedAssetsAndInlineStyles(): void
+    {
+        $policy = ContentSecurityPolicy::value();
+
+        $this->assertStringContainsString("default-src 'self'", $policy);
+        $this->assertStringContainsString("script-src 'self' 'unsafe-inline'", $policy);
+        $this->assertStringContainsString("style-src 'self' 'unsafe-inline'", $policy);
+        $this->assertStringContainsString("img-src 'self' data: https:", $policy);
+        $this->assertStringContainsString("connect-src 'self'", $policy);
+        $this->assertFalse(str_contains($policy, 'cdn.jsdelivr.net'));
+        $this->assertFalse(str_contains($policy, 'Report-Only'));
+    }
+}

--- a/wwwroot/classes/ContentSecurityPolicy.php
+++ b/wwwroot/classes/ContentSecurityPolicy.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+final class ContentSecurityPolicy
+{
+    public const HEADER_NAME = 'Content-Security-Policy';
+
+    public static function value(): string
+    {
+        return "default-src 'self'; "
+            . "script-src 'self' 'unsafe-inline'; "
+            . "style-src 'self' 'unsafe-inline'; "
+            . "img-src 'self' data: https:; "
+            . "font-src 'self'; "
+            . "connect-src 'self'; "
+            . "frame-ancestors 'self'; "
+            . "base-uri 'self'; "
+            . "form-action 'self'";
+    }
+}

--- a/wwwroot/init.php
+++ b/wwwroot/init.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/classes/Cron/CronCliAccessGuard.php';
+require_once __DIR__ . '/classes/ContentSecurityPolicy.php';
 
 CronCliAccessGuard::denyWebCronScriptAccess($_SERVER ?? []);
 
@@ -12,17 +13,7 @@ header("Expires: 0");
 header('X-Content-Type-Options: nosniff');
 header('Referrer-Policy: strict-origin-when-cross-origin');
 header('X-Frame-Options: SAMEORIGIN');
-header(
-    "Content-Security-Policy-Report-Only: default-src 'self'; "
-    . "script-src 'self' 'unsafe-inline'; "
-    . "style-src 'self' 'unsafe-inline'; "
-    . "img-src 'self' data: https:; "
-    . "font-src 'self'; "
-    . "connect-src 'self'; "
-    . "frame-ancestors 'self'; "
-    . "base-uri 'self'; "
-    . "form-action 'self'"
-);
+header(ContentSecurityPolicy::HEADER_NAME . ': ' . ContentSecurityPolicy::value());
 
 require_once __DIR__ . '/classes/ApplicationBootstrapper.php';
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Flip CSP from `Content-Security-Policy-Report-Only` to enforced `Content-Security-Policy`.
- Extract the directive string into `ContentSecurityPolicy` so the policy is defined in one place and testable.

## Policy (unchanged from Report-Only)

- Self-hosted scripts/styles (`'self'`) with `'unsafe-inline'` for remaining inline `<style>` blocks and form `onChange`/`onsubmit` handlers
- External trophy/title images via `img-src https:`
- Same-origin `connect-src` for queue polling and admin streaming endpoints

## Test plan

- [x] `php tests/run.php` — 792 tests passing
- [ ] Smoke-test homepage, a player page filter checkbox, and an admin page in the browser after deploy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c51ce0a-c1e8-4947-8d3d-16cf4dee1a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

