### PR TITLE
Security: mask worker credentials in admin UI

### DIFF
--- a/tests/AdminWorkerPageTest.php
+++ b/tests/AdminWorkerPageTest.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerPage.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerPageResult.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerPageSortLink.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerService.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerCredentialField.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/Worker.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/CommandExecutionResult.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/CommandExecutorInterface.php';
@@ -109,6 +110,32 @@ final class AdminWorkerPageTest extends TestCase
 
         $this->assertSame(null, $result->getSuccessMessage());
         $this->assertSame('Unable to restart all workers (exit code 2). error', $result->getErrorMessage());
+    }
+
+    public function testWorkersTemplateMasksCredentialsInsteadOfRenderingValues(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/admin/workers.php');
+
+        $this->assertTrue(is_string($source));
+        $this->assertTrue(str_contains($source, 'WorkerCredentialMasker::mask'));
+        $this->assertTrue(str_contains($source, 'admin-worker-credentials.js'));
+        $this->assertFalse(str_contains($source, 'getRefreshToken(), ENT_QUOTES'));
+        $this->assertFalse(str_contains($source, 'getNpsso(), ENT_QUOTES'));
+
+        $scriptSource = file_get_contents(__DIR__ . '/../wwwroot/js/admin-worker-credentials.js');
+        $this->assertTrue(is_string($scriptSource));
+        $this->assertTrue(str_contains($scriptSource, 'worker-credential.php'));
+    }
+
+    public function testWorkerServiceFetchWorkerCredentialReturnsStoredValue(): void
+    {
+        $this->database->exec("INSERT INTO setting (id, refresh_token, npsso, scanning, scan_start, scan_progress) VALUES (4, 'secret-refresh', 'secret-npsso', '', '2024-01-01 00:00:00', null)");
+
+        $service = new WorkerService($this->database, new FakeCommandExecutor(new CommandExecutionResult(0, '')));
+
+        $this->assertSame('secret-refresh', $service->fetchWorkerCredential(4, WorkerCredentialField::RefreshToken));
+        $this->assertSame('secret-npsso', $service->fetchWorkerCredential(4, WorkerCredentialField::Npsso));
+        $this->assertSame(null, $service->fetchWorkerCredential(99, WorkerCredentialField::Npsso));
     }
 
     private PDO $database;

--- a/tests/WorkerCredentialMaskerTest.php
+++ b/tests/WorkerCredentialMaskerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerCredentialMasker.php';
+
+final class WorkerCredentialMaskerTest extends TestCase
+{
+    public function testMaskReturnsNotConfiguredForEmptySecret(): void
+    {
+        $this->assertSame('Not configured', WorkerCredentialMasker::mask(''));
+    }
+
+    public function testMaskHidesShortSecretsCompletely(): void
+    {
+        $this->assertSame('••••••••', WorkerCredentialMasker::mask('abc'));
+    }
+
+    public function testMaskShowsOnlyLastFourCharacters(): void
+    {
+        $this->assertSame('••••••••mnop', WorkerCredentialMasker::mask('abcdefghijklmnop'));
+    }
+
+    public function testIsConfiguredDetectsEmptySecrets(): void
+    {
+        $this->assertFalse(WorkerCredentialMasker::isConfigured(''));
+        $this->assertTrue(WorkerCredentialMasker::isConfigured('token'));
+    }
+}

--- a/tests/WorkerCredentialRevealHandlerTest.php
+++ b/tests/WorkerCredentialRevealHandlerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/AdminRequest.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerCredentialRevealHandler.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerCredentialRevealResult.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerService.php';
+
+final class WorkerCredentialRevealHandlerTest extends TestCase
+{
+    private PDO $database;
+
+    private WorkerCredentialRevealHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec(
+            'CREATE TABLE setting (
+                id INTEGER PRIMARY KEY,
+                refresh_token TEXT NOT NULL,
+                npsso TEXT NOT NULL,
+                scanning TEXT NOT NULL DEFAULT \'\',
+                scan_start TEXT NOT NULL DEFAULT \'1970-01-01 00:00:00\',
+                scan_progress TEXT
+            )'
+        );
+        $this->database->exec(
+            "INSERT INTO setting (id, refresh_token, npsso) VALUES (1, 'refresh-secret-token', 'npsso-secret-value')"
+        );
+
+        $this->handler = new WorkerCredentialRevealHandler(new WorkerService($this->database));
+    }
+
+    public function testHandleRevealsRefreshTokenForExistingWorker(): void
+    {
+        $result = $this->handler->handle($this->createPostRequest([
+            'worker_id' => '1',
+            'credential' => 'refresh_token',
+        ]));
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertSame('refresh-secret-token', $result->getCredential());
+        $this->assertSame([
+            'status' => 'ok',
+            'credential' => 'refresh-secret-token',
+        ], $result->toPayload());
+    }
+
+    public function testHandleRevealsNpssoForExistingWorker(): void
+    {
+        $result = $this->handler->handle($this->createPostRequest([
+            'worker_id' => '1',
+            'credential' => 'npsso',
+        ]));
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertSame('npsso-secret-value', $result->getCredential());
+    }
+
+    public function testHandleRejectsInvalidCredentialField(): void
+    {
+        $result = $this->handler->handle($this->createPostRequest([
+            'worker_id' => '1',
+            'credential' => 'password',
+        ]));
+
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame('Invalid worker credential request.', $result->getErrorMessage());
+    }
+
+    public function testHandleRejectsMissingWorker(): void
+    {
+        $result = $this->handler->handle($this->createPostRequest([
+            'worker_id' => '99',
+            'credential' => 'npsso',
+        ]));
+
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame('Worker not found.', $result->getErrorMessage());
+    }
+
+    /**
+     * @param array<string, string> $postData
+     */
+    private function createPostRequest(array $postData): AdminRequest
+    {
+        return AdminRequest::fromGlobals(
+            ['REQUEST_METHOD' => 'POST'],
+            $postData,
+        );
+    }
+}

--- a/wwwroot/admin/worker-credential.php
+++ b/wwwroot/admin/worker-credential.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/bootstrap.php';
+require_once '../classes/Admin/AdminRequest.php';
+require_once '../classes/Admin/WorkerCredentialRevealHandler.php';
+require_once '../classes/Admin/WorkerService.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$handler = new WorkerCredentialRevealHandler(new WorkerService($database));
+$result = $handler->handle(AdminRequest::fromGlobals($_SERVER ?? [], $_POST ?? []));
+
+http_response_code($result->isSuccess() ? 200 : 400);
+echo json_encode($result->toPayload(), JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);

--- a/wwwroot/admin/workers.php
+++ b/wwwroot/admin/workers.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/bootstrap.php';
 require_once '../classes/StaticAsset.php';
 require_once '../classes/Admin/AdminRequest.php';
+require_once '../classes/Admin/WorkerCredentialMasker.php';
 require_once '../classes/Admin/WorkerService.php';
 require_once '../classes/Admin/WorkerPage.php';
 
@@ -32,9 +33,11 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="csrf-token" content="<?= Html::escape(AdminBootstrap::getCsrfToken()); ?>">
         <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
         <title>Admin ~ Workers</title>
         <script src="<?= htmlspecialchars(StaticAsset::url('/js/localized-date-formatter.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
+        <script src="<?= htmlspecialchars(StaticAsset::url('/js/admin-worker-credentials.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
     </head>
     <body>
         <div class="container py-4">
@@ -113,14 +116,28 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                                 <label class="form-label small text-body-secondary mb-0 text-nowrap" for="refresh-token-<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
                                                     Refresh Token
                                                 </label>
-                                                <input
-                                                    id="refresh-token-<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>"
-                                                    type="text"
-                                                    name="refresh_token"
-                                                    class="form-control form-control-sm"
-                                                    value="<?= htmlspecialchars($worker->getRefreshToken(), ENT_QUOTES, 'UTF-8'); ?>"
-                                                    maxlength="36"
-                                                >
+                                                <div class="d-flex gap-2 flex-grow-1" data-worker-credential-field>
+                                                    <input
+                                                        id="refresh-token-<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                        type="password"
+                                                        name="refresh_token"
+                                                        class="form-control form-control-sm"
+                                                        placeholder="<?= Html::escape(WorkerCredentialMasker::mask($worker->getRefreshToken())); ?>"
+                                                        maxlength="36"
+                                                        autocomplete="off"
+                                                        data-worker-credential-input
+                                                        data-worker-credential="refresh_token"
+                                                        data-worker-id="<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                    >
+                                                    <button
+                                                        type="button"
+                                                        class="btn btn-sm btn-outline-secondary text-nowrap"
+                                                        data-worker-credential-toggle
+                                                        aria-pressed="false"
+                                                    >
+                                                        Reveal
+                                                    </button>
+                                                </div>
                                                 <button type="submit" class="btn btn-sm btn-primary">Save</button>
                                             </form>
                                             <form method="post" class="d-flex gap-2 align-items-center" autocomplete="off">
@@ -130,14 +147,28 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                                 <label class="form-label small text-body-secondary mb-0 text-nowrap" for="npsso-<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
                                                     NPSSO
                                                 </label>
-                                                <input
-                                                    id="npsso-<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>"
-                                                    type="text"
-                                                    name="npsso"
-                                                    class="form-control form-control-sm"
-                                                    value="<?= htmlspecialchars($worker->getNpsso(), ENT_QUOTES, 'UTF-8'); ?>"
-                                                    maxlength="64"
-                                                >
+                                                <div class="d-flex gap-2 flex-grow-1" data-worker-credential-field>
+                                                    <input
+                                                        id="npsso-<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                        type="password"
+                                                        name="npsso"
+                                                        class="form-control form-control-sm"
+                                                        placeholder="<?= Html::escape(WorkerCredentialMasker::mask($worker->getNpsso())); ?>"
+                                                        maxlength="64"
+                                                        autocomplete="off"
+                                                        data-worker-credential-input
+                                                        data-worker-credential="npsso"
+                                                        data-worker-id="<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                    >
+                                                    <button
+                                                        type="button"
+                                                        class="btn btn-sm btn-outline-secondary text-nowrap"
+                                                        data-worker-credential-toggle
+                                                        aria-pressed="false"
+                                                    >
+                                                        Reveal
+                                                    </button>
+                                                </div>
                                                 <button type="submit" class="btn btn-sm btn-primary">Save</button>
                                             </form>
                                         </div>

--- a/wwwroot/classes/Admin/WorkerCredentialField.php
+++ b/wwwroot/classes/Admin/WorkerCredentialField.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+enum WorkerCredentialField: string
+{
+    case RefreshToken = 'refresh_token';
+    case Npsso = 'npsso';
+
+    public static function fromMixed(mixed $value): ?self
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return self::tryFrom($value);
+    }
+}

--- a/wwwroot/classes/Admin/WorkerCredentialMasker.php
+++ b/wwwroot/classes/Admin/WorkerCredentialMasker.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+final class WorkerCredentialMasker
+{
+    private const string MASK_CHAR = '•';
+    private const int MASK_LENGTH = 8;
+    private const int VISIBLE_SUFFIX_LENGTH = 4;
+
+    public static function mask(string $secret): string
+    {
+        if ($secret === '') {
+            return 'Not configured';
+        }
+
+        if (strlen($secret) <= self::VISIBLE_SUFFIX_LENGTH) {
+            return str_repeat(self::MASK_CHAR, self::MASK_LENGTH);
+        }
+
+        return str_repeat(self::MASK_CHAR, self::MASK_LENGTH)
+            . substr($secret, -self::VISIBLE_SUFFIX_LENGTH);
+    }
+
+    public static function isConfigured(string $secret): bool
+    {
+        return $secret !== '';
+    }
+}

--- a/wwwroot/classes/Admin/WorkerCredentialRevealHandler.php
+++ b/wwwroot/classes/Admin/WorkerCredentialRevealHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/AdminRequest.php';
+require_once __DIR__ . '/WorkerCredentialField.php';
+require_once __DIR__ . '/WorkerCredentialRevealResult.php';
+require_once __DIR__ . '/WorkerService.php';
+
+final class WorkerCredentialRevealHandler
+{
+    public function __construct(private readonly WorkerService $workerService)
+    {
+    }
+
+    public function handle(AdminRequest $request): WorkerCredentialRevealResult
+    {
+        if (!$request->isPost()) {
+            return WorkerCredentialRevealResult::error('Invalid request method.');
+        }
+
+        $workerId = $request->getPostPositiveInt('worker_id');
+        $credentialField = WorkerCredentialField::fromMixed($request->getPostString('credential'));
+
+        if ($workerId === null || $credentialField === null) {
+            return WorkerCredentialRevealResult::error('Invalid worker credential request.');
+        }
+
+        $credential = $this->workerService->fetchWorkerCredential($workerId, $credentialField);
+
+        if ($credential === null) {
+            return WorkerCredentialRevealResult::error('Worker not found.');
+        }
+
+        return WorkerCredentialRevealResult::success($credential);
+    }
+}

--- a/wwwroot/classes/Admin/WorkerCredentialRevealResult.php
+++ b/wwwroot/classes/Admin/WorkerCredentialRevealResult.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+final readonly class WorkerCredentialRevealResult
+{
+    private function __construct(
+        private bool $success,
+        private ?string $credential,
+        private ?string $errorMessage,
+    ) {
+    }
+
+    public static function success(string $credential): self
+    {
+        return new self(true, $credential, null);
+    }
+
+    public static function error(string $errorMessage): self
+    {
+        return new self(false, null, $errorMessage);
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->success;
+    }
+
+    public function getCredential(): ?string
+    {
+        return $this->credential;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+
+    /**
+     * @return array{status: string, credential?: string, message?: string}
+     */
+    public function toPayload(): array
+    {
+        if ($this->success) {
+            return [
+                'status' => 'ok',
+                'credential' => $this->credential ?? '',
+            ];
+        }
+
+        return [
+            'status' => 'error',
+            'message' => $this->errorMessage ?? 'Unable to reveal credential.',
+        ];
+    }
+}

--- a/wwwroot/classes/Admin/WorkerService.php
+++ b/wwwroot/classes/Admin/WorkerService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Worker.php';
+require_once __DIR__ . '/WorkerCredentialField.php';
 require_once __DIR__ . '/CommandExecutionResult.php';
 require_once __DIR__ . '/CommandExecutorInterface.php';
 require_once __DIR__ . '/SystemCommandExecutor.php';
@@ -105,6 +106,31 @@ final class WorkerService
         $statement->execute();
 
         return $statement->rowCount() > 0;
+    }
+
+    public function fetchWorkerCredential(int $workerId, WorkerCredentialField $field): ?string
+    {
+        $query = match ($field) {
+            WorkerCredentialField::RefreshToken => 'SELECT refresh_token FROM setting WHERE id = :id',
+            WorkerCredentialField::Npsso => 'SELECT npsso FROM setting WHERE id = :id',
+        };
+
+        $statement = $this->database->prepare($query);
+
+        if ($statement === false) {
+            return null;
+        }
+
+        $statement->bindValue(':id', $workerId, PDO::PARAM_INT);
+        $statement->execute();
+
+        $credential = $statement->fetchColumn();
+
+        if ($credential === false) {
+            return null;
+        }
+
+        return (string) $credential;
     }
 
     public function restartWorker(int $workerId): CommandExecutionResult

--- a/wwwroot/js/admin-worker-credentials.js
+++ b/wwwroot/js/admin-worker-credentials.js
@@ -1,0 +1,95 @@
+class WorkerCredentialController {
+    constructor() {
+        this.endpoint = 'worker-credential.php';
+    }
+
+    initialize() {
+        document.querySelectorAll('[data-worker-credential-toggle]').forEach((button) => {
+            button.addEventListener('click', () => this.handleToggle(button));
+        });
+    }
+
+    async handleToggle(button) {
+        const input = this.findCredentialInput(button);
+
+        if (!(input instanceof HTMLInputElement)) {
+            return;
+        }
+
+        if (input.dataset.revealed === 'true') {
+            this.hideCredential(input, button);
+            return;
+        }
+
+        button.disabled = true;
+
+        try {
+            const credential = await this.fetchCredential(input);
+            this.revealCredential(input, button, credential);
+        } catch (error) {
+            window.alert(error instanceof Error ? error.message : 'Unable to reveal credential.');
+        } finally {
+            button.disabled = false;
+        }
+    }
+
+    findCredentialInput(button) {
+        const container = button.closest('[data-worker-credential-field]');
+        return container?.querySelector('[data-worker-credential-input]') ?? null;
+    }
+
+    async fetchCredential(input) {
+        const workerId = (input.dataset.workerId ?? '').trim();
+        const credentialField = (input.dataset.workerCredential ?? '').trim();
+        const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+
+        const response = await fetch(this.endpoint, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams({
+                worker_id: workerId,
+                credential: credentialField,
+                _csrf_token: csrfToken,
+            }),
+            credentials: 'same-origin',
+        });
+
+        let payload = null;
+
+        try {
+            payload = await response.json();
+        } catch (error) {
+            throw new Error('Unexpected response while revealing credential.');
+        }
+
+        if (!response.ok || payload?.status !== 'ok') {
+            throw new Error(payload?.message ?? 'Unable to reveal credential.');
+        }
+
+        return typeof payload.credential === 'string' ? payload.credential : '';
+    }
+
+    revealCredential(input, button, credential) {
+        input.value = credential;
+        input.type = 'text';
+        input.dataset.revealed = 'true';
+        button.textContent = 'Hide';
+        button.setAttribute('aria-pressed', 'true');
+    }
+
+    hideCredential(input, button) {
+        input.value = '';
+        input.type = 'password';
+        delete input.dataset.revealed;
+        button.textContent = 'Reveal';
+        button.setAttribute('aria-pressed', 'false');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const controller = new WorkerCredentialController();
+    controller.initialize();
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Masks PlayStation worker credentials on the admin workers page. Refresh tokens and NPSSO values are no longer embedded in HTML form `value` attributes.

## Changes

- Show masked placeholders (`••••••••` + last 4 characters) instead of full secrets
- Use password inputs with empty values by default
- Add **Reveal / Hide** toggle that fetches the full credential via CSRF-protected `POST /admin/worker-credential.php`
- Add `WorkerCredentialMasker`, `WorkerCredentialRevealHandler`, and `admin-worker-credentials.js`
- Add `WorkerService::fetchWorkerCredential()` for on-demand credential lookup

## Security notes

- Full credentials are only returned after an authenticated admin POST with CSRF validation
- Page HTML and view-source no longer contain complete tokens by default
- Saving still requires entering a new value or revealing the existing credential first

## Tests

- `WorkerCredentialMaskerTest`
- `WorkerCredentialRevealHandlerTest`
- `AdminWorkerPageTest` template + `fetchWorkerCredential` coverage
- `php tests/run.php` — all 815 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-490dadeb-8a42-4e5e-84fa-4c4df8d035ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-490dadeb-8a42-4e5e-84fa-4c4df8d035ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

