### PR TITLE
Peel merge metadata persistence out of TrophyMergeService

### DIFF
--- a/tests/TrophyMergeMetadataRepositoryTest.php
+++ b/tests/TrophyMergeMetadataRepositoryTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/NestedDatabaseTransactionRunner.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMergeMetadataRepository.php';
+
+final class TrophyMergeMetadataRepositoryTest extends TestCase
+{
+    private PDO $database;
+    private TrophyMergeMetadataRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->createTables();
+
+        $this->repository = new TrophyMergeMetadataRepository(
+            $this->database,
+            new NestedDatabaseTransactionRunner($this->database)
+        );
+    }
+
+    public function testUpdateParentRelationshipStoresParentInMeta(): void
+    {
+        $this->insertGame(1, 'NP_PARENT', 'PS4');
+        $this->insertGame(2, 'NP_CHILD', 'PS4,PS5');
+        $this->insertMeta('NP_PARENT', null, 0);
+        $this->insertMeta('NP_CHILD', null, 0);
+
+        $this->repository->updateParentRelationship('NP_CHILD', 'NP_PARENT');
+
+        $parent = $this->database
+            ->query("SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NP_CHILD'")
+            ->fetchColumn();
+        $this->assertSame('NP_PARENT', $parent, 'Expected child to reference parent in meta table.');
+
+        $platform = $this->database
+            ->query("SELECT platform FROM trophy_title WHERE np_communication_id = 'NP_PARENT'")
+            ->fetchColumn();
+        $this->assertSame('PS4,PS5', $platform, 'Expected parent platforms to include child platforms.');
+    }
+
+    public function testMarkGameAsMergedByNpIdUpdatesMetaStatus(): void
+    {
+        $this->insertGame(1, 'NP_CHILD', 'PS4');
+        $this->insertMeta('NP_CHILD', null, 0);
+
+        $this->repository->markGameAsMergedByNpId('NP_CHILD');
+
+        $status = $this->database
+            ->query("SELECT status FROM trophy_title_meta WHERE np_communication_id = 'NP_CHILD'")
+            ->fetchColumn();
+        $this->assertSame(2, (int) $status, 'Expected merged game status to be stored in meta table.');
+    }
+
+    public function testMarkGameAsMergedByIdUpdatesMetaStatus(): void
+    {
+        $this->insertGame(42, 'NP_CHILD', 'PS4');
+        $this->insertMeta('NP_CHILD', null, 0);
+
+        $this->repository->markGameAsMergedById(42);
+
+        $status = $this->database
+            ->query("SELECT status FROM trophy_title_meta WHERE np_communication_id = 'NP_CHILD'")
+            ->fetchColumn();
+        $this->assertSame(2, (int) $status, 'Expected merged game status to be stored in meta table.');
+    }
+
+    public function testLogChangeInsertsChangelogRow(): void
+    {
+        $this->repository->logChange('GAME_MERGE', 10, 20);
+
+        $row = $this->database
+            ->query("SELECT change_type, param_1, param_2 FROM psn100_change")
+            ->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertSame('GAME_MERGE', $row['change_type']);
+        $this->assertSame(10, (int) $row['param_1']);
+        $this->assertSame(20, (int) $row['param_2']);
+    }
+
+    private function createTables(): void
+    {
+        $this->database->exec(
+            'CREATE TABLE trophy_title (
+                id INTEGER PRIMARY KEY,
+                np_communication_id TEXT NOT NULL UNIQUE,
+                platform TEXT NOT NULL
+            )'
+        );
+
+        $this->database->exec(
+            'CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                parent_np_communication_id TEXT NULL,
+                status INTEGER NOT NULL DEFAULT 0,
+                obsolete_ids TEXT NULL,
+                psnprofiles_id TEXT NULL,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0
+            )'
+        );
+
+        $this->database->exec(
+            'CREATE TABLE psn100_change (
+                change_type TEXT NOT NULL,
+                param_1 INTEGER NOT NULL,
+                param_2 INTEGER NOT NULL
+            )'
+        );
+    }
+
+    private function insertGame(int $id, string $npCommunicationId, string $platform): void
+    {
+        $query = $this->database->prepare(
+            'INSERT INTO trophy_title (id, np_communication_id, platform) VALUES (:id, :np_communication_id, :platform)'
+        );
+        $query->bindValue(':id', $id, PDO::PARAM_INT);
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':platform', $platform, PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    private function insertMeta(string $npCommunicationId, ?string $parent, int $status): void
+    {
+        $query = $this->database->prepare(
+            'INSERT INTO trophy_title_meta (np_communication_id, parent_np_communication_id, status) VALUES (:np_communication_id, :parent_np_communication_id, :status)'
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+
+        if ($parent === null) {
+            $query->bindValue(':parent_np_communication_id', null, PDO::PARAM_NULL);
+        } else {
+            $query->bindValue(':parent_np_communication_id', $parent, PDO::PARAM_STR);
+        }
+
+        $query->bindValue(':status', $status, PDO::PARAM_INT);
+        $query->execute();
+    }
+}

--- a/tests/TrophyMergeServiceMetaUsageTest.php
+++ b/tests/TrophyMergeServiceMetaUsageTest.php
@@ -2,13 +2,11 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../wwwroot/classes/TrophyMergeService.php';
 require_once __DIR__ . '/../wwwroot/classes/TrophyMergePlayerProgressUpdater.php';
 
 final class TrophyMergeServiceMetaUsageTest extends TestCase
 {
     private PDO $database;
-    private TrophyMergeService $service;
 
     protected function setUp(): void
     {
@@ -16,60 +14,6 @@ final class TrophyMergeServiceMetaUsageTest extends TestCase
         $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         $this->createTables();
-
-        $this->service = new TrophyMergeService($this->database);
-    }
-
-    public function testUpdateParentRelationshipStoresParentInMeta(): void
-    {
-        $this->insertGame(1, 'NP_PARENT', 'PS4');
-        $this->insertGame(2, 'NP_CHILD', 'PS4,PS5');
-        $this->insertMeta('NP_PARENT', null, 0);
-        $this->insertMeta('NP_CHILD', null, 0);
-
-        $method = new ReflectionMethod(TrophyMergeService::class, 'updateParentRelationship');
-        $method->setAccessible(true);
-        $method->invoke($this->service, 'NP_CHILD', 'NP_PARENT');
-
-        $parent = $this->database
-            ->query("SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NP_CHILD'")
-            ->fetchColumn();
-        $this->assertSame('NP_PARENT', $parent, 'Expected child to reference parent in meta table.');
-
-        $platform = $this->database
-            ->query("SELECT platform FROM trophy_title WHERE np_communication_id = 'NP_PARENT'")
-            ->fetchColumn();
-        $this->assertSame('PS4,PS5', $platform, 'Expected parent platforms to include child platforms.');
-    }
-
-    public function testMarkGameAsMergedByNpIdUpdatesMetaStatus(): void
-    {
-        $this->insertGame(1, 'NP_CHILD', 'PS4');
-        $this->insertMeta('NP_CHILD', null, 0);
-
-        $method = new ReflectionMethod(TrophyMergeService::class, 'markGameAsMergedByNpId');
-        $method->setAccessible(true);
-        $method->invoke($this->service, 'NP_CHILD');
-
-        $status = $this->database
-            ->query("SELECT status FROM trophy_title_meta WHERE np_communication_id = 'NP_CHILD'")
-            ->fetchColumn();
-        $this->assertSame(2, (int) $status, 'Expected merged game status to be stored in meta table.');
-    }
-
-    public function testMarkGameAsMergedByIdUpdatesMetaStatus(): void
-    {
-        $this->insertGame(42, 'NP_CHILD', 'PS4');
-        $this->insertMeta('NP_CHILD', null, 0);
-
-        $method = new ReflectionMethod(TrophyMergeService::class, 'markGameAsMergedById');
-        $method->setAccessible(true);
-        $method->invoke($this->service, 42);
-
-        $status = $this->database
-            ->query("SELECT status FROM trophy_title_meta WHERE np_communication_id = 'NP_CHILD'")
-            ->fetchColumn();
-        $this->assertSame(2, (int) $status, 'Expected merged game status to be stored in meta table.');
     }
 
     public function testGetMergeParentAndChildrenPrefersMetaParent(): void
@@ -88,14 +32,6 @@ final class TrophyMergeServiceMetaUsageTest extends TestCase
 
     private function createTables(): void
     {
-        $this->database->exec(
-            'CREATE TABLE trophy_title (
-                id INTEGER PRIMARY KEY,
-                np_communication_id TEXT NOT NULL UNIQUE,
-                platform TEXT NOT NULL
-            )'
-        );
-
         $this->database->exec(
             'CREATE TABLE trophy_title_meta (
                 np_communication_id TEXT PRIMARY KEY,
@@ -117,17 +53,6 @@ final class TrophyMergeServiceMetaUsageTest extends TestCase
                 parent_order_id INTEGER NOT NULL
             )'
         );
-    }
-
-    private function insertGame(int $id, string $npCommunicationId, string $platform): void
-    {
-        $query = $this->database->prepare(
-            'INSERT INTO trophy_title (id, np_communication_id, platform) VALUES (:id, :np_communication_id, :platform)'
-        );
-        $query->bindValue(':id', $id, PDO::PARAM_INT);
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->bindValue(':platform', $platform, PDO::PARAM_STR);
-        $query->execute();
     }
 
     private function insertMeta(string $npCommunicationId, ?string $parent, int $status): void

--- a/wwwroot/classes/TrophyMergeMetadataRepository.php
+++ b/wwwroot/classes/TrophyMergeMetadataRepository.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
+
+/**
+ * Persists trophy-title merge metadata: merged status, parent links, platform union, and changelog rows.
+ */
+final class TrophyMergeMetadataRepository
+{
+    private const PLATFORM_ORDER = ['PS3', 'PSVITA', 'PS4', 'PSVR', 'PS5', 'PSVR2', 'PC'];
+
+    public function __construct(
+        private readonly PDO $database,
+        private readonly NestedDatabaseTransactionRunner $transactionRunner
+    ) {
+    }
+
+    public function markGameAsMergedByNpId(string $npCommunicationId): void
+    {
+        $this->transactionRunner->execute(function () use ($npCommunicationId): void {
+            $query = $this->database->prepare(
+                <<<'SQL'
+                UPDATE trophy_title_meta
+                SET    status = 2
+                WHERE  np_communication_id = :child_np_communication_id
+                SQL
+            );
+            $query->bindValue(':child_np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+            $query->execute();
+        });
+    }
+
+    public function markGameAsMergedById(int $gameId): void
+    {
+        $this->transactionRunner->execute(function () use ($gameId): void {
+            $lookup = $this->database->prepare(
+                <<<'SQL'
+                SELECT np_communication_id
+                FROM   trophy_title
+                WHERE  id = :game_id
+                SQL
+            );
+            $lookup->bindValue(':game_id', $gameId, PDO::PARAM_INT);
+            $lookup->execute();
+
+            $npCommunicationId = $lookup->fetchColumn();
+
+            if ($npCommunicationId === false || $npCommunicationId === null) {
+                return;
+            }
+
+            $query = $this->database->prepare(
+                <<<'SQL'
+                UPDATE trophy_title_meta
+                SET    status = 2
+                WHERE  np_communication_id = :np_communication_id
+                SQL
+            );
+            $query->bindValue(':np_communication_id', (string) $npCommunicationId, PDO::PARAM_STR);
+            $query->execute();
+        });
+    }
+
+    public function updateParentRelationship(string $childNpCommunicationId, string $parentNpCommunicationId): void
+    {
+        $query = $this->database->prepare(
+            'UPDATE trophy_title_meta SET parent_np_communication_id = :parent_np_communication_id WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        if ($query->rowCount() === 0) {
+            $metaExists = $this->database->prepare(
+                'SELECT 1 FROM trophy_title_meta WHERE np_communication_id = :np_communication_id'
+            );
+            $metaExists->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+            $metaExists->execute();
+
+            if ($metaExists->fetchColumn() === false) {
+                $metaInsert = $this->database->prepare(
+                    <<<'SQL'
+                    INSERT INTO trophy_title_meta (
+                        np_communication_id,
+                        message,
+                        parent_np_communication_id,
+                        status
+                    ) VALUES (
+                        :np_communication_id,
+                        '',
+                        :parent_np_communication_id,
+                        2
+                    )
+SQL
+                );
+                $metaInsert->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+                $metaInsert->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+                $metaInsert->execute();
+            }
+        }
+
+        $this->updateParentPlatform($parentNpCommunicationId, $childNpCommunicationId);
+    }
+
+    public function logChange(string $changeType, int $param1, int $param2): void
+    {
+        $query = $this->database->prepare(
+            'INSERT INTO `psn100_change` (`change_type`, `param_1`, `param_2`) VALUES (:change_type, :param_1, :param_2)'
+        );
+        $query->bindValue(':change_type', $changeType, PDO::PARAM_STR);
+        $query->bindValue(':param_1', $param1, PDO::PARAM_INT);
+        $query->bindValue(':param_2', $param2, PDO::PARAM_INT);
+        $query->execute();
+    }
+
+    private function updateParentPlatform(string $parentNpCommunicationId, string $childNpCommunicationId): void
+    {
+        $parentPlatforms = $this->getPlatformsByNpCommunicationId($parentNpCommunicationId);
+        $childPlatforms = $this->getPlatformsByNpCommunicationId($childNpCommunicationId);
+
+        if ($childPlatforms === []) {
+            return;
+        }
+
+        $platformLookup = [];
+        foreach ($parentPlatforms as $platform) {
+            if ($platform === '') {
+                continue;
+            }
+
+            $platformLookup[$platform] = true;
+        }
+
+        $updated = false;
+
+        foreach ($childPlatforms as $platform) {
+            if ($platform === '') {
+                continue;
+            }
+
+            if (!isset($platformLookup[$platform])) {
+                $platformLookup[$platform] = true;
+                $updated = true;
+            }
+        }
+
+        if (!$updated) {
+            return;
+        }
+
+        $sortedPlatforms = $this->sortPlatforms(array_keys($platformLookup));
+
+        $query = $this->database->prepare(
+            'UPDATE trophy_title SET platform = :platform WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':platform', implode(',', $sortedPlatforms), PDO::PARAM_STR);
+        $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getPlatformsByNpCommunicationId(string $npCommunicationId): array
+    {
+        $query = $this->database->prepare(
+            'SELECT platform FROM trophy_title WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        $platforms = $query->fetchColumn();
+
+        if ($platforms === false || $platforms === null || $platforms === '') {
+            return [];
+        }
+
+        $platforms = array_map('trim', explode(',', (string) $platforms));
+        $platforms = array_filter($platforms, static fn(string $platform): bool => $platform !== '');
+
+        return array_values($platforms);
+    }
+
+    /**
+     * @param list<string> $platforms
+     *
+     * @return list<string>
+     */
+    private function sortPlatforms(array $platforms): array
+    {
+        $order = array_flip(self::PLATFORM_ORDER);
+
+        usort(
+            $platforms,
+            static function (string $left, string $right) use ($order): int {
+                $leftOrder = $order[$left] ?? PHP_INT_MAX;
+                $rightOrder = $order[$right] ?? PHP_INT_MAX;
+
+                if ($leftOrder === $rightOrder) {
+                    return strcmp($left, $right);
+                }
+
+                return $leftOrder <=> $rightOrder;
+            }
+        );
+
+        return $platforms;
+    }
+}

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -7,13 +7,12 @@ require_once __DIR__ . '/Admin/TrophyMergeProgressListener.php';
 require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
 require_once __DIR__ . '/TrophyMergeEarnedCopier.php';
 require_once __DIR__ . '/TrophyMergeMappingService.php';
+require_once __DIR__ . '/TrophyMergeMetadataRepository.php';
 require_once __DIR__ . '/TrophyMergePlayerProgressUpdater.php';
 require_once __DIR__ . '/TrophyTitleCloneService.php';
 
 class TrophyMergeService
 {
-    private const PLATFORM_ORDER = ['PS3', 'PSVITA', 'PS4', 'PSVR', 'PS5', 'PSVR2', 'PC'];
-
     private PDO $database;
 
     private NestedDatabaseTransactionRunner $transactionRunner;
@@ -21,6 +20,8 @@ class TrophyMergeService
     private ?TrophyMergeEarnedCopier $earnedCopier = null;
 
     private ?TrophyMergeMappingService $mappingService = null;
+
+    private ?TrophyMergeMetadataRepository $metadataRepository = null;
 
     private ?TrophyMergePlayerProgressUpdater $playerProgressUpdater = null;
 
@@ -70,7 +71,7 @@ class TrophyMergeService
                 $childTrophy = $childData['trophy'];
 
                 $this->insertTrophyMergeMappingFromIds($childTrophyId, $parentTrophyId);
-                $this->markGameAsMergedByNpId($childTrophy['np_communication_id']);
+                $this->metadataRepository()->markGameAsMergedByNpId($childTrophy['np_communication_id']);
 
                 $childGameId = $this->getGameIdByTrophyId($childTrophyId);
 
@@ -143,7 +144,7 @@ class TrophyMergeService
             $this->notifyProgress($progressListener, 55, 'Trophy mappings saved.');
             $this->notifyProgress($progressListener, 60, 'Preparing to mark child game as merged…');
             $this->notifyProgress($progressListener, 62, 'Marking child game as merged…');
-            $this->markGameAsMergedById($childGameId);
+            $this->metadataRepository()->markGameAsMergedById($childGameId);
             $this->notifyProgress($progressListener, 65, 'Child game marked as merged.');
             $this->notifyProgress($progressListener, 70, 'Preparing to copy merged trophies…');
             $this->notifyProgress($progressListener, 72, 'Copying merged trophies…');
@@ -156,10 +157,10 @@ class TrophyMergeService
             $this->updateTrophyTitlePlayer($childGameId);
             $this->notifyProgress($progressListener, 92, 'Player trophy titles updated.');
             $this->notifyProgress($progressListener, 94, 'Updating parent relationship…');
-            $this->updateParentRelationship($childNpCommunicationId, $parentNpCommunicationId);
+            $this->metadataRepository()->updateParentRelationship($childNpCommunicationId, $parentNpCommunicationId);
             $this->notifyProgress($progressListener, 96, 'Parent relationship updated.');
             $this->notifyProgress($progressListener, 98, 'Logging merge activity…');
-            $this->logChange('GAME_MERGE', $childGameId, $parentGameId);
+            $this->metadataRepository()->logChange('GAME_MERGE', $childGameId, $parentGameId);
             $this->notifyProgress($progressListener, 100, 'Merge process complete.');
         });
 
@@ -265,6 +266,14 @@ SQL
         return $this->mappingService ??= new TrophyMergeMappingService($this->database);
     }
 
+    private function metadataRepository(): TrophyMergeMetadataRepository
+    {
+        return $this->metadataRepository ??= new TrophyMergeMetadataRepository(
+            $this->database,
+            $this->transactionRunner
+        );
+    }
+
     private function playerProgressUpdater(): TrophyMergePlayerProgressUpdater
     {
         return $this->playerProgressUpdater ??= new TrophyMergePlayerProgressUpdater($this->database);
@@ -306,190 +315,6 @@ SQL
             $query->bindValue(':parent_trophy_id', $parentTrophyId, PDO::PARAM_INT);
             $query->execute();
         });
-    }
-
-    private function markGameAsMergedByNpId(string $npCommunicationId): void
-    {
-        $this->transactionRunner->execute(function () use ($npCommunicationId): void {
-            $query = $this->database->prepare(
-                <<<'SQL'
-                UPDATE trophy_title_meta
-                SET    status = 2
-                WHERE  np_communication_id = :child_np_communication_id
-                SQL
-            );
-            $query->bindValue(':child_np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-            $query->execute();
-        });
-    }
-
-    private function markGameAsMergedById(int $gameId): void
-    {
-        $this->transactionRunner->execute(function () use ($gameId): void {
-            $lookup = $this->database->prepare(
-                <<<'SQL'
-                SELECT np_communication_id
-                FROM   trophy_title
-                WHERE  id = :game_id
-                SQL
-            );
-            $lookup->bindValue(':game_id', $gameId, PDO::PARAM_INT);
-            $lookup->execute();
-
-            $npCommunicationId = $lookup->fetchColumn();
-
-            if ($npCommunicationId === false || $npCommunicationId === null) {
-                return;
-            }
-
-            $query = $this->database->prepare(
-                <<<'SQL'
-                UPDATE trophy_title_meta
-                SET    status = 2
-                WHERE  np_communication_id = :np_communication_id
-                SQL
-            );
-            $query->bindValue(':np_communication_id', (string) $npCommunicationId, PDO::PARAM_STR);
-            $query->execute();
-        });
-    }
-
-    private function updateParentRelationship(string $childNpCommunicationId, string $parentNpCommunicationId): void
-    {
-        $query = $this->database->prepare(
-            "UPDATE trophy_title_meta SET parent_np_communication_id = :parent_np_communication_id WHERE np_communication_id = :np_communication_id"
-        );
-        $query->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
-        $query->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-        $query->execute();
-
-        if ($query->rowCount() === 0) {
-            $metaExists = $this->database->prepare(
-                'SELECT 1 FROM trophy_title_meta WHERE np_communication_id = :np_communication_id'
-            );
-            $metaExists->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-            $metaExists->execute();
-
-            if ($metaExists->fetchColumn() === false) {
-                $metaInsert = $this->database->prepare(
-                    <<<'SQL'
-                    INSERT INTO trophy_title_meta (
-                        np_communication_id,
-                        message,
-                        parent_np_communication_id,
-                        status
-                    ) VALUES (
-                        :np_communication_id,
-                        '',
-                        :parent_np_communication_id,
-                        2
-                    )
-SQL
-                );
-                $metaInsert->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-                $metaInsert->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
-                $metaInsert->execute();
-            }
-        }
-
-        $this->updateParentPlatform($parentNpCommunicationId, $childNpCommunicationId);
-    }
-
-    private function updateParentPlatform(string $parentNpCommunicationId, string $childNpCommunicationId): void
-    {
-        $parentPlatforms = $this->getPlatformsByNpCommunicationId($parentNpCommunicationId);
-        $childPlatforms = $this->getPlatformsByNpCommunicationId($childNpCommunicationId);
-
-        if ($childPlatforms === []) {
-            return;
-        }
-
-        $platformLookup = [];
-        foreach ($parentPlatforms as $platform) {
-            if ($platform === '') {
-                continue;
-            }
-
-            $platformLookup[$platform] = true;
-        }
-
-        $updated = false;
-
-        foreach ($childPlatforms as $platform) {
-            if ($platform === '') {
-                continue;
-            }
-
-            if (!isset($platformLookup[$platform])) {
-                $platformLookup[$platform] = true;
-                $updated = true;
-            }
-        }
-
-        if (!$updated) {
-            return;
-        }
-
-        $sortedPlatforms = $this->sortPlatforms(array_keys($platformLookup));
-
-        $query = $this->database->prepare(
-            'UPDATE trophy_title SET platform = :platform WHERE np_communication_id = :np_communication_id'
-        );
-        $query->bindValue(':platform', implode(',', $sortedPlatforms), PDO::PARAM_STR);
-        $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
-        $query->execute();
-    }
-
-    private function getPlatformsByNpCommunicationId(string $npCommunicationId): array
-    {
-        $query = $this->database->prepare(
-            'SELECT platform FROM trophy_title WHERE np_communication_id = :np_communication_id'
-        );
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->execute();
-
-        $platforms = $query->fetchColumn();
-
-        if ($platforms === false || $platforms === null || $platforms === '') {
-            return [];
-        }
-
-        $platforms = array_map('trim', explode(',', (string) $platforms));
-        $platforms = array_filter($platforms, static fn(string $platform): bool => $platform !== '');
-
-        return array_values($platforms);
-    }
-
-    private function sortPlatforms(array $platforms): array
-    {
-        $order = array_flip(self::PLATFORM_ORDER);
-
-        usort(
-            $platforms,
-            static function (string $left, string $right) use ($order): int {
-                $leftOrder = $order[$left] ?? PHP_INT_MAX;
-                $rightOrder = $order[$right] ?? PHP_INT_MAX;
-
-                if ($leftOrder === $rightOrder) {
-                    return strcmp($left, $right);
-                }
-
-                return $leftOrder <=> $rightOrder;
-            }
-        );
-
-        return $platforms;
-    }
-
-    private function logChange(string $changeType, int $param1, int $param2): void
-    {
-        $query = $this->database->prepare(
-            "INSERT INTO `psn100_change` (`change_type`, `param_1`, `param_2`) VALUES (:change_type, :param_1, :param_2)"
-        );
-        $query->bindValue(':change_type', $changeType, PDO::PARAM_STR);
-        $query->bindValue(':param_1', $param1, PDO::PARAM_INT);
-        $query->bindValue(':param_2', $param2, PDO::PARAM_INT);
-        $query->execute();
     }
 
     private function getGameNpCommunicationId(int $gameId): string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`TrophyMergeService` (~545 lines) mixed merge orchestration with raw SQL for trophy-title metadata. This PR extracts one concern — **merge metadata persistence** — into a new `TrophyMergeMetadataRepository`.

### Extracted responsibilities

- Mark child games as merged (`markGameAsMergedByNpId`, `markGameAsMergedById`)
- Store parent/child relationships in `trophy_title_meta` (`updateParentRelationship`)
- Union child platforms onto the parent title (`updateParentPlatform`, `sortPlatforms`)
- Write merge changelog rows (`logChange`)

### Result

- `TrophyMergeService`: 545 → 370 lines (orchestration only)
- New `TrophyMergeMetadataRepository`: 211 lines
- Tests now target the repository directly instead of reflection on private service methods
- All 837 tests pass

## Follow-up PRs (not in scope)

Other God-class candidates identified for incremental peels:

1. **TrophyMergeService** — extract game/trophy lookup queries (`getTrophyById`, `getGameNpCommunicationId`, etc.)
2. **PlayerScanProfileSynchronizer** — extract pure identity helpers (`determineResolvedOnlineId`, `extractCountryFromNpId`)
3. **PsnGameLookupService** — extract trophy API response grouping
4. **TrophyMergePlayerProgressUpdater** — split SQL recalculators
5. **PlayerScanTitleCatalogSynchronizer** — extract per-group catalog sync loop
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-446c1e9a-72bf-4089-98fe-a2a501d25824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-446c1e9a-72bf-4089-98fe-a2a501d25824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

