### PR TITLE
Extract GameDetailFormParser from GameDetailPage

### DIFF
--- a/tests/GameDetailFormParserTest.php
+++ b/tests/GameDetailFormParserTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameDetail.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameDetailFormParser.php';
+require_once __DIR__ . '/../wwwroot/classes/GameAvailabilityStatus.php';
+
+final class GameDetailFormParserTest extends TestCase
+{
+    private GameDetailFormParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new GameDetailFormParser();
+    }
+
+    public function testParseGameIdAcceptsValidValues(): void
+    {
+        $this->assertSame(42, $this->parser->parseGameId(42));
+        $this->assertSame(7, $this->parser->parseGameId('7'));
+        $this->assertSame(0, $this->parser->parseGameId('0'));
+        $this->assertSame(123, $this->parser->parseGameId(' 123 '));
+    }
+
+    public function testParseGameIdRejectsInvalidValues(): void
+    {
+        $this->assertSame(null, $this->parser->parseGameId(-1));
+        $this->assertSame(null, $this->parser->parseGameId('-5'));
+        $this->assertSame(null, $this->parser->parseGameId(''));
+        $this->assertSame(null, $this->parser->parseGameId('abc'));
+        $this->assertSame(null, $this->parser->parseGameId('12a'));
+        $this->assertSame(null, $this->parser->parseGameId(null));
+    }
+
+    public function testParseNpCommunicationIdTrimsAndRejectsEmpty(): void
+    {
+        $this->assertSame('NPWR10853_00', $this->parser->parseNpCommunicationId(' NPWR10853_00 '));
+        $this->assertSame(null, $this->parser->parseNpCommunicationId(''));
+        $this->assertSame(null, $this->parser->parseNpCommunicationId('   '));
+        $this->assertSame(null, $this->parser->parseNpCommunicationId(123));
+    }
+
+    public function testParseActionNormalizesCaseAndWhitespace(): void
+    {
+        $this->assertSame('update-status', $this->parser->parseAction('Update-Status'));
+        $this->assertSame('update-detail', $this->parser->parseAction(' update-detail '));
+        $this->assertSame('', $this->parser->parseAction(''));
+        $this->assertSame('', $this->parser->parseAction(null));
+    }
+
+    public function testParseStatusAcceptsValidEnumValues(): void
+    {
+        $this->assertSame(GameAvailabilityStatus::NORMAL, $this->parser->parseStatus(0));
+        $this->assertSame(GameAvailabilityStatus::OBSOLETE, $this->parser->parseStatus('3'));
+        $this->assertSame(GameAvailabilityStatus::MERGED, $this->parser->parseStatus(' 2 '));
+    }
+
+    public function testParseStatusRejectsInvalidValues(): void
+    {
+        $this->assertSame(null, $this->parser->parseStatus(''));
+        $this->assertSame(null, $this->parser->parseStatus('-1'));
+        $this->assertSame(null, $this->parser->parseStatus('abc'));
+        $this->assertSame(null, $this->parser->parseStatus(999));
+        $this->assertSame(null, $this->parser->parseStatus(null));
+    }
+
+    public function testNormalizePlatformsOrdersKnownPlatforms(): void
+    {
+        $this->assertSame('PS4,PS5', $this->parser->normalizePlatforms(['PS5', 'PS4']));
+        $this->assertSame('PS3,PC', $this->parser->normalizePlatforms('pc, ps3'));
+        $this->assertSame('', $this->parser->normalizePlatforms([]));
+        $this->assertSame('', $this->parser->normalizePlatforms('UNKNOWN'));
+    }
+
+    public function testNormalizeObsoleteIdsDeduplicatesAndFilters(): void
+    {
+        $this->assertSame('42,1,84', $this->parser->normalizeObsoleteIds('42, 1, 84, 42'));
+        $this->assertSame('7', $this->parser->normalizeObsoleteIds('007'));
+        $this->assertSame(null, $this->parser->normalizeObsoleteIds(''));
+        $this->assertSame(null, $this->parser->normalizeObsoleteIds('abc,def'));
+        $this->assertSame(null, $this->parser->normalizeObsoleteIds(null));
+    }
+
+    public function testCreateGameDetailFromPostBuildsGameDetail(): void
+    {
+        $detail = $this->parser->createGameDetailFromPost(10, [
+            'np_communication_id' => ' NPWR-123 ',
+            'name' => 'Example Game',
+            'icon_url' => 'icon.png',
+            'platform' => ['PS5', 'PS4'],
+            'message' => 'hello',
+            'set_version' => '01.00',
+            'region' => ' US ',
+            'psnprofiles_id' => ' 999 ',
+            'obsolete_ids' => '42, 42, 84',
+        ], GameAvailabilityStatus::OBSOLETE);
+
+        $this->assertSame(10, $detail->getId());
+        $this->assertSame('NPWR-123', $detail->getNpCommunicationId());
+        $this->assertSame('Example Game', $detail->getName());
+        $this->assertSame('icon.png', $detail->getIconUrl());
+        $this->assertSame('PS4,PS5', $detail->getPlatform());
+        $this->assertSame('hello', $detail->getMessage());
+        $this->assertSame('01.00', $detail->getSetVersion());
+        $this->assertSame('US', $detail->getRegion());
+        $this->assertSame('999', $detail->getPsnprofilesId());
+        $this->assertSame(GameAvailabilityStatus::OBSOLETE, $detail->getStatus());
+        $this->assertSame('42,84', $detail->getObsoleteIds());
+    }
+}

--- a/wwwroot/classes/Admin/GameDetailFormParser.php
+++ b/wwwroot/classes/Admin/GameDetailFormParser.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/GameDetail.php';
+require_once __DIR__ . '/../GameAvailabilityStatus.php';
+
+final class GameDetailFormParser
+{
+    /**
+     * @var list<string>
+     */
+    public const array PLATFORM_OPTIONS = [
+        'PS3',
+        'PSVITA',
+        'PS4',
+        'PSVR',
+        'PS5',
+        'PSVR2',
+        'PC',
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public function getPlatformOptions(): array
+    {
+        return self::PLATFORM_OPTIONS;
+    }
+
+    public function parseNpCommunicationId(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    public function parseGameId(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value >= 0 ? $value : null;
+        }
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if ($trimmed[0] === '-') {
+            return null;
+        }
+
+        if (!ctype_digit($trimmed)) {
+            return null;
+        }
+
+        return (int) $trimmed;
+    }
+
+    public function parseAction(mixed $value): string
+    {
+        if (!is_string($value)) {
+            return '';
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? '' : strtolower($trimmed);
+    }
+
+    public function parseStatus(mixed $value): ?GameAvailabilityStatus
+    {
+        if (is_int($value)) {
+            return GameAvailabilityStatus::tryFrom($value);
+        }
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '' || $trimmed[0] === '-') {
+            return null;
+        }
+
+        if (!ctype_digit($trimmed)) {
+            return null;
+        }
+
+        return GameAvailabilityStatus::tryFrom((int) $trimmed);
+    }
+
+    /**
+     * @param array<string, mixed> $postData
+     */
+    public function createGameDetailFromPost(int $gameId, array $postData, GameAvailabilityStatus $status): GameDetail
+    {
+        $npCommunicationId = $this->normalizeOptionalString($postData['np_communication_id'] ?? null);
+        $region = $this->normalizeOptionalString($postData['region'] ?? null);
+        $psnprofilesId = $this->normalizeOptionalString($postData['psnprofiles_id'] ?? null);
+        $obsoleteIds = $this->normalizeObsoleteIds($postData['obsolete_ids'] ?? null);
+
+        return new GameDetail(
+            $gameId,
+            $npCommunicationId,
+            (string) ($postData['name'] ?? ''),
+            (string) ($postData['icon_url'] ?? ''),
+            $this->normalizePlatforms($postData['platform'] ?? null),
+            (string) ($postData['message'] ?? ''),
+            (string) ($postData['set_version'] ?? ''),
+            $region,
+            $psnprofilesId,
+            $status,
+            $obsoleteIds
+        );
+    }
+
+    public function normalizePlatforms(mixed $value): string
+    {
+        $candidates = [];
+
+        if (is_array($value)) {
+            $candidates = $value;
+        } elseif (is_string($value)) {
+            $candidates = explode(',', $value);
+        }
+
+        $selected = [];
+        foreach ($candidates as $candidate) {
+            if (!is_string($candidate)) {
+                continue;
+            }
+
+            $platform = strtoupper(trim($candidate));
+            if ($platform === '') {
+                continue;
+            }
+
+            $selected[$platform] = true;
+        }
+
+        $ordered = [];
+        foreach (self::PLATFORM_OPTIONS as $platform) {
+            if (isset($selected[$platform])) {
+                $ordered[] = $platform;
+            }
+        }
+
+        return implode(',', $ordered);
+    }
+
+    public function normalizeOptionalString(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    public function normalizeObsoleteIds(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $segments = array_filter(
+            array_map(static fn(string $segment): string => trim($segment), explode(',', $value)),
+            static fn(string $segment): bool => $segment !== ''
+        );
+
+        if ($segments === []) {
+            return null;
+        }
+
+        $normalized = [];
+        foreach ($segments as $segment) {
+            if (!ctype_digit($segment)) {
+                continue;
+            }
+
+            $normalized[] = (string) (int) $segment;
+        }
+
+        if ($normalized === []) {
+            return null;
+        }
+
+        $normalized = array_values(array_unique($normalized));
+
+        return implode(',', $normalized);
+    }
+}

--- a/wwwroot/classes/Admin/GameDetailPage.php
+++ b/wwwroot/classes/Admin/GameDetailPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../Html.php';
 
+require_once __DIR__ . '/GameDetailFormParser.php';
 require_once __DIR__ . '/GameDetailService.php';
 require_once __DIR__ . '/GameDetailPageResult.php';
 require_once __DIR__ . '/../GameStatusService.php';
@@ -11,24 +12,20 @@ require_once __DIR__ . '/../GameAvailabilityStatus.php';
 
 class GameDetailPage
 {
-    private const array PLATFORM_OPTIONS = [
-        'PS3',
-        'PSVITA',
-        'PS4',
-        'PSVR',
-        'PS5',
-        'PSVR2',
-        'PC',
-    ];
-
     private GameDetailService $gameDetailService;
 
     private GameStatusService $gameStatusService;
 
-    public function __construct(GameDetailService $gameDetailService, GameStatusService $gameStatusService)
-    {
+    private GameDetailFormParser $formParser;
+
+    public function __construct(
+        GameDetailService $gameDetailService,
+        GameStatusService $gameStatusService,
+        ?GameDetailFormParser $formParser = null,
+    ) {
         $this->gameDetailService = $gameDetailService;
         $this->gameStatusService = $gameStatusService;
+        $this->formParser = $formParser ?? new GameDetailFormParser();
     }
 
     /**
@@ -50,7 +47,7 @@ class GameDetailPage
      */
     public function getPlatformOptions(): array
     {
-        return self::PLATFORM_OPTIONS;
+        return $this->formParser->getPlatformOptions();
     }
 
     /**
@@ -68,7 +65,7 @@ class GameDetailPage
             $method = strtoupper((string) ($serverParameters['REQUEST_METHOD'] ?? 'GET'));
 
             if ($method === 'POST') {
-                $action = $this->parseAction($postData['action'] ?? null);
+                $action = $this->formParser->parseAction($postData['action'] ?? null);
 
                 if ($action === 'update-status') {
                     [$gameDetail, $success, $error] = $this->handleStatusUpdate($postData);
@@ -77,12 +74,12 @@ class GameDetailPage
                 }
             } elseif ($method === 'GET') {
                 $npCommunicationId = null;
-                $gameId = $this->parseGameId($queryParameters['game'] ?? null);
+                $gameId = $this->formParser->parseGameId($queryParameters['game'] ?? null);
 
                 if ($gameId !== null) {
                     $gameDetail = $this->gameDetailService->getGameDetail($gameId);
                 } else {
-                    $npCommunicationId = $this->parseNpCommunicationId($queryParameters['np_communication_id'] ?? null);
+                    $npCommunicationId = $this->formParser->parseNpCommunicationId($queryParameters['np_communication_id'] ?? null);
 
                     if ($npCommunicationId !== null) {
                         $gameDetail = $this->gameDetailService->getGameDetailByNpCommunicationId($npCommunicationId);
@@ -106,13 +103,13 @@ class GameDetailPage
      */
     private function handleDetailUpdate(array $postData): array
     {
-        $gameId = $this->parseGameId($postData['game'] ?? null);
+        $gameId = $this->formParser->parseGameId($postData['game'] ?? null);
 
         if ($gameId === null) {
             return [null, null, '<p>Invalid game ID provided.</p>'];
         }
 
-        $status = $this->parseStatus($postData['status'] ?? null);
+        $status = $this->formParser->parseStatus($postData['status'] ?? null);
         if ($status === null) {
             return [
                 $this->gameDetailService->getGameDetail($gameId),
@@ -122,7 +119,7 @@ class GameDetailPage
         }
 
         $gameDetail = $this->gameDetailService->updateGameDetail(
-            $this->createGameDetailFromPost($gameId, $postData, $status)
+            $this->formParser->createGameDetailFromPost($gameId, $postData, $status)
         );
 
         $successMessages = [sprintf('<p>Game ID %d is updated.</p>', $gameDetail->getId())];
@@ -150,12 +147,12 @@ class GameDetailPage
      */
     private function handleStatusUpdate(array $postData): array
     {
-        $gameId = $this->parseGameId($postData['game'] ?? null);
+        $gameId = $this->formParser->parseGameId($postData['game'] ?? null);
         if ($gameId === null) {
             return [null, null, '<p>Invalid game ID provided.</p>'];
         }
 
-        $status = $this->parseStatus($postData['status'] ?? null);
+        $status = $this->formParser->parseStatus($postData['status'] ?? null);
         if ($status === null) {
             return [
                 $this->gameDetailService->getGameDetail($gameId),
@@ -196,179 +193,6 @@ class GameDetailPage
             $this->formatStatusSuccessMessage($gameId, $statusText),
             null,
         ];
-    }
-
-    private function parseNpCommunicationId(mixed $value): ?string
-    {
-        if (!is_string($value)) {
-            return null;
-        }
-
-        $trimmed = trim($value);
-
-        return $trimmed === '' ? null : $trimmed;
-    }
-
-    private function parseGameId(mixed $value): ?int
-    {
-        if (is_int($value)) {
-            return $value >= 0 ? $value : null;
-        }
-
-        if (!is_string($value)) {
-            return null;
-        }
-
-        $trimmed = trim($value);
-        if ($trimmed === '') {
-            return null;
-        }
-
-        if ($trimmed[0] === '-') {
-            return null;
-        }
-
-        if (!ctype_digit($trimmed)) {
-            return null;
-        }
-
-        return (int) $trimmed;
-    }
-
-    private function parseAction(mixed $value): string
-    {
-        if (!is_string($value)) {
-            return '';
-        }
-
-        $trimmed = trim($value);
-
-        return $trimmed === '' ? '' : strtolower($trimmed);
-    }
-
-    private function parseStatus(mixed $value): ?GameAvailabilityStatus
-    {
-        if (is_int($value)) {
-            return GameAvailabilityStatus::tryFrom($value);
-        }
-
-        if (!is_string($value)) {
-            return null;
-        }
-
-        $trimmed = trim($value);
-        if ($trimmed === '' || $trimmed[0] === '-') {
-            return null;
-        }
-
-        if (!ctype_digit($trimmed)) {
-            return null;
-        }
-
-        return GameAvailabilityStatus::tryFrom((int) $trimmed);
-    }
-
-    /**
-     * @param array<string, mixed> $postData
-     */
-    private function createGameDetailFromPost(int $gameId, array $postData, GameAvailabilityStatus $status): GameDetail
-    {
-        $npCommunicationId = $this->normalizeOptionalString($postData['np_communication_id'] ?? null);
-        $region = $this->normalizeOptionalString($postData['region'] ?? null);
-        $psnprofilesId = $this->normalizeOptionalString($postData['psnprofiles_id'] ?? null);
-        $obsoleteIds = $this->normalizeObsoleteIds($postData['obsolete_ids'] ?? null);
-
-        return new GameDetail(
-            $gameId,
-            $npCommunicationId,
-            (string) ($postData['name'] ?? ''),
-            (string) ($postData['icon_url'] ?? ''),
-            $this->normalizePlatforms($postData['platform'] ?? null),
-            (string) ($postData['message'] ?? ''),
-            (string) ($postData['set_version'] ?? ''),
-            $region,
-            $psnprofilesId,
-            $status,
-            $obsoleteIds
-        );
-    }
-
-    private function normalizePlatforms(mixed $value): string
-    {
-        $candidates = [];
-
-        if (is_array($value)) {
-            $candidates = $value;
-        } elseif (is_string($value)) {
-            $candidates = explode(',', $value);
-        }
-
-        $selected = [];
-        foreach ($candidates as $candidate) {
-            if (!is_string($candidate)) {
-                continue;
-            }
-
-            $platform = strtoupper(trim($candidate));
-            if ($platform === '') {
-                continue;
-            }
-
-            $selected[$platform] = true;
-        }
-
-        $ordered = [];
-        foreach (self::PLATFORM_OPTIONS as $platform) {
-            if (isset($selected[$platform])) {
-                $ordered[] = $platform;
-            }
-        }
-
-        return implode(',', $ordered);
-    }
-
-    private function normalizeOptionalString(mixed $value): ?string
-    {
-        if (!is_string($value)) {
-            return null;
-        }
-
-        $trimmed = trim($value);
-
-        return $trimmed === '' ? null : $trimmed;
-    }
-
-    private function normalizeObsoleteIds(mixed $value): ?string
-    {
-        if (!is_string($value)) {
-            return null;
-        }
-
-        $segments = array_filter(
-            array_map(static fn(string $segment): string => trim($segment), explode(',', $value)),
-            static fn(string $segment): bool => $segment !== ''
-        );
-
-        if ($segments === []) {
-            return null;
-        }
-
-        $normalized = [];
-        foreach ($segments as $segment) {
-            if (!ctype_digit($segment)) {
-                continue;
-            }
-
-            $normalized[] = (string) (int) $segment;
-        }
-
-        if ($normalized === []) {
-            return null;
-        }
-
-        $normalized = array_values(array_unique($normalized));
-
-        return implode(',', $normalized);
     }
 
     private function formatStatusSuccessMessage(int $gameId, string $statusText): string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels HTTP form parsing and normalization out of `GameDetailPage` into a dedicated `GameDetailFormParser` class. This is the first step in breaking down God classes incrementally — one concern per PR.

**Before:** `GameDetailPage` (~385 lines) mixed request handling, input parsing/normalization, and domain service calls.

**After:** `GameDetailPage` (~200 lines) focuses on orchestration; `GameDetailFormParser` owns all `parse*` / `normalize*` logic.

## Changes

- Add `GameDetailFormParser` with:
  - `parseGameId`, `parseNpCommunicationId`, `parseAction`, `parseStatus`
  - `createGameDetailFromPost`, `normalizePlatforms`, `normalizeOptionalString`, `normalizeObsoleteIds`
  - `PLATFORM_OPTIONS` constant and `getPlatformOptions()`
- `GameDetailPage` delegates to the parser (optional constructor injection for tests)
- Add `GameDetailFormParserTest` with unit coverage for parsing edge cases

## Follow-up candidates (future PRs)

Other God classes identified for incremental peel-offs:

1. `PlayerQueueService` — scan-status reader
2. `LogEntryFormatter` — link builder
3. `GameHeaderService` — PSNP+ note resolver
4. `PsnGameLookupService` — trophy response assembler
5. Cron scan pipeline classes (`PlayerScanProfileSynchronizer`, etc.)

## Test plan

- [x] `php tests/run.php` — all 846 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc1f0eb8-0858-4181-9d83-2694787b3319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc1f0eb8-0858-4181-9d83-2694787b3319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

