### PR TITLE
Extract GameRescanPsnAccessor from GameRescanService

### DIFF
--- a/tests/GameRescanPsnAccessorTest.php
+++ b/tests/GameRescanPsnAccessorTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanPsnAccessor.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/Worker.php';
+
+final class GameRescanPsnAccessorTest extends TestCase
+{
+    public function testIsOriginalGameAcceptsNpwrIds(): void
+    {
+        $accessor = $this->createAccessor();
+
+        $this->assertTrue($accessor->isOriginalGame('NPWR00001_00'));
+        $this->assertFalse($accessor->isOriginalGame('CUSA12345_00'));
+    }
+
+    public function testGetGameNpCommunicationIdReturnsStoredValue(): void
+    {
+        $database = $this->createDatabaseWithTitle('NPWR12345_00');
+        $accessor = $this->createAccessor($database);
+
+        $this->assertSame('NPWR12345_00', $accessor->getGameNpCommunicationId(7));
+    }
+
+    public function testGetGameNpCommunicationIdThrowsWhenGameMissing(): void
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE trophy_title (id INTEGER PRIMARY KEY, np_communication_id TEXT NOT NULL)');
+
+        $accessor = $this->createAccessor($database);
+
+        try {
+            $accessor->getGameNpCommunicationId(99);
+            $this->fail('Expected RuntimeException when game is missing.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Unable to find the specified game.', $exception->getMessage());
+        }
+    }
+
+    public function testFindTrophyTitleForUserReturnsMatchingTitle(): void
+    {
+        $accessor = $this->createAccessor();
+        $user = new GameRescanPsnAccessorTestUser([
+            new GameRescanPsnAccessorTestTrophyTitle('NPWR11111_00'),
+            new GameRescanPsnAccessorTestTrophyTitle('NPWR22222_00'),
+        ]);
+
+        $title = $accessor->findTrophyTitleForUser($user, 'NPWR22222_00');
+
+        $this->assertTrue($title !== null);
+        $this->assertSame('NPWR22222_00', $title->npCommunicationId());
+    }
+
+    public function testFindTrophyTitleForUserReturnsNullWhenNoMatch(): void
+    {
+        $accessor = $this->createAccessor();
+        $user = new GameRescanPsnAccessorTestUser([
+            new GameRescanPsnAccessorTestTrophyTitle('NPWR11111_00'),
+        ]);
+
+        $this->assertTrue($accessor->findTrophyTitleForUser($user, 'NPWR99999_00') === null);
+    }
+
+    public function testFindAccessibleUserWithGameSkipsPrivatePlayers(): void
+    {
+        $database = $this->createDatabaseWithTitlePlayers([
+            ['account_id' => 100, 'np_communication_id' => 'NPWR00001_00'],
+            ['account_id' => 200, 'np_communication_id' => 'NPWR00001_00'],
+        ]);
+        $accessor = $this->createAccessor($database);
+        $client = new GameRescanPsnAccessorTestClient([
+            100 => new GameRescanPsnAccessorTestUser([], privateProfile: true),
+            200 => new GameRescanPsnAccessorTestUser([], privateProfile: false),
+        ]);
+
+        $user = $accessor->findAccessibleUserWithGame($client, 'NPWR00001_00');
+
+        $this->assertTrue($user !== null);
+        $this->assertSame('200', $user->accountId());
+    }
+
+    public function testLoginToWorkerDelegatesToAuthenticator(): void
+    {
+        $worker = new Worker(5, 'refresh-token', '', '', new DateTimeImmutable('2024-01-01'), null);
+        $authenticator = new PlayStationWorkerAuthenticator(
+            static fn (): array => [$worker],
+            static fn (): object => new GameRescanPsnAccessorTestClient([]),
+        );
+        $accessor = new GameRescanPsnAccessor(new PDO('sqlite::memory:'), $authenticator);
+
+        $client = $accessor->loginToWorker();
+
+        $this->assertTrue($client instanceof GameRescanPsnAccessorTestClient);
+    }
+
+    private function createAccessor(?PDO $database = null): GameRescanPsnAccessor
+    {
+        $database ??= new PDO('sqlite::memory:');
+
+        return new GameRescanPsnAccessor(
+            $database,
+            new PlayStationWorkerAuthenticator(static fn (): array => []),
+        );
+    }
+
+    private function createDatabaseWithTitle(string $npCommunicationId): PDO
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE trophy_title (id INTEGER PRIMARY KEY, np_communication_id TEXT NOT NULL)');
+        $statement = $database->prepare(
+            'INSERT INTO trophy_title (id, np_communication_id) VALUES (7, :np_communication_id)'
+        );
+        $statement->execute(['np_communication_id' => $npCommunicationId]);
+
+        return $database;
+    }
+
+    /**
+     * @param list<array{account_id: int, np_communication_id: string}> $rows
+     */
+    private function createDatabaseWithTitlePlayers(array $rows): PDO
+    {
+        $database = new PDO('sqlite::memory:');
+        $database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $database->exec('CREATE TABLE player (account_id INTEGER PRIMARY KEY)');
+        $database->exec(
+            'CREATE TABLE trophy_title_player (
+                account_id INTEGER NOT NULL,
+                np_communication_id TEXT NOT NULL,
+                last_updated_date TEXT NOT NULL
+            )'
+        );
+
+        foreach ($rows as $row) {
+            $database->exec('INSERT INTO player (account_id) VALUES (' . (int) $row['account_id'] . ')');
+            $statement = $database->prepare(
+                'INSERT INTO trophy_title_player (account_id, np_communication_id, last_updated_date)
+                VALUES (:account_id, :np_communication_id, :last_updated_date)'
+            );
+            $statement->execute([
+                'account_id' => $row['account_id'],
+                'np_communication_id' => $row['np_communication_id'],
+                'last_updated_date' => '2024-01-01T00:00:00Z',
+            ]);
+        }
+
+        return $database;
+    }
+}
+
+final class GameRescanPsnAccessorTestTrophyTitle
+{
+    public function __construct(private string $npCommunicationId)
+    {
+    }
+
+    public function npCommunicationId(): string
+    {
+        return $this->npCommunicationId;
+    }
+}
+
+final class GameRescanPsnAccessorTestUser
+{
+    /**
+     * @param list<GameRescanPsnAccessorTestTrophyTitle> $trophyTitles
+     */
+    public function __construct(
+        private array $trophyTitles,
+        private bool $privateProfile = false,
+        private string $accountId = '0',
+    ) {
+    }
+
+    public function accountId(): string
+    {
+        return $this->accountId;
+    }
+
+    /**
+     * @return list<GameRescanPsnAccessorTestTrophyTitle>
+     */
+    public function trophyTitles(): array
+    {
+        return $this->trophyTitles;
+    }
+
+    public function isPrivateProfile(): bool
+    {
+        return $this->privateProfile;
+    }
+
+    public function trophySummary(): object
+    {
+        if ($this->privateProfile) {
+            throw new RuntimeException('Private profile');
+        }
+
+        return new class {
+            public function level(): int
+            {
+                return 100;
+            }
+        };
+    }
+}
+
+final class GameRescanPsnAccessorTestClient
+{
+    /**
+     * @param array<int|string, GameRescanPsnAccessorTestUser> $users
+     */
+    public function __construct(private array $users)
+    {
+    }
+
+    public function loginWithRefreshToken(string $refreshToken): void
+    {
+    }
+
+    public function users(): object
+    {
+        $users = $this->users;
+
+        return new class($users) {
+            /**
+             * @param array<int|string, GameRescanPsnAccessorTestUser> $users
+             */
+            public function __construct(private array $users)
+            {
+            }
+
+            public function find(string $accountId): GameRescanPsnAccessorTestUser
+            {
+                $user = $this->users[$accountId] ?? new GameRescanPsnAccessorTestUser([]);
+
+                return new GameRescanPsnAccessorTestUser(
+                    $user->trophyTitles(),
+                    $user->isPrivateProfile(),
+                    $accountId,
+                );
+            }
+        };
+    }
+}

--- a/wwwroot/classes/Admin/GameRescanPsnAccessor.php
+++ b/wwwroot/classes/Admin/GameRescanPsnAccessor.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PlayStationWorkerAuthenticator.php';
+
+/**
+ * PSN lookups and worker authentication used during admin game rescans.
+ *
+ * Extracted from GameRescanService so rescan orchestration stays separate from
+ * database title resolution and PlayStation API player discovery.
+ */
+final class GameRescanPsnAccessor
+{
+    private const ORIGINAL_GAME_PREFIX = 'NPWR';
+    private const LOGIN_RETRY_DELAY_SECONDS = 300;
+
+    public function __construct(
+        private PDO $database,
+        private PlayStationWorkerAuthenticator $workerAuthenticator,
+    ) {
+    }
+
+    public function getGameNpCommunicationId(int $gameId): string
+    {
+        $query = $this->database->prepare('SELECT np_communication_id FROM trophy_title WHERE id = :id');
+        $query->bindValue(':id', $gameId, PDO::PARAM_INT);
+        $query->execute();
+
+        $npCommunicationId = $query->fetchColumn();
+        if ($npCommunicationId === false) {
+            throw new RuntimeException('Unable to find the specified game.');
+        }
+
+        return (string) $npCommunicationId;
+    }
+
+    public function isOriginalGame(string $npCommunicationId): bool
+    {
+        return str_starts_with($npCommunicationId, self::ORIGINAL_GAME_PREFIX);
+    }
+
+    /**
+     * @param callable(int, Throwable): void|null $onLoginFailure
+     */
+    public function loginToWorker(?callable $onLoginFailure = null): object
+    {
+        return $this->workerAuthenticator->authenticateWithRetry(
+            self::LOGIN_RETRY_DELAY_SECONDS,
+            $onLoginFailure,
+        );
+    }
+
+    public function findAccessibleUserWithGame(object $client, string $npCommunicationId): ?object
+    {
+        $query = $this->database->prepare(
+            'SELECT account_id
+            FROM trophy_title_player ttp
+            JOIN player p USING(account_id)
+            WHERE ttp.np_communication_id = :np_communication_id
+            ORDER BY ttp.last_updated_date DESC'
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        while (($accountId = $query->fetchColumn()) !== false) {
+            $user = $client->users()->find((string) $accountId);
+
+            try {
+                $user->trophySummary()->level();
+
+                return $user;
+            } catch (TypeError) {
+                // Something odd, try next player.
+            } catch (Exception) {
+                // Player probably private, try next player.
+            }
+        }
+
+        return null;
+    }
+
+    public function findTrophyTitleForUser(object $user, string $npCommunicationId): ?object
+    {
+        foreach ($user->trophyTitles() as $trophyTitle) {
+            if ($trophyTitle->npCommunicationId() === $npCommunicationId) {
+                return $trophyTitle;
+            }
+        }
+
+        return null;
+    }
+}

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/../TrophyImageDownloader.php';
 require_once __DIR__ . '/../TrophyCatalogSynchronizer.php';
 require_once __DIR__ . '/PsnGameLookupService.php';
 require_once __DIR__ . '/PsnTrophyLookupGroupDataProvider.php';
+require_once __DIR__ . '/GameRescanPsnAccessor.php';
 require_once __DIR__ . '/PlayStationWorkerAuthenticator.php';
 require_once __DIR__ . '/WorkerService.php';
 
@@ -21,9 +22,6 @@ use Tustin\PlayStation\Client;
 
 class GameRescanService
 {
-    private const ORIGINAL_GAME_PREFIX = 'NPWR';
-    private const LOGIN_RETRY_DELAY_SECONDS = 300;
-
     private PDO $database;
     private TrophyCalculator $trophyCalculator;
     private TrophyMetaRepository $trophyMetaRepository;
@@ -35,7 +33,7 @@ class GameRescanService
     private PsnTrophyLookupGroupDataProvider $trophyLookupGroupDataProvider;
     private TrophyImageDirectories $imageDirectories;
     private TrophyImageDownloader $imageDownloader;
-    private PlayStationWorkerAuthenticator $workerAuthenticator;
+    private GameRescanPsnAccessor $psnAccessor;
     private TrophyCatalogSynchronizer $trophyCatalogSynchronizer;
 
     /**
@@ -53,6 +51,7 @@ class GameRescanService
         ?TrophyImageDirectories $imageDirectories = null,
         ?TrophyImageDownloader $imageDownloader = null,
         ?PlayStationWorkerAuthenticator $workerAuthenticator = null,
+        ?GameRescanPsnAccessor $psnAccessor = null,
         ?TrophyCatalogSynchronizer $trophyCatalogSynchronizer = null,
     )
     {
@@ -67,9 +66,10 @@ class GameRescanService
         $this->imageDirectories = $imageDirectories ?? TrophyImageDirectories::productionDefault();
         $this->imageDownloader = $imageDownloader ?? new TrophyImageDownloader($this->imageHashCalculator);
         $this->trophyCatalogSynchronizer = $trophyCatalogSynchronizer ?? new TrophyCatalogSynchronizer($database);
-        $this->workerAuthenticator = $workerAuthenticator ?? PlayStationWorkerAuthenticator::fromWorkerService(
+        $workerAuthenticator = $workerAuthenticator ?? PlayStationWorkerAuthenticator::fromWorkerService(
             new WorkerService($database),
         );
+        $this->psnAccessor = $psnAccessor ?? new GameRescanPsnAccessor($database, $workerAuthenticator);
     }
 
     /**
@@ -95,11 +95,11 @@ class GameRescanService
             $differenceTracker = new GameRescanDifferenceTracker();
             $progressReporter = new GameRescanProgressReporter($progressListener);
             $progressReporter->notify(5, 'Validating game id…');
-            $npCommunicationId = $this->getGameNpCommunicationId($gameId);
+            $npCommunicationId = $this->psnAccessor->getGameNpCommunicationId($gameId);
 
             $progressReporter->notify(10, 'Checking game entry…');
 
-            if (!$this->isOriginalGame($npCommunicationId)) {
+            if (!$this->psnAccessor->isOriginalGame($npCommunicationId)) {
                 return new GameRescanResult(
                     'Can only rescan original game entries.',
                     $differenceTracker->getDifferences()
@@ -107,15 +107,19 @@ class GameRescanService
             }
 
             $progressReporter->notify(15, 'Signing in to worker account…');
-            $client = $this->loginToWorker();
+            $client = $this->psnAccessor->loginToWorker(
+                function (int $workerId, Throwable $exception): void {
+                    $this->logMessage("Can't login with worker " . $workerId);
+                },
+            );
             $progressReporter->notify(20, 'Locating accessible player…');
-            $user = $this->findAccessibleUserWithGame($client, $npCommunicationId);
+            $user = $this->psnAccessor->findAccessibleUserWithGame($client, $npCommunicationId);
 
             if ($user === null) {
                 throw new RuntimeException('Unable to find accessible player for the specified game.');
             }
 
-            $trophyTitle = $this->findTrophyTitleForUser($user, $npCommunicationId);
+            $trophyTitle = $this->psnAccessor->findTrophyTitleForUser($user, $npCommunicationId);
 
             if ($trophyTitle === null) {
                 throw new RuntimeException('Unable to find trophy title for the specified game.');
@@ -160,38 +164,6 @@ class GameRescanService
         }
     }
 
-    private function getGameNpCommunicationId(int $gameId): string
-    {
-        $query = $this->database->prepare('SELECT np_communication_id FROM trophy_title WHERE id = :id');
-        $query->bindValue(':id', $gameId, PDO::PARAM_INT);
-        $query->execute();
-
-        $npCommunicationId = $query->fetchColumn();
-        if ($npCommunicationId === false) {
-            throw new RuntimeException('Unable to find the specified game.');
-        }
-
-        return (string) $npCommunicationId;
-    }
-
-    private function isOriginalGame(string $npCommunicationId): bool
-    {
-        return str_starts_with($npCommunicationId, self::ORIGINAL_GAME_PREFIX);
-    }
-
-    private function loginToWorker(): Client
-    {
-        /** @var Client $client */
-        $client = $this->workerAuthenticator->authenticateWithRetry(
-            self::LOGIN_RETRY_DELAY_SECONDS,
-            function (int $workerId, Throwable $exception): void {
-                $this->logMessage("Can't login with worker " . $workerId);
-            },
-        );
-
-        return $client;
-    }
-
     private function logMessage(string $message): void
     {
         if ($this->logListener !== null) {
@@ -203,46 +175,6 @@ class GameRescanService
         $query = $this->database->prepare('INSERT INTO log(message) VALUES(:message)');
         $query->bindValue(':message', $message, PDO::PARAM_STR);
         $query->execute();
-    }
-
-    private function findAccessibleUserWithGame(Client $client, string $npCommunicationId): ?object
-    {
-        $query = $this->database->prepare(
-            'SELECT account_id
-            FROM trophy_title_player ttp
-            JOIN player p USING(account_id)
-            WHERE ttp.np_communication_id = :np_communication_id
-            ORDER BY ttp.last_updated_date DESC'
-        );
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->execute();
-
-        while (($accountId = $query->fetchColumn()) !== false) {
-            $user = $client->users()->find((string) $accountId);
-
-            try {
-                $user->trophySummary()->level();
-
-                return $user;
-            } catch (TypeError $exception) {
-                // Something odd, try next player.
-            } catch (Exception $exception) {
-                // Player probably private, try next player.
-            }
-        }
-
-        return null;
-    }
-
-    private function findTrophyTitleForUser(object $user, string $npCommunicationId): ?object
-    {
-        foreach ($user->trophyTitles() as $trophyTitle) {
-            if ($trophyTitle->npCommunicationId() === $npCommunicationId) {
-                return $trophyTitle;
-            }
-        }
-
-        return null;
     }
 
     private function updateTrophyTitle(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels PSN access concerns out of `GameRescanService` (~722 lines), which was handling orchestration, catalog refresh, stat recalculation, and PlayStation API lookups in one class.

This PR introduces `GameRescanPsnAccessor` with a single responsibility: resolving the game's NP communication ID, validating it is an original (NPWR) title, authenticating a worker, and locating an accessible player who owns the game.

## Changes

- **New** `GameRescanPsnAccessor` — title lookup, original-game check, worker login, accessible-player search, trophy-title match
- **Updated** `GameRescanService` — delegates the above to the accessor; catalog refresh and recalculation logic unchanged
- **New** `GameRescanPsnAccessorTest` — 7 unit tests covering the extracted methods

## Why this peel-off first

`GameRescanService` is the largest admin God class and duplicates catalog-sync patterns elsewhere. PSN accessors are a self-contained ~80-line slice with no DB writes beyond read queries, making this a low-risk first step before tackling `updateTrophyTitle()` deduplication with `PlayerScanTitleCatalogSynchronizer`.

## Test plan

- [x] `php tests/run.php` — all 799 tests pass
- [x] Existing `GameRescanServiceSetVersionTest` still passes (rescan early-exit path for non-NPWR titles)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb3d1c68-7012-4eeb-a88c-ebf7f71d1fe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb3d1c68-7012-4eeb-a88c-ebf7f71d1fe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

