### PR TITLE
Extract TrophySetComparator from AutomaticTrophyTitleMergeService

### DIFF
--- a/tests/TrophySetComparatorTest.php
+++ b/tests/TrophySetComparatorTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/TrophySetComparator.php';
+
+final class TrophySetComparatorTest extends TestCase
+{
+    private TrophySetComparator $comparator;
+
+    protected function setUp(): void
+    {
+        $this->comparator = new TrophySetComparator();
+    }
+
+    public function testCompareReturnsNoMatchWhenCountsDiffer(): void
+    {
+        $left = [
+            ['group_id' => 'default', 'order_id' => 0, 'name' => 'Trophy A', 'detail' => 'Detail A'],
+        ];
+        $right = [
+            ['group_id' => 'default', 'order_id' => 0, 'name' => 'Trophy A', 'detail' => 'Detail A'],
+            ['group_id' => 'default', 'order_id' => 1, 'name' => 'Trophy B', 'detail' => 'Detail B'],
+        ];
+
+        $this->assertSame(
+            ['matches' => false, 'orderMatches' => false, 'nameMatches' => false],
+            $this->comparator->compare($left, $right),
+        );
+    }
+
+    public function testCompareReturnsMatchForEmptySets(): void
+    {
+        $this->assertSame(
+            ['matches' => true, 'orderMatches' => true, 'nameMatches' => true],
+            $this->comparator->compare([], []),
+        );
+    }
+
+    public function testCompareReturnsOrderMatchForIdenticalSets(): void
+    {
+        $trophies = [
+            ['group_id' => 'default', 'order_id' => 0, 'name' => 'Trophy A', 'detail' => 'Detail A'],
+            ['group_id' => 'default', 'order_id' => 1, 'name' => 'Trophy B', 'detail' => 'Detail B'],
+        ];
+
+        $this->assertSame(
+            ['matches' => true, 'orderMatches' => true, 'nameMatches' => true],
+            $this->comparator->compare($trophies, $trophies),
+        );
+    }
+
+    public function testCompareIsCaseInsensitive(): void
+    {
+        $left = [
+            ['group_id' => 'default', 'order_id' => 0, 'name' => 'Trophy A', 'detail' => 'Detail A'],
+        ];
+        $right = [
+            ['group_id' => 'default', 'order_id' => 0, 'name' => 'trophy a', 'detail' => 'detail a'],
+        ];
+
+        $this->assertSame(
+            ['matches' => true, 'orderMatches' => true, 'nameMatches' => true],
+            $this->comparator->compare($left, $right),
+        );
+    }
+
+    public function testCompareReturnsNoMatchWhenNameDetailMultisetDiffers(): void
+    {
+        $left = [
+            ['group_id' => 'default', 'order_id' => 0, 'name' => 'Trophy A', 'detail' => 'Alpha'],
+            ['group_id' => 'default', 'order_id' => 1, 'name' => 'Trophy B', 'detail' => 'Beta'],
+        ];
+        $right = [
+            ['group_id' => 'default', 'order_id' => 0, 'name' => 'Trophy A', 'detail' => 'Beta'],
+            ['group_id' => 'default', 'order_id' => 1, 'name' => 'Trophy B', 'detail' => 'Alpha'],
+        ];
+
+        $this->assertSame(
+            ['matches' => false, 'orderMatches' => false, 'nameMatches' => false],
+            $this->comparator->compare($left, $right),
+        );
+    }
+
+    public function testCompareReturnsNameMatchWhenOrderDiffersButNamesAreUnique(): void
+    {
+        $left = [
+            ['group_id' => 'default', 'order_id' => 0, 'name' => 'Trophy A', 'detail' => 'Alpha'],
+            ['group_id' => 'default', 'order_id' => 1, 'name' => 'Trophy B', 'detail' => 'Beta'],
+        ];
+        $right = [
+            ['group_id' => 'default', 'order_id' => 0, 'name' => 'Trophy B', 'detail' => 'Beta'],
+            ['group_id' => 'default', 'order_id' => 1, 'name' => 'Trophy A', 'detail' => 'Alpha'],
+        ];
+
+        $this->assertSame(
+            ['matches' => true, 'orderMatches' => false, 'nameMatches' => true],
+            $this->comparator->compare($left, $right),
+        );
+    }
+
+    public function testCompareReturnsAmbiguousWhenDuplicateNamesPreventNameMatch(): void
+    {
+        $left = [
+            ['group_id' => 'default', 'order_id' => 0, 'name' => 'Hidden Trophy', 'detail' => 'Secret'],
+            ['group_id' => 'default', 'order_id' => 1, 'name' => 'Hidden Trophy', 'detail' => 'Secret'],
+        ];
+        $right = [
+            ['group_id' => 'default', 'order_id' => 0, 'name' => 'Hidden Trophy', 'detail' => 'Secret'],
+            ['group_id' => 'dlc', 'order_id' => 0, 'name' => 'Hidden Trophy', 'detail' => 'Secret'],
+        ];
+
+        $this->assertSame(
+            ['matches' => true, 'orderMatches' => false, 'nameMatches' => false],
+            $this->comparator->compare($left, $right),
+        );
+    }
+
+    public function testSelectMergeMethodPrefersOrder(): void
+    {
+        $this->assertSame('order', $this->comparator->selectMergeMethod([
+            'matches' => true,
+            'orderMatches' => true,
+            'nameMatches' => true,
+        ]));
+    }
+
+    public function testSelectMergeMethodFallsBackToName(): void
+    {
+        $this->assertSame('name', $this->comparator->selectMergeMethod([
+            'matches' => true,
+            'orderMatches' => false,
+            'nameMatches' => true,
+        ]));
+    }
+
+    public function testSelectMergeMethodReturnsNullWhenAmbiguous(): void
+    {
+        $this->assertSame(null, $this->comparator->selectMergeMethod([
+            'matches' => true,
+            'orderMatches' => false,
+            'nameMatches' => false,
+        ]));
+    }
+}

--- a/wwwroot/classes/AutomaticTrophyTitleMergeService.php
+++ b/wwwroot/classes/AutomaticTrophyTitleMergeService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/TrophyMergeService.php';
+require_once __DIR__ . '/TrophySetComparator.php';
 
 final class AutomaticTrophyTitleMergeService
 {
@@ -10,13 +11,19 @@ final class AutomaticTrophyTitleMergeService
 
     private TrophyMergeService $trophyMergeService;
 
+    private TrophySetComparator $trophySetComparator;
+
     /** @var array<string, list<array{group_id:string, order_id:int, name:string, detail:string}>> */
     private array $trophyCache = [];
 
-    public function __construct(PDO $database, TrophyMergeService $trophyMergeService)
-    {
+    public function __construct(
+        PDO $database,
+        TrophyMergeService $trophyMergeService,
+        ?TrophySetComparator $trophySetComparator = null,
+    ) {
         $this->database = $database;
         $this->trophyMergeService = $trophyMergeService;
+        $this->trophySetComparator = $trophySetComparator ?? new TrophySetComparator();
     }
 
     /**
@@ -48,7 +55,7 @@ final class AutomaticTrophyTitleMergeService
                 return [];
             }
 
-            $mergeMethod = $this->selectMergeMethod($comparison);
+            $mergeMethod = $this->trophySetComparator->selectMergeMethod($comparison);
 
             if ($mergeMethod === null) {
                 $this->logAmbiguousNameMerge(
@@ -100,7 +107,7 @@ final class AutomaticTrophyTitleMergeService
                 continue;
             }
 
-            $mergeMethod = $this->selectMergeMethod($comparison);
+            $mergeMethod = $this->trophySetComparator->selectMergeMethod($comparison);
 
             if ($mergeMethod === null) {
                 $this->logAmbiguousNameMerge(
@@ -295,127 +302,14 @@ final class AutomaticTrophyTitleMergeService
     }
 
     /**
-     * @param string $leftNpCommunicationId
-     * @param string $rightNpCommunicationId
      * @return array{matches:bool, orderMatches:bool, nameMatches:bool}
      */
     private function compareTrophies(string $leftNpCommunicationId, string $rightNpCommunicationId): array
     {
-        $leftTrophies = $this->getTrophiesByNpCommunicationId($leftNpCommunicationId);
-        $rightTrophies = $this->getTrophiesByNpCommunicationId($rightNpCommunicationId);
-
-        if (count($leftTrophies) !== count($rightTrophies)) {
-            return ['matches' => false, 'orderMatches' => false, 'nameMatches' => false];
-        }
-
-        if ($leftTrophies === [] && $rightTrophies === []) {
-            return ['matches' => true, 'orderMatches' => true, 'nameMatches' => true];
-        }
-
-        $leftCounts = $this->createNameDetailCounter($leftTrophies);
-        $rightCounts = $this->createNameDetailCounter($rightTrophies);
-
-        if ($leftCounts !== $rightCounts) {
-            return ['matches' => false, 'orderMatches' => false, 'nameMatches' => false];
-        }
-
-        $orderMatches = $this->trophiesMatchByOrder($leftTrophies, $rightTrophies);
-        $nameMatches = $this->trophiesMatchByName($leftTrophies, $rightTrophies);
-
-        return ['matches' => true, 'orderMatches' => $orderMatches, 'nameMatches' => $nameMatches];
-    }
-
-    /**
-     * @param list<array{group_id:string, order_id:int, name:string, detail:string}> $left
-     * @param list<array{group_id:string, order_id:int, name:string, detail:string}> $right
-     */
-    private function trophiesMatchByOrder(array $left, array $right): bool
-    {
-        $lookup = [];
-
-        foreach ($left as $trophy) {
-            $key = $this->createOrderKey($trophy['group_id'], $trophy['order_id']);
-            $lookup[$key] = $this->createTrophyKey($trophy['name'], $trophy['detail']);
-        }
-
-        foreach ($right as $trophy) {
-            $key = $this->createOrderKey($trophy['group_id'], $trophy['order_id']);
-            $value = $this->createTrophyKey($trophy['name'], $trophy['detail']);
-
-            if (!isset($lookup[$key]) || $lookup[$key] !== $value) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * @param list<array{group_id:string, order_id:int, name:string, detail:string}> $trophies
-     * @return array<string,int>
-     */
-    private function createNameDetailCounter(array $trophies): array
-    {
-        $counts = [];
-
-        foreach ($trophies as $trophy) {
-            $key = $this->createTrophyKey($trophy['name'], $trophy['detail']);
-            $counts[$key] = ($counts[$key] ?? 0) + 1;
-        }
-
-        ksort($counts);
-
-        return $counts;
-    }
-
-    /**
-     * @param list<array{group_id:string, order_id:int, name:string, detail:string}> $left
-     * @param list<array{group_id:string, order_id:int, name:string, detail:string}> $right
-     */
-    private function trophiesMatchByName(array $left, array $right): bool
-    {
-        $leftNames = array_map(fn(array $trophy): string => $this->normalizeString($trophy['name']), $left);
-        $rightNames = array_map(fn(array $trophy): string => $this->normalizeString($trophy['name']), $right);
-
-        sort($leftNames);
-        sort($rightNames);
-
-        if ($leftNames !== $rightNames) {
-            return false;
-        }
-
-        return count($leftNames) === count(array_unique($leftNames));
-    }
-
-    private function createTrophyKey(string $name, string $detail): string
-    {
-        return $this->normalizeString($name) . "\0" . $this->normalizeString($detail);
-    }
-
-    private function createOrderKey(string $groupId, int $orderId): string
-    {
-        return $groupId . '|' . $orderId;
-    }
-
-    private function normalizeString(string $value): string
-    {
-        return mb_strtolower($value, 'UTF-8');
-    }
-
-    /**
-     * @param array{matches:bool, orderMatches:bool, nameMatches:bool} $comparison
-     */
-    private function selectMergeMethod(array $comparison): ?string
-    {
-        if ($comparison['orderMatches']) {
-            return 'order';
-        }
-
-        if ($comparison['nameMatches']) {
-            return 'name';
-        }
-
-        return null;
+        return $this->trophySetComparator->compare(
+            $this->getTrophiesByNpCommunicationId($leftNpCommunicationId),
+            $this->getTrophiesByNpCommunicationId($rightNpCommunicationId),
+        );
     }
 
     private function logAmbiguousNameMerge(string $childNpCommunicationId, string $parentNpCommunicationId): void

--- a/wwwroot/classes/TrophySetComparator.php
+++ b/wwwroot/classes/TrophySetComparator.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Compares two trophy sets to decide whether automatic title merges are safe.
+ */
+final class TrophySetComparator
+{
+    /**
+     * @param list<array{group_id:string, order_id:int, name:string, detail:string}> $leftTrophies
+     * @param list<array{group_id:string, order_id:int, name:string, detail:string}> $rightTrophies
+     * @return array{matches:bool, orderMatches:bool, nameMatches:bool}
+     */
+    public function compare(array $leftTrophies, array $rightTrophies): array
+    {
+        if (count($leftTrophies) !== count($rightTrophies)) {
+            return ['matches' => false, 'orderMatches' => false, 'nameMatches' => false];
+        }
+
+        if ($leftTrophies === [] && $rightTrophies === []) {
+            return ['matches' => true, 'orderMatches' => true, 'nameMatches' => true];
+        }
+
+        $leftCounts = $this->createNameDetailCounter($leftTrophies);
+        $rightCounts = $this->createNameDetailCounter($rightTrophies);
+
+        if ($leftCounts !== $rightCounts) {
+            return ['matches' => false, 'orderMatches' => false, 'nameMatches' => false];
+        }
+
+        $orderMatches = $this->trophiesMatchByOrder($leftTrophies, $rightTrophies);
+        $nameMatches = $this->trophiesMatchByName($leftTrophies, $rightTrophies);
+
+        return ['matches' => true, 'orderMatches' => $orderMatches, 'nameMatches' => $nameMatches];
+    }
+
+    /**
+     * @param array{matches:bool, orderMatches:bool, nameMatches:bool} $comparison
+     */
+    public function selectMergeMethod(array $comparison): ?string
+    {
+        if ($comparison['orderMatches']) {
+            return 'order';
+        }
+
+        if ($comparison['nameMatches']) {
+            return 'name';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<array{group_id:string, order_id:int, name:string, detail:string}> $left
+     * @param list<array{group_id:string, order_id:int, name:string, detail:string}> $right
+     */
+    private function trophiesMatchByOrder(array $left, array $right): bool
+    {
+        $lookup = [];
+
+        foreach ($left as $trophy) {
+            $key = $this->createOrderKey($trophy['group_id'], $trophy['order_id']);
+            $lookup[$key] = $this->createTrophyKey($trophy['name'], $trophy['detail']);
+        }
+
+        foreach ($right as $trophy) {
+            $key = $this->createOrderKey($trophy['group_id'], $trophy['order_id']);
+            $value = $this->createTrophyKey($trophy['name'], $trophy['detail']);
+
+            if (!isset($lookup[$key]) || $lookup[$key] !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param list<array{group_id:string, order_id:int, name:string, detail:string}> $trophies
+     * @return array<string,int>
+     */
+    private function createNameDetailCounter(array $trophies): array
+    {
+        $counts = [];
+
+        foreach ($trophies as $trophy) {
+            $key = $this->createTrophyKey($trophy['name'], $trophy['detail']);
+            $counts[$key] = ($counts[$key] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @param list<array{group_id:string, order_id:int, name:string, detail:string}> $left
+     * @param list<array{group_id:string, order_id:int, name:string, detail:string}> $right
+     */
+    private function trophiesMatchByName(array $left, array $right): bool
+    {
+        $leftNames = array_map(fn (array $trophy): string => $this->normalizeString($trophy['name']), $left);
+        $rightNames = array_map(fn (array $trophy): string => $this->normalizeString($trophy['name']), $right);
+
+        sort($leftNames);
+        sort($rightNames);
+
+        if ($leftNames !== $rightNames) {
+            return false;
+        }
+
+        return count($leftNames) === count(array_unique($leftNames));
+    }
+
+    private function createTrophyKey(string $name, string $detail): string
+    {
+        return $this->normalizeString($name) . "\0" . $this->normalizeString($detail);
+    }
+
+    private function createOrderKey(string $groupId, int $orderId): string
+    {
+        return $groupId . '|' . $orderId;
+    }
+
+    private function normalizeString(string $value): string
+    {
+        return mb_strtolower($value, 'UTF-8');
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels trophy-set comparison logic out of `AutomaticTrophyTitleMergeService` (~534 lines) into a new `TrophySetComparator` class. This is the first incremental step toward breaking up God classes in the codebase — one concern per PR, no big-bang rewrite.

**Extracted concern:** deciding whether two trophy sets match (by order, by unique name, or not at all) and selecting the merge method (`order` / `name` / ambiguous).

**Left in `AutomaticTrophyTitleMergeService`:** orchestration, DB queries, trophy caching, clone/merge workflow, and platform-copy rules.

## Changes

- Add `wwwroot/classes/TrophySetComparator.php` with `compare()` and `selectMergeMethod()`
- Delegate comparison from `AutomaticTrophyTitleMergeService::compareTrophies()` to the new class
- Optional constructor injection with default `new TrophySetComparator()` — existing call sites unchanged
- Add `tests/TrophySetComparatorTest.php` with focused unit tests for comparison edge cases

## Testing

- [x] `php tests/run.php` — all 815 tests pass
- Existing `AutomaticTrophyTitleMergeServiceTest` integration tests continue to pass unchanged

## Follow-up candidates (future PRs)

Other God classes identified for incremental extraction:

1. **`ThirtyMinuteCronJob`** — extract per-player scan session runner
2. **`GameRescanService`** — share `updateTrophyTitle()` catalog refresh with scan path
3. **`PlayerScanTitleCatalogSynchronizer`** — extract per-trophy sync loop
4. **`TrophyMergePlayerProgressUpdater`** — split group vs title recalculation
5. **`TrophyStatusService`** — extract progress recalculation SQL
6. **`GameDetailPage`** — extract request parsing/validation

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8b82eda-dc7a-4ed5-80c3-f4ad8f61c423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8b82eda-dc7a-4ed5-80c3-f4ad8f61c423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

