### PR TITLE
Fix hourly Cloudflare 525 errors by restoring batched trophy stats updates

### DIFF
--- a/tests/HourlyCronJobTest.php
+++ b/tests/HourlyCronJobTest.php
@@ -15,8 +15,8 @@ final class HourlyCronJobTest extends TestCase
         $insertStatsQuery = $this->readPrivateConstantValue($class, 'INSERT_STATS_QUERY');
         $updateMetaQuery = $this->readPrivateConstantValue($class, 'UPDATE_META_QUERY');
 
-        $this->assertStringContainsString('COLLATE utf8mb4_unicode_ci', $createBatchTableQuery);
-        $this->assertStringContainsString('COLLATE utf8mb4_unicode_ci', $createStatsTableQuery);
+        $this->assertStringContainsString('COLLATE utf8mb4_0900_ai_ci', $createBatchTableQuery);
+        $this->assertStringContainsString('COLLATE utf8mb4_0900_ai_ci', $createStatsTableQuery);
         $this->assertStringContainsString('INSERT INTO tmp_hourly_stats', $insertStatsQuery);
         $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id', $insertStatsQuery);
         $this->assertStringContainsString('COUNT(*) AS owners', $insertStatsQuery);

--- a/tests/HourlyCronJobTest.php
+++ b/tests/HourlyCronJobTest.php
@@ -7,53 +7,50 @@ require_once __DIR__ . '/../wwwroot/classes/Cron/HourlyCronJob.php';
 
 final class HourlyCronJobTest extends TestCase
 {
-    public function testUsesSingleSetBasedUpdateQuery(): void
+    public function testUsesBatchAndStatsTemporaryTablesForNonEmptyBatchUpdates(): void
     {
         $class = new ReflectionClass(HourlyCronJob::class);
-        $updateAllMetaQuery = $this->readPrivateConstantValue($class, 'UPDATE_ALL_META_QUERY');
+        $createBatchTableQuery = $this->readPrivateConstantValue($class, 'CREATE_BATCH_TEMP_TABLE_QUERY');
+        $createStatsTableQuery = $this->readPrivateConstantValue($class, 'CREATE_STATS_TEMP_TABLE_QUERY');
+        $insertStatsQuery = $this->readPrivateConstantValue($class, 'INSERT_STATS_QUERY');
+        $updateMetaQuery = $this->readPrivateConstantValue($class, 'UPDATE_META_QUERY');
 
-        $this->assertStringContainsString('UPDATE trophy_title_meta ttm', $updateAllMetaQuery);
-        $this->assertStringContainsString('LEFT JOIN (', $updateAllMetaQuery);
-        $this->assertStringContainsString('FROM trophy_title_player ttp', $updateAllMetaQuery);
-        $this->assertStringContainsString('JOIN player_ranking pr ON pr.account_id = ttp.account_id', $updateAllMetaQuery);
-        $this->assertStringContainsString('WHERE pr.ranking <= 10000', $updateAllMetaQuery);
-        $this->assertStringContainsString('GROUP BY ttp.np_communication_id', $updateAllMetaQuery);
-        $this->assertStringContainsString('COUNT(*) AS owners', $updateAllMetaQuery);
-        $this->assertStringContainsString('SUM(ttp.progress = 100) AS owners_completed', $updateAllMetaQuery);
-        $this->assertStringContainsString('SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players', $updateAllMetaQuery);
+        $this->assertStringContainsString('COLLATE utf8mb4_unicode_ci', $createBatchTableQuery);
+        $this->assertStringContainsString('COLLATE utf8mb4_unicode_ci', $createStatsTableQuery);
+        $this->assertStringContainsString('INSERT INTO tmp_hourly_stats', $insertStatsQuery);
+        $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id', $insertStatsQuery);
+        $this->assertStringContainsString('COUNT(*) AS owners', $insertStatsQuery);
+        $this->assertStringContainsString('SUM(ttp.progress = 100) AS owners_completed', $insertStatsQuery);
+        $this->assertStringContainsString('SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players', $insertStatsQuery);
 
-        $this->assertFalse(str_contains($updateAllMetaQuery, 'tmp_hourly_batch'));
-        $this->assertFalse(str_contains($updateAllMetaQuery, 'tmp_hourly_stats'));
+        $this->assertStringContainsString('UPDATE trophy_title_meta ttm', $updateMetaQuery);
+        $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttm.np_communication_id', $updateMetaQuery);
     }
 
-    public function testResetsTitlesWithoutQualifyingPlayersToZeroValues(): void
+    public function testResetsBatchTitlesWithoutQualifyingPlayersToZeroValues(): void
     {
         $class = new ReflectionClass(HourlyCronJob::class);
-        $updateAllMetaQuery = $this->readPrivateConstantValue($class, 'UPDATE_ALL_META_QUERY');
+        $updateMetaQuery = $this->readPrivateConstantValue($class, 'UPDATE_META_QUERY');
 
-        $this->assertStringContainsString('LEFT JOIN (', $updateAllMetaQuery);
-        $this->assertStringContainsString(') s ON s.np_communication_id = ttm.np_communication_id', $updateAllMetaQuery);
-        $this->assertStringContainsString('ttm.owners = COALESCE(s.owners, 0)', $updateAllMetaQuery);
-        $this->assertStringContainsString('ttm.owners_completed = COALESCE(s.owners_completed, 0)', $updateAllMetaQuery);
-        $this->assertStringContainsString('ttm.recent_players = COALESCE(s.recent_players, 0)', $updateAllMetaQuery);
-        $this->assertStringContainsString('COALESCE(s.owners, 0) = 0', $updateAllMetaQuery);
-        $this->assertStringContainsString('(COALESCE(s.owners_completed, 0) / COALESCE(s.owners, 0)) * 100', $updateAllMetaQuery);
+        $this->assertStringContainsString('LEFT JOIN tmp_hourly_stats s ON s.np_communication_id = ttm.np_communication_id', $updateMetaQuery);
+        $this->assertStringContainsString('ttm.owners = COALESCE(s.owners, 0)', $updateMetaQuery);
+        $this->assertStringContainsString('ttm.owners_completed = COALESCE(s.owners_completed, 0)', $updateMetaQuery);
+        $this->assertStringContainsString('ttm.recent_players = COALESCE(s.recent_players, 0)', $updateMetaQuery);
+        $this->assertStringContainsString('COALESCE(s.owners, 0) = 0', $updateMetaQuery);
+        $this->assertStringContainsString('(COALESCE(s.owners_completed, 0) / COALESCE(s.owners, 0)) * 100', $updateMetaQuery);
     }
 
 
-    public function testDoesNotUseTempTableBatchFlow(): void
+    public function testUsesDeleteInsteadOfTruncateInBatchUpdateFlow(): void
     {
         $class = new ReflectionClass(HourlyCronJob::class);
         $source = file_get_contents((string) $class->getFileName());
         $this->assertTrue(is_string($source));
 
-        $this->assertFalse(str_contains($source, 'tmp_hourly_batch'));
-        $this->assertFalse(str_contains($source, 'tmp_hourly_stats'));
-        $this->assertFalse(str_contains($source, 'TRUNCATE TABLE'));
-        $this->assertFalse($class->hasConstant('CREATE_BATCH_TEMP_TABLE_QUERY'));
-        $this->assertFalse($class->hasConstant('CREATE_STATS_TEMP_TABLE_QUERY'));
-        $this->assertFalse($class->hasConstant('INSERT_STATS_QUERY'));
-        $this->assertFalse($class->hasConstant('UPDATE_META_QUERY'));
+        $this->assertStringContainsString("DELETE FROM tmp_hourly_batch", $source);
+        $this->assertStringContainsString("DELETE FROM tmp_hourly_stats", $source);
+        $this->assertFalse(str_contains($source, 'TRUNCATE TABLE tmp_hourly_batch'));
+        $this->assertFalse(str_contains($source, 'TRUNCATE TABLE tmp_hourly_stats'));
     }
 
     public function testNoDynamicUnionAllSelectBatchPathExists(): void
@@ -65,6 +62,16 @@ final class HourlyCronJobTest extends TestCase
         $this->assertFalse($class->hasMethod('buildBatchUnionQuery'));
         $this->assertFalse(str_contains($source, 'UNION ALL'));
         $this->assertFalse(str_contains($source, 'SELECT ? AS np_communication_id'));
+    }
+
+    public function testDoesNotUseSingleSetBasedUpdateForAllTitles(): void
+    {
+        $class = new ReflectionClass(HourlyCronJob::class);
+        $source = file_get_contents((string) $class->getFileName());
+        $this->assertTrue(is_string($source));
+
+        $this->assertFalse($class->hasConstant('UPDATE_ALL_META_QUERY'));
+        $this->assertStringContainsString('BATCH_SIZE', $source);
     }
 
     private function readPrivateConstantValue(ReflectionClass $class, string $name): string

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -10,13 +10,13 @@ final readonly class HourlyCronJob implements CronJobInterface
 
     private const CREATE_BATCH_TEMP_TABLE_QUERY = <<<'SQL'
         CREATE TEMPORARY TABLE IF NOT EXISTS tmp_hourly_batch (
-            np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci PRIMARY KEY
+            np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci PRIMARY KEY
         )
         SQL;
 
     private const CREATE_STATS_TEMP_TABLE_QUERY = <<<'SQL'
         CREATE TEMPORARY TABLE IF NOT EXISTS tmp_hourly_stats (
-            np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci PRIMARY KEY,
+            np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci PRIMARY KEY,
             owners INT NOT NULL,
             owners_completed INT NOT NULL,
             recent_players INT NOT NULL

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -6,19 +6,40 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final readonly class HourlyCronJob implements CronJobInterface
 {
-    private const UPDATE_ALL_META_QUERY = <<<'SQL'
+    private const BATCH_SIZE = 500;
+
+    private const CREATE_BATCH_TEMP_TABLE_QUERY = <<<'SQL'
+        CREATE TEMPORARY TABLE IF NOT EXISTS tmp_hourly_batch (
+            np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci PRIMARY KEY
+        )
+        SQL;
+
+    private const CREATE_STATS_TEMP_TABLE_QUERY = <<<'SQL'
+        CREATE TEMPORARY TABLE IF NOT EXISTS tmp_hourly_stats (
+            np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci PRIMARY KEY,
+            owners INT NOT NULL,
+            owners_completed INT NOT NULL,
+            recent_players INT NOT NULL
+        )
+        SQL;
+
+    private const INSERT_STATS_QUERY = <<<'SQL'
+        INSERT INTO tmp_hourly_stats (np_communication_id, owners, owners_completed, recent_players)
+        SELECT
+            ttp.np_communication_id,
+            COUNT(*) AS owners,
+            SUM(ttp.progress = 100) AS owners_completed,
+            SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players
+        FROM trophy_title_player ttp
+        JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id
+        JOIN player_ranking pr ON pr.account_id = ttp.account_id AND pr.ranking <= 10000
+        GROUP BY ttp.np_communication_id
+        SQL;
+
+    private const UPDATE_META_QUERY = <<<'SQL'
         UPDATE trophy_title_meta ttm
-        LEFT JOIN (
-            SELECT
-                ttp.np_communication_id,
-                COUNT(*) AS owners,
-                SUM(ttp.progress = 100) AS owners_completed,
-                SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players
-            FROM trophy_title_player ttp
-            JOIN player_ranking pr ON pr.account_id = ttp.account_id
-            WHERE pr.ranking <= 10000
-            GROUP BY ttp.np_communication_id
-        ) s ON s.np_communication_id = ttm.np_communication_id
+        JOIN tmp_hourly_batch b ON b.np_communication_id = ttm.np_communication_id
+        LEFT JOIN tmp_hourly_stats s ON s.np_communication_id = ttm.np_communication_id
         SET
             ttm.owners = COALESCE(s.owners, 0),
             ttm.owners_completed = COALESCE(s.owners_completed, 0),
@@ -37,10 +58,93 @@ final readonly class HourlyCronJob implements CronJobInterface
     #[\Override]
     public function run(): void
     {
-        $this->executeWithRetry(function (): void {
-            $query = $this->database->prepare(self::UPDATE_ALL_META_QUERY);
-            $query->execute();
-        });
+        $this->executeWithRetry([$this, 'updateTrophyTitleStatistics']);
+    }
+
+    private function updateTrophyTitleStatistics(): void
+    {
+        $lastId = null;
+
+        $this->initializeTemporaryTables();
+
+        try {
+            while (true) {
+                $batchIds = $this->getBatchNpCommunicationIds($lastId, self::BATCH_SIZE);
+
+                if ($batchIds === []) {
+                    break;
+                }
+
+                $this->database->beginTransaction();
+
+                try {
+                    $this->updateStatisticsForBatch($batchIds);
+                    $this->database->commit();
+                } catch (Exception $exception) {
+                    $this->database->rollBack();
+
+                    throw $exception;
+                }
+
+                $lastId = end($batchIds);
+            }
+        } finally {
+            $this->dropTemporaryTables();
+        }
+    }
+
+    private function getBatchNpCommunicationIds(?string $lastId, int $limit): array
+    {
+        $baseQuery = 'SELECT np_communication_id FROM trophy_title_meta %s ORDER BY np_communication_id LIMIT :limit';
+
+        if ($lastId === null) {
+            $query = $this->database->prepare(sprintf($baseQuery, ''));
+        } else {
+            $query = $this->database->prepare(sprintf($baseQuery, 'WHERE np_communication_id > :last_id'));
+            $query->bindValue(':last_id', $lastId, PDO::PARAM_STR);
+        }
+
+        $query->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $query->execute();
+
+        return $query->fetchAll(PDO::FETCH_COLUMN);
+    }
+
+    private function updateStatisticsForBatch(array $batchIds): void
+    {
+        $this->database->exec('DELETE FROM tmp_hourly_batch');
+        $this->insertBatchIdsIntoTemporaryTable($batchIds);
+
+        $this->database->exec('DELETE FROM tmp_hourly_stats');
+        $insertStatsQuery = $this->database->prepare(self::INSERT_STATS_QUERY);
+        $insertStatsQuery->execute();
+
+        $updateMetaQuery = $this->database->prepare(self::UPDATE_META_QUERY);
+        $updateMetaQuery->execute();
+    }
+
+    private function initializeTemporaryTables(): void
+    {
+        $this->database->exec(self::CREATE_BATCH_TEMP_TABLE_QUERY);
+        $this->database->exec(self::CREATE_STATS_TEMP_TABLE_QUERY);
+    }
+
+    private function dropTemporaryTables(): void
+    {
+        $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_hourly_stats');
+        $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_hourly_batch');
+    }
+
+    private function insertBatchIdsIntoTemporaryTable(array $batchIds): void
+    {
+        $placeholders = implode(', ', array_fill(0, count($batchIds), '(?)'));
+        $query = $this->database->prepare(
+            sprintf(
+                'INSERT INTO tmp_hourly_batch (np_communication_id) VALUES %s',
+                $placeholders
+            )
+        );
+        $query->execute(array_values($batchIds));
     }
 
     private function executeWithRetry(callable $operation): void


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Every whole hour, for about a minute, Cloudflare returns **SSL handshake failed (error 525)** for psn100.net.

Cloudflare 525 means the origin accepted a TCP connection but the TLS handshake failed. In practice this often shows up when the origin is so overloaded it cannot complete handshakes in time — not when the certificate itself is wrong (that would fail constantly).

The timing lines up with `hourly.php`, which recalculates `trophy_title_meta` owner statistics for all titles.

## Root cause

PR #15963 replaced the batched temp-table flow with a single set-based `UPDATE` that:

1. Aggregates `trophy_title_player` joined to `player_ranking` for **every** title in one subquery
2. Updates **every** row in `trophy_title_meta` in one statement

On production-sized data this holds locks and hammers MySQL for roughly a minute at `:00`, starving Apache/PHP workers. The site becomes unresponsive and Cloudflare reports 525.

This matches an earlier production issue noted in commit `39f5eec0` ("10 minute delay that happen every hour") before per-game and batched approaches were introduced.

## Fix

Restore the batched temp-table implementation (500 titles per transaction) that was in place before #15963:

- Short transactions limit `trophy_title_meta` lock duration
- Web requests can be served between batches
- Same statistical output (including zeroing titles with no qualifying top-10k players)
- Temp table `np_communication_id` columns use `utf8mb4_0900_ai_ci` to match `trophy_title_meta` / `trophy_title_player` and avoid collation-mismatch errors on batch joins

## Testing

- `php tests/run.php` — all 793 tests pass
- `HourlyCronJobTest` updated to assert batched flow and schema-aligned collation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f465a2bf-8a13-4776-899e-787c07f2300d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f465a2bf-8a13-4776-899e-787c07f2300d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

