### PR TITLE
Extract CronWorkerLoginSession from ThirtyMinuteCronJob

### DIFF
--- a/tests/CronWorkerLoginSessionTest.php
+++ b/tests/CronWorkerLoginSessionTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/CronWorkerLoginSession.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/WorkerScanCoordinator.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerService.php';
+require_once __DIR__ . '/../wwwroot/classes/Psn100Logger.php';
+
+final class CronWorkerLoginSessionTest extends TestCase
+{
+    private PDO $database;
+    private Psn100Logger $logger;
+    private WorkerScanCoordinator $workerScanCoordinator;
+    /** @var list<int> */
+    private array $sleptSeconds = [];
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec(
+            'CREATE TABLE setting (id INTEGER PRIMARY KEY, refresh_token TEXT, npsso TEXT, scanning TEXT, scan_progress TEXT)'
+        );
+        $this->database->exec('CREATE TABLE log (message TEXT NOT NULL)');
+        $this->database->exec(
+            "INSERT INTO setting (id, refresh_token, npsso, scanning, scan_progress) VALUES (1, '', 'npsso-token', 'queued-player', NULL)"
+        );
+
+        $this->logger = new Psn100Logger($this->database);
+        $this->sleptSeconds = [];
+        $this->workerScanCoordinator = new WorkerScanCoordinator($this->database);
+    }
+
+    public function testAuthenticateThrowsWhenWorkerDoesNotExist(): void
+    {
+        $loginSession = $this->createLoginSession(
+            new PlayStationWorkerAuthenticator(
+                static fn (): array => [],
+                static fn (): object => self::createAuthenticatedClientStub(),
+            ),
+        );
+
+        try {
+            $loginSession->authenticate(999);
+            $this->fail('Expected RuntimeException for unknown worker id.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Worker 999 not found in setting table', $exception->getMessage());
+        }
+
+        $statement = $this->database->query('SELECT message FROM log');
+        $message = $statement !== false ? $statement->fetchColumn() : false;
+        $this->assertSame('Worker 999 not found in setting table', $message !== false ? (string) $message : '');
+    }
+
+    public function testAuthenticateRetriesAfterTypeErrorThenSucceeds(): void
+    {
+        $attempts = 0;
+        $authenticator = new PlayStationWorkerAuthenticator(
+            static fn (): array => [],
+            static function () use (&$attempts): object {
+                $attempts++;
+
+                if ($attempts === 1) {
+                    throw new TypeError('Unexpected API response shape');
+                }
+
+                return self::createAuthenticatedClientStub();
+            },
+        );
+
+        $loginSession = $this->createLoginSession($authenticator);
+        $result = $loginSession->authenticate(1);
+
+        $this->assertSame(2, $attempts);
+        $this->assertSame([60], $this->sleptSeconds);
+        $this->assertTrue(is_object($result['client']));
+        $this->assertSame('1', (string) ($result['worker']['id'] ?? ''));
+
+        $setting = $this->fetchSetting(1);
+        $scanProgress = json_decode((string) $setting['scan_progress'], true);
+        $this->assertTrue(is_array($scanProgress));
+        $this->assertSame(
+            'Encountered a login problem. Waiting 1 minute before retrying.',
+            (string) ($scanProgress['title'] ?? '')
+        );
+    }
+
+    public function testAuthenticateReleasesWorkerAndWaitsAfterLoginException(): void
+    {
+        $attempts = 0;
+        $loginSession = new CronWorkerLoginSession(
+            $this->database,
+            new PlayStationWorkerAuthenticator(
+                static fn (): array => [],
+                static function () use (&$attempts): object {
+                    $attempts++;
+
+                    if ($attempts === 1) {
+                        throw new RuntimeException('login failed');
+                    }
+
+                    return self::createAuthenticatedClientStub();
+                },
+            ),
+            $this->workerScanCoordinator,
+            $this->logger,
+            function (int $seconds): void {
+                $this->sleptSeconds[] = $seconds;
+            },
+        );
+
+        $result = $loginSession->authenticate(1);
+
+        $this->assertSame(2, $attempts);
+        $this->assertSame([60 * 30], $this->sleptSeconds);
+        $this->assertTrue(is_object($result['client']));
+
+        $setting = $this->fetchSetting(1);
+        $this->assertSame('1', (string) $setting['scanning']);
+        $this->assertSame(null, $setting['scan_progress']);
+
+        $statement = $this->database->query('SELECT message FROM log ORDER BY rowid DESC LIMIT 1');
+        $message = $statement !== false ? $statement->fetchColumn() : false;
+        $this->assertSame("Can't login with worker 1", $message !== false ? (string) $message : '');
+    }
+
+    private function createLoginSession(PlayStationWorkerAuthenticator $authenticator): CronWorkerLoginSession
+    {
+        return new CronWorkerLoginSession(
+            $this->database,
+            $authenticator,
+            $this->workerScanCoordinator,
+            $this->logger,
+            function (int $seconds): void {
+                $this->sleptSeconds[] = $seconds;
+            },
+        );
+    }
+
+    private static function createAuthenticatedClientStub(): object
+    {
+        static $client = new class {
+            public function loginWithNpsso(string $npsso): void
+            {
+            }
+
+            public function getRefreshToken(): object
+            {
+                return new class {
+                    public function getToken(): string
+                    {
+                        return '';
+                    }
+                };
+            }
+        };
+
+        return $client;
+    }
+
+    /**
+     * @return array{scanning: mixed, scan_progress: mixed}
+     */
+    private function fetchSetting(int $workerId): array
+    {
+        $settingQuery = $this->database->query(
+            sprintf('SELECT scanning, scan_progress FROM setting WHERE id = %d', $workerId)
+        );
+        $setting = $settingQuery !== false ? $settingQuery->fetch(PDO::FETCH_ASSOC) : false;
+        $this->assertTrue(is_array($setting));
+
+        return $setting;
+    }
+}

--- a/wwwroot/classes/Cron/CronWorkerLoginSession.php
+++ b/wwwroot/classes/Cron/CronWorkerLoginSession.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../Admin/PlayStationWorkerAuthenticator.php';
+require_once __DIR__ . '/../Admin/Worker.php';
+require_once __DIR__ . '/WorkerScanCoordinator.php';
+
+/**
+ * Loads a worker row from the setting table and authenticates with infinite retry.
+ *
+ * Extracted from ThirtyMinuteCronJob so login backoff and release behavior can be
+ * tested without running the full player scan loop.
+ */
+final class CronWorkerLoginSession
+{
+    public function __construct(
+        private readonly PDO $database,
+        private readonly PlayStationWorkerAuthenticator $workerAuthenticator,
+        private readonly WorkerScanCoordinator $workerScanCoordinator,
+        private readonly Psn100Logger $logger,
+        private readonly ?\Closure $sleeper = null,
+    ) {
+    }
+
+    /**
+     * @return array{client: object, worker: array<string, mixed>}
+     */
+    public function authenticate(int $workerId): array
+    {
+        while (true) {
+            $worker = $this->loadWorkerRow($workerId);
+
+            try {
+                $workerAccount = new Worker(
+                    (int) $worker['id'],
+                    (string) ($worker['refresh_token'] ?? ''),
+                    (string) ($worker['npsso'] ?? ''),
+                    '',
+                    new DateTimeImmutable('1970-01-01 00:00:00'),
+                    null,
+                );
+                $client = $this->workerAuthenticator->authenticateWorker($workerAccount);
+
+                return [
+                    'client' => $client,
+                    'worker' => $worker,
+                ];
+            } catch (TypeError) {
+                $this->workerScanCoordinator->setWaitingScanProgress(
+                    (int) $worker['id'],
+                    'Encountered a login problem. Waiting 1 minute before retrying.'
+                );
+                $this->pause(60);
+            } catch (Exception $exception) {
+                $this->logger->log("Can't login with worker " . $worker['id']);
+
+                $this->workerScanCoordinator->releaseWorkerFromCurrentScan((int) $worker['id']);
+
+                $this->pause(60 * 30);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadWorkerRow(int $workerId): array
+    {
+        $query = $this->database->prepare(
+            'SELECT
+                id,
+                refresh_token,
+                npsso,
+                scanning
+            FROM
+                setting
+            WHERE
+                id = :id'
+        );
+        $query->bindValue(':id', $workerId, PDO::PARAM_INT);
+        $query->execute();
+        $worker = $query->fetch(PDO::FETCH_ASSOC);
+
+        if ($worker === false) {
+            $message = sprintf(
+                'Worker %d not found in setting table',
+                $workerId
+            );
+            $this->logger->log($message);
+
+            throw new RuntimeException($message);
+        }
+
+        return $worker;
+    }
+
+    private function pause(int $seconds): void
+    {
+        if ($this->sleeper !== null) {
+            ($this->sleeper)($seconds);
+
+            return;
+        }
+
+        sleep($seconds);
+    }
+}

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/CronJobInterface.php';
 require_once __DIR__ . '/../Admin/PlayStationWorkerAuthenticator.php';
-require_once __DIR__ . '/../Admin/Worker.php';
 require_once __DIR__ . '/../Admin/WorkerService.php';
 require_once __DIR__ . '/../AutomaticTrophyTitleMergeService.php';
 require_once __DIR__ . '/../ImageHashCalculator.php';
 require_once __DIR__ . '/../Psn100Logger.php';
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../TrophyMergeService.php';
+require_once __DIR__ . '/CronWorkerLoginSession.php';
 require_once __DIR__ . '/WorkerScanCoordinator.php';
 require_once __DIR__ . '/PlayerScanQueueSelector.php';
 require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
@@ -38,6 +38,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
 
     private readonly ImageHashCalculator $imageHashCalculator;
     private readonly WorkerScanCoordinator $workerScanCoordinator;
+    private readonly CronWorkerLoginSession $workerLoginSession;
     private readonly PlayerScanQueueSelector $playerScanQueueSelector;
     private readonly PlayStationWorkerAuthenticator $workerAuthenticator;
     private readonly PlayerScanTitleMetadataHelper $titleMetadataHelper;
@@ -59,6 +60,7 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         ?AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService = null,
         ?ImageHashCalculator $imageHashCalculator = null,
         ?WorkerScanCoordinator $workerScanCoordinator = null,
+        ?CronWorkerLoginSession $workerLoginSession = null,
         ?PlayerScanQueueSelector $playerScanQueueSelector = null,
         ?PlayStationWorkerAuthenticator $workerAuthenticator = null,
         ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
@@ -76,7 +78,6 @@ final class ThirtyMinuteCronJob implements CronJobInterface
             ?? new AutomaticTrophyTitleMergeService($database, new TrophyMergeService($database));
         $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
         $this->workerScanCoordinator = $workerScanCoordinator ?? new WorkerScanCoordinator($database);
-        $this->playerScanQueueSelector = $playerScanQueueSelector ?? new PlayerScanQueueSelector($database);
         $this->workerAuthenticator = $workerAuthenticator ?? PlayStationWorkerAuthenticator::fromWorkerService(
             new WorkerService($database),
             null,
@@ -84,6 +85,13 @@ final class ThirtyMinuteCronJob implements CronJobInterface
                 $logger->log(sprintf('Failed to persist refresh token for worker %d: %s', $workerId, $message));
             },
         );
+        $this->workerLoginSession = $workerLoginSession ?? new CronWorkerLoginSession(
+            $database,
+            $this->workerAuthenticator,
+            $this->workerScanCoordinator,
+            $logger,
+        );
+        $this->playerScanQueueSelector = $playerScanQueueSelector ?? new PlayerScanQueueSelector($database);
         $this->titleMetadataHelper = $titleMetadataHelper ?? new PlayerScanTitleMetadataHelper();
         $this->profileSynchronizer = $profileSynchronizer ?? new PlayerScanProfileSynchronizer(
             $database,
@@ -188,60 +196,9 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         $invalidTitleDateRetry = [];
 
         while (true) {
-            // Login with a token
-            $loggedIn = false;
-            while (!$loggedIn) {
-                $query = $this->database->prepare("SELECT
-                    id,
-                    refresh_token,
-                    npsso,
-                    scanning
-                FROM
-                    setting
-                WHERE
-                    id = :id");
-                $query->bindValue(":id", $this->workerId, PDO::PARAM_INT);
-                $query->execute();
-                $worker = $query->fetch(PDO::FETCH_ASSOC);
-
-                if ($worker === false) {
-                    $message = sprintf(
-                        'Worker %d not found in setting table',
-                        $this->workerId
-                    );
-                    $this->logger->log($message);
-
-                    throw new RuntimeException($message);
-                }
-
-                try {
-                    $workerAccount = new Worker(
-                        (int) $worker['id'],
-                        (string) ($worker['refresh_token'] ?? ''),
-                        (string) ($worker['npsso'] ?? ''),
-                        '',
-                        new DateTimeImmutable('1970-01-01 00:00:00'),
-                        null,
-                    );
-                    $client = $this->workerAuthenticator->authenticateWorker($workerAccount);
-                    $loggedIn = true;
-                } catch (TypeError $e) {
-                    // Something odd, let's wait a minute
-                    $this->workerScanCoordinator->setWaitingScanProgress(
-                        (int) $worker['id'],
-                        'Encountered a login problem. Waiting 1 minute before retrying.'
-                    );
-                    sleep(60 * 1);
-                } catch (Exception $e) {
-                    $this->logger->log("Can't login with worker ". $worker["id"]);
-
-                    // Something went wrong, 'release' the current scanning profile so other workers can pick it up.
-                    $this->workerScanCoordinator->releaseWorkerFromCurrentScan((int) $worker['id']);
-
-                    // Wait 30 minutes to not hammer login
-                    sleep(60 * 30);
-                }
-            }
+            $loginResult = $this->workerLoginSession->authenticate($this->workerId);
+            $client = $loginResult['client'];
+            $worker = $loginResult['worker'];
 
             try {
                 $player = $this->playerScanQueueSelector->selectNextCandidate((int) $worker['id']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ThirtyMinuteCronJob` (~600 lines) is the largest remaining cron orchestrator and still mixes worker login, queue selection, profile sync, catalog sync, and completion logic in one class.

This PR peels off **one concern**: worker credential loading and infinite-retry PSN authentication.

## Changes

- Add `CronWorkerLoginSession` — loads the worker row from `setting`, authenticates via `PlayStationWorkerAuthenticator`, and retries with the same backoff rules as before:
  - **TypeError** → set waiting scan progress, pause 1 minute
  - **Other login failures** → log, release worker from current scan, pause 30 minutes
  - **Missing worker** → log and throw `RuntimeException`
- `ThirtyMinuteCronJob::run()` now calls `authenticate()` at the start of each outer loop iteration instead of inlining ~50 lines of login logic.
- Add `CronWorkerLoginSessionTest` with injectable sleeper to verify retry and release behavior without real sleeps.

## Why this first

Follows the existing extraction pattern (`WorkerScanCoordinator`, `PlayerScanTitleMetadataHelper`, etc.) and makes the main scan loop easier to read for future peel-offs (queue selection, game loop, etc.).

## Testing

- `php tests/run.php` — full suite passes
- New unit tests: `CronWorkerLoginSessionTest`
- Existing `ThirtyMinuteCronJobWorkerValidationTest` still passes (unknown worker throws before scan loop)

## Follow-up candidates (separate PRs)

- `GameRescanService` — share set-version policy with `PlayerScanTitleMetadataHelper`
- `TrophyStatusUpdateResult` — move out of `TrophyStatusService.php`
- `TrophyMergePlayerProgressUpdater` — extract group-level merge SQL
- `PsnGameLookupService` — extract `PsnTrophyResponseParser`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73a74a48-0e27-408d-86a8-f1e5bc50b9b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73a74a48-0e27-408d-86a8-f1e5bc50b9b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

