### PR TITLE
Extract PlayerScanTrophyTitleRefresher from ThirtyMinuteCronJob

### DIFF
--- a/tests/PlayerScanTrophyTitleRefresherTest.php
+++ b/tests/PlayerScanTrophyTitleRefresherTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Psn100Logger.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanTitleMetadataHelper.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/WorkerScanCoordinator.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanTrophyTitleRefresher.php';
+
+final class PlayerScanTrophyTitleRefresherTest extends TestCase
+{
+    private PDO $database;
+    private PlayerScanTrophyTitleRefresher $refresher;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec('CREATE TABLE log (message TEXT NOT NULL)');
+
+        $logger = new Psn100Logger($this->database);
+        $this->refresher = new PlayerScanTrophyTitleRefresher(
+            $logger,
+            new PlayerScanTitleMetadataHelper(),
+            new WorkerScanCoordinator($this->database),
+        );
+    }
+
+    public function testEnsureValidTrophyTitleLastUpdatedDateReturnsTitleWhenDateIsValid(): void
+    {
+        $title = new PlayerScanTrophyTitleRefresherTestTrophyTitle('NPWR12345_00', '2024-06-15T10:30:00Z', 'Example Game');
+        $user = new PlayerScanTrophyTitleRefresherTestUser([]);
+
+        $result = $this->refresher->ensureValidTrophyTitleLastUpdatedDate(
+            $user,
+            $title,
+            'ExampleUser'
+        );
+
+        $this->assertSame($title, $result);
+        $this->assertSame(0, $user->getFetchCount());
+    }
+
+    public function testEnsureValidTrophyTitleLastUpdatedDateRefetchesSonyDataWhenDateIsInvalid(): void
+    {
+        $invalidTitle = new PlayerScanTrophyTitleRefresherTestTrophyTitle('NPWR12345_00', 'not-a-valid-date', 'Example Game');
+        $user = new PlayerScanTrophyTitleRefresherTestUser([
+            [new PlayerScanTrophyTitleRefresherTestTrophyTitle('NPWR12345_00', '2024-06-15T10:30:00Z', 'Example Game')],
+        ]);
+
+        $result = $this->refresher->ensureValidTrophyTitleLastUpdatedDate(
+            $user,
+            $invalidTitle,
+            'ExampleUser'
+        );
+
+        $this->assertSame('2024-06-15T10:30:00Z', $result->lastUpdatedDateTime());
+        $this->assertSame(1, $user->getFetchCount());
+    }
+
+    public function testEnsureValidTrophyTitleLastUpdatedDateReturnsNullWhenRefetchStillInvalid(): void
+    {
+        $invalidTitle = new PlayerScanTrophyTitleRefresherTestTrophyTitle('NPWR12345_00', 'not-a-valid-date', 'Example Game');
+        $user = new PlayerScanTrophyTitleRefresherTestUser([
+            [new PlayerScanTrophyTitleRefresherTestTrophyTitle('NPWR12345_00', 'still-not-valid', 'Example Game')],
+        ]);
+
+        $result = $this->refresher->ensureValidTrophyTitleLastUpdatedDate(
+            $user,
+            $invalidTitle,
+            'ExampleUser'
+        );
+
+        $this->assertSame(null, $result);
+        $this->assertSame(1, $user->getFetchCount());
+
+        $logMessage = $this->database->query('SELECT message FROM log ORDER BY rowid DESC LIMIT 1')->fetchColumn();
+        $this->assertStringContainsString('invalid last updated date', (string) $logMessage);
+    }
+
+    public function testEnsureTrophyTitleIconReturnsTitleWhenIconIsPresent(): void
+    {
+        $title = new PlayerScanTrophyTitleRefresherTestTrophyTitle(
+            'NPWR12345_00',
+            '2024-06-15T10:30:00Z',
+            'Example Game',
+            'https://example.com/icon.png'
+        );
+        $user = new PlayerScanTrophyTitleRefresherTestUser([]);
+
+        $result = $this->refresher->ensureTrophyTitleIcon($user, $title, 'ExampleUser');
+
+        $this->assertSame($title, $result);
+        $this->assertSame(0, $user->getFetchCount());
+    }
+
+    public function testEnsureTrophyTitleIconRefetchesSonyDataWhenIconIsMissing(): void
+    {
+        $missingIconTitle = new PlayerScanTrophyTitleRefresherTestTrophyTitle(
+            'NPWR12345_00',
+            '2024-06-15T10:30:00Z',
+            'Example Game',
+            ''
+        );
+        $user = new PlayerScanTrophyTitleRefresherTestUser([
+            [new PlayerScanTrophyTitleRefresherTestTrophyTitle(
+                'NPWR12345_00',
+                '2024-06-15T10:30:00Z',
+                'Example Game',
+                'https://example.com/icon.png'
+            )],
+        ]);
+
+        $result = $this->refresher->ensureTrophyTitleIcon($user, $missingIconTitle, 'ExampleUser');
+
+        $this->assertSame('https://example.com/icon.png', $result->iconUrl());
+        $this->assertSame(1, $user->getFetchCount());
+    }
+
+    public function testEnsureTrophyTitleIconReturnsNullWhenRefetchStillMissingIcon(): void
+    {
+        $missingIconTitle = new PlayerScanTrophyTitleRefresherTestTrophyTitle(
+            'NPWR12345_00',
+            '2024-06-15T10:30:00Z',
+            'Example Game',
+            ''
+        );
+        $user = new PlayerScanTrophyTitleRefresherTestUser([
+            [new PlayerScanTrophyTitleRefresherTestTrophyTitle(
+                'NPWR12345_00',
+                '2024-06-15T10:30:00Z',
+                'Example Game',
+                ''
+            )],
+        ]);
+
+        $result = $this->refresher->ensureTrophyTitleIcon($user, $missingIconTitle, 'ExampleUser');
+
+        $this->assertSame(null, $result);
+        $this->assertSame(1, $user->getFetchCount());
+
+        $logMessage = $this->database->query('SELECT message FROM log ORDER BY rowid DESC LIMIT 1')->fetchColumn();
+        $this->assertStringContainsString('missing an icon', (string) $logMessage);
+    }
+}
+
+final class PlayerScanTrophyTitleRefresherTestTrophyTitle
+{
+    public function __construct(
+        private readonly string $npCommunicationId,
+        private readonly string $lastUpdatedDateTime,
+        private readonly string $name = '',
+        private readonly string $iconUrl = 'https://example.com/default.png',
+    ) {
+    }
+
+    public function npCommunicationId(): string
+    {
+        return $this->npCommunicationId;
+    }
+
+    public function lastUpdatedDateTime(): string
+    {
+        return $this->lastUpdatedDateTime;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function iconUrl(): string
+    {
+        return $this->iconUrl;
+    }
+}
+
+final class PlayerScanTrophyTitleRefresherTestUser
+{
+    /** @var list<list<PlayerScanTrophyTitleRefresherTestTrophyTitle>> */
+    private array $fetchResults;
+    private int $fetchCount = 0;
+
+    /**
+     * @param list<list<PlayerScanTrophyTitleRefresherTestTrophyTitle>> $fetchResults
+     */
+    public function __construct(array $fetchResults)
+    {
+        $this->fetchResults = $fetchResults;
+    }
+
+    public function trophyTitles(): PlayerScanTrophyTitleRefresherTestTrophyTitleCollection
+    {
+        $titles = $this->fetchResults[$this->fetchCount] ?? $this->fetchResults[array_key_last($this->fetchResults)] ?? [];
+        $this->fetchCount++;
+
+        return new PlayerScanTrophyTitleRefresherTestTrophyTitleCollection($titles);
+    }
+
+    public function getFetchCount(): int
+    {
+        return $this->fetchCount;
+    }
+}
+
+final class PlayerScanTrophyTitleRefresherTestTrophyTitleCollection implements IteratorAggregate
+{
+    /** @param list<PlayerScanTrophyTitleRefresherTestTrophyTitle> $titles */
+    public function __construct(private readonly array $titles)
+    {
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->titles);
+    }
+}

--- a/tests/ThirtyMinuteCronJobDateParsingTest.php
+++ b/tests/ThirtyMinuteCronJobDateParsingTest.php
@@ -13,7 +13,6 @@ final class ThirtyMinuteCronJobDateParsingTest extends TestCase
     private PDO $database;
     private ThirtyMinuteCronJob $cronJob;
     private ReflectionMethod $determineScanStartIndexMethod;
-    private ReflectionMethod $ensureValidTrophyTitleLastUpdatedDateMethod;
     private ReflectionMethod $handleInvalidTitleLastUpdatedDateResponseMethod;
 
     protected function setUp(): void
@@ -37,12 +36,6 @@ final class ThirtyMinuteCronJobDateParsingTest extends TestCase
 
         $this->determineScanStartIndexMethod = new ReflectionMethod(ThirtyMinuteCronJob::class, 'determineScanStartIndex');
         $this->determineScanStartIndexMethod->setAccessible(true);
-
-        $this->ensureValidTrophyTitleLastUpdatedDateMethod = new ReflectionMethod(
-            ThirtyMinuteCronJob::class,
-            'ensureValidTrophyTitleLastUpdatedDate'
-        );
-        $this->ensureValidTrophyTitleLastUpdatedDateMethod->setAccessible(true);
 
         $this->handleInvalidTitleLastUpdatedDateResponseMethod = new ReflectionMethod(
             ThirtyMinuteCronJob::class,
@@ -88,63 +81,6 @@ final class ThirtyMinuteCronJobDateParsingTest extends TestCase
         );
 
         $this->assertSame(0, $result);
-    }
-
-    public function testEnsureValidTrophyTitleLastUpdatedDateReturnsTitleWhenDateIsValid(): void
-    {
-        $title = new ThirtyMinuteCronJobDateParsingTestTrophyTitle('NPWR12345_00', '2024-06-15T10:30:00Z', 'Example Game');
-        $user = new ThirtyMinuteCronJobDateParsingTestUser([]);
-
-        $result = $this->ensureValidTrophyTitleLastUpdatedDateMethod->invoke(
-            $this->cronJob,
-            $user,
-            $title,
-            'ExampleUser'
-        );
-
-        $this->assertSame($title, $result);
-        $this->assertSame(0, $user->getFetchCount());
-    }
-
-    public function testEnsureValidTrophyTitleLastUpdatedDateRefetchesSonyDataWhenDateIsInvalid(): void
-    {
-        $invalidTitle = new ThirtyMinuteCronJobDateParsingTestTrophyTitle('NPWR12345_00', 'not-a-valid-date', 'Example Game');
-        $validTitle = new ThirtyMinuteCronJobDateParsingTestTrophyTitle('NPWR12345_00', '2024-06-15T10:30:00Z', 'Example Game');
-        $user = new ThirtyMinuteCronJobDateParsingTestUser([
-            [new ThirtyMinuteCronJobDateParsingTestTrophyTitle('NPWR12345_00', '2024-06-15T10:30:00Z', 'Example Game')],
-        ]);
-
-        $result = $this->ensureValidTrophyTitleLastUpdatedDateMethod->invoke(
-            $this->cronJob,
-            $user,
-            $invalidTitle,
-            'ExampleUser'
-        );
-
-        $this->assertSame('2024-06-15T10:30:00Z', $result->lastUpdatedDateTime());
-        $this->assertSame(1, $user->getFetchCount());
-        $this->assertSame($validTitle->lastUpdatedDateTime(), $result->lastUpdatedDateTime());
-    }
-
-    public function testEnsureValidTrophyTitleLastUpdatedDateReturnsNullWhenRefetchStillInvalid(): void
-    {
-        $invalidTitle = new ThirtyMinuteCronJobDateParsingTestTrophyTitle('NPWR12345_00', 'not-a-valid-date', 'Example Game');
-        $user = new ThirtyMinuteCronJobDateParsingTestUser([
-            [new ThirtyMinuteCronJobDateParsingTestTrophyTitle('NPWR12345_00', 'still-not-valid', 'Example Game')],
-        ]);
-
-        $result = $this->ensureValidTrophyTitleLastUpdatedDateMethod->invoke(
-            $this->cronJob,
-            $user,
-            $invalidTitle,
-            'ExampleUser'
-        );
-
-        $this->assertSame(null, $result);
-        $this->assertSame(1, $user->getFetchCount());
-
-        $logMessage = $this->database->query('SELECT message FROM log ORDER BY rowid DESC LIMIT 1')->fetchColumn();
-        $this->assertStringContainsString('invalid last updated date', (string) $logMessage);
     }
 
     public function testHandleInvalidTitleLastUpdatedDateResponseDefersPlayerScan(): void
@@ -193,46 +129,5 @@ final class ThirtyMinuteCronJobDateParsingTestTrophyTitle
     public function name(): string
     {
         return $this->name;
-    }
-}
-
-final class ThirtyMinuteCronJobDateParsingTestUser
-{
-    /** @var list<list<ThirtyMinuteCronJobDateParsingTestTrophyTitle>> */
-    private array $fetchResults;
-    private int $fetchCount = 0;
-
-    /**
-     * @param list<list<ThirtyMinuteCronJobDateParsingTestTrophyTitle>> $fetchResults
-     */
-    public function __construct(array $fetchResults)
-    {
-        $this->fetchResults = $fetchResults;
-    }
-
-    public function trophyTitles(): ThirtyMinuteCronJobDateParsingTestTrophyTitleCollection
-    {
-        $titles = $this->fetchResults[$this->fetchCount] ?? $this->fetchResults[array_key_last($this->fetchResults)] ?? [];
-        $this->fetchCount++;
-
-        return new ThirtyMinuteCronJobDateParsingTestTrophyTitleCollection($titles);
-    }
-
-    public function getFetchCount(): int
-    {
-        return $this->fetchCount;
-    }
-}
-
-final class ThirtyMinuteCronJobDateParsingTestTrophyTitleCollection implements IteratorAggregate
-{
-    /** @param list<ThirtyMinuteCronJobDateParsingTestTrophyTitle> $titles */
-    public function __construct(private readonly array $titles)
-    {
-    }
-
-    public function getIterator(): Traversable
-    {
-        return new ArrayIterator($this->titles);
     }
 }

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleRefresher.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleRefresher.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../Psn100Logger.php';
+require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
+require_once __DIR__ . '/WorkerScanCoordinator.php';
+
+/**
+ * Validates and refreshes PSN trophy title payloads during player scans.
+ *
+ * Encapsulates PSN title icon and last-updated-date retry logic that was
+ * previously embedded in ThirtyMinuteCronJob.
+ */
+final class PlayerScanTrophyTitleRefresher
+{
+    public function __construct(
+        private readonly Psn100Logger $logger,
+        private readonly PlayerScanTitleMetadataHelper $titleMetadataHelper,
+        private readonly WorkerScanCoordinator $workerScanCoordinator,
+    ) {
+    }
+
+    public function ensureTrophyTitleIcon(
+        object $user,
+        object $trophyTitle,
+        string $onlineId
+    ): ?object {
+        $maxAttempts = 2;
+        $npCommunicationId = (string) $trophyTitle->npCommunicationId();
+
+        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+            $iconUrl = trim((string) $trophyTitle->iconUrl());
+
+            if ($iconUrl !== '') {
+                return $trophyTitle;
+            }
+
+            if ($attempt === $maxAttempts) {
+                $titleName = trim((string) $trophyTitle->name());
+                $titleNameForLog = $titleName === '' ? $npCommunicationId : $titleName;
+
+                $this->logger->log(sprintf(
+                    'Trophy title "%s" (%s) is missing an icon while processing user %s (attempt %d/%d).',
+                    $titleNameForLog,
+                    $npCommunicationId,
+                    $onlineId,
+                    $attempt,
+                    $maxAttempts
+                ));
+
+                break;
+            }
+
+            sleep(2);
+
+            $trophyTitle = $this->refetchTrophyTitleByNpCommunicationId($user, $npCommunicationId, $trophyTitle);
+        }
+
+        return null;
+    }
+
+    public function ensureValidTrophyTitleLastUpdatedDate(
+        object $user,
+        object $trophyTitle,
+        string $onlineId
+    ): ?object {
+        $maxAttempts = 2;
+        $npCommunicationId = (string) $trophyTitle->npCommunicationId();
+
+        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+            if ($this->titleMetadataHelper->isValidSonyLastUpdatedDateTime($trophyTitle->lastUpdatedDateTime())) {
+                return $trophyTitle;
+            }
+
+            if ($attempt === $maxAttempts) {
+                $titleName = trim((string) $trophyTitle->name());
+                $titleNameForLog = $titleName === '' ? $npCommunicationId : $titleName;
+
+                $this->logger->log(sprintf(
+                    'Trophy title "%s" (%s) has an invalid last updated date while processing user %s (attempt %d/%d).',
+                    $titleNameForLog,
+                    $npCommunicationId,
+                    $onlineId,
+                    $attempt,
+                    $maxAttempts
+                ));
+
+                break;
+            }
+
+            sleep(2);
+
+            $trophyTitle = $this->refetchTrophyTitleByNpCommunicationId($user, $npCommunicationId, $trophyTitle);
+        }
+
+        return null;
+    }
+
+    public function pauseBeforeRetryingInvalidApiResponse(int $workerId, string $onlineId): void
+    {
+        $this->workerScanCoordinator->setWaitingScanProgress(
+            $workerId,
+            sprintf(
+                'Encountered an invalid response from the PlayStation API while scanning %s. Waiting 1 minute before retrying.',
+                $onlineId
+            )
+        );
+
+        sleep(60);
+    }
+
+    private function refetchTrophyTitleByNpCommunicationId(
+        object $user,
+        string $npCommunicationId,
+        object $fallbackTitle
+    ): object {
+        $trophyTitleCollection = $user->trophyTitles();
+
+        foreach ($trophyTitleCollection as $refreshedTitle) {
+            if ((string) $refreshedTitle->npCommunicationId() === $npCommunicationId) {
+                return $refreshedTitle;
+            }
+        }
+
+        return $fallbackTitle;
+    }
+}

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -26,6 +26,7 @@ require_once __DIR__ . '/PlayerScanTitleCatalogSyncResult.php';
 require_once __DIR__ . '/PlayerScanTrophyProgressSynchronizer.php';
 require_once __DIR__ . '/PlayerScanPrivacyService.php';
 require_once __DIR__ . '/PlayerScanTrophySummaryAccessResult.php';
+require_once __DIR__ . '/PlayerScanTrophyTitleRefresher.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\Haste\Exception\UnauthorizedHttpException;
@@ -47,6 +48,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
     private readonly PlayerScanTitleCatalogSynchronizer $titleCatalogSynchronizer;
     private readonly PlayerScanTrophyProgressSynchronizer $trophyProgressSynchronizer;
     private readonly PlayerScanPrivacyService $privacyService;
+    private readonly PlayerScanTrophyTitleRefresher $trophyTitleRefresher;
 
     public function __construct(
         private readonly PDO $database,
@@ -67,6 +69,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         ?PlayerScanTitleCatalogSynchronizer $titleCatalogSynchronizer = null,
         ?PlayerScanTrophyProgressSynchronizer $trophyProgressSynchronizer = null,
         ?PlayerScanPrivacyService $privacyService = null,
+        ?PlayerScanTrophyTitleRefresher $trophyTitleRefresher = null,
     )
     {
         $this->automaticTrophyTitleMergeService = $automaticTrophyTitleMergeService
@@ -109,6 +112,11 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         );
         $this->privacyService = $privacyService ?? new PlayerScanPrivacyService(
             $database,
+            $this->workerScanCoordinator,
+        );
+        $this->trophyTitleRefresher = $trophyTitleRefresher ?? new PlayerScanTrophyTitleRefresher(
+            $logger,
+            $this->titleMetadataHelper,
             $this->workerScanCoordinator,
         );
     }
@@ -168,109 +176,6 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         );
 
         $this->workerScanCoordinator->deferPlayerScanAfterFailure($player, $workerId);
-    }
-
-    private function pauseBeforeRetryingInvalidApiResponse(int $workerId, string $onlineId): void
-    {
-        $this->workerScanCoordinator->setWaitingScanProgress(
-            $workerId,
-            sprintf(
-                'Encountered an invalid response from the PlayStation API while scanning %s. Waiting 1 minute before retrying.',
-                $onlineId
-            )
-        );
-
-        sleep(60);
-    }
-
-    private function ensureTrophyTitleIcon(
-        object $user,
-        object $trophyTitle,
-        string $onlineId
-    ): ?object {
-        $maxAttempts = 2;
-        $npCommunicationId = (string) $trophyTitle->npCommunicationId();
-
-        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
-            $iconUrl = trim((string) $trophyTitle->iconUrl());
-
-            if ($iconUrl !== '') {
-                return $trophyTitle;
-            }
-
-            if ($attempt === $maxAttempts) {
-                $titleName = trim((string) $trophyTitle->name());
-                $titleNameForLog = $titleName === '' ? $npCommunicationId : $titleName;
-
-                $this->logger->log(sprintf(
-                    'Trophy title "%s" (%s) is missing an icon while processing user %s (attempt %d/%d).',
-                    $titleNameForLog,
-                    $npCommunicationId,
-                    $onlineId,
-                    $attempt,
-                    $maxAttempts
-                ));
-
-                break;
-            }
-
-            sleep(2);
-
-            $trophyTitleCollection = $user->trophyTitles();
-
-            foreach ($trophyTitleCollection as $refreshedTitle) {
-                if ((string) $refreshedTitle->npCommunicationId() === $npCommunicationId) {
-                    $trophyTitle = $refreshedTitle;
-                    break;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private function ensureValidTrophyTitleLastUpdatedDate(
-        object $user,
-        object $trophyTitle,
-        string $onlineId
-    ): ?object {
-        $maxAttempts = 2;
-        $npCommunicationId = (string) $trophyTitle->npCommunicationId();
-
-        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
-            if ($this->titleMetadataHelper->isValidSonyLastUpdatedDateTime($trophyTitle->lastUpdatedDateTime())) {
-                return $trophyTitle;
-            }
-
-            if ($attempt === $maxAttempts) {
-                $titleName = trim((string) $trophyTitle->name());
-                $titleNameForLog = $titleName === '' ? $npCommunicationId : $titleName;
-
-                $this->logger->log(sprintf(
-                    'Trophy title "%s" (%s) has an invalid last updated date while processing user %s (attempt %d/%d).',
-                    $titleNameForLog,
-                    $npCommunicationId,
-                    $onlineId,
-                    $attempt,
-                    $maxAttempts
-                ));
-
-                break;
-            }
-
-            sleep(2);
-
-            $trophyTitleCollection = $user->trophyTitles();
-
-            foreach ($trophyTitleCollection as $refreshedTitle) {
-                if ((string) $refreshedTitle->npCommunicationId() === $npCommunicationId) {
-                    $trophyTitle = $refreshedTitle;
-                    break;
-                }
-            }
-        }
-
-        return null;
     }
 
     #[\Override]
@@ -480,7 +385,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 continue;
                             }
 
-                            $trophyTitle = $this->ensureTrophyTitleIcon(
+                            $trophyTitle = $this->trophyTitleRefresher->ensureTrophyTitleIcon(
                                 $user,
                                 $trophyTitle,
                                 (string) $player['online_id']
@@ -496,7 +401,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                 break;
                             }
 
-                            $trophyTitle = $this->ensureValidTrophyTitleLastUpdatedDate(
+                            $trophyTitle = $this->trophyTitleRefresher->ensureValidTrophyTitleLastUpdatedDate(
                                 $user,
                                 $trophyTitle,
                                 (string) $player['online_id']
@@ -511,7 +416,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                                         (string) $player['online_id'],
                                         $npid
                                     ));
-                                    $this->pauseBeforeRetryingInvalidApiResponse((int) $worker['id'], $onlineId);
+                                    $this->trophyTitleRefresher->pauseBeforeRetryingInvalidApiResponse((int) $worker['id'], $onlineId);
                                     $restartScan = true;
 
                                     break;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels PSN trophy title payload validation and retry logic out of `ThirtyMinuteCronJob` into a new `PlayerScanTrophyTitleRefresher` class. This continues the incremental decomposition of the cron orchestrator (following `PlayerScanTitleCatalogSynchronizer`, `PlayerScanProfileSynchronizer`, etc.) without changing scan behavior.

**Extracted concerns:**
- Missing trophy title icon detection and PSN refetch
- Invalid last-updated-date detection and PSN refetch
- Worker pause before retrying after invalid API responses

`ThirtyMinuteCronJob` now delegates to the refresher and shrinks by ~95 lines.

## Testing

- Added `PlayerScanTrophyTitleRefresherTest` with direct unit tests for icon and date validation paths
- Moved date/icon retry tests out of `ThirtyMinuteCronJobDateParsingTest` (orchestrator tests remain for `determineScanStartIndex` and failure deferral)
- `php tests/run.php` — all 802 tests pass

## Follow-up candidates (separate PRs)

Other God-class peel-offs identified for future work:
1. `GameRescanService::updateTrophyTitle()` → shared catalog updater
2. `TrophyStatusService` → `TrophyObtainabilityRecalculator`
3. `TrophyMergeService` → metadata/repository extraction
4. `TrophyMergePlayerProgressUpdater` → graph resolver extraction

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51e173fb-8c9b-486c-a774-a1c4187eb176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51e173fb-8c9b-486c-a774-a1c4187eb176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

