### PR TITLE
Docs: update AGENTS.md online ID validation pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,9 @@ the non-obvious steps to actually run the services.
     php -d variables_order=EGPCS -S 0.0.0.0:8000 /tmp/psn100-router.php
   ```
 - The "Update" box on the homepage submits a PSN name to `add_to_queue.php?q=<name>`
-  (param key is `q`); valid names match `^[\w\-]{3,16}$` and are inserted into
+  (param key is `q`); valid names must match `PlayerQueueService::ONLINE_ID_PATTERN`
+  (`^[a-zA-Z][a-zA-Z0-9_-]{2,15}$` — 3–16 characters, starting with a letter;
+  letters, numbers, hyphens, and underscores allowed) and are inserted into
   `player_queue`. This is a quick way to exercise a real DB write.
 
 ### `/admin` and `/cron` access control


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `AGENTS.md` to reflect the Sony-aligned online ID validation introduced in PR #16105.

The old documentation referenced `^[\w\-]{3,16}$`, which allowed names starting with digits. The app now requires names to start with a letter via `PlayerQueueService::ONLINE_ID_PATTERN` (`^[a-zA-Z][a-zA-Z0-9_-]{2,15}$`).

## Changes

- Replace the stale regex in the homepage queue submission note
- Point to `PlayerQueueService::ONLINE_ID_PATTERN` as the canonical source of truth
- Document the 3–16 character rule and allowed character set in plain language

## Test plan

- [x] Documentation-only change; no runtime impact
- [x] Verified pattern matches `wwwroot/classes/PlayerQueueService.php`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-490dadeb-8a42-4e5e-84fa-4c4df8d035ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-490dadeb-8a42-4e5e-84fa-4c4df8d035ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

