### PR TITLE
Extract GameRescanCatalogUpdater from GameRescanService

### DIFF
--- a/tests/GameRescanCatalogUpdaterTest.php
+++ b/tests/GameRescanCatalogUpdaterTest.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/ImageHashCalculatorTest.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyImageDownloader.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyImageDirectories.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyCatalogSynchronizer.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMetaRepository.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanDifferenceTracker.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanProgressReporter.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanGroupDataFetcher.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanCatalogUpdater.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PsnTrophyApiAdapter.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PsnTrophyGroupApiAdapter.php';
+
+if (!class_exists('Tustin\\PlayStation\\Client')) {
+    eval('namespace Tustin\\PlayStation; final class Client {}');
+}
+
+final class GameRescanCatalogUpdaterTest extends TestCase
+{
+    private PDO $database;
+    private GameRescanCatalogUpdater $catalogUpdater;
+    private StubGameRescanGroupDataFetcher $groupDataFetcher;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec(
+            'CREATE TABLE trophy_title (
+                np_communication_id TEXT PRIMARY KEY,
+                detail TEXT,
+                icon_url TEXT,
+                platform TEXT,
+                set_version TEXT
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_group (
+                np_communication_id TEXT NOT NULL,
+                group_id TEXT NOT NULL,
+                name TEXT,
+                detail TEXT,
+                icon_url TEXT,
+                PRIMARY KEY (np_communication_id, group_id)
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                np_communication_id TEXT NOT NULL,
+                group_id TEXT NOT NULL,
+                order_id INTEGER NOT NULL,
+                hidden INTEGER,
+                type TEXT,
+                name TEXT,
+                detail TEXT,
+                icon_url TEXT,
+                progress_target_value INTEGER,
+                reward_name TEXT,
+                reward_image_url TEXT
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_meta (
+                trophy_id INTEGER PRIMARY KEY,
+                rarity_percent REAL NOT NULL DEFAULT 0,
+                rarity_point INTEGER NOT NULL DEFAULT 0,
+                status INTEGER NOT NULL DEFAULT 0,
+                owners INTEGER NOT NULL DEFAULT 0,
+                rarity_name TEXT NOT NULL DEFAULT "NONE"
+            )'
+        );
+
+        $imageDownloader = new TrophyImageDownloader(
+            new ImageHashCalculator(new FakeImageProcessor(supported: false)),
+            null,
+            static fn (string $url): ?string => 'image-bytes',
+        );
+        $this->groupDataFetcher = new StubGameRescanGroupDataFetcher();
+        $this->catalogUpdater = new GameRescanCatalogUpdater(
+            $this->database,
+            new TrophyCatalogSynchronizer($this->database),
+            new TrophyMetaRepository($this->database),
+            $this->groupDataFetcher,
+            new TrophyImageDirectories('/tmp/title', '/tmp/group', '/tmp/trophy', '/tmp/reward'),
+            $imageDownloader,
+        );
+    }
+
+    public function testUpdateFromPsnSkipsWhenIncomingSetVersionIsLower(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, detail, icon_url, platform, set_version)
+            VALUES ('NPWR00001_00', 'Old detail', 'old.png', 'PS5', '01.10')"
+        );
+
+        $differenceTracker = new GameRescanDifferenceTracker();
+        $progressReporter = new GameRescanProgressReporter();
+        $trophyTitle = new GameRescanCatalogUpdaterTestTrophyTitle(
+            detail: 'New detail',
+            setVersion: '01.09',
+        );
+
+        $groups = $this->catalogUpdater->updateFromPsn(
+            new \Tustin\PlayStation\Client(),
+            $trophyTitle,
+            'NPWR00001_00',
+            $progressReporter,
+            $differenceTracker,
+        );
+
+        $this->assertSame([], $groups);
+        $this->assertSame([], $differenceTracker->getDifferences());
+
+        $detail = $this->database->query(
+            "SELECT detail FROM trophy_title WHERE np_communication_id = 'NPWR00001_00'"
+        )->fetchColumn();
+        $this->assertSame('Old detail', $detail);
+    }
+
+    public function testUpdateFromPsnRecordsTitleDetailChanges(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, detail, icon_url, platform, set_version)
+            VALUES ('NPWR00001_00', 'Old detail', 'old.png', 'PS5', '01.00')"
+        );
+        $this->groupDataFetcher->setGroupData([]);
+
+        $differenceTracker = new GameRescanDifferenceTracker();
+        $progressReporter = new GameRescanProgressReporter();
+        $trophyTitle = new GameRescanCatalogUpdaterTestTrophyTitle(
+            detail: 'New detail',
+            setVersion: '01.10',
+        );
+
+        $this->catalogUpdater->updateFromPsn(
+            new \Tustin\PlayStation\Client(),
+            $trophyTitle,
+            'NPWR00001_00',
+            $progressReporter,
+            $differenceTracker,
+        );
+
+        $differences = $differenceTracker->getDifferences();
+        $detailDifference = null;
+        foreach ($differences as $difference) {
+            if ($difference['field'] === 'Detail') {
+                $detailDifference = $difference;
+                break;
+            }
+        }
+
+        $this->assertTrue($detailDifference !== null);
+        $this->assertSame('Trophy Title', $detailDifference['context']);
+        $this->assertSame('Old detail', $detailDifference['previous']);
+        $this->assertSame('New detail', $detailDifference['current']);
+
+        $detail = $this->database->query(
+            "SELECT detail FROM trophy_title WHERE np_communication_id = 'NPWR00001_00'"
+        )->fetchColumn();
+        $this->assertSame('New detail', $detail);
+    }
+
+    public function testUpdateFromPsnPreservesPsvr2PlatformWhenMissingFromIncomingTitle(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, detail, icon_url, platform, set_version)
+            VALUES ('NPWR00001_00', 'Details', 'title.png', 'PSVR2', '01.00')"
+        );
+        $this->groupDataFetcher->setGroupData([]);
+
+        $differenceTracker = new GameRescanDifferenceTracker();
+        $progressReporter = new GameRescanProgressReporter();
+        $trophyTitle = new GameRescanCatalogUpdaterTestTrophyTitle(
+            detail: 'Details',
+            setVersion: '01.00',
+            platforms: [new GameRescanCatalogUpdaterTestPlatform('PS5')],
+        );
+
+        $this->catalogUpdater->updateFromPsn(
+            new \Tustin\PlayStation\Client(),
+            $trophyTitle,
+            'NPWR00001_00',
+            $progressReporter,
+            $differenceTracker,
+        );
+
+        $platform = $this->database->query(
+            "SELECT platform FROM trophy_title WHERE np_communication_id = 'NPWR00001_00'"
+        )->fetchColumn();
+
+        $this->assertSame('PSVR2', $platform);
+    }
+}
+
+final class StubGameRescanGroupDataFetcher implements GameRescanGroupDataFetcher
+{
+    /**
+     * @var array<int, array{group: PsnTrophyGroupApiAdapter, trophies: array<int, PsnTrophyApiAdapter>}>
+     */
+    private array $groupData = [];
+
+    /**
+     * @param array<int, array{group: PsnTrophyGroupApiAdapter, trophies: array<int, PsnTrophyApiAdapter>}> $groupData
+     */
+    public function setGroupData(array $groupData): void
+    {
+        $this->groupData = $groupData;
+    }
+
+    public function fetchGroupData(\Tustin\PlayStation\Client $client, string $npCommunicationId): array
+    {
+        return $this->groupData;
+    }
+}
+
+final class GameRescanCatalogUpdaterTestTrophyTitle
+{
+    /**
+     * @param list<GameRescanCatalogUpdaterTestPlatform> $platforms
+     */
+    public function __construct(
+        private readonly string $detail,
+        private readonly string $setVersion,
+        private readonly array $platforms = [new GameRescanCatalogUpdaterTestPlatform('PS5')],
+    ) {
+    }
+
+    public function detail(): string
+    {
+        return $this->detail;
+    }
+
+    public function iconUrl(): string
+    {
+        return 'https://example.test/title.png';
+    }
+
+    public function trophySetVersion(): string
+    {
+        return $this->setVersion;
+    }
+
+    /**
+     * @return list<GameRescanCatalogUpdaterTestPlatform>
+     */
+    public function platform(): array
+    {
+        return $this->platforms;
+    }
+}
+
+final class GameRescanCatalogUpdaterTestPlatform
+{
+    public function __construct(public readonly string $value)
+    {
+    }
+}

--- a/tests/GameRescanServiceSetVersionTest.php
+++ b/tests/GameRescanServiceSetVersionTest.php
@@ -6,13 +6,14 @@ require_once __DIR__ . '/ImageHashCalculatorTest.php';
 require_once __DIR__ . '/../wwwroot/classes/TrophyCalculator.php';
 require_once __DIR__ . '/../wwwroot/classes/TrophyImageDownloader.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanDifferenceTracker.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanCatalogUpdater.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/GameRescanService.php';
 
 final class GameRescanServiceSetVersionTest extends TestCase
 {
     public function testIsSetVersionAtLeastCurrentReturnsFalseForLowerVersion(): void
     {
-        $method = new ReflectionMethod(GameRescanService::class, 'isSetVersionAtLeastCurrent');
+        $method = new ReflectionMethod(GameRescanCatalogUpdater::class, 'isSetVersionAtLeastCurrent');
         $method->setAccessible(true);
 
         $result = $method->invoke(null, '01.09', '01.10');
@@ -22,7 +23,7 @@ final class GameRescanServiceSetVersionTest extends TestCase
 
     public function testIsSetVersionAtLeastCurrentAllowsEqualOrGreaterVersions(): void
     {
-        $method = new ReflectionMethod(GameRescanService::class, 'isSetVersionAtLeastCurrent');
+        $method = new ReflectionMethod(GameRescanCatalogUpdater::class, 'isSetVersionAtLeastCurrent');
         $method->setAccessible(true);
 
         $this->assertTrue($method->invoke(null, '01.10', '01.10'));

--- a/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
+++ b/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
@@ -1,0 +1,367 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/GameRescanDifferenceTracker.php';
+require_once __DIR__ . '/GameRescanProgressReporter.php';
+require_once __DIR__ . '/GameRescanGroupDataFetcher.php';
+require_once __DIR__ . '/PsnTrophyLookupGroupDataProvider.php';
+require_once __DIR__ . '/../TrophyMetaRepository.php';
+require_once __DIR__ . '/../TrophyImageDirectories.php';
+require_once __DIR__ . '/../TrophyImageDownloader.php';
+require_once __DIR__ . '/../TrophyCatalogSynchronizer.php';
+
+use Tustin\PlayStation\Client;
+
+/**
+ * Refreshes trophy title, group, and trophy catalog rows during admin game rescans.
+ */
+final class GameRescanCatalogUpdater
+{
+    public function __construct(
+        private readonly PDO $database,
+        private readonly TrophyCatalogSynchronizer $trophyCatalogSynchronizer,
+        private readonly TrophyMetaRepository $trophyMetaRepository,
+        private readonly GameRescanGroupDataFetcher $groupDataFetcher,
+        private readonly TrophyImageDirectories $imageDirectories,
+        private readonly TrophyImageDownloader $imageDownloader,
+    ) {
+    }
+
+    public function updateFromPsn(
+        Client $client,
+        object $trophyTitle,
+        string $npCommunicationId,
+        GameRescanProgressReporter $progressReporter,
+        GameRescanDifferenceTracker $differenceTracker
+    ): array {
+        $existingTitleInfo = $this->trophyCatalogSynchronizer->fetchExistingTrophyTitleInfo($npCommunicationId);
+
+        if (!self::isSetVersionAtLeastCurrent((string) $trophyTitle->trophySetVersion(), $existingTitleInfo['set_version'])) {
+            $progressReporter->notify(70, 'Skipping trophy refresh because incoming set version is lower.');
+
+            return [];
+        }
+
+        $existingGroupData = $this->trophyCatalogSynchronizer->fetchExistingTrophyGroupData($npCommunicationId);
+        $existingTrophyData = $this->trophyCatalogSynchronizer->fetchExistingTrophyData($npCommunicationId);
+
+        $titleDetail = (string) $trophyTitle->detail();
+        $titleIconFilename = $this->imageDownloader->downloadMandatoryForRescan(
+            $trophyTitle->iconUrl(),
+            $this->imageDirectories->title,
+            $existingTitleInfo['icon']
+        );
+        $platforms = $this->buildPlatformList($trophyTitle, $existingTitleInfo['platforms']);
+
+        $differenceTracker->recordTitleChange('Detail', $existingTitleInfo['detail'], $titleDetail);
+        $differenceTracker->recordTitleChange('Icon', $existingTitleInfo['icon'], $titleIconFilename);
+        $differenceTracker->recordTitleChange('Platforms', $existingTitleInfo['platform'], $platforms);
+
+        $query = $this->database->prepare(
+            'UPDATE trophy_title
+            SET detail = :detail,
+                icon_url = :icon_url,
+                platform = :platform
+            WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':detail', $titleDetail, PDO::PARAM_STR);
+        $query->bindValue(':icon_url', $titleIconFilename, PDO::PARAM_STR);
+        $query->bindValue(':platform', $platforms, PDO::PARAM_STR);
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        $groupData = $this->groupDataFetcher->fetchGroupData($client, $npCommunicationId);
+        $totalSteps = array_reduce(
+            $groupData,
+            static fn (int $carry, array $data): int => $carry + 1 + count($data['trophies']),
+            0
+        );
+
+        if ($groupData === []) {
+            $progressReporter->notify(70, 'Refreshing trophy details…');
+
+            return [];
+        }
+
+        $currentStep = 0;
+        $totalGroups = count($groupData);
+        $processedGroups = 0;
+
+        foreach ($groupData as $data) {
+            $trophyGroup = $data['group'];
+            $groupId = (string) $trophyGroup->id();
+            $existingGroup = $existingGroupData[$groupId] ?? [
+                'name' => null,
+                'detail' => null,
+                'icon' => null,
+            ];
+
+            $groupIconFilename = $this->imageDownloader->downloadMandatoryForRescan(
+                $trophyGroup->iconUrl(),
+                $this->imageDirectories->group,
+                $existingGroup['icon']
+            );
+
+            $groupLabel = $progressReporter->describeTrophyGroup($trophyGroup);
+            $contextLabel = $groupLabel !== ''
+                ? $groupLabel
+                : ($existingGroup['name'] ?? ($existingGroup['detail'] ?? $groupId));
+            $contextLabel = (string) $contextLabel;
+
+            $differenceTracker->recordGroupChange(
+                $groupId,
+                $contextLabel,
+                'Detail',
+                $existingGroup['detail'],
+                (string) $trophyGroup->detail()
+            );
+            $differenceTracker->recordGroupChange(
+                $groupId,
+                $contextLabel,
+                'Icon',
+                $existingGroup['icon'],
+                $groupIconFilename
+            );
+
+            $this->trophyCatalogSynchronizer->upsertTrophyGroup(
+                $npCommunicationId,
+                (string) $trophyGroup->id(),
+                $trophyGroup->name(),
+                (string) $trophyGroup->detail(),
+                $groupIconFilename,
+                false,
+            );
+
+            $processedGroups++;
+            $currentStep++;
+            $progressReporter->notifyRange(
+                25,
+                70,
+                $currentStep,
+                $totalSteps,
+                sprintf(
+                    'Refreshing trophy group "%s" (%d/%d groups)',
+                    $contextLabel,
+                    $processedGroups,
+                    $totalGroups
+                )
+            );
+
+            $groupTrophyCount = count($data['trophies']);
+            $processedTrophiesInGroup = 0;
+
+            foreach ($data['trophies'] as $trophy) {
+                $orderId = (int) $trophy->id();
+                $trophyHidden = (int) $trophy->hidden();
+                $existingTrophy = $existingTrophyData[$groupId][$orderId] ?? [
+                    'hidden' => null,
+                    'type' => null,
+                    'name' => null,
+                    'detail' => null,
+                    'icon' => null,
+                    'progress_target_value' => null,
+                    'reward_name' => null,
+                    'reward_image' => null,
+                ];
+
+                $trophyIconFilename = $this->imageDownloader->downloadMandatoryForRescan(
+                    $trophy->iconUrl(),
+                    $this->imageDirectories->trophy,
+                    $existingTrophy['icon']
+                );
+                $rewardImageFilename = $this->imageDownloader->downloadOptionalForRescan(
+                    $trophy->rewardImageUrl(),
+                    $this->imageDirectories->reward,
+                    $existingTrophy['reward_image']
+                );
+
+                $trophyLabel = $progressReporter->describeTrophy($trophy);
+                $trophyContextLabel = $trophyLabel !== ''
+                    ? $trophyLabel
+                    : ($existingTrophy['name'] ?? ('#' . $orderId));
+                $trophyContextLabel = (string) $trophyContextLabel;
+
+                $differenceTracker->recordTrophyChange(
+                    $groupId,
+                    $orderId,
+                    $contextLabel,
+                    $trophyContextLabel,
+                    'Hidden',
+                    $existingTrophy['hidden'],
+                    $trophyHidden
+                );
+                $differenceTracker->recordTrophyChange(
+                    $groupId,
+                    $orderId,
+                    $contextLabel,
+                    $trophyContextLabel,
+                    'Type',
+                    $existingTrophy['type'],
+                    $trophy->type()->value
+                );
+                $differenceTracker->recordTrophyChange(
+                    $groupId,
+                    $orderId,
+                    $contextLabel,
+                    $trophyContextLabel,
+                    'Name',
+                    $existingTrophy['name'],
+                    $trophy->name()
+                );
+                $differenceTracker->recordTrophyChange(
+                    $groupId,
+                    $orderId,
+                    $contextLabel,
+                    $trophyContextLabel,
+                    'Detail',
+                    $existingTrophy['detail'],
+                    $trophy->detail()
+                );
+                $differenceTracker->recordTrophyChange(
+                    $groupId,
+                    $orderId,
+                    $contextLabel,
+                    $trophyContextLabel,
+                    'Icon',
+                    $existingTrophy['icon'],
+                    $trophyIconFilename
+                );
+
+                $normalizedProgressTargetValue = null;
+                $progressTargetValue = $trophy->progressTargetValue();
+                $normalizedProgressTargetValue = $progressTargetValue === ''
+                    ? null
+                    : (int) $progressTargetValue;
+
+                $differenceTracker->recordTrophyChange(
+                    $groupId,
+                    $orderId,
+                    $contextLabel,
+                    $trophyContextLabel,
+                    'Progress Target',
+                    $existingTrophy['progress_target_value'],
+                    $normalizedProgressTargetValue
+                );
+
+                $rewardName = $trophy->rewardName();
+                $normalizedRewardName = $rewardName === '' ? null : $rewardName;
+
+                $differenceTracker->recordTrophyChange(
+                    $groupId,
+                    $orderId,
+                    $contextLabel,
+                    $trophyContextLabel,
+                    'Reward Name',
+                    $existingTrophy['reward_name'],
+                    $normalizedRewardName
+                );
+                $differenceTracker->recordTrophyChange(
+                    $groupId,
+                    $orderId,
+                    $contextLabel,
+                    $trophyContextLabel,
+                    'Reward Image',
+                    $existingTrophy['reward_image'],
+                    $rewardImageFilename
+                );
+
+                $this->trophyCatalogSynchronizer->upsertTrophy(
+                    $npCommunicationId,
+                    (string) $trophyGroup->id(),
+                    (int) $trophy->id(),
+                    (int) $trophy->hidden(),
+                    $trophy->type()->value,
+                    $trophy->name(),
+                    $trophy->detail(),
+                    $trophyIconFilename,
+                    $normalizedProgressTargetValue,
+                    $normalizedRewardName,
+                    $rewardImageFilename,
+                );
+                $this->trophyMetaRepository->ensureExists($npCommunicationId, $trophyGroup->id(), (int) $trophy->id());
+
+                $processedTrophiesInGroup++;
+                $currentStep++;
+                $progressReporter->notifyRange(
+                    25,
+                    70,
+                    $currentStep,
+                    $totalSteps,
+                    sprintf(
+                        'Refreshing trophy "%s" in group "%s" (%d/%d trophies, group %d/%d)',
+                        $trophyContextLabel,
+                        $contextLabel,
+                        $processedTrophiesInGroup,
+                        max(1, $groupTrophyCount),
+                        $processedGroups,
+                        $totalGroups
+                    )
+                );
+            }
+        }
+
+        return array_map(
+            static fn (array $data) => $data['group'],
+            $groupData
+        );
+    }
+
+    public static function isSetVersionAtLeastCurrent(string $newVersion, ?string $currentVersion): bool
+    {
+        $normalizedCurrentVersion = $currentVersion === null ? null : trim($currentVersion);
+
+        if ($normalizedCurrentVersion === null || $normalizedCurrentVersion === '') {
+            return true;
+        }
+
+        return version_compare(trim($newVersion), $normalizedCurrentVersion, '>=');
+    }
+
+    /**
+     * @param array<int, string> $existingPlatforms
+     */
+    private function buildPlatformList(object $trophyTitle, array $existingPlatforms): string
+    {
+        $platforms = [];
+        foreach ($trophyTitle->platform() as $platform) {
+            $platforms[] = $platform->value;
+        }
+
+        $platforms = array_values(array_filter($platforms, static fn(string $platform): bool => $platform !== ''));
+        $platforms = array_values(array_unique($platforms));
+
+        $existingPlatforms = array_values(array_unique(array_filter(
+            $existingPlatforms,
+            static fn(string $platform): bool => $platform !== ''
+        )));
+
+        if (in_array('PSVR2', $existingPlatforms, true)) {
+            if (!in_array('PSVR2', $platforms, true)) {
+                $platforms[] = 'PSVR2';
+            }
+
+            if (!in_array('PS5', $existingPlatforms, true)) {
+                $platforms = array_values(array_filter(
+                    $platforms,
+                    static fn(string $platform): bool => $platform !== 'PS5'
+                ));
+            }
+        }
+
+        if (in_array('PSVR', $existingPlatforms, true)) {
+            if (!in_array('PSVR', $platforms, true)) {
+                $platforms[] = 'PSVR';
+            }
+
+            if (!in_array('PS4', $existingPlatforms, true)) {
+                $platforms = array_values(array_filter(
+                    $platforms,
+                    static fn(string $platform): bool => $platform !== 'PS4'
+                ));
+            }
+        }
+
+        return implode(',', $platforms);
+    }
+}

--- a/wwwroot/classes/Admin/GameRescanGroupDataFetcher.php
+++ b/wwwroot/classes/Admin/GameRescanGroupDataFetcher.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Tustin\PlayStation\Client;
+
+interface GameRescanGroupDataFetcher
+{
+    /**
+     * @return array<int, array{group: PsnTrophyGroupApiAdapter, trophies: array<int, PsnTrophyApiAdapter>}>
+     */
+    public function fetchGroupData(Client $client, string $npCommunicationId): array;
+}

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/GameRescanProgressListener.php';
 require_once __DIR__ . '/GameRescanProgressReporter.php';
 require_once __DIR__ . '/GameRescanDifferenceTracker.php';
 require_once __DIR__ . '/GameRescanResult.php';
+require_once __DIR__ . '/GameRescanCatalogUpdater.php';
 require_once __DIR__ . '/../ImageHashCalculator.php';
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../TrophyMetaRepository.php';
@@ -24,7 +25,6 @@ class GameRescanService
 {
     private PDO $database;
     private TrophyCalculator $trophyCalculator;
-    private TrophyMetaRepository $trophyMetaRepository;
 
     private TrophyHistoryRecorder $historyRecorder;
 
@@ -35,6 +35,7 @@ class GameRescanService
     private TrophyImageDownloader $imageDownloader;
     private GameRescanPsnAccessor $psnAccessor;
     private TrophyCatalogSynchronizer $trophyCatalogSynchronizer;
+    private GameRescanCatalogUpdater $catalogUpdater;
 
     /**
      * @var \Closure(string):void|null
@@ -53,12 +54,12 @@ class GameRescanService
         ?PlayStationWorkerAuthenticator $workerAuthenticator = null,
         ?GameRescanPsnAccessor $psnAccessor = null,
         ?TrophyCatalogSynchronizer $trophyCatalogSynchronizer = null,
+        ?GameRescanCatalogUpdater $catalogUpdater = null,
     )
     {
         $this->database = $database;
         $this->trophyCalculator = $trophyCalculator;
         $this->historyRecorder = $historyRecorder ?? new TrophyHistoryRecorder($database);
-        $this->trophyMetaRepository = new TrophyMetaRepository($database);
         $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
         $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase($database);
         $this->trophyLookupGroupDataProvider = $trophyLookupGroupDataProvider
@@ -70,6 +71,14 @@ class GameRescanService
             new WorkerService($database),
         );
         $this->psnAccessor = $psnAccessor ?? new GameRescanPsnAccessor($database, $workerAuthenticator);
+        $this->catalogUpdater = $catalogUpdater ?? new GameRescanCatalogUpdater(
+            $database,
+            $this->trophyCatalogSynchronizer,
+            new TrophyMetaRepository($database),
+            $this->trophyLookupGroupDataProvider,
+            $this->imageDirectories,
+            $this->imageDownloader,
+        );
     }
 
     /**
@@ -89,6 +98,15 @@ class GameRescanService
             function (string $message): void {
                 $this->logMessage($message);
             }
+        );
+        $previousCatalogUpdater = $this->catalogUpdater;
+        $this->catalogUpdater = new GameRescanCatalogUpdater(
+            $this->database,
+            $this->trophyCatalogSynchronizer,
+            new TrophyMetaRepository($this->database),
+            $this->trophyLookupGroupDataProvider,
+            $this->imageDirectories,
+            $this->imageDownloader,
         );
 
         try {
@@ -126,7 +144,7 @@ class GameRescanService
             }
 
             $progressReporter->notify(25, 'Refreshing trophy details…');
-            $trophyGroups = $this->updateTrophyTitle(
+            $trophyGroups = $this->catalogUpdater->updateFromPsn(
                 $client,
                 $trophyTitle,
                 $npCommunicationId,
@@ -161,6 +179,7 @@ class GameRescanService
         } finally {
             $this->logListener = $previousLogListener;
             $this->imageDownloader = $previousImageDownloader;
+            $this->catalogUpdater = $previousCatalogUpdater;
         }
     }
 
@@ -175,285 +194,6 @@ class GameRescanService
         $query = $this->database->prepare('INSERT INTO log(message) VALUES(:message)');
         $query->bindValue(':message', $message, PDO::PARAM_STR);
         $query->execute();
-    }
-
-    private function updateTrophyTitle(
-        Client $client,
-        object $trophyTitle,
-        string $npCommunicationId,
-        GameRescanProgressReporter $progressReporter,
-        GameRescanDifferenceTracker $differenceTracker
-    ): array {
-        $existingTitleInfo = $this->trophyCatalogSynchronizer->fetchExistingTrophyTitleInfo($npCommunicationId);
-
-        if (!self::isSetVersionAtLeastCurrent((string) $trophyTitle->trophySetVersion(), $existingTitleInfo['set_version'])) {
-            $progressReporter->notify(70, 'Skipping trophy refresh because incoming set version is lower.');
-
-            return [];
-        }
-
-        $existingGroupData = $this->trophyCatalogSynchronizer->fetchExistingTrophyGroupData($npCommunicationId);
-        $existingTrophyData = $this->trophyCatalogSynchronizer->fetchExistingTrophyData($npCommunicationId);
-
-        $titleDetail = (string) $trophyTitle->detail();
-        $titleIconFilename = $this->imageDownloader->downloadMandatoryForRescan(
-            $trophyTitle->iconUrl(),
-            $this->imageDirectories->title,
-            $existingTitleInfo['icon']
-        );
-        $platforms = $this->buildPlatformList($trophyTitle, $existingTitleInfo['platforms']);
-
-        $differenceTracker->recordTitleChange('Detail', $existingTitleInfo['detail'], $titleDetail);
-        $differenceTracker->recordTitleChange('Icon', $existingTitleInfo['icon'], $titleIconFilename);
-        $differenceTracker->recordTitleChange('Platforms', $existingTitleInfo['platform'], $platforms);
-
-        $query = $this->database->prepare(
-            'UPDATE trophy_title
-            SET detail = :detail,
-                icon_url = :icon_url,
-                platform = :platform
-            WHERE np_communication_id = :np_communication_id'
-        );
-        $query->bindValue(':detail', $titleDetail, PDO::PARAM_STR);
-        $query->bindValue(':icon_url', $titleIconFilename, PDO::PARAM_STR);
-        $query->bindValue(':platform', $platforms, PDO::PARAM_STR);
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->execute();
-
-        $groupData = $this->trophyLookupGroupDataProvider->fetchGroupData($client, $npCommunicationId);
-        $totalSteps = array_reduce(
-            $groupData,
-            static fn (int $carry, array $data): int => $carry + 1 + count($data['trophies']),
-            0
-        );
-
-        if ($groupData === []) {
-            $progressReporter->notify(70, 'Refreshing trophy details…');
-
-            return [];
-        }
-
-        $currentStep = 0;
-        $totalGroups = count($groupData);
-        $processedGroups = 0;
-
-        foreach ($groupData as $data) {
-            $trophyGroup = $data['group'];
-            $groupId = (string) $trophyGroup->id();
-            $existingGroup = $existingGroupData[$groupId] ?? [
-                'name' => null,
-                'detail' => null,
-                'icon' => null,
-            ];
-
-            $groupIconFilename = $this->imageDownloader->downloadMandatoryForRescan(
-                $trophyGroup->iconUrl(),
-                $this->imageDirectories->group,
-                $existingGroup['icon']
-            );
-
-            $groupLabel = $progressReporter->describeTrophyGroup($trophyGroup);
-            $contextLabel = $groupLabel !== ''
-                ? $groupLabel
-                : ($existingGroup['name'] ?? ($existingGroup['detail'] ?? $groupId));
-            $contextLabel = (string) $contextLabel;
-
-            $differenceTracker->recordGroupChange(
-                $groupId,
-                $contextLabel,
-                'Detail',
-                $existingGroup['detail'],
-                (string) $trophyGroup->detail()
-            );
-            $differenceTracker->recordGroupChange(
-                $groupId,
-                $contextLabel,
-                'Icon',
-                $existingGroup['icon'],
-                $groupIconFilename
-            );
-
-            $this->trophyCatalogSynchronizer->upsertTrophyGroup(
-                $npCommunicationId,
-                (string) $trophyGroup->id(),
-                $trophyGroup->name(),
-                (string) $trophyGroup->detail(),
-                $groupIconFilename,
-                false,
-            );
-
-            $processedGroups++;
-            $currentStep++;
-            $progressReporter->notifyRange(
-                25,
-                70,
-                $currentStep,
-                $totalSteps,
-                sprintf(
-                    'Refreshing trophy group "%s" (%d/%d groups)',
-                    $contextLabel,
-                    $processedGroups,
-                    $totalGroups
-                )
-            );
-
-            $groupTrophyCount = count($data['trophies']);
-            $processedTrophiesInGroup = 0;
-
-            foreach ($data['trophies'] as $trophy) {
-                $orderId = (int) $trophy->id();
-                $trophyHidden = (int) $trophy->hidden();
-                $existingTrophy = $existingTrophyData[$groupId][$orderId] ?? [
-                    'hidden' => null,
-                    'type' => null,
-                    'name' => null,
-                    'detail' => null,
-                    'icon' => null,
-                    'progress_target_value' => null,
-                    'reward_name' => null,
-                    'reward_image' => null,
-                ];
-
-                $trophyIconFilename = $this->imageDownloader->downloadMandatoryForRescan(
-                    $trophy->iconUrl(),
-                    $this->imageDirectories->trophy,
-                    $existingTrophy['icon']
-                );
-                $rewardImageFilename = $this->imageDownloader->downloadOptionalForRescan(
-                    $trophy->rewardImageUrl(),
-                    $this->imageDirectories->reward,
-                    $existingTrophy['reward_image']
-                );
-
-                $trophyLabel = $progressReporter->describeTrophy($trophy);
-                $trophyContextLabel = $trophyLabel !== ''
-                    ? $trophyLabel
-                    : ($existingTrophy['name'] ?? ('#' . $orderId));
-                $trophyContextLabel = (string) $trophyContextLabel;
-
-                $differenceTracker->recordTrophyChange(
-                    $groupId,
-                    $orderId,
-                    $contextLabel,
-                    $trophyContextLabel,
-                    'Hidden',
-                    $existingTrophy['hidden'],
-                    $trophyHidden
-                );
-                $differenceTracker->recordTrophyChange(
-                    $groupId,
-                    $orderId,
-                    $contextLabel,
-                    $trophyContextLabel,
-                    'Type',
-                    $existingTrophy['type'],
-                    $trophy->type()->value
-                );
-                $differenceTracker->recordTrophyChange(
-                    $groupId,
-                    $orderId,
-                    $contextLabel,
-                    $trophyContextLabel,
-                    'Name',
-                    $existingTrophy['name'],
-                    $trophy->name()
-                );
-                $differenceTracker->recordTrophyChange(
-                    $groupId,
-                    $orderId,
-                    $contextLabel,
-                    $trophyContextLabel,
-                    'Detail',
-                    $existingTrophy['detail'],
-                    $trophy->detail()
-                );
-                $differenceTracker->recordTrophyChange(
-                    $groupId,
-                    $orderId,
-                    $contextLabel,
-                    $trophyContextLabel,
-                    'Icon',
-                    $existingTrophy['icon'],
-                    $trophyIconFilename
-                );
-
-                $normalizedProgressTargetValue = null;
-                $progressTargetValue = $trophy->progressTargetValue();
-                $normalizedProgressTargetValue = $progressTargetValue === ''
-                    ? null
-                    : (int) $progressTargetValue;
-
-                $differenceTracker->recordTrophyChange(
-                    $groupId,
-                    $orderId,
-                    $contextLabel,
-                    $trophyContextLabel,
-                    'Progress Target',
-                    $existingTrophy['progress_target_value'],
-                    $normalizedProgressTargetValue
-                );
-
-                $rewardName = $trophy->rewardName();
-                $normalizedRewardName = $rewardName === '' ? null : $rewardName;
-
-                $differenceTracker->recordTrophyChange(
-                    $groupId,
-                    $orderId,
-                    $contextLabel,
-                    $trophyContextLabel,
-                    'Reward Name',
-                    $existingTrophy['reward_name'],
-                    $normalizedRewardName
-                );
-                $differenceTracker->recordTrophyChange(
-                    $groupId,
-                    $orderId,
-                    $contextLabel,
-                    $trophyContextLabel,
-                    'Reward Image',
-                    $existingTrophy['reward_image'],
-                    $rewardImageFilename
-                );
-
-                $this->trophyCatalogSynchronizer->upsertTrophy(
-                    $npCommunicationId,
-                    (string) $trophyGroup->id(),
-                    (int) $trophy->id(),
-                    (int) $trophy->hidden(),
-                    $trophy->type()->value,
-                    $trophy->name(),
-                    $trophy->detail(),
-                    $trophyIconFilename,
-                    $normalizedProgressTargetValue,
-                    $normalizedRewardName,
-                    $rewardImageFilename,
-                );
-                $this->trophyMetaRepository->ensureExists($npCommunicationId, $trophyGroup->id(), (int) $trophy->id());
-
-                $processedTrophiesInGroup++;
-                $currentStep++;
-                $progressReporter->notifyRange(
-                    25,
-                    70,
-                    $currentStep,
-                    $totalSteps,
-                    sprintf(
-                        'Refreshing trophy "%s" in group "%s" (%d/%d trophies, group %d/%d)',
-                        $trophyContextLabel,
-                        $contextLabel,
-                        $processedTrophiesInGroup,
-                        max(1, $groupTrophyCount),
-                        $processedGroups,
-                        $totalGroups
-                    )
-                );
-            }
-        }
-
-        return array_map(
-            static fn (array $data) => $data['group'],
-            $groupData
-        );
     }
 
     private function recalculateTrophies(
@@ -549,7 +289,7 @@ class GameRescanService
     ): void {
         $previousVersion = $this->fetchCurrentTrophySetVersion($npCommunicationId);
 
-        if (!self::isSetVersionAtLeastCurrent($setVersion, $previousVersion)) {
+        if (!GameRescanCatalogUpdater::isSetVersionAtLeastCurrent($setVersion, $previousVersion)) {
             return;
         }
 
@@ -563,17 +303,6 @@ class GameRescanService
         $query->execute();
 
         $differenceTracker->recordTitleChange('Set Version', $previousVersion, $setVersion);
-    }
-
-    private static function isSetVersionAtLeastCurrent(string $newVersion, ?string $currentVersion): bool
-    {
-        $normalizedCurrentVersion = $currentVersion === null ? null : trim($currentVersion);
-
-        if ($normalizedCurrentVersion === null || $normalizedCurrentVersion === '') {
-            return true;
-        }
-
-        return version_compare(trim($newVersion), $normalizedCurrentVersion, '>=');
     }
 
     private function recordRescan(int $gameId): void
@@ -602,52 +331,5 @@ class GameRescanService
         $version = (string) $version;
 
         return $version === '' ? null : $version;
-    }
-
-    /**
-     * @param array<int, string> $existingPlatforms
-     */
-    private function buildPlatformList(object $trophyTitle, array $existingPlatforms): string
-    {
-        $platforms = [];
-        foreach ($trophyTitle->platform() as $platform) {
-            $platforms[] = $platform->value;
-        }
-
-        $platforms = array_values(array_filter($platforms, static fn(string $platform): bool => $platform !== ''));
-        $platforms = array_values(array_unique($platforms));
-
-        $existingPlatforms = array_values(array_unique(array_filter(
-            $existingPlatforms,
-            static fn(string $platform): bool => $platform !== ''
-        )));
-
-        if (in_array('PSVR2', $existingPlatforms, true)) {
-            if (!in_array('PSVR2', $platforms, true)) {
-                $platforms[] = 'PSVR2';
-            }
-
-            if (!in_array('PS5', $existingPlatforms, true)) {
-                $platforms = array_values(array_filter(
-                    $platforms,
-                    static fn(string $platform): bool => $platform !== 'PS5'
-                ));
-            }
-        }
-
-        if (in_array('PSVR', $existingPlatforms, true)) {
-            if (!in_array('PSVR', $platforms, true)) {
-                $platforms[] = 'PSVR';
-            }
-
-            if (!in_array('PS4', $existingPlatforms, true)) {
-                $platforms = array_values(array_filter(
-                    $platforms,
-                    static fn(string $platform): bool => $platform !== 'PS4'
-                ));
-            }
-        }
-
-        return implode(',', $platforms);
     }
 }

--- a/wwwroot/classes/Admin/PsnTrophyLookupGroupDataProvider.php
+++ b/wwwroot/classes/Admin/PsnTrophyLookupGroupDataProvider.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PsnGameLookupService.php';
+require_once __DIR__ . '/GameRescanGroupDataFetcher.php';
 require_once __DIR__ . '/PsnTrophyApiAdapter.php';
 require_once __DIR__ . '/PsnTrophyGroupApiAdapter.php';
 
@@ -11,7 +12,7 @@ use Tustin\PlayStation\Client;
 /**
  * Fetches PSN trophy group data and adapts raw API payloads to objects used during game rescans.
  */
-final class PsnTrophyLookupGroupDataProvider
+final class PsnTrophyLookupGroupDataProvider implements GameRescanGroupDataFetcher
 {
     public function __construct(
         private readonly PsnGameLookupService $psnGameLookupService,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels trophy catalog synchronization out of `GameRescanService` (654 → 335 lines) into a new `GameRescanCatalogUpdater` class. This is the first step in breaking down the admin rescan god class — one concern per PR.

**Extracted concern:** refreshing trophy title, group, and trophy rows from PSN during admin rescans (including set-version gating, image downloads, diff tracking, and platform list merging).

**Still in `GameRescanService`:** worker auth, player lookup, stat recalculation, set-version persistence, rescan audit logging.

## Changes

- Add `GameRescanCatalogUpdater` with `updateFromPsn()` and `isSetVersionAtLeastCurrent()`
- Add `GameRescanGroupDataFetcher` interface (implemented by `PsnTrophyLookupGroupDataProvider`) for testable group-data injection
- `GameRescanService::rescan()` delegates catalog refresh to the new class
- Add `GameRescanCatalogUpdaterTest` covering version gating, title diff recording, and PSVR2 platform preservation

## Follow-up PRs (not in scope)

- `GameRescanStatsRecalculator` — trophy/parent stat recalculation
- `TrophySetVersionUpdater` — set-version DB update logic
- Converge catalog sync with `PlayerScanTitleCatalogSynchronizer` (shared pipeline)

## Test plan

- [x] `php tests/run.php` — 835 tests, 0 failures
- [x] New `GameRescanCatalogUpdaterTest` (3 cases)
- [x] Existing `GameRescanServiceSetVersionTest` updated for moved `isSetVersionAtLeastCurrent`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73b7978f-6b4a-49c3-b683-cc935002dc1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73b7978f-6b4a-49c3-b683-cc935002dc1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

