### PR TITLE
Fix: propagate account IDs as strings through scan pipeline

### DIFF
--- a/tests/PlayerScanCompletionServiceTest.php
+++ b/tests/PlayerScanCompletionServiceTest.php
@@ -130,7 +130,7 @@ final class PlayerScanCompletionServiceTest extends TestCase
             VALUES (9, 'NPWR00003_00', 1, 1)"
         );
 
-        $result = $this->service->recalculatePlayerTrophyStatsAndStatus(9, 5, 'recheck');
+        $result = $this->service->recalculatePlayerTrophyStatsAndStatus('9', 5, 'recheck');
 
         $this->assertTrue($result->shouldContinueScan());
         $npwrCount = $this->database->query('SELECT trophy_count_npwr FROM player WHERE account_id = 9')->fetchColumn();
@@ -147,7 +147,7 @@ final class PlayerScanCompletionServiceTest extends TestCase
             ) VALUES (9, 'NPWR00003_00', 1, datetime('now'))"
         );
 
-        $result = $this->service->recalculatePlayerTrophyStatsAndStatus(9, 5, 'recheck');
+        $result = $this->service->recalculatePlayerTrophyStatsAndStatus('9', 5, 'recheck');
 
         $this->assertTrue($result->shouldContinueScan());
     }
@@ -164,7 +164,7 @@ final class PlayerScanCompletionServiceTest extends TestCase
     {
         $this->database->exec("INSERT INTO player (account_id, status, rarity_points) VALUES (15, 1, 0)");
 
-        $this->service->updateRarityPointsForActivePlayer(15);
+        $this->service->updateRarityPointsForActivePlayer('15');
 
         $rarityPoints = $this->database->query('SELECT rarity_points FROM player WHERE account_id = 15')->fetchColumn();
         $this->assertSame(0, (int) $rarityPoints);

--- a/tests/PlayerScanPrivacyServiceTest.php
+++ b/tests/PlayerScanPrivacyServiceTest.php
@@ -74,7 +74,7 @@ final class PlayerScanPrivacyServiceTest extends TestCase
         );
         $this->database->exec("INSERT INTO player_queue (online_id) VALUES ('queue-name')");
 
-        $this->service->markAsPrivateByAccountId(200, 'queue-name');
+        $this->service->markAsPrivateByAccountId('200', 'queue-name');
 
         $status = $this->database->query('SELECT status FROM player WHERE account_id = 200')->fetchColumn();
         $queueCount = $this->database->query('SELECT COUNT(*) FROM player_queue')->fetchColumn();
@@ -113,9 +113,9 @@ final class PlayerScanPrivacyServiceTest extends TestCase
         $user = new class {
             public int $attempts = 0;
 
-            public function accountId(): int
+            public function accountId(): string
             {
-                return 300;
+                return '300';
             }
 
             public function onlineId(): string

--- a/tests/PlayerScanProfileSynchronizerTest.php
+++ b/tests/PlayerScanProfileSynchronizerTest.php
@@ -22,7 +22,7 @@ final class PlayerScanProfileSynchronizerTest extends TestCase
         $database->exec('CREATE TABLE player_queue (online_id TEXT PRIMARY KEY)');
         $database->exec(
             'CREATE TABLE player (
-                account_id INTEGER PRIMARY KEY,
+                account_id TEXT PRIMARY KEY,
                 online_id TEXT NOT NULL,
                 country TEXT,
                 status INTEGER NOT NULL DEFAULT 99,
@@ -107,5 +107,42 @@ final class PlayerScanProfileSynchronizerTest extends TestCase
         $this->assertFalse($success->shouldSkipPlayer());
         $this->assertFalse($skip->isSuccess());
         $this->assertTrue($skip->shouldSkipPlayer());
+    }
+
+    public function testCountryHelpersAcceptStringAccountIds(): void
+    {
+        $largeAccountId = '9223372036854775808';
+        $statement = $this->synchronizerDatabase()->prepare(
+            'INSERT INTO player (account_id, online_id, country, status) VALUES (:account_id, :online_id, :country, :status)'
+        );
+        $statement->bindValue(':account_id', $largeAccountId, PDO::PARAM_STR);
+        $statement->bindValue(':online_id', 'large-id-player', PDO::PARAM_STR);
+        $statement->bindValue(':country', 'se', PDO::PARAM_STR);
+        $statement->bindValue(':status', 0, PDO::PARAM_INT);
+        $statement->execute();
+
+        $fetchStoredCountry = new ReflectionMethod(PlayerScanProfileSynchronizer::class, 'fetchStoredCountryByAccountId');
+        $fetchStoredCountry->setAccessible(true);
+        $this->assertSame('se', $fetchStoredCountry->invoke($this->synchronizer, $largeAccountId));
+
+        $updatePlayerCountry = new ReflectionMethod(PlayerScanProfileSynchronizer::class, 'updatePlayerCountry');
+        $updatePlayerCountry->setAccessible(true);
+        $updatePlayerCountry->invoke($this->synchronizer, $largeAccountId, 'no');
+
+        $country = $this->synchronizerDatabase()
+            ->query("SELECT country FROM player WHERE account_id = '{$largeAccountId}'")
+            ->fetchColumn();
+        $this->assertSame('no', $country);
+    }
+
+    private function synchronizerDatabase(): PDO
+    {
+        $property = new ReflectionProperty(PlayerScanProfileSynchronizer::class, 'database');
+        $property->setAccessible(true);
+
+        /** @var PDO $database */
+        $database = $property->getValue($this->synchronizer);
+
+        return $database;
     }
 }

--- a/tests/PlayerScanTrophyProgressSynchronizerTest.php
+++ b/tests/PlayerScanTrophyProgressSynchronizerTest.php
@@ -36,7 +36,7 @@ final class PlayerScanTrophyProgressSynchronizerTest extends TestCase
             new AutomaticTrophyTitleMergeService($mergeDatabase, $mergeService),
         );
 
-        $user = new PlayerScanTrophyProgressSynchronizerTestUser(42);
+        $user = new PlayerScanTrophyProgressSynchronizerTestUser('42');
         $trophyTitle = new PlayerScanTrophyProgressSynchronizerTestTrophyTitle(
             'NPWR12345_00',
             'Example Game',
@@ -57,10 +57,55 @@ final class PlayerScanTrophyProgressSynchronizerTest extends TestCase
         $this->assertSame(1, $earnedDatabase->upsertExecutions, 'Only earned trophies should be persisted.');
         $this->assertSame('42', $earnedDatabase->upsertParameters[0][':account_id']);
         $this->assertTrue(
-            $calculatorDatabase->getTrophyGroupPlayer('NPWR12345_00', 'default', 42) !== null,
+            $calculatorDatabase->getTrophyGroupPlayer('NPWR12345_00', 'default', '42') !== null,
             'Group progress should be recalculated.'
         );
         $this->assertSame([], $mergeService->recomputedParents);
+    }
+
+    public function testSynchronizeTrophyProgressPreservesAccountIdsAbovePhpIntMax(): void
+    {
+        $largeAccountId = '9223372036854775808';
+        $mergeDatabase = new PlayerScanTrophyProgressSynchronizerMergePDO([]);
+        $earnedDatabase = new PlayerEarnedTrophyPersisterRecordingPDO(null);
+        $calculatorDatabase = new PlayerScanTrophyProgressSynchronizerCalculatorPDO();
+        $calculatorDatabase->setTrophyGroup('NPWR12345_00', 'default');
+        $calculatorDatabase->addTrophy('NPWR12345_00', 'default', 1, 'bronze');
+
+        $loggerDatabase = new PDO('sqlite::memory:');
+        $loggerDatabase->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $loggerDatabase->exec('CREATE TABLE log (message TEXT NOT NULL)');
+
+        $synchronizer = new PlayerScanTrophyProgressSynchronizer(
+            $mergeDatabase,
+            new TrophyCalculator($calculatorDatabase),
+            new Psn100Logger($loggerDatabase),
+            new PlayerEarnedTrophyPersister($earnedDatabase),
+            new AutomaticTrophyTitleMergeService($mergeDatabase, new RecordingTrophyMergeService($mergeDatabase)),
+        );
+
+        $user = new PlayerScanTrophyProgressSynchronizerTestUser($largeAccountId);
+        $trophyTitle = new PlayerScanTrophyProgressSynchronizerTestTrophyTitle(
+            'NPWR12345_00',
+            'Example Game',
+            '2024-06-15T10:30:00Z',
+            [
+                new PlayerScanTrophyProgressSynchronizerTestTrophyGroup(
+                    'default',
+                    [
+                        new PlayerScanTrophyProgressSynchronizerTestTrophy(1, true, '', '2024-06-15T10:30:00Z'),
+                    ],
+                ),
+            ],
+        );
+
+        $synchronizer->synchronizeTrophyProgress($user, $trophyTitle, 'NPWR12345_00', false, []);
+
+        $this->assertSame($largeAccountId, $earnedDatabase->upsertParameters[0][':account_id'] ?? null);
+        $this->assertTrue(
+            $calculatorDatabase->getTrophyGroupPlayer('NPWR12345_00', 'default', $largeAccountId) !== null,
+            'Group progress should be recalculated for large account IDs.'
+        );
     }
 
     public function testSynchronizeTrophyProgressRecalculatesMergeParentsFromDatabaseAndCatalog(): void
@@ -89,7 +134,7 @@ final class PlayerScanTrophyProgressSynchronizerTest extends TestCase
             new AutomaticTrophyTitleMergeService($mergeDatabase, $mergeService),
         );
 
-        $user = new PlayerScanTrophyProgressSynchronizerTestUser(7);
+        $user = new PlayerScanTrophyProgressSynchronizerTestUser('7');
         $trophyTitle = new PlayerScanTrophyProgressSynchronizerTestTrophyTitle(
             'NPWR12345_00',
             'Example Game',
@@ -113,7 +158,7 @@ final class PlayerScanTrophyProgressSynchronizerTest extends TestCase
             'Catalog merge parents should be recomputed via merge service.'
         );
         $this->assertTrue(
-            $calculatorDatabase->getTrophyGroupPlayer('NPWR99999_00', 'default', 7) !== null,
+            $calculatorDatabase->getTrophyGroupPlayer('NPWR99999_00', 'default', '7') !== null,
             'Merge parent group progress should be recalculated.'
         );
     }
@@ -206,15 +251,15 @@ final class PlayerScanTrophyProgressSynchronizerCalculatorPDO extends PDO
         $this->delegate->addTrophy($npCommunicationId, $groupId, $orderId, $type, $status);
     }
 
-    public function addEarnedTrophy(string $npCommunicationId, string $groupId, int $orderId, int $accountId, int $earned = 1): void
+    public function addEarnedTrophy(string $npCommunicationId, string $groupId, int $orderId, string $accountId, int $earned = 1): void
     {
         $this->delegate->addEarnedTrophy($npCommunicationId, $groupId, $orderId, $accountId, $earned);
     }
 
     /**
-     * @return array{np_communication_id:string,group_id:string,account_id:int,bronze:int,silver:int,gold:int,platinum:int,progress:int}|null
+     * @return array{np_communication_id:string,group_id:string,account_id:string,bronze:int,silver:int,gold:int,platinum:int,progress:int}|null
      */
-    public function getTrophyGroupPlayer(string $npCommunicationId, string $groupId, int $accountId): ?array
+    public function getTrophyGroupPlayer(string $npCommunicationId, string $groupId, string $accountId): ?array
     {
         return $this->delegate->getTrophyGroupPlayer($npCommunicationId, $groupId, $accountId);
     }
@@ -318,11 +363,11 @@ final class PlayerScanTrophyProgressSynchronizerMergeStatement extends PDOStatem
 
 final class PlayerScanTrophyProgressSynchronizerTestUser
 {
-    public function __construct(private readonly int $accountId)
+    public function __construct(private readonly string $accountId)
     {
     }
 
-    public function accountId(): int
+    public function accountId(): string
     {
         return $this->accountId;
     }

--- a/tests/TrophyCalculatorTest.php
+++ b/tests/TrophyCalculatorTest.php
@@ -19,7 +19,7 @@ final class TrophyCalculatorTest extends TestCase
     {
         $npCommunicationId = 'NPWR99999';
         $groupId = '000';
-        $accountId = 42;
+        $accountId = '42';
 
         $this->database->setTrophyGroup($npCommunicationId, $groupId);
 
@@ -49,7 +49,7 @@ final class TrophyCalculatorTest extends TestCase
     {
         $npCommunicationId = 'NPWR88888';
         $groupId = '000';
-        $accountId = 99;
+        $accountId = '99';
 
         $this->database->setTrophyGroup($npCommunicationId, $groupId);
 
@@ -82,7 +82,7 @@ final class TrophyCalculatorTest extends TestCase
     {
         $npCommunicationId = 'NPWR77777';
         $groupId = '100';
-        $accountId = 7;
+        $accountId = '7';
 
         $this->database->setTrophyGroup($npCommunicationId, $groupId);
 
@@ -103,6 +103,23 @@ final class TrophyCalculatorTest extends TestCase
         $this->assertSame(0, $playerProgress['gold']);
         $this->assertSame(0, $playerProgress['platinum']);
     }
+
+    public function testRecalculateTrophyGroupPreservesAccountIdsAbovePhpIntMax(): void
+    {
+        $npCommunicationId = 'NPWR66666';
+        $groupId = '000';
+        $accountId = '9223372036854775808';
+
+        $this->database->setTrophyGroup($npCommunicationId, $groupId);
+        $this->database->addTrophy($npCommunicationId, $groupId, 1, 'bronze');
+        $this->database->addEarnedTrophy($npCommunicationId, $groupId, 1, $accountId);
+
+        $this->calculator->recalculateTrophyGroup($npCommunicationId, $groupId, $accountId);
+
+        $playerProgress = $this->database->getTrophyGroupPlayer($npCommunicationId, $groupId, $accountId);
+        $this->assertTrue($playerProgress !== null);
+        $this->assertSame($accountId, $playerProgress['account_id']);
+    }
 }
 
 final class FakePDO extends PDO
@@ -115,11 +132,11 @@ final class FakePDO extends PDO
      */
     public array $trophyGroups = [];
 
-    /** @var list<array{np_communication_id:string,group_id:string,order_id:int,account_id:int,earned:int}> */
+    /** @var list<array{np_communication_id:string,group_id:string,order_id:int,account_id:string,earned:int}> */
     public array $trophyEarned = [];
 
     /**
-     * @var array<string, array{np_communication_id:string,group_id:string,account_id:int,bronze:int,silver:int,gold:int,platinum:int,progress:int}>
+     * @var array<string, array{np_communication_id:string,group_id:string,account_id:string,bronze:int,silver:int,gold:int,platinum:int,progress:int}>
      */
     public array $trophyGroupPlayers = [];
 
@@ -155,7 +172,7 @@ final class FakePDO extends PDO
         ];
     }
 
-    public function addEarnedTrophy(string $npCommunicationId, string $groupId, int $orderId, int $accountId, int $earned = 1): void
+    public function addEarnedTrophy(string $npCommunicationId, string $groupId, int $orderId, string $accountId, int $earned = 1): void
     {
         $this->trophyEarned[] = [
             'np_communication_id' => $npCommunicationId,
@@ -175,9 +192,9 @@ final class FakePDO extends PDO
     }
 
     /**
-     * @return array{np_communication_id:string,group_id:string,account_id:int,bronze:int,silver:int,gold:int,platinum:int,progress:int}|null
+     * @return array{np_communication_id:string,group_id:string,account_id:string,bronze:int,silver:int,gold:int,platinum:int,progress:int}|null
      */
-    public function getTrophyGroupPlayer(string $npCommunicationId, string $groupId, int $accountId): ?array
+    public function getTrophyGroupPlayer(string $npCommunicationId, string $groupId, string $accountId): ?array
     {
         return $this->trophyGroupPlayers[$this->buildGroupPlayerKey($npCommunicationId, $groupId, $accountId)] ?? null;
     }
@@ -196,7 +213,7 @@ final class FakePDO extends PDO
         $this->trophyGroups[$key]['platinum'] = $platinum;
     }
 
-    public function saveTrophyGroupPlayer(string $npCommunicationId, string $groupId, int $accountId, int $bronze, int $silver, int $gold, int $platinum, int $progress): void
+    public function saveTrophyGroupPlayer(string $npCommunicationId, string $groupId, string $accountId, int $bronze, int $silver, int $gold, int $platinum, int $progress): void
     {
         $this->trophyGroupPlayers[$this->buildGroupPlayerKey($npCommunicationId, $groupId, $accountId)] = [
             'np_communication_id' => $npCommunicationId,
@@ -230,7 +247,7 @@ final class FakePDO extends PDO
         return $npCommunicationId . '|' . $groupId;
     }
 
-    private function buildGroupPlayerKey(string $npCommunicationId, string $groupId, int $accountId): string
+    private function buildGroupPlayerKey(string $npCommunicationId, string $groupId, string $accountId): string
     {
         return $npCommunicationId . '|' . $groupId . '|' . $accountId;
     }
@@ -358,7 +375,7 @@ final class FakePDOStatement extends PDOStatement
     {
         $npCommunicationId = (string) $this->parameters[':np_communication_id'];
         $groupId = (string) $this->parameters[':group_id'];
-        $accountId = (int) $this->parameters[':account_id'];
+        $accountId = (string) $this->parameters[':account_id'];
 
         $counts = [];
 
@@ -390,7 +407,7 @@ final class FakePDOStatement extends PDOStatement
         $this->database->saveTrophyGroupPlayer(
             (string) $this->parameters[':np_communication_id'],
             (string) $this->parameters[':group_id'],
-            (int) $this->parameters[':account_id'],
+            (string) $this->parameters[':account_id'],
             (int) $this->parameters[':bronze'],
             (int) $this->parameters[':silver'],
             (int) $this->parameters[':gold'],

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -137,7 +137,7 @@ class GameRescanService
             $this->recalculateTrophies(
                 $trophyTitle,
                 $npCommunicationId,
-                (int) $user->accountId(),
+                (string) $user->accountId(),
                 $trophyGroups,
                 $progressReporter
             );
@@ -459,7 +459,7 @@ class GameRescanService
     private function recalculateTrophies(
         object $trophyTitle,
         string $npCommunicationId,
-        int $accountId,
+        string $accountId,
         array $trophyGroups,
         GameRescanProgressReporter $progressReporter
     ): void {
@@ -503,7 +503,7 @@ class GameRescanService
     private function recalculateParentTitles(
         string $childNpCommunicationId,
         string $lastUpdatedDateTime,
-        int $accountId,
+        string $accountId,
         GameRescanProgressReporter $progressReporter
     ): void {
         $query = $this->database->prepare(

--- a/wwwroot/classes/Cron/PlayerScanCompletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionService.php
@@ -47,7 +47,7 @@ final class PlayerScanCompletionService
     }
 
     public function recalculatePlayerTrophyStatsAndStatus(
-        int $accountId,
+        string $accountId,
         int $totalTrophiesSony,
         string $recheck,
     ): PlayerScanCompletionResult {
@@ -60,7 +60,7 @@ final class PlayerScanCompletionService
                 JOIN trophy_title_meta ttm USING (np_communication_id)
             WHERE  ttm.status = 0
                 AND ttp.account_id = :account_id ");
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
         $trophies = $query->fetch();
         $points = $trophies['bronze'] * 15
@@ -85,23 +85,23 @@ final class PlayerScanCompletionService
         $query->bindValue(':level', $levelAndProgress['level'], PDO::PARAM_INT);
         $query->bindValue(':progress', $levelAndProgress['progress'], PDO::PARAM_INT);
         $query->bindValue(':points', $points, PDO::PARAM_INT);
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
 
         $playerStatus = 0;
 
         $query = $this->database->prepare('SELECT trophy_count_npwr FROM player WHERE account_id = :account_id');
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
         $ourTotalTrophies = $query->fetchColumn();
 
         if ($ourTotalTrophies > $totalTrophiesSony) {
             $query = $this->database->prepare("UPDATE `player` SET trophy_count_npwr = (SELECT COUNT(*) FROM `trophy_earned` WHERE account_id = :account_id AND earned = 1 AND np_communication_id LIKE 'N%') WHERE account_id = :account_id");
-            $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+            $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
             $query->execute();
 
             $query = $this->database->prepare('SELECT trophy_count_npwr FROM player WHERE account_id = :account_id');
-            $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+            $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
             $query->execute();
             $ourTotalTrophies = $query->fetchColumn();
 
@@ -125,7 +125,7 @@ final class PlayerScanCompletionService
             WHERE
                 account_id = :account_id
             ");
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
         $withinAYear = $query->fetchColumn();
         if ($withinAYear == 0) {
@@ -143,13 +143,13 @@ final class PlayerScanCompletionService
             ");
         $query->bindValue(':status', $playerStatus, PDO::PARAM_INT);
         $query->bindValue(':trophy_count_sony', $totalTrophiesSony, PDO::PARAM_INT);
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
 
         return PlayerScanCompletionResult::completed();
     }
 
-    public function updateRarityPointsForActivePlayer(int $accountId): void
+    public function updateRarityPointsForActivePlayer(string $accountId): void
     {
         $query = $this->database->prepare('SELECT
                 p.status
@@ -157,7 +157,7 @@ final class PlayerScanCompletionService
                 player p
             WHERE
                 p.account_id = :account_id');
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
         $playerStatus = $query->fetchColumn();
 
@@ -211,7 +211,7 @@ final class PlayerScanCompletionService
                     ttp.in_game_legendary = rarity.in_game_legendary
                 WHERE
                     ttp.account_id = :account_id AND ttp.np_communication_id = rarity.np_communication_id");
-            $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+            $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
             $query->execute();
 
             $query = $this->database->prepare("WITH
@@ -253,7 +253,7 @@ final class PlayerScanCompletionService
                     p.in_game_legendary = rarity.in_game_legendary
                 WHERE
                     p.account_id = :account_id AND p.status = 0");
-            $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+            $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
             $query->execute();
         });
     }

--- a/wwwroot/classes/Cron/PlayerScanPrivacyService.php
+++ b/wwwroot/classes/Cron/PlayerScanPrivacyService.php
@@ -44,7 +44,7 @@ final class PlayerScanPrivacyService
         $query->execute();
     }
 
-    public function markAsPrivateByAccountId(int $accountId, string $queueOnlineId): void
+    public function markAsPrivateByAccountId(string $accountId, string $queueOnlineId): void
     {
         $privateStatus = PlayerStatus::PRIVATE_PROFILE->value;
 
@@ -54,7 +54,7 @@ final class PlayerScanPrivacyService
             WHERE account_id = :account_id AND `status` != :flagged_status'
         );
         $query->bindValue(':status', $privateStatus, PDO::PARAM_INT);
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->bindValue(':flagged_status', PlayerStatus::FLAGGED->value, PDO::PARAM_INT);
         $query->execute();
 
@@ -85,7 +85,7 @@ final class PlayerScanPrivacyService
 
                 return PlayerScanTrophySummaryAccessResult::abortScan();
             } catch (Exception) {
-                $this->markAsPrivateByAccountId((int) $user->accountId(), (string) $user->onlineId());
+                $this->markAsPrivateByAccountId((string) $user->accountId(), (string) $user->onlineId());
 
                 return PlayerScanTrophySummaryAccessResult::privateProfile();
             }

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -203,7 +203,7 @@ final class PlayerScanProfileSynchronizer
                     $country = $countryFromProfile;
 
                     if ($country === null || strtolower($country) === 'zz') {
-                        $storedCountry = $this->fetchStoredCountryByAccountId((int) $profileAccountId);
+                        $storedCountry = $this->fetchStoredCountryByAccountId($profileAccountId);
 
                         if (is_string($storedCountry) && $storedCountry !== '') {
                             $country = $storedCountry;
@@ -216,11 +216,11 @@ final class PlayerScanProfileSynchronizer
 
                             if ($resolvedCountry !== null) {
                                 $country = $resolvedCountry;
-                                $this->updatePlayerCountry((int) $profileAccountId, $resolvedCountry);
+                                $this->updatePlayerCountry($profileAccountId, $resolvedCountry);
                             }
                         }
                     } else {
-                        $this->updatePlayerCountry((int) $profileAccountId, $country);
+                        $this->updatePlayerCountry($profileAccountId, $country);
                     }
                 } else {
                     if ($existingAccountId === null) {
@@ -241,7 +241,7 @@ final class PlayerScanProfileSynchronizer
                         $player['online_id'] = $originalOnlineId;
                     }
 
-                    $storedCountry = $this->fetchStoredCountryByAccountId((int) $existingAccountId);
+                    $storedCountry = $this->fetchStoredCountryByAccountId($existingAccountId);
 
                     if (is_string($storedCountry) && $storedCountry !== '') {
                         $country = $storedCountry;
@@ -252,7 +252,7 @@ final class PlayerScanProfileSynchronizer
 
                         if ($resolvedCountry !== null) {
                             $country = $resolvedCountry;
-                            $this->updatePlayerCountry((int) $existingAccountId, $resolvedCountry);
+                            $this->updatePlayerCountry($existingAccountId, $resolvedCountry);
                         }
                     }
                 }

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -136,7 +136,13 @@ final class PlayerScanProfileSynchronizer
         }
 
         if (is_float($accountId)) {
-            return (string) (int) $accountId;
+            if (!is_finite($accountId) || floor($accountId) !== $accountId) {
+                return null;
+            }
+
+            $asString = sprintf('%.0f', $accountId);
+
+            return ctype_digit($asString) ? $asString : null;
         }
 
         if (is_numeric($accountId)) {
@@ -320,7 +326,7 @@ final class PlayerScanProfileSynchronizer
                 plus = new.plus,
                 about_me = new.about_me'
         );
-        $query->bindValue(':account_id', $user->accountId(), PDO::PARAM_INT);
+        $query->bindValue(':account_id', (string) $user->accountId(), PDO::PARAM_STR);
         $query->bindValue(':online_id', $user->onlineId(), PDO::PARAM_STR);
         $query->bindValue(':country', strtolower($country), PDO::PARAM_STR);
         $query->bindValue(':avatar_url', $avatarFilename, PDO::PARAM_STR);
@@ -372,10 +378,10 @@ final class PlayerScanProfileSynchronizer
         $query->execute();
     }
 
-    private function fetchStoredCountryByAccountId(int $accountId): ?string
+    private function fetchStoredCountryByAccountId(string $accountId): ?string
     {
         $query = $this->database->prepare('SELECT country FROM player WHERE account_id = :account_id');
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
 
         $country = $query->fetchColumn();
@@ -423,13 +429,13 @@ final class PlayerScanProfileSynchronizer
         return null;
     }
 
-    private function updatePlayerCountry(int $accountId, string $country): void
+    private function updatePlayerCountry(string $accountId, string $country): void
     {
         $query = $this->database->prepare(
             'UPDATE player SET country = :country WHERE account_id = :account_id'
         );
         $query->bindValue(':country', strtolower($country), PDO::PARAM_STR);
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
     }
 
@@ -472,7 +478,7 @@ final class PlayerScanProfileSynchronizer
                 $query = $this->database->prepare(
                     'UPDATE player SET `status` = 5, last_updated_date = NOW() WHERE account_id = :account_id'
                 );
-                $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+                $query->bindValue(':account_id', (string) $accountId, PDO::PARAM_STR);
                 $query->execute();
             }
         }

--- a/wwwroot/classes/Cron/PlayerScanStaleGameDeletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanStaleGameDeletionService.php
@@ -13,12 +13,12 @@ final class PlayerScanStaleGameDeletionService
     {
     }
 
-    public function countLocalGames(int $accountId): int
+    public function countLocalGames(string $accountId): int
     {
         $query = $this->database->prepare("SELECT COUNT(ttp.np_communication_id)
             FROM   trophy_title_player ttp
             WHERE  ttp.account_id = :account_id AND ttp.np_communication_id LIKE 'N%'");
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
 
         return (int) $query->fetchColumn();
@@ -54,12 +54,12 @@ final class PlayerScanStaleGameDeletionService
     /**
      * @param list<string> $scannedGames
      */
-    public function deleteMissingZeroPercentGames(int $accountId, array $scannedGames): void
+    public function deleteMissingZeroPercentGames(string $accountId, array $scannedGames): void
     {
         $query = $this->database->prepare("SELECT ttp.np_communication_id
             FROM   trophy_title_player ttp
             WHERE  ttp.account_id = :account_id AND ttp.np_communication_id LIKE 'N%'");
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
         $playerGames = $query->fetchAll();
 
@@ -74,7 +74,7 @@ final class PlayerScanStaleGameDeletionService
         }
     }
 
-    private function deleteMergedParentIfNoStackRemains(int $accountId, string $game): void
+    private function deleteMergedParentIfNoStackRemains(string $accountId, string $game): void
     {
         $query = $this->database->prepare("SELECT ttm.parent_np_communication_id
             FROM   trophy_title_meta ttm
@@ -100,7 +100,7 @@ final class PlayerScanStaleGameDeletionService
             $query = $this->database->prepare("SELECT ttp.np_communication_id
                 FROM   trophy_title_player ttp
                 WHERE  ttp.account_id = :account_id AND ttp.np_communication_id = :np_communication_id");
-            $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+            $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
             $query->bindValue(':np_communication_id', $stackedGameId, PDO::PARAM_STR);
             $query->execute();
 
@@ -112,20 +112,20 @@ final class PlayerScanStaleGameDeletionService
         $this->deletePlayerGameProgress($accountId, (string) $mergedGame);
     }
 
-    private function deletePlayerGameProgress(int $accountId, string $npCommunicationId): void
+    private function deletePlayerGameProgress(string $accountId, string $npCommunicationId): void
     {
         $query = $this->database->prepare("DELETE FROM trophy_group_player tgp WHERE tgp.account_id = :account_id AND tgp.np_communication_id = :np_communication_id");
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->execute();
 
         $query = $this->database->prepare("DELETE FROM trophy_title_player ttp WHERE ttp.account_id = :account_id AND ttp.np_communication_id = :np_communication_id");
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->execute();
 
         $query = $this->database->prepare("DELETE FROM trophy_earned te WHERE te.account_id = :account_id AND te.np_communication_id = :np_communication_id");
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->execute();
     }

--- a/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
@@ -71,7 +71,7 @@ final class PlayerScanTrophyProgressSynchronizer
             $this->trophyCalculator->recalculateTrophyGroup(
                 $npCommunicationId,
                 $trophyGroup->id(),
-                (int) $user->accountId()
+                (string) $user->accountId()
             );
         }
 
@@ -79,7 +79,7 @@ final class PlayerScanTrophyProgressSynchronizer
             $npCommunicationId,
             $trophyTitle->lastUpdatedDateTime(),
             $newTrophies,
-            (int) $user->accountId(),
+            (string) $user->accountId(),
             false
         );
 
@@ -93,13 +93,13 @@ final class PlayerScanTrophyProgressSynchronizer
             $this->trophyCalculator->recalculateTrophyGroup(
                 $row['parent_np_communication_id'],
                 $row['parent_group_id'],
-                (int) $user->accountId()
+                (string) $user->accountId()
             );
             $this->trophyCalculator->recalculateTrophyTitle(
                 $row['parent_np_communication_id'],
                 $trophyTitle->lastUpdatedDateTime(),
                 false,
-                (int) $user->accountId(),
+                (string) $user->accountId(),
                 true
             );
         }

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -411,7 +411,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 last_updated_date
                             FROM   trophy_title_player
                             WHERE  account_id = :account_id AND np_communication_id LIKE 'N%'");
-                        $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
+                        $query->bindValue(":account_id", (string) $user->accountId(), PDO::PARAM_STR);
                         $query->execute();
                         $gameLastUpdatedDate = $query->fetchAll(PDO::FETCH_KEY_PAIR);
 
@@ -583,7 +583,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                         }
 
                         // Delete missing 0% games (and this will also delete hidden games, and any trophies for those hidden games)
-                        $ourGameCount = $this->staleGameDeletionService->countLocalGames((int) $user->accountId());
+                        $ourGameCount = $this->staleGameDeletionService->countLocalGames((string) $user->accountId());
 
                         $scanReachedEnd = $currentScanPosition === $totalGamesToProcess;
                         $scanCompletedCleanly = $trophyTitleFetchCompleted
@@ -628,7 +628,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                             }
 
                             $this->staleGameDeletionService->deleteMissingZeroPercentGames(
-                                (int) $user->accountId(),
+                                (string) $user->accountId(),
                                 $scannedGames,
                             );
                         } elseif ($this->staleGameDeletionService->shouldRetryWhenSonyReturnsNoGames((int) $psnGameCount, $ourGameCount)) {
@@ -647,14 +647,14 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                             }
 
                             $this->logger->log(sprintf(
-                                'Skipped deleting missing games for %s (%d) because no trophy titles were returned.',
+                                'Skipped deleting missing games for %s (%s) because no trophy titles were returned.',
                                 (string) $player['online_id'],
-                                (int) $user->accountId()
+                                (string) $user->accountId()
                             ));
                         }
 
                         $completionResult = $this->scanCompletionService->recalculatePlayerTrophyStatsAndStatus(
-                            (int) $user->accountId(),
+                            (string) $user->accountId(),
                             $totalTrophiesStart,
                             $recheck,
                         );
@@ -664,13 +664,13 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                         }
                     }
 
-                    $this->scanCompletionService->updateRarityPointsForActivePlayer((int) $user->accountId());
+                    $this->scanCompletionService->updateRarityPointsForActivePlayer((string) $user->accountId());
 
                     // Done with the user, update the date
                     $query = $this->database->prepare("UPDATE player
                         SET    last_updated_date = Now()
                         WHERE  account_id = :account_id ");
-                    $query->bindValue(":account_id", $user->accountId(), PDO::PARAM_INT);
+                    $query->bindValue(":account_id", (string) $user->accountId(), PDO::PARAM_STR);
                     $query->execute();
 
                     // Delete user from the queue

--- a/wwwroot/classes/Cron/WorkerScanCoordinator.php
+++ b/wwwroot/classes/Cron/WorkerScanCoordinator.php
@@ -116,7 +116,7 @@ final class WorkerScanCoordinator
                 END
                 WHERE  account_id = :account_id '
             );
-            $query->bindValue(':account_id', (int) $accountId, PDO::PARAM_INT);
+            $query->bindValue(':account_id', (string) $accountId, PDO::PARAM_STR);
             $query->execute();
         }
 

--- a/wwwroot/classes/TrophyCalculator.php
+++ b/wwwroot/classes/TrophyCalculator.php
@@ -92,7 +92,7 @@ final class TrophyCalculator
         return $this->clampProgress($progress);
     }
 
-    public function recalculateTrophyGroup(string $npCommunicationId, string $groupId, int $accountId): void
+    public function recalculateTrophyGroup(string $npCommunicationId, string $groupId, string $accountId): void
     {
         $query = $this->database->prepare(
             'SELECT t.type, COUNT(*) AS count
@@ -144,7 +144,7 @@ final class TrophyCalculator
                 AND tm.status = 0
             GROUP BY t.type'
         );
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
         $query->execute();
@@ -184,7 +184,7 @@ final class TrophyCalculator
         );
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->bindValue(':bronze', $earnedTrophyTypes['bronze'], PDO::PARAM_INT);
         $query->bindValue(':silver', $earnedTrophyTypes['silver'], PDO::PARAM_INT);
         $query->bindValue(':gold', $earnedTrophyTypes['gold'], PDO::PARAM_INT);
@@ -193,7 +193,7 @@ final class TrophyCalculator
         $query->execute();
     }
 
-    public function recalculateTrophyTitle(string $npCommunicationId, string $lastUpdateDate, bool $newTrophies, int $accountId, bool $merge): void
+    public function recalculateTrophyTitle(string $npCommunicationId, string $lastUpdateDate, bool $newTrophies, string $accountId, bool $merge): void
     {
         $query = $this->database->prepare(
             'SELECT SUM(bronze) AS bronze,
@@ -239,7 +239,7 @@ final class TrophyCalculator
                     AND account_id != :account_id'
             );
             $select->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-            $select->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+            $select->bindValue(':account_id', $accountId, PDO::PARAM_STR);
             $select->execute();
 
             $updateProgress = $this->database->prepare(
@@ -259,7 +259,7 @@ final class TrophyCalculator
 
                 $updateProgress->bindValue(':progress', $progress, PDO::PARAM_INT);
                 $updateProgress->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-                $updateProgress->bindValue(':account_id', (int) $row['account_id'], PDO::PARAM_INT);
+                $updateProgress->bindValue(':account_id', (string) $row['account_id'], PDO::PARAM_STR);
                 $updateProgress->execute();
             }
         }
@@ -273,7 +273,7 @@ final class TrophyCalculator
             WHERE account_id = :account_id
                 AND np_communication_id = :np_communication_id'
         );
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->execute();
         /** @var array<string, int|string|null>|false $playerTrophiesRow */
@@ -297,7 +297,7 @@ final class TrophyCalculator
         $query = $this->database->prepare(sprintf(self::TROPHY_TITLE_PLAYER_UPSERT_TEMPLATE, $lastUpdatedDateExpression));
 
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_INT);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->bindValue(':bronze', $playerTrophies['bronze'], PDO::PARAM_INT);
         $query->bindValue(':silver', $playerTrophies['silver'], PDO::PARAM_INT);
         $query->bindValue(':gold', $playerTrophies['gold'], PDO::PARAM_INT);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Propagates Sony account IDs as strings through the scan pipeline to prevent truncation of `BIGINT UNSIGNED` values above `PHP_INT_MAX`.

`PlayerEarnedTrophyPersister` already bound account IDs as strings; upstream callers still cast with `(int) $user->accountId()`, which could corrupt reads/writes for large account IDs.

## Changes

- Change `TrophyCalculator::recalculateTrophyGroup()` / `recalculateTrophyTitle()` to accept `string $accountId` and bind with `PDO::PARAM_STR`
- Remove `(int)` casts in `ThirtyMinuteCronJob`, `PlayerScanTrophyProgressSynchronizer`, and related scan services
- Update scan-path services to use `string $accountId`:
  - `PlayerScanCompletionService`
  - `PlayerScanStaleGameDeletionService`
  - `PlayerScanPrivacyService`
  - `PlayerScanProfileSynchronizer`
  - `WorkerScanCoordinator`
  - `GameRescanService`
- Improve `PlayerScanProfileSynchronizer::normalizeAccountIdValue()` float handling to avoid `(int)` truncation
- **Review fix:** pass normalized string account IDs (not `(int)` casts) into `fetchStoredCountryByAccountId()` / `updatePlayerCountry()` in `resolvePlayerForScan()`
- Merged latest `master` (`PlayerScanTrophyTitleRefresher` extraction)

## Tests

- Add `TrophyCalculatorTest::testRecalculateTrophyGroupPreservesAccountIdsAbovePhpIntMax`
- Add `PlayerScanTrophyProgressSynchronizerTest::testSynchronizeTrophyProgressPreservesAccountIdsAbovePhpIntMax`
- Add `PlayerScanProfileSynchronizerTest::testCountryHelpersAcceptStringAccountIds`
- Update existing scan service tests to pass account IDs as strings
- `php tests/run.php` — all 805 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-490dadeb-8a42-4e5e-84fa-4c4df8d035ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-490dadeb-8a42-4e5e-84fa-4c4df8d035ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

