### PR TITLE
Align PSN online ID validation with Sony requirements

### DIFF
--- a/tests/PlayerQueueHandlerTest.php
+++ b/tests/PlayerQueueHandlerTest.php
@@ -293,11 +293,7 @@ final class PlayerQueueHandlerTest extends TestCase
         $response = $handler->handleAddToQueueRequest($request);
 
         $this->assertSame('error', $response->getStatus());
-        $this->assertSame(
-            'PSN name must contain between three and 16 characters, and can consist of letters, numbers, hyphens (-) '
-            . 'and underscores (_).',
-            $response->getMessage()
-        );
+        $this->assertSame(PlayerQueueService::INVALID_ONLINE_ID_MESSAGE, $response->getMessage());
     }
 
     public function testHandleAddToQueueRequestQueuesPlayerWhenValidationPasses(): void
@@ -357,11 +353,7 @@ final class PlayerQueueHandlerTest extends TestCase
         $response = $handler->handleQueuePositionRequest($request);
 
         $this->assertSame('error', $response->getStatus());
-        $this->assertSame(
-            'PSN name must contain between three and 16 characters, and can consist of letters, numbers, hyphens (-) '
-            . 'and underscores (_).',
-            $response->getMessage()
-        );
+        $this->assertSame(PlayerQueueService::INVALID_ONLINE_ID_MESSAGE, $response->getMessage());
     }
 
     public function testHandleQueuePositionRequestReturnsCheaterResponseWhenStatusMatches(): void

--- a/tests/PlayerQueueServiceTest.php
+++ b/tests/PlayerQueueServiceTest.php
@@ -123,11 +123,16 @@ final class PlayerQueueServiceTest extends TestCase
         $this->assertTrue($this->service->isValidPlayerName('Alpha-123'));
         $this->assertTrue($this->service->isValidPlayerName('ABC'));
         $this->assertTrue($this->service->isValidPlayerName('SixteenCharsHere'));
+        $this->assertTrue($this->service->isValidPlayerName('user_name'));
+        $this->assertTrue($this->service->isValidPlayerName('aBC'));
 
         $this->assertFalse($this->service->isValidPlayerName('ab'));
         $this->assertFalse($this->service->isValidPlayerName('name with space'));
         $this->assertFalse($this->service->isValidPlayerName('invalid!'));
         $this->assertFalse($this->service->isValidPlayerName(str_repeat('a', 17)));
+        $this->assertFalse($this->service->isValidPlayerName('1Alpha'));
+        $this->assertFalse($this->service->isValidPlayerName('_Alpha'));
+        $this->assertFalse($this->service->isValidPlayerName('-Alpha'));
     }
 
     public function testEscapeHtmlEncodesSpecialCharacters(): void

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/GameListItem.php';
 require_once __DIR__ . '/GameListPageResult.php';
 require_once __DIR__ . '/SearchQueryHelper.php';
+require_once __DIR__ . '/PlayerQueueService.php';
 
 class GameListService
 {
@@ -23,7 +24,7 @@ class GameListService
         }
 
         $onlineId = trim($onlineId);
-        if ($onlineId === '') {
+        if ($onlineId === '' || !PlayerQueueService::isValidOnlineId($onlineId)) {
             return null;
         }
 

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -13,7 +13,6 @@ final class PlayerQueueResponseFactory
 {
     private const string EMPTY_NAME_MESSAGE = "PSN name can't be empty.";
 
-    private const string INVALID_NAME_MESSAGE = "PSN name must contain between three and 16 characters, and can consist of letters, numbers, hyphens (-) and underscores (_).";
 
     private const string BUSY_MESSAGE = 'The server is busy processing another request. Please try again in a moment.';
 
@@ -28,7 +27,7 @@ final class PlayerQueueResponseFactory
 
     public function createInvalidNameResponse(): PlayerQueueResponse
     {
-        return PlayerQueueResponse::error(self::INVALID_NAME_MESSAGE);
+        return PlayerQueueResponse::error(PlayerQueueService::INVALID_ONLINE_ID_MESSAGE);
     }
 
     public function createQueueLimitResponse(): PlayerQueueResponse

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -12,7 +12,9 @@ class PlayerQueueService
 {
     public const int MAX_QUEUE_SUBMISSIONS_PER_IP = 10;
     public const int CHEATER_STATUS = 1;
-    private const string PLAYER_NAME_PATTERN = '/^[\\w\-]{3,16}$/';
+    public const string ONLINE_ID_HTML_PATTERN = '[A-Za-z][A-Za-z0-9_-]{2,15}';
+    public const string INVALID_ONLINE_ID_MESSAGE = 'PSN name must contain between three and 16 characters, start with a letter, and can consist of letters, numbers, hyphens (-) and underscores (_). Letters are not case-sensitive.';
+    private const string ONLINE_ID_PATTERN = '/^[a-zA-Z][a-zA-Z0-9_-]{2,15}$/';
     private const string SQL_IP_SUBMISSION_COUNT = <<<'SQL'
         SELECT
             COUNT(*)
@@ -200,7 +202,7 @@ class PlayerQueueService
 
     public static function isValidOnlineId(string $playerName): bool
     {
-        return $playerName !== '' && preg_match(self::PLAYER_NAME_PATTERN, $playerName) === 1;
+        return $playerName !== '' && preg_match(self::ONLINE_ID_PATTERN, $playerName) === 1;
     }
 
     public function isValidPlayerName(string $playerName): bool

--- a/wwwroot/games.php
+++ b/wwwroot/games.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/classes/Html.php';
+require_once __DIR__ . '/classes/PlayerQueueService.php';
 
 require_once __DIR__ . '/classes/GameListFilter.php';
 require_once __DIR__ . '/classes/GameListService.php';
@@ -36,7 +37,7 @@ require_once("header.php");
                 <div class="input-group d-flex justify-content-end">
                     <input type="hidden" name="page" value="<?= $gameListPage->getCurrentPage(); ?>">
                     <input type="hidden" name="search" value="<?= Html::escape($filter->getSearch()); ?>">
-                    <input type="text" name="player" class="form-control rounded-start" maxlength="16" placeholder="View as player..." value="<?= Html::escape($filter->getPlayer() ?? ''); ?>" aria-label="Text input to show completed games for specified player">
+                    <input type="text" name="player" class="form-control rounded-start" minlength="3" maxlength="16" pattern="<?= Html::escape(PlayerQueueService::ONLINE_ID_HTML_PATTERN); ?>" placeholder="View as player..." value="<?= Html::escape($filter->getPlayer() ?? ''); ?>" aria-label="Text input to show completed games for specified player">
 
                     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Filter</button>
                     <ul class="dropdown-menu p-2">

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/classes/Html.php';
+require_once __DIR__ . '/classes/PlayerQueueService.php';
 
 require_once 'classes/HomepageController.php';
 require_once 'classes/HomepagePopularGamesFilter.php';
@@ -25,7 +26,7 @@ require_once("header.php");
         <div class="row row-cols">
             <div class="col">
                 <div class="input-group mb-1">
-                    <input type="text" class="form-control" placeholder="PSN name..." id="player" maxlength="16" aria-label="PSN name..." aria-describedby="player-button">
+                    <input type="text" class="form-control" placeholder="PSN name..." id="player" minlength="3" maxlength="16" pattern="<?= Html::escape(PlayerQueueService::ONLINE_ID_HTML_PATTERN); ?>" aria-label="PSN name..." aria-describedby="player-button">
                     <button class="btn btn-primary" type="button" id="player-button">Update</button>
                 </div>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates PSN online ID validation across the site to match Sony's rules:

- 3–16 characters
- Letters, numbers, hyphens (`-`), and underscores (`_`)
- First character must be a letter
- Letters are case-insensitive (both cases accepted)

## Changes

- Tightened `PlayerQueueService::isValidOnlineId()` regex from `^[\w\-]{3,16}$` to `^[a-zA-Z][a-zA-Z0-9_-]{2,15}$`
- Centralized the HTML `pattern`, error message, and validation logic in `PlayerQueueService`
- Added `minlength`/`pattern` attributes on the homepage queue input and games page player filter
- Reject invalid player filters server-side in `GameListService::resolvePlayer()`
- Extended unit tests for IDs starting with digits, hyphens, or underscores

## Test plan

- [x] `php tests/run.php` (all tests pass)
- [x] New cases cover valid underscores/mixed case and invalid leading digit/hyphen/underscore
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adc1600e-eff9-494e-ad93-177db9332d16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adc1600e-eff9-494e-ad93-177db9332d16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

