### PR TITLE
Speed up hourly cron by precomputing stats once

### DIFF
--- a/tests/HourlyCronJobTest.php
+++ b/tests/HourlyCronJobTest.php
@@ -12,16 +12,18 @@ final class HourlyCronJobTest extends TestCase
         $class = new ReflectionClass(HourlyCronJob::class);
         $createBatchTableQuery = $this->readPrivateConstantValue($class, 'CREATE_BATCH_TEMP_TABLE_QUERY');
         $createStatsTableQuery = $this->readPrivateConstantValue($class, 'CREATE_STATS_TEMP_TABLE_QUERY');
-        $insertStatsQuery = $this->readPrivateConstantValue($class, 'INSERT_STATS_QUERY');
+        $populateAllStatsQuery = $this->readPrivateConstantValue($class, 'POPULATE_ALL_STATS_QUERY');
         $updateMetaQuery = $this->readPrivateConstantValue($class, 'UPDATE_META_QUERY');
 
         $this->assertStringContainsString('COLLATE utf8mb4_0900_ai_ci', $createBatchTableQuery);
         $this->assertStringContainsString('COLLATE utf8mb4_0900_ai_ci', $createStatsTableQuery);
-        $this->assertStringContainsString('INSERT INTO tmp_hourly_stats', $insertStatsQuery);
-        $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id', $insertStatsQuery);
-        $this->assertStringContainsString('COUNT(*) AS owners', $insertStatsQuery);
-        $this->assertStringContainsString('SUM(ttp.progress = 100) AS owners_completed', $insertStatsQuery);
-        $this->assertStringContainsString('SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players', $insertStatsQuery);
+        $this->assertStringContainsString('INSERT INTO tmp_hourly_stats', $populateAllStatsQuery);
+        $this->assertStringContainsString('FROM trophy_title_player ttp', $populateAllStatsQuery);
+        $this->assertStringContainsString('JOIN player_ranking pr ON pr.account_id = ttp.account_id AND pr.ranking <= 10000', $populateAllStatsQuery);
+        $this->assertStringContainsString('COUNT(*) AS owners', $populateAllStatsQuery);
+        $this->assertStringContainsString('SUM(ttp.progress = 100) AS owners_completed', $populateAllStatsQuery);
+        $this->assertStringContainsString('SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players', $populateAllStatsQuery);
+        $this->assertFalse(str_contains($populateAllStatsQuery, 'tmp_hourly_batch'));
 
         $this->assertStringContainsString('UPDATE trophy_title_meta ttm', $updateMetaQuery);
         $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttm.np_communication_id', $updateMetaQuery);
@@ -48,9 +50,28 @@ final class HourlyCronJobTest extends TestCase
         $this->assertTrue(is_string($source));
 
         $this->assertStringContainsString("DELETE FROM tmp_hourly_batch", $source);
-        $this->assertStringContainsString("DELETE FROM tmp_hourly_stats", $source);
+        $this->assertFalse(str_contains($source, 'DELETE FROM tmp_hourly_stats'));
         $this->assertFalse(str_contains($source, 'TRUNCATE TABLE tmp_hourly_batch'));
         $this->assertFalse(str_contains($source, 'TRUNCATE TABLE tmp_hourly_stats'));
+    }
+
+    public function testPopulatesAllStatisticsOnceBeforeBatchUpdates(): void
+    {
+        $class = new ReflectionClass(HourlyCronJob::class);
+
+        $this->assertTrue($class->hasMethod('populateAllStatistics'));
+        $this->assertFalse(str_contains(
+            $this->readMethodSource($class, 'updateStatisticsForBatch'),
+            'POPULATE_ALL_STATS_QUERY'
+        ));
+
+        $updateSource = $this->readMethodSource($class, 'updateTrophyTitleStatistics');
+        $this->assertStringContainsString('$this->populateAllStatistics();', $updateSource);
+        $populatePosition = strpos($updateSource, '$this->populateAllStatistics();');
+        $loopPosition = strpos($updateSource, 'while (true)');
+        $this->assertTrue(is_int($populatePosition));
+        $this->assertTrue(is_int($loopPosition));
+        $this->assertTrue($populatePosition < $loopPosition);
     }
 
     public function testNoDynamicUnionAllSelectBatchPathExists(): void
@@ -82,5 +103,18 @@ final class HourlyCronJobTest extends TestCase
         $this->assertTrue(is_string($value));
 
         return $value;
+    }
+
+    private function readMethodSource(ReflectionClass $class, string $methodName): string
+    {
+        $method = $class->getMethod($methodName);
+        $source = file_get_contents((string) $class->getFileName());
+        $this->assertTrue(is_string($source));
+
+        $lines = explode("\n", $source);
+        $startLine = $method->getStartLine() - 1;
+        $lineCount = $method->getEndLine() - $method->getStartLine() + 1;
+
+        return implode("\n", array_slice($lines, $startLine, $lineCount));
     }
 }

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -23,7 +23,7 @@ final readonly class HourlyCronJob implements CronJobInterface
         )
         SQL;
 
-    private const INSERT_STATS_QUERY = <<<'SQL'
+    private const POPULATE_ALL_STATS_QUERY = <<<'SQL'
         INSERT INTO tmp_hourly_stats (np_communication_id, owners, owners_completed, recent_players)
         SELECT
             ttp.np_communication_id,
@@ -31,7 +31,6 @@ final readonly class HourlyCronJob implements CronJobInterface
             SUM(ttp.progress = 100) AS owners_completed,
             SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players
         FROM trophy_title_player ttp
-        JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id
         JOIN player_ranking pr ON pr.account_id = ttp.account_id AND pr.ranking <= 10000
         GROUP BY ttp.np_communication_id
         SQL;
@@ -68,6 +67,8 @@ final readonly class HourlyCronJob implements CronJobInterface
         $this->initializeTemporaryTables();
 
         try {
+            $this->populateAllStatistics();
+
             while (true) {
                 $batchIds = $this->getBatchNpCommunicationIds($lastId, self::BATCH_SIZE);
 
@@ -93,6 +94,12 @@ final readonly class HourlyCronJob implements CronJobInterface
         }
     }
 
+    private function populateAllStatistics(): void
+    {
+        $query = $this->database->prepare(self::POPULATE_ALL_STATS_QUERY);
+        $query->execute();
+    }
+
     private function getBatchNpCommunicationIds(?string $lastId, int $limit): array
     {
         $baseQuery = 'SELECT np_communication_id FROM trophy_title_meta %s ORDER BY np_communication_id LIMIT :limit';
@@ -114,10 +121,6 @@ final readonly class HourlyCronJob implements CronJobInterface
     {
         $this->database->exec('DELETE FROM tmp_hourly_batch');
         $this->insertBatchIdsIntoTemporaryTable($batchIds);
-
-        $this->database->exec('DELETE FROM tmp_hourly_stats');
-        $insertStatsQuery = $this->database->prepare(self::INSERT_STATS_QUERY);
-        $insertStatsQuery->execute();
 
         $updateMetaQuery = $this->database->prepare(self::UPDATE_META_QUERY);
         $updateMetaQuery->execute();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

#16103 fixed the hourly Cloudflare 525 outages by restoring batched `trophy_title_meta` updates, but production runtime grew from ~1 minute to 10+ minutes.

The merged batch flow re-ran the expensive `trophy_title_player` + `player_ranking` aggregation for **every** 500-title batch. With tens of thousands of titles that means repeating the heavy scan dozens of times.

## Fix

Split the job into two phases:

1. **Precompute once** — insert all top-10k owner statistics into `tmp_hourly_stats` with a single aggregation query (same logic as the old monolithic subquery).
2. **Batch updates** — keep the existing 500-title `UPDATE trophy_title_meta` transactions, joining against the precomputed stats table.

This keeps the short lock windows that prevent origin overload while removing repeated aggregation work.

## Testing

- `php tests/run.php` — all 827 tests pass
- `HourlyCronJobTest` asserts stats are populated once before the batch loop and not recomputed per batch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f465a2bf-8a13-4776-899e-787c07f2300d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f465a2bf-8a13-4776-899e-787c07f2300d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

