### PR TITLE
Extract TrophyStatusUpdateResult DTO and HTML presenter from TrophyStatusService

### DIFF
--- a/tests/TrophyStatusUpdateResultPresenterTest.php
+++ b/tests/TrophyStatusUpdateResultPresenterTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyStatusUpdateResult.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyStatusUpdateResultPresenter.php';
+
+final class TrophyStatusUpdateResultPresenterTest extends TestCase
+{
+    public function testRenderToHtmlEscapesTrophyNamesAndStatusText(): void
+    {
+        $presenter = new TrophyStatusUpdateResultPresenter();
+        $result = new TrophyStatusUpdateResult(
+            ['1 (Test &amp; Trophy)', '2 (<script>)'],
+            'unobtainable &amp; locked',
+        );
+
+        $html = $presenter->renderToHtml($result);
+
+        $this->assertSame(
+            '<p>Trophy ID 1 (Test &amp;amp; Trophy)<br>Trophy ID 2 (&lt;script&gt;)<br>is now set as unobtainable &amp;amp; locked</p>',
+            $html,
+        );
+    }
+}

--- a/wwwroot/classes/Admin/TrophyStatusPage.php
+++ b/wwwroot/classes/Admin/TrophyStatusPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/TrophyStatusInputParser.php';
 require_once __DIR__ . '/TrophyStatusService.php';
+require_once __DIR__ . '/TrophyStatusUpdateResultPresenter.php';
 
 class TrophyStatusPageResult
 {
@@ -47,12 +48,16 @@ class TrophyStatusPage
 
     private TrophyStatusService $trophyStatusService;
 
+    private TrophyStatusUpdateResultPresenter $trophyStatusUpdateResultPresenter;
+
     public function __construct(
         TrophyStatusInputParser $trophyStatusInputParser,
         TrophyStatusService $trophyStatusService,
+        ?TrophyStatusUpdateResultPresenter $trophyStatusUpdateResultPresenter = null,
     ) {
         $this->trophyStatusInputParser = $trophyStatusInputParser;
         $this->trophyStatusService = $trophyStatusService;
+        $this->trophyStatusUpdateResultPresenter = $trophyStatusUpdateResultPresenter ?? new TrophyStatusUpdateResultPresenter();
     }
 
     /**
@@ -90,7 +95,7 @@ class TrophyStatusPage
                 }
 
                 $result = $this->trophyStatusService->updateTrophies($trophyIds, $status);
-                $message = $result->toHtml();
+                $message = $this->trophyStatusUpdateResultPresenter->renderToHtml($result);
             } catch (\Throwable $exception) {
                 $message = '<p>' . htmlspecialchars($exception->getMessage(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</p>';
             }

--- a/wwwroot/classes/Admin/TrophyStatusService.php
+++ b/wwwroot/classes/Admin/TrophyStatusService.php
@@ -2,48 +2,7 @@
 
 declare(strict_types=1);
 
-class TrophyStatusUpdateResult
-{
-    /** @var string[] */
-    private array $trophyNames;
-
-    private string $statusText;
-
-    /**
-     * @param string[] $trophyNames
-     */
-    public function __construct(array $trophyNames, string $statusText)
-    {
-        $this->trophyNames = $trophyNames;
-        $this->statusText = $statusText;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getTrophyNames(): array
-    {
-        return $this->trophyNames;
-    }
-
-    public function getStatusText(): string
-    {
-        return $this->statusText;
-    }
-
-    public function toHtml(): string
-    {
-        $html = '<p>';
-
-        foreach ($this->trophyNames as $trophyName) {
-            $html .= 'Trophy ID ' . htmlspecialchars($trophyName, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '<br>';
-        }
-
-        $html .= 'is now set as ' . htmlspecialchars($this->statusText, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</p>';
-
-        return $html;
-    }
-}
+require_once __DIR__ . '/TrophyStatusUpdateResult.php';
 
 class TrophyStatusService
 {

--- a/wwwroot/classes/Admin/TrophyStatusUpdateResult.php
+++ b/wwwroot/classes/Admin/TrophyStatusUpdateResult.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+final readonly class TrophyStatusUpdateResult
+{
+    /**
+     * @param string[] $trophyNames
+     */
+    public function __construct(
+        private array $trophyNames,
+        private string $statusText,
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getTrophyNames(): array
+    {
+        return $this->trophyNames;
+    }
+
+    public function getStatusText(): string
+    {
+        return $this->statusText;
+    }
+}

--- a/wwwroot/classes/Admin/TrophyStatusUpdateResultPresenter.php
+++ b/wwwroot/classes/Admin/TrophyStatusUpdateResultPresenter.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TrophyStatusUpdateResult.php';
+require_once __DIR__ . '/../Html.php';
+
+final class TrophyStatusUpdateResultPresenter
+{
+    public function renderToHtml(TrophyStatusUpdateResult $result): string
+    {
+        $html = '<p>';
+
+        foreach ($result->getTrophyNames() as $trophyName) {
+            $html .= 'Trophy ID ' . Html::escape($trophyName) . '<br>';
+        }
+
+        $html .= 'is now set as ' . Html::escape($result->getStatusText()) . '</p>';
+
+        return $html;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`TrophyStatusService` mixed domain logic (status updates, aggregate recalculation) with presentation (`TrophyStatusUpdateResult::toHtml()`). This PR peels off the first concern: a pure result DTO plus a small admin presenter.

## Changes

- **`TrophyStatusUpdateResult`** — moved to its own file as a readonly value object (data only).
- **`TrophyStatusUpdateResultPresenter`** — renders the admin success message using `Html::escape()`.
- **`TrophyStatusPage`** — delegates HTML rendering to the presenter (optional constructor injection for tests).
- **`TrophyStatusService`** — now only returns the DTO; no HTML knowledge.

## Why this first

`TrophyStatusService` (~485 lines) is a god-class candidate: it handles trophy status writes, group/title/player aggregate SQL, temp-table management, and changelog inserts. Extracting the DTO/presenter is a low-risk, zero-behavior-change step that clears the path for a follow-up PR to extract `UnobtainableTrophyAggregateRecalculator` (~300 lines of SQL).

## Testing

- Added `TrophyStatusUpdateResultPresenterTest` (HTML escaping).
- Full suite: `php tests/run.php` — 836 tests passed.

## Follow-up candidates (not in this PR)

1. Extract aggregate recalculation from `TrophyStatusService`.
2. Extract `PsnTrophyPayloadGrouper` from `PsnGameLookupService`.
3. Extract per-group sync loop from `PlayerScanTitleCatalogSynchronizer`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02562a5e-b047-4404-aad8-ce820fef81dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02562a5e-b047-4404-aad8-ce820fef81dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

