### PR TITLE
Document cron job infinite retry loops for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,27 @@ the non-obvious steps to actually run the services.
   Admin is intentionally left reachable in dev for login testing.
 - Cron jobs must be run via CLI, e.g. `php wwwroot/cron/hourly.php`. Each script in
   `wwwroot/cron/` loads `cron/bootstrap.php` first to reject HTTP execution.
+
+### Cron job retry loops
+
+Cron jobs are **intentionally written with infinite retry loops** (`while (true)` with
+`sleep` / backoff between attempts). The site depends on these jobs eventually
+succeeding — player scans, rankings, trophy metadata, and related data go stale or stop
+updating if a cron run gives up.
+
+- Do **not** cap retries, add `maxAttempts`, or refactor infinite loops into "fail
+  fast" error handling unless explicitly asked. That pattern is deliberate, not a bug.
+- Examples: `HourlyCronJob`, `DailyCronJob`, and `WeeklyCronJob` use
+  `executeWithRetry()`; `ThirtyMinuteCronJob` and `PlayerRankingUpdater` retry PSN/API
+  and database failures indefinitely; `PlayerScanTrophyProgressSynchronizer::retryNotFound()`
+  retries 404s from Sony's API.
+- Tests such as `WeeklyCronJobTest` and `PlayerRankingUpdaterTest` assert that
+  `while (true)` remains and that there is no `maxAttempt` cap — keep those guarantees
+  when touching cron code.
+- When improving cron code, preserve or strengthen retry behavior (e.g. better logging,
+  backoff tuning). Only exit a loop after success or when the work item is definitively
+  unrecoverable (e.g. invalid player data), not on transient errors.
+
 - Queue polling and admin login abuse controls use `ip_rate_limit` and
   `admin_login_throttle` tables (see `database/psn100.sql`). Import the schema on
   fresh VMs; existing production DBs need those tables added before deploying Phase 2.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Cron job retry loops** section to `AGENTS.md` so future agents understand that infinite `while (true)` retry loops in cron code are intentional and critical to site operation.

## Context

Cron jobs (`HourlyCronJob`, `DailyCronJob`, `WeeklyCronJob`, `ThirtyMinuteCronJob`, `PlayerRankingUpdater`, etc.) deliberately retry transient PSN API and database failures indefinitely. The site depends on these jobs eventually succeeding to keep player scans, rankings, and trophy metadata up to date.

## What changed

- Documents that agents should not cap retries, add `maxAttempts`, or refactor loops into fail-fast behavior unless explicitly requested.
- Points to representative classes and tests that enforce this pattern.
- Clarifies that cron improvements should preserve or strengthen retry behavior.

## Testing

Documentation-only change; no code or test updates required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b8e0771-2016-4215-8769-0f0f4d7bd640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b8e0771-2016-4215-8769-0f0f4d7bd640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

