### PR TITLE
Peel scan finalization SQL out of ThirtyMinuteCronJob

### DIFF
--- a/tests/PlayerScanCompletionServiceTest.php
+++ b/tests/PlayerScanCompletionServiceTest.php
@@ -44,6 +44,11 @@ final class PlayerScanCompletionServiceTest extends TestCase
             )'
         );
         $this->database->exec(
+            'CREATE TABLE player_queue (
+                online_id TEXT PRIMARY KEY
+            )'
+        );
+        $this->database->exec(
             'CREATE TABLE trophy_title (
                 id INTEGER PRIMARY KEY,
                 np_communication_id TEXT NOT NULL UNIQUE
@@ -158,6 +163,27 @@ final class PlayerScanCompletionServiceTest extends TestCase
 
         $this->assertStringContainsString('INTERVAL 1 YEAR', $source);
         $this->assertStringContainsString('AND p.status != 1', $source);
+    }
+
+    public function testRemovePlayerFromScanQueueDeletesOnlyMatchingOnlineId(): void
+    {
+        $this->database->exec("INSERT INTO player_queue (online_id) VALUES ('CurrentPsnName')");
+        $this->database->exec("INSERT INTO player_queue (online_id) VALUES ('SomeoneElse')");
+
+        $this->service->removePlayerFromScanQueue('CurrentPsnName');
+
+        $remainingQueueEntries = $this->database->query('SELECT online_id FROM player_queue ORDER BY online_id')->fetchAll(
+            PDO::FETCH_COLUMN
+        );
+        $this->assertSame(['SomeoneElse'], $remainingQueueEntries);
+    }
+
+    public function testFinalizeSuccessfulScanSourceUsesMysqlTimestampUpdate(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/PlayerScanCompletionService.php');
+
+        $this->assertStringContainsString('last_updated_date = Now()', $source);
+        $this->assertStringContainsString('DELETE FROM player_queue', $source);
     }
 
     public function testUpdateRarityPointsForActivePlayerSkipsNonActiveStatuses(): void

--- a/wwwroot/classes/Cron/PlayerScanCompletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionService.php
@@ -149,6 +149,30 @@ final class PlayerScanCompletionService
         return PlayerScanCompletionResult::completed();
     }
 
+    public function finalizeSuccessfulScan(string $accountId, string $currentOnlineId): void
+    {
+        $this->updatePlayerLastScannedAt($accountId);
+        $this->removePlayerFromScanQueue($currentOnlineId);
+    }
+
+    public function updatePlayerLastScannedAt(string $accountId): void
+    {
+        $query = $this->database->prepare("UPDATE player
+            SET    last_updated_date = Now()
+            WHERE  account_id = :account_id ");
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    public function removePlayerFromScanQueue(string $currentOnlineId): void
+    {
+        $query = $this->database->prepare("DELETE FROM player_queue
+            WHERE  online_id = :online_id ");
+        // Use the current PSN name; profile sync may have updated the queue row after a rename.
+        $query->bindValue(':online_id', $currentOnlineId, PDO::PARAM_STR);
+        $query->execute();
+    }
+
     public function updateRarityPointsForActivePlayer(string $accountId): void
     {
         $query = $this->database->prepare('SELECT

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -571,19 +571,10 @@ final class ThirtyMinuteCronJob implements CronJobInterface
 
                     $this->scanCompletionService->updateRarityPointsForActivePlayer((string) $user->accountId());
 
-                    // Done with the user, update the date
-                    $query = $this->database->prepare("UPDATE player
-                        SET    last_updated_date = Now()
-                        WHERE  account_id = :account_id ");
-                    $query->bindValue(":account_id", (string) $user->accountId(), PDO::PARAM_STR);
-                    $query->execute();
-
-                    // Delete user from the queue
-                    $query = $this->database->prepare("DELETE FROM player_queue
-                        WHERE  online_id = :online_id ");
-                    // Don't use $user->onlineId(), since the user can have changed its name from what was entered into the queue.
-                    $query->bindValue(":online_id", $user->onlineId(), PDO::PARAM_STR);
-                    $query->execute();
+                    $this->scanCompletionService->finalizeSuccessfulScan(
+                        (string) $user->accountId(),
+                        $user->onlineId(),
+                    );
 
                     unset($missingGameDeletionCheck[$onlineId]);
                     unset($missingTrophyTitleRetry[$onlineId]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ThirtyMinuteCronJob` (~616 lines) is the largest remaining god class in the player-scan cron path. Its `run()` loop still mixes orchestration, retry state, and inline persistence.

This PR peels off one concern: **post-scan finalization persistence** (updating `player.last_updated_date` and removing the row from `player_queue`). That logic now lives in `PlayerScanCompletionService`, which already owns related completion work.

## Changes

- Add `finalizeSuccessfulScan()`, `updatePlayerLastScannedAt()`, and `removePlayerFromScanQueue()` to `PlayerScanCompletionService`
- Replace inline SQL at the end of `ThirtyMinuteCronJob::run()` with a single service call
- Clarify the queue-delete comment (profile sync may rename the queued PSN ID before completion)
- Add tests for queue removal and MySQL timestamp update (source inspection)

## Testing

- `php tests/run.php` — all 828 tests pass

## Follow-up peel-offs (separate PRs)

Other high-value god classes identified for incremental extraction:

1. **`PlayerScanTitleCatalogSynchronizer`** — extract trophy payload normalization (`PlayerScanTrophyPayloadNormalizer`)
2. **`PlayerScanProfileSynchronizer`** — extract country resolution (`PlayerCountryResolver`)
3. **`TrophyMergePlayerProgressUpdater`** — extract merge graph reads (`TrophyMergeGraphRepository`)
4. **`TrophyMergeService`** — extract metadata updates (`TrophyMergeMetadataUpdater`)
5. **`Admin/TrophyStatusService`** — extract recalculation SQL or split result DTO
6. **`GameHeaderService`** — extract PSNP+ note resolution
7. **`AutomaticTrophyTitleMergeService`** — extract title matching heuristics

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd2c3b14-d381-447e-b4ef-5589a4d33629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd2c3b14-d381-447e-b4ef-5589a4d33629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

