### PR TITLE
Extract TrophyMergeRelationshipResolver from TrophyMergePlayerProgressUpdater

### DIFF
--- a/tests/TrophyMergeServiceMetaUsageTest.php
+++ b/tests/TrophyMergeServiceMetaUsageTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../wwwroot/classes/TrophyMergePlayerProgressUpdater.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMergeRelationshipResolver.php';
 
 final class TrophyMergeServiceMetaUsageTest extends TestCase
 {
@@ -23,8 +23,8 @@ final class TrophyMergeServiceMetaUsageTest extends TestCase
         $this->insertMergeMapping('NP_CHILD', 'NP_PARENT_2');
         $this->insertMergeMapping('NP_CHILD_2', 'NP_PARENT_2');
 
-        $updater = new TrophyMergePlayerProgressUpdater($this->database);
-        $mergeData = $updater->getMergeParentAndChildren('NP_CHILD');
+        $resolver = new TrophyMergeRelationshipResolver($this->database);
+        $mergeData = $resolver->getMergeParentAndChildren('NP_CHILD');
 
         $this->assertSame('NP_PARENT_2', $mergeData['parent_np_communication_id']);
         $this->assertSame(['NP_CHILD', 'NP_CHILD_2'], $mergeData['child_np_communication_ids']);

--- a/wwwroot/classes/TrophyMergePlayerProgressUpdater.php
+++ b/wwwroot/classes/TrophyMergePlayerProgressUpdater.php
@@ -2,10 +2,17 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/TrophyMergeRelationshipResolver.php';
+
 class TrophyMergePlayerProgressUpdater
 {
-    public function __construct(private readonly PDO $database)
-    {
+    private readonly TrophyMergeRelationshipResolver $relationshipResolver;
+
+    public function __construct(
+        private readonly PDO $database,
+        ?TrophyMergeRelationshipResolver $relationshipResolver = null,
+    ) {
+        $this->relationshipResolver = $relationshipResolver ?? new TrophyMergeRelationshipResolver($database);
     }
 
     public function updateTrophyGroupPlayer(int $childGameId): void
@@ -36,7 +43,7 @@ class TrophyMergePlayerProgressUpdater
             throw new InvalidArgumentException('Parent must be a merge title.');
         }
 
-        $childNpCommunicationIds = $this->getMergeChildrenByParent($parentNpCommunicationId);
+        $childNpCommunicationIds = $this->relationshipResolver->getMergeChildrenByParent($parentNpCommunicationId);
 
         if ($childNpCommunicationIds === []) {
             throw new RuntimeException('Unable to locate child trophy titles.');
@@ -51,54 +58,7 @@ class TrophyMergePlayerProgressUpdater
      */
     public function getMergeParentAndChildren(string $childNpCommunicationId): array
     {
-        $query = $this->database->prepare(
-            <<<'SQL'
-            SELECT DISTINCT
-                parent_np_communication_id
-            FROM
-                trophy_merge
-            WHERE
-                child_np_communication_id = :child_np_communication_id
-SQL
-        );
-        $query->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-        $query->execute();
-
-        /** @var list<string> $parentIds */
-        $parentIds = $query->fetchAll(PDO::FETCH_COLUMN);
-
-        if ($parentIds === []) {
-            throw new RuntimeException('Unable to locate parent trophy title.');
-        }
-
-        if (count($parentIds) === 1) {
-            $parentNpCommunicationId = $parentIds[0];
-        } else {
-            $parentNpCommunicationId = $this->resolveMergeParent($childNpCommunicationId, $parentIds);
-        }
-
-        $childQuery = $this->database->prepare(
-            <<<'SQL'
-            SELECT DISTINCT
-                child_np_communication_id
-            FROM
-                trophy_merge
-            WHERE
-                parent_np_communication_id = :parent_np_communication_id
-            ORDER BY
-                child_np_communication_id
-SQL
-        );
-        $childQuery->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
-        $childQuery->execute();
-
-        /** @var list<string> $childNpCommunicationIds */
-        $childNpCommunicationIds = $childQuery->fetchAll(PDO::FETCH_COLUMN);
-
-        return [
-            'parent_np_communication_id' => $parentNpCommunicationId,
-            'child_np_communication_ids' => $childNpCommunicationIds,
-        ];
+        return $this->relationshipResolver->getMergeParentAndChildren($childNpCommunicationId);
     }
 
     /**
@@ -448,63 +408,6 @@ SQL
             $query->bindValue(':child_np_' . $index, $childNpCommunicationId, PDO::PARAM_STR);
         }
         $query->execute();
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function getMergeChildrenByParent(string $parentNpCommunicationId): array
-    {
-        $childQuery = $this->database->prepare(
-            <<<'SQL'
-            SELECT DISTINCT
-                child_np_communication_id
-            FROM
-                trophy_merge
-            WHERE
-                parent_np_communication_id = :parent_np_communication_id
-            ORDER BY
-                child_np_communication_id
-SQL
-        );
-        $childQuery->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
-        $childQuery->execute();
-
-        /** @var list<string> $childNpCommunicationIds */
-        $childNpCommunicationIds = $childQuery->fetchAll(PDO::FETCH_COLUMN);
-
-        return $childNpCommunicationIds;
-    }
-
-    /**
-     * @param list<string> $parentIds
-     */
-    private function resolveMergeParent(string $childNpCommunicationId, array $parentIds): string
-    {
-        $parentFromMeta = $this->getParentFromMeta($childNpCommunicationId);
-        if ($parentFromMeta !== null && in_array($parentFromMeta, $parentIds, true)) {
-            return $parentFromMeta;
-        }
-
-        sort($parentIds, SORT_STRING);
-
-        return $parentIds[0];
-    }
-
-    private function getParentFromMeta(string $childNpCommunicationId): ?string
-    {
-        $query = $this->database->prepare(
-            'SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = :np_communication_id'
-        );
-        $query->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-        $query->execute();
-
-        $parent = $query->fetchColumn();
-        if ($parent === false || $parent === null || $parent === '') {
-            return null;
-        }
-
-        return (string) $parent;
     }
 
     private function getGameNpCommunicationId(int $gameId): string

--- a/wwwroot/classes/TrophyMergeRelationshipResolver.php
+++ b/wwwroot/classes/TrophyMergeRelationshipResolver.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Resolves parent/child relationships for merged trophy titles from trophy_merge and trophy_title_meta.
+ */
+final class TrophyMergeRelationshipResolver
+{
+    public function __construct(private readonly PDO $database)
+    {
+    }
+
+    /**
+     * @return array{parent_np_communication_id:string, child_np_communication_ids:list<string>}
+     */
+    public function getMergeParentAndChildren(string $childNpCommunicationId): array
+    {
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT DISTINCT
+                parent_np_communication_id
+            FROM
+                trophy_merge
+            WHERE
+                child_np_communication_id = :child_np_communication_id
+SQL
+        );
+        $query->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        /** @var list<string> $parentIds */
+        $parentIds = $query->fetchAll(PDO::FETCH_COLUMN);
+
+        if ($parentIds === []) {
+            throw new RuntimeException('Unable to locate parent trophy title.');
+        }
+
+        if (count($parentIds) === 1) {
+            $parentNpCommunicationId = $parentIds[0];
+        } else {
+            $parentNpCommunicationId = $this->resolveMergeParent($childNpCommunicationId, $parentIds);
+        }
+
+        return [
+            'parent_np_communication_id' => $parentNpCommunicationId,
+            'child_np_communication_ids' => $this->getMergeChildrenByParent($parentNpCommunicationId),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getMergeChildrenByParent(string $parentNpCommunicationId): array
+    {
+        $childQuery = $this->database->prepare(
+            <<<'SQL'
+            SELECT DISTINCT
+                child_np_communication_id
+            FROM
+                trophy_merge
+            WHERE
+                parent_np_communication_id = :parent_np_communication_id
+            ORDER BY
+                child_np_communication_id
+SQL
+        );
+        $childQuery->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+        $childQuery->execute();
+
+        /** @var list<string> $childNpCommunicationIds */
+        $childNpCommunicationIds = $childQuery->fetchAll(PDO::FETCH_COLUMN);
+
+        return $childNpCommunicationIds;
+    }
+
+    /**
+     * @param list<string> $parentIds
+     */
+    private function resolveMergeParent(string $childNpCommunicationId, array $parentIds): string
+    {
+        $parentFromMeta = $this->getParentFromMeta($childNpCommunicationId);
+        if ($parentFromMeta !== null && in_array($parentFromMeta, $parentIds, true)) {
+            return $parentFromMeta;
+        }
+
+        sort($parentIds, SORT_STRING);
+
+        return $parentIds[0];
+    }
+
+    private function getParentFromMeta(string $childNpCommunicationId): ?string
+    {
+        $query = $this->database->prepare(
+            'SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        $parent = $query->fetchColumn();
+        if ($parent === false || $parent === null || $parent === '') {
+            return null;
+        }
+
+        return (string) $parent;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`TrophyMergePlayerProgressUpdater` (530 lines) mixed two concerns: resolving merge parent/child relationships from the database, and recomputing `trophy_group_player` / `trophy_title_player` rows after a merge.

This PR peels off the first concern into a new `TrophyMergeRelationshipResolver` class.

## Changes

- **New `TrophyMergeRelationshipResolver`** — owns lookup of parent/child NP communication IDs from `trophy_merge` and `trophy_title_meta`, including the meta-based parent preference when multiple parents exist.
- **`TrophyMergePlayerProgressUpdater` slimmed down** — delegates relationship resolution to the resolver; keeps the heavy SQL for player progress recomputation.
- **Test updated** — `TrophyMergeServiceMetaUsageTest` now targets the resolver directly since that is where the behavior lives.

## Follow-up candidates (future PRs)

Other God-class peel-offs worth tackling one at a time:

| Class | Lines | Suggested extraction |
|---|---|---|
| `TrophyMergePlayerProgressUpdater` | ~430 | Group-player vs title-player SQL updaters |
| `Admin/TrophyStatusService` | 443 | Group/title recalculation after status change |
| `Admin/PsnGameLookupService` | 460 | Trophy payload parsing / grouping |
| `Cron/PlayerScanProfileSynchronizer` | 523 | Profile sync vs privacy handling |
| `Cron/PlayerScanTitleCatalogSynchronizer` | 528 | Catalog sync vs stale-game deletion |

## Testing

- `php tests/run.php` — all 837 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1eb98f2-5959-43ac-9582-fc39ed898e1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1eb98f2-5959-43ac-9582-fc39ed898e1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

