### PR TITLE
Fix Possible Cheaters admin page freezing the site

### DIFF
--- a/tests/PossibleCheaterRuleConditionParserTest.php
+++ b/tests/PossibleCheaterRuleConditionParserTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterRulesCatalog.php';
+
+final class PossibleCheaterRuleConditionParserTest extends TestCase
+{
+    private PossibleCheaterRuleConditionParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new PossibleCheaterRuleConditionParser();
+    }
+
+    public function testParsesSimpleCondition(): void
+    {
+        $tuple = $this->parser->parse("te.np_communication_id = 'NPWR05066_00' AND te.order_id = 2");
+
+        $this->assertSame('NPWR05066_00', $tuple->getNpCommunicationId());
+        $this->assertSame(2, $tuple->getOrderId());
+        $this->assertSame(null, $tuple->getDateOperator());
+        $this->assertSame(null, $tuple->getDateValue());
+    }
+
+    public function testParsesConditionWithMinimumEarnedDate(): void
+    {
+        $tuple = $this->parser->parse(
+            "te.np_communication_id = 'NPWR00550_00' AND te.order_id = 4 AND te.earned_date >= '2015-01-01'"
+        );
+
+        $this->assertSame('>=', $tuple->getDateOperator());
+        $this->assertSame('2015-01-01', $tuple->getDateValue());
+    }
+
+    public function testParsesConditionWithMaximumEarnedDate(): void
+    {
+        $tuple = $this->parser->parse(
+            "te.np_communication_id = 'NPWR14225_00' AND te.order_id = 6 AND te.earned_date <= '2020-04-12'"
+        );
+
+        $this->assertSame('<=', $tuple->getDateOperator());
+        $this->assertSame('2020-04-12', $tuple->getDateValue());
+    }
+
+    public function testParsesConditionWithExclusiveMaximumEarnedDate(): void
+    {
+        $tuple = $this->parser->parse(
+            "te.np_communication_id = 'NPWR18341_00' AND te.order_id = 0 AND te.earned_date < '2020-03-01'"
+        );
+
+        $this->assertSame('<', $tuple->getDateOperator());
+        $this->assertSame('2020-03-01', $tuple->getDateValue());
+    }
+
+    public function testParsesMergedGameCondition(): void
+    {
+        $tuple = $this->parser->parse("te.np_communication_id = 'MERGE_011562' AND te.order_id = 0");
+
+        $this->assertSame('MERGE_011562', $tuple->getNpCommunicationId());
+        $this->assertSame(0, $tuple->getOrderId());
+    }
+
+    public function testParsesAllDefaultGeneralRuleConditions(): void
+    {
+        $catalog = new PossibleCheaterRulesCatalog();
+
+        foreach ($catalog->getGeneralRuleGroups() as $group) {
+            foreach ($group->getRules() as $rule) {
+                $tuple = $this->parser->parse($rule->getCondition());
+                $this->assertTrue($tuple->getNpCommunicationId() !== '');
+            }
+        }
+    }
+
+    public function testBuildRuleDerivedTableSqlIncludesDateConstraints(): void
+    {
+        $catalog = new PossibleCheaterRulesCatalog();
+        $sql = $this->parser->buildRuleDerivedTableSql($catalog->getGeneralRuleGroups());
+
+        $this->assertStringContainsString("SELECT 'NPWR05066_00' AS np_communication_id, 2 AS order_id", $sql);
+        $this->assertStringContainsString("SELECT 'NPWR00550_00' AS np_communication_id, 4 AS order_id, '>=' AS date_operator, '2015-01-01' AS date_value", $sql);
+        $this->assertStringContainsString("UNION ALL", $sql);
+    }
+
+    public function testRejectsUnsupportedCondition(): void
+    {
+        try {
+            $this->parser->parse('te.progress > 0');
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertStringContainsString('Unsupported possible cheater rule condition', $exception->getMessage());
+        }
+    }
+}

--- a/tests/PossibleCheaterServiceTest.php
+++ b/tests/PossibleCheaterServiceTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterRuleGroup.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterRulesCatalog.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterService.php';
+
+final class PossibleCheaterServiceTest extends TestCase
+{
+    private PDO $database;
+    private PossibleCheaterService $service;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->database->exec(
+            <<<SQL
+            CREATE TABLE player (
+                account_id INTEGER PRIMARY KEY,
+                online_id TEXT NOT NULL,
+                status INTEGER NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE trophy_title (
+                id INTEGER PRIMARY KEY,
+                np_communication_id TEXT NOT NULL,
+                name TEXT NOT NULL
+            );
+
+            CREATE TABLE trophy_earned (
+                np_communication_id TEXT NOT NULL,
+                group_id TEXT NOT NULL DEFAULT 'default',
+                order_id INTEGER NOT NULL,
+                account_id INTEGER NOT NULL,
+                earned_date TEXT,
+                progress INTEGER,
+                earned INTEGER NOT NULL DEFAULT 1
+            );
+            SQL
+        );
+
+        $rulesCatalog = new PossibleCheaterRulesCatalog(
+            $this->createGeneralRulesFile([
+                [
+                    'label' => 'Luftrausers',
+                    'conditions' => [
+                        "te.np_communication_id = 'NPWR05066_00' AND te.order_id = 2",
+                    ],
+                ],
+                [
+                    'label' => 'Planet Minigolf',
+                    'conditions' => [
+                        "te.np_communication_id = 'NPWR00550_00' AND te.order_id = 4 AND te.earned_date >= '2015-01-01'",
+                    ],
+                ],
+            ]),
+            $this->createSectionsFile([
+                [
+                    'title' => 'FUEL',
+                    'query' => <<<'SQL'
+                        SELECT
+                            p.account_id,
+                            p.online_id
+                        FROM
+                            trophy_earned fuel_start
+                        JOIN trophy_earned fuel_end ON
+                            fuel_end.account_id = fuel_start.account_id
+                            AND fuel_end.np_communication_id = 'NPWR00481_00'
+                            AND fuel_end.order_id = 34
+                        JOIN player p ON
+                            p.account_id = fuel_start.account_id
+                            AND p.status != 1
+                        WHERE
+                            fuel_start.np_communication_id = 'NPWR00481_00'
+                            AND fuel_start.order_id = 33
+                            AND ABS(strftime('%s', fuel_end.earned_date) - strftime('%s', fuel_start.earned_date)) <= 60
+                        ORDER BY
+                            p.online_id
+                    SQL,
+                    'linkPattern' => '/game/4390-fuel/%s?sort=date',
+                ],
+            ])
+        );
+
+        $this->service = new PossibleCheaterService($this->database, $rulesCatalog);
+    }
+
+    public function testCreateReportFindsMatchingGeneralCheaters(): void
+    {
+        $this->database->exec(
+            <<<SQL
+            INSERT INTO player (account_id, online_id, status) VALUES
+                (1, 'CheaterOne', 0),
+                (2, 'LegitPlayer', 0),
+                (3, 'TaggedCheater', 1);
+
+            INSERT INTO trophy_title (id, np_communication_id, name) VALUES
+                (10, 'NPWR05066_00', 'Luftrausers'),
+                (11, 'NPWR99999_00', 'Other Game');
+
+            INSERT INTO trophy_earned (np_communication_id, group_id, order_id, account_id, earned_date) VALUES
+                ('NPWR05066_00', 'default', 2, 1, '2020-01-01 00:00:00'),
+                ('NPWR99999_00', 'default', 0, 1, '2019-01-01 00:00:00'),
+                ('NPWR05066_00', 'default', 2, 3, '2020-01-01 00:00:00');
+            SQL
+        );
+
+        $report = $this->service->createReport();
+        $generalCheaters = $report->getGeneralCheaters();
+
+        $this->assertCount(1, $generalCheaters);
+        $this->assertSame('CheaterOne', $generalCheaters[0]->getPlayerName());
+        $this->assertSame(1, $generalCheaters[0]->getAccountId());
+    }
+
+    public function testCreateReportAppliesEarnedDateConstraint(): void
+    {
+        $this->database->exec(
+            <<<SQL
+            INSERT INTO player (account_id, online_id, status) VALUES
+                (4, 'TooEarly', 0),
+                (5, 'JustRight', 0);
+
+            INSERT INTO trophy_title (id, np_communication_id, name) VALUES
+                (12, 'NPWR00550_00', 'Planet Minigolf');
+
+            INSERT INTO trophy_earned (np_communication_id, group_id, order_id, account_id, earned_date) VALUES
+                ('NPWR00550_00', 'default', 4, 4, '2014-12-31 23:59:59'),
+                ('NPWR00550_00', 'default', 4, 5, '2015-01-01 00:00:00');
+            SQL
+        );
+
+        $report = $this->service->createReport();
+        $playerNames = array_map(
+            static fn($entry) => $entry->getPlayerName(),
+            $report->getGeneralCheaters()
+        );
+
+        $this->assertTrue(in_array('JustRight', $playerNames, true));
+        $this->assertFalse(in_array('TooEarly', $playerNames, true));
+    }
+
+    public function testCreateReportBuildsSectionEntries(): void
+    {
+        $this->database->exec(
+            <<<SQL
+            INSERT INTO player (account_id, online_id, status) VALUES
+                (6, 'FastFuel', 0);
+
+            INSERT INTO trophy_earned (np_communication_id, group_id, order_id, account_id, earned_date) VALUES
+                ('NPWR00481_00', 'default', 33, 6, '2020-01-01 00:00:00'),
+                ('NPWR00481_00', 'default', 34, 6, '2020-01-01 00:00:30');
+            SQL
+        );
+
+        $report = $this->service->createReport();
+        $sections = $report->getSections();
+
+        $this->assertCount(1, $sections);
+        $this->assertSame('FUEL', $sections[0]->getTitle());
+        $this->assertCount(1, $sections[0]->getEntries());
+        $this->assertSame('FastFuel', $sections[0]->getEntries()[0]->getOnlineId());
+        $this->assertSame('/game/4390-fuel/FastFuel?sort=date', $sections[0]->getEntries()[0]->getUrl());
+    }
+
+    /**
+     * @param list<array<string, mixed>> $groups
+     */
+    private function createGeneralRulesFile(array $groups): string
+    {
+        $path = sys_get_temp_dir() . '/possible-cheater-general-' . uniqid('', true) . '.php';
+        file_put_contents($path, '<?php return ' . var_export($groups, true) . ';');
+
+        return $path;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $sections
+     */
+    private function createSectionsFile(array $sections): string
+    {
+        $path = sys_get_temp_dir() . '/possible-cheater-sections-' . uniqid('', true) . '.php';
+        file_put_contents($path, '<?php return ' . var_export($sections, true) . ';');
+
+        return $path;
+    }
+}

--- a/wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/PossibleCheaterRuleGroup.php';
+require_once __DIR__ . '/PossibleCheaterRuleTuple.php';
+
+final class PossibleCheaterRuleConditionParser
+{
+    private const CONDITION_PATTERN = '/^te\.np_communication_id = \'([^\']+)\' AND te\.order_id = (\d+)(?: AND te\.earned_date (>=|<=|<) \'([^\']+)\')?$/';
+
+    public function parse(string $condition): PossibleCheaterRuleTuple
+    {
+        if (!preg_match(self::CONDITION_PATTERN, $condition, $matches)) {
+            throw new InvalidArgumentException('Unsupported possible cheater rule condition: ' . $condition);
+        }
+
+        return new PossibleCheaterRuleTuple(
+            $matches[1],
+            (int) $matches[2],
+            isset($matches[3]) && $matches[3] !== '' ? $matches[3] : null,
+            isset($matches[4]) && $matches[4] !== '' ? $matches[4] : null
+        );
+    }
+
+    /**
+     * @param PossibleCheaterRuleGroup[] $groups
+     */
+    public function buildRuleDerivedTableSql(array $groups): string
+    {
+        $selects = [];
+
+        foreach ($groups as $group) {
+            foreach ($group->getRules() as $rule) {
+                $selects[] = $this->parse($rule->getCondition())->toUnionSelect();
+            }
+        }
+
+        if ($selects === []) {
+            return 'SELECT NULL AS np_communication_id, NULL AS order_id, NULL AS date_operator, NULL AS date_value WHERE 0';
+        }
+
+        return implode("\nUNION ALL\n", $selects);
+    }
+}

--- a/wwwroot/classes/Admin/PossibleCheaterRuleTuple.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleTuple.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+final class PossibleCheaterRuleTuple
+{
+    public function __construct(
+        private string $npCommunicationId,
+        private int $orderId,
+        private ?string $dateOperator,
+        private ?string $dateValue
+    ) {
+    }
+
+    public function getNpCommunicationId(): string
+    {
+        return $this->npCommunicationId;
+    }
+
+    public function getOrderId(): int
+    {
+        return $this->orderId;
+    }
+
+    public function getDateOperator(): ?string
+    {
+        return $this->dateOperator;
+    }
+
+    public function getDateValue(): ?string
+    {
+        return $this->dateValue;
+    }
+
+    public function toUnionSelect(): string
+    {
+        $npCommunicationId = $this->quote($this->npCommunicationId);
+        $orderId = $this->orderId;
+        $dateOperator = $this->dateOperator !== null ? $this->quote($this->dateOperator) : 'NULL';
+        $dateValue = $this->dateValue !== null ? $this->quote($this->dateValue) : 'NULL';
+
+        return 'SELECT '
+            . $npCommunicationId . ' AS np_communication_id, '
+            . $orderId . ' AS order_id, '
+            . $dateOperator . ' AS date_operator, '
+            . $dateValue . ' AS date_value';
+    }
+
+    private function quote(string $value): string
+    {
+        return "'" . str_replace("'", "''", $value) . "'";
+    }
+}

--- a/wwwroot/classes/Admin/PossibleCheaterService.php
+++ b/wwwroot/classes/Admin/PossibleCheaterService.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PossibleCheaterRuleConditionParser.php';
 require_once __DIR__ . '/PossibleCheaterRulesCatalog.php';
 require_once __DIR__ . '/PossibleCheaterReport.php';
 
@@ -9,36 +10,34 @@ class PossibleCheaterService
 {
     private PDO $database;
     private PossibleCheaterRulesCatalog $rulesCatalog;
+    private PossibleCheaterRuleConditionParser $conditionParser;
 
-    public function __construct(PDO $database, ?PossibleCheaterRulesCatalog $rulesCatalog = null)
-    {
+    public function __construct(
+        PDO $database,
+        ?PossibleCheaterRulesCatalog $rulesCatalog = null,
+        ?PossibleCheaterRuleConditionParser $conditionParser = null
+    ) {
         $this->database = $database;
         $this->rulesCatalog = $rulesCatalog ?? new PossibleCheaterRulesCatalog();
+        $this->conditionParser = $conditionParser ?? new PossibleCheaterRuleConditionParser();
     }
 
     public function createReport(): PossibleCheaterReport
     {
-        return new PossibleCheaterReport(
-            $this->buildGeneralReportEntries(),
-            $this->buildSectionReports()
-        );
-    }
+        $this->beginReadOnlyTransaction();
 
-    private function buildGeneralWhereClause(): string
-    {
-        $conditions = [];
+        try {
+            $report = new PossibleCheaterReport(
+                $this->buildGeneralReportEntries(),
+                $this->buildSectionReports()
+            );
+            $this->commitReadOnlyTransaction();
 
-        foreach ($this->rulesCatalog->getGeneralRuleGroups() as $group) {
-            foreach ($group->getRules() as $rule) {
-                $conditions[] = '(' . $rule->getCondition() . ')';
-            }
+            return $report;
+        } catch (Throwable $exception) {
+            $this->rollbackReadOnlyTransaction();
+            throw $exception;
         }
-
-        if ($conditions === []) {
-            return '()';
-        }
-
-        return '(' . implode(' OR ', $conditions) . ')';
     }
 
     /**
@@ -87,9 +86,11 @@ class PossibleCheaterService
      */
     private function fetchGeneralPossibleCheaterRows(): array
     {
-        $whereClause = $this->buildGeneralWhereClause();
+        $ruleDerivedTable = $this->conditionParser->buildRuleDerivedTableSql(
+            $this->rulesCatalog->getGeneralRuleGroups()
+        );
 
-        $sql = <<<'SQL'
+        $sql = <<<SQL
         SELECT
             first_games.account_id,
             first_games.player_name,
@@ -102,11 +103,21 @@ class PossibleCheaterService
                 MIN(tt.np_communication_id) AS first_np_communication_id
             FROM
                 trophy_earned te
+            INNER JOIN (
+                {$ruleDerivedTable}
+            ) cheat_rules ON
+                te.np_communication_id = cheat_rules.np_communication_id
+                AND te.order_id = cheat_rules.order_id
+                AND (
+                    cheat_rules.date_operator IS NULL
+                    OR (cheat_rules.date_operator = '>=' AND te.earned_date >= cheat_rules.date_value)
+                    OR (cheat_rules.date_operator = '<=' AND te.earned_date <= cheat_rules.date_value)
+                    OR (cheat_rules.date_operator = '<' AND te.earned_date < cheat_rules.date_value)
+                )
             JOIN player p ON p.account_id = te.account_id
             JOIN trophy_title tt ON tt.np_communication_id = te.np_communication_id
             WHERE
-                __WHERE_CLAUSE__
-                AND p.status != 1
+                p.status != 1
             GROUP BY
                 p.account_id,
                 p.online_id
@@ -115,8 +126,6 @@ class PossibleCheaterService
         ORDER BY
             first_games.player_name
         SQL;
-
-        $sql = str_replace('__WHERE_CLAUSE__', $whereClause, $sql);
 
         $rows = $this->fetchAll($sql);
 
@@ -142,5 +151,32 @@ class PossibleCheaterService
         $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
 
         return is_array($rows) ? $rows : [];
+    }
+
+    private function beginReadOnlyTransaction(): void
+    {
+        if ($this->database->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'mysql') {
+            return;
+        }
+
+        $this->database->exec('START TRANSACTION READ ONLY');
+    }
+
+    private function commitReadOnlyTransaction(): void
+    {
+        if ($this->database->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'mysql') {
+            return;
+        }
+
+        $this->database->exec('COMMIT');
+    }
+
+    private function rollbackReadOnlyTransaction(): void
+    {
+        if ($this->database->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'mysql') {
+            return;
+        }
+
+        $this->database->exec('ROLLBACK');
     }
 }

--- a/wwwroot/config/possible-cheater-sections.php
+++ b/wwwroot/config/possible-cheater-sections.php
@@ -11,17 +11,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, fuel_start.earned_date, fuel_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned fuel_start ON
-                    fuel_start.account_id = p.account_id
-                    AND fuel_start.np_communication_id = 'NPWR00481_00'
-                    AND fuel_start.order_id = 33
+                    trophy_earned fuel_start
                 JOIN trophy_earned fuel_end ON
-                    fuel_end.account_id = p.account_id
+                    fuel_end.account_id = fuel_start.account_id
                     AND fuel_end.np_communication_id = 'NPWR00481_00'
                     AND fuel_end.order_id = 34
+                JOIN player p ON
+                    p.account_id = fuel_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    fuel_start.np_communication_id = 'NPWR00481_00'
+                    AND fuel_start.order_id = 33
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -37,17 +37,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, socom_start.earned_date, socom_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned socom_start ON
-                    socom_start.account_id = p.account_id
-                    AND socom_start.np_communication_id = 'NPWR00302_00'
-                    AND socom_start.order_id = 32
+                    trophy_earned socom_start
                 JOIN trophy_earned socom_end ON
-                    socom_end.account_id = p.account_id
+                    socom_end.account_id = socom_start.account_id
                     AND socom_end.np_communication_id = 'NPWR00302_00'
                     AND socom_end.order_id = 33
+                JOIN player p ON
+                    p.account_id = socom_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    socom_start.np_communication_id = 'NPWR00302_00'
+                    AND socom_start.order_id = 32
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -63,17 +63,17 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR01103_00'
-                    AND trophy_start.order_id = 38
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR01103_00'
                     AND trophy_end.order_id = 48
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR01103_00'
+                    AND trophy_start.order_id = 38
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -89,17 +89,17 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR00987_00'
-                    AND trophy_start.order_id = 38
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR00987_00'
                     AND trophy_end.order_id = 48
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR00987_00'
+                    AND trophy_start.order_id = 38
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -115,17 +115,17 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR17582_00'
-                    AND trophy_start.order_id = 50
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR17582_00'
                     AND trophy_end.order_id = 51
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR17582_00'
+                    AND trophy_start.order_id = 50
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -141,17 +141,17 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR17415_00'
-                    AND trophy_start.order_id = 50
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR17415_00'
                     AND trophy_end.order_id = 51
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR17415_00'
+                    AND trophy_start.order_id = 50
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -167,17 +167,17 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR14836_00'
-                    AND trophy_start.order_id = 50
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR14836_00'
                     AND trophy_end.order_id = 51
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR14836_00'
+                    AND trophy_start.order_id = 50
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -193,17 +193,17 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR00928_00'
-                    AND trophy_start.order_id = 10
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR00928_00'
                     AND trophy_end.order_id = 11
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR00928_00'
+                    AND trophy_start.order_id = 10
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -219,17 +219,17 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR00928_00'
-                    AND trophy_start.order_id = 19
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR00928_00'
                     AND trophy_end.order_id = 20
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR00928_00'
+                    AND trophy_start.order_id = 19
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -245,17 +245,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, rer_start.earned_date, rer_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned rer_start ON
-                    rer_start.account_id = p.account_id
-                    AND rer_start.np_communication_id = 'NPWR11777_00'
-                    AND rer_start.order_id = 54
+                    trophy_earned rer_start
                 JOIN trophy_earned rer_end ON
-                    rer_end.account_id = p.account_id
+                    rer_end.account_id = rer_start.account_id
                     AND rer_end.np_communication_id = 'NPWR11777_00'
                     AND rer_end.order_id = 55
+                JOIN player p ON
+                    p.account_id = rer_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    rer_start.np_communication_id = 'NPWR11777_00'
+                    AND rer_start.order_id = 54
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -271,17 +271,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, rer_start.earned_date, rer_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned rer_start ON
-                    rer_start.account_id = p.account_id
-                    AND rer_start.np_communication_id = 'NPWR11777_00'
-                    AND rer_start.order_id = 37
+                    trophy_earned rer_start
                 JOIN trophy_earned rer_end ON
-                    rer_end.account_id = p.account_id
+                    rer_end.account_id = rer_start.account_id
                     AND rer_end.np_communication_id = 'NPWR11777_00'
                     AND rer_end.order_id = 38
+                JOIN player p ON
+                    p.account_id = rer_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    rer_start.np_communication_id = 'NPWR11777_00'
+                    AND rer_start.order_id = 37
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -297,17 +297,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, rer_start.earned_date, rer_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned rer_start ON
-                    rer_start.account_id = p.account_id
-                    AND rer_start.np_communication_id = 'NPWR03903_00'
-                    AND rer_start.order_id = 49
+                    trophy_earned rer_start
                 JOIN trophy_earned rer_end ON
-                    rer_end.account_id = p.account_id
+                    rer_end.account_id = rer_start.account_id
                     AND rer_end.np_communication_id = 'NPWR03903_00'
                     AND rer_end.order_id = 50
+                JOIN player p ON
+                    p.account_id = rer_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    rer_start.np_communication_id = 'NPWR03903_00'
+                    AND rer_start.order_id = 49
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -323,17 +323,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, rer_start.earned_date, rer_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned rer_start ON
-                    rer_start.account_id = p.account_id
-                    AND rer_start.np_communication_id = 'NPWR03903_00'
-                    AND rer_start.order_id = 36
+                    trophy_earned rer_start
                 JOIN trophy_earned rer_end ON
-                    rer_end.account_id = p.account_id
+                    rer_end.account_id = rer_start.account_id
                     AND rer_end.np_communication_id = 'NPWR03903_00'
                     AND rer_end.order_id = 37
+                JOIN player p ON
+                    p.account_id = rer_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    rer_start.np_communication_id = 'NPWR03903_00'
+                    AND rer_start.order_id = 36
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -349,17 +349,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, abt_start.earned_date, abt_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned abt_start ON
-                    abt_start.account_id = p.account_id
-                    AND abt_start.np_communication_id = 'NPWR03771_00'
-                    AND abt_start.order_id = 30
+                    trophy_earned abt_start
                 JOIN trophy_earned abt_end ON
-                    abt_end.account_id = p.account_id
+                    abt_end.account_id = abt_start.account_id
                     AND abt_end.np_communication_id = 'NPWR03771_00'
                     AND abt_end.order_id = 31
+                JOIN player p ON
+                    p.account_id = abt_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    abt_start.np_communication_id = 'NPWR03771_00'
+                    AND abt_start.order_id = 30
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -371,34 +371,33 @@ return [
             'title' => 'Terminator Salvation',
             'query' => <<<'SQL'
                 SELECT
-                    account_id,
-                    online_id,
-                    trophy_count
-                FROM
-                    player p
-                JOIN(
-                    SELECT account_id,
-                        COUNT(account_id) AS trophy_count
+                    p.account_id,
+                    p.online_id,
+                    trophy_counter.trophy_count
+                FROM (
+                    SELECT
+                        te.account_id,
+                        COUNT(*) AS trophy_count
                     FROM
                         trophy_earned te
+                    INNER JOIN trophy_earned marker ON
+                        marker.account_id = te.account_id
+                        AND marker.np_communication_id = 'NPWR00623_00'
+                        AND marker.order_id = 9
                     WHERE
-                        np_communication_id = 'NPWR00623_00' AND order_id != 9 AND earned_date >=(
-                        SELECT
-                            earned_date
-                        FROM
-                            trophy_earned
-                        WHERE
-                            account_id = te.account_id AND np_communication_id = 'NPWR00623_00' AND order_id = 9
-                    )
-                GROUP BY
-                    account_id
-                ) trophy_counter USING(account_id)
-                WHERE
-                    p.status != 1
-                HAVING
-                    trophy_count >= 9
+                        te.np_communication_id = 'NPWR00623_00'
+                        AND te.order_id != 9
+                        AND te.earned_date >= marker.earned_date
+                    GROUP BY
+                        te.account_id
+                    HAVING
+                        trophy_count >= 9
+                ) trophy_counter
+                INNER JOIN player p ON
+                    p.account_id = trophy_counter.account_id
+                    AND p.status != 1
                 ORDER BY
-                    online_id
+                    p.online_id
             SQL,
             'linkPattern' => '/game/294-terminator-salvation/%s?sort=date',
         ],
@@ -410,17 +409,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR03734_00'
-                    AND trophy_start.order_id = 3
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR03734_00'
                     AND trophy_end.order_id = 4
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR03734_00'
+                    AND trophy_start.order_id = 3
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -436,17 +435,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR09098_00'
-                    AND trophy_start.order_id = 6
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR09098_00'
                     AND trophy_end.order_id = 7
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR09098_00'
+                    AND trophy_start.order_id = 6
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -462,17 +461,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR00626_00'
-                    AND trophy_start.order_id = 31
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR00626_00'
                     AND trophy_end.order_id = 32
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR00626_00'
+                    AND trophy_start.order_id = 31
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -488,17 +487,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR01012_00'
-                    AND trophy_start.order_id = 31
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR01012_00'
                     AND trophy_end.order_id = 32
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR01012_00'
+                    AND trophy_start.order_id = 31
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -514,17 +513,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR00464_00'
-                    AND trophy_start.order_id = 19
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR00464_00'
                     AND trophy_end.order_id = 20
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR00464_00'
+                    AND trophy_start.order_id = 19
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -540,17 +539,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR03139_00'
-                    AND trophy_start.order_id = 36
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR03139_00'
                     AND trophy_end.order_id = 37
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR03139_00'
+                    AND trophy_start.order_id = 36
                 HAVING
                     time_difference <= 600
                 ORDER BY
@@ -566,17 +565,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR01781_00'
-                    AND trophy_start.order_id = 38
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR01781_00'
                     AND trophy_end.order_id = 39
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR01781_00'
+                    AND trophy_start.order_id = 38
                 HAVING
                     time_difference <= 600
                 ORDER BY
@@ -592,17 +591,17 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR00737_00'
-                    AND trophy_start.order_id = 0
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR00737_00'
                     AND trophy_end.order_id = 26
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR00737_00'
+                    AND trophy_start.order_id = 0
                 HAVING
                     time_difference <= 300
                 ORDER BY
@@ -618,17 +617,17 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR14318_00'
-                    AND trophy_start.order_id = 2
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR14318_00'
                     AND trophy_end.order_id = 39
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR14318_00'
+                    AND trophy_start.order_id = 2
                 HAVING
                     time_difference >= 10
                 ORDER BY
@@ -644,17 +643,17 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR14318_00'
-                    AND trophy_start.order_id = 2
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR14318_00'
                     AND trophy_end.order_id = 40
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR14318_00'
+                    AND trophy_start.order_id = 2
                 HAVING
                     time_difference >= 10
                 ORDER BY
@@ -670,17 +669,17 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR14318_00'
-                    AND trophy_start.order_id = 2
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR14318_00'
                     AND trophy_end.order_id = 41
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR14318_00'
+                    AND trophy_start.order_id = 2
                 HAVING
                     time_difference >= 10
                 ORDER BY
@@ -696,17 +695,17 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR05019_00'
-                    AND trophy_start.order_id = 34
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR05019_00'
                     AND trophy_end.order_id = 32
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR05019_00'
+                    AND trophy_start.order_id = 34
                 HAVING
                     time_difference >= 10
                 ORDER BY
@@ -722,17 +721,17 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    player p
-                JOIN trophy_earned trophy_start ON
-                    trophy_start.account_id = p.account_id
-                    AND trophy_start.np_communication_id = 'NPWR18592_00'
-                    AND trophy_start.order_id = 1
+                    trophy_earned trophy_start
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = p.account_id
+                    trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR18592_00'
                     AND trophy_end.order_id = 4
+                JOIN player p ON
+                    p.account_id = trophy_start.account_id
+                    AND p.status != 1
                 WHERE
-                    p.status != 1
+                    trophy_start.np_communication_id = 'NPWR18592_00'
+                    AND trophy_start.order_id = 1
                 HAVING
                     time_difference <= 10
                 ORDER BY


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Loading `/admin/possible.php` ("Possible Cheaters") ran very expensive SQL against the `trophy_earned` table and saturated MySQL for 10–15 seconds, causing the rest of the site to hang while the report was generated.

## Root cause

1. **General cheater query** — ~200 trophy/order rule conditions were combined into one giant `OR` clause, forcing a full scan of `trophy_earned` instead of using the `(np_communication_id, order_id)` index.
2. **Section queries** — 27 of 28 sections started `FROM player`, scanning every player before joining into `trophy_earned`.
3. **Terminator Salvation section** — used a correlated subquery per row.

## Solution

- Parse general-rule conditions into structured tuples and join `trophy_earned` against a derived rule table (`UNION ALL` of rule rows), so MySQL can seek by `(np_communication_id, order_id)`.
- Rewrite all section queries to start from `trophy_earned` and filter by indexed trophy/order columns first.
- Replace the Terminator Salvation correlated subquery with a self-join.
- Wrap report generation in a MySQL `READ ONLY` transaction to reduce lock contention with concurrent writes.

## Testing

- Added `PossibleCheaterRuleConditionParserTest` (parses all 240 default rule conditions).
- Added `PossibleCheaterServiceTest` (SQLite-backed report generation).
- Full suite: `php tests/run.php` — 848 tests passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e6e4c88-31a8-4f16-9136-74c1d135c322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e6e4c88-31a8-4f16-9136-74c1d135c322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

