### PR TITLE
Escape TrophyRarity renderSpan output to prevent stored XSS

### DIFF
--- a/tests/TrophyRarityTest.php
+++ b/tests/TrophyRarityTest.php
@@ -32,4 +32,23 @@ final class TrophyRarityTest extends TestCase
 
         $this->assertSame('<span class="trophy-unobtainable">0.1% / Unobtainable</span>', $html);
     }
+
+    public function testRenderSpanEscapesMaliciousPercentageLabelAndCssClass(): void
+    {
+        $rarity = new TrophyRarity(
+            '<img src=x onerror=alert(1)>',
+            '"><script>alert(1)</script>',
+            '"><script>alert(1)</script>',
+            false,
+        );
+
+        $html = $rarity->renderSpan();
+
+        $this->assertSame(
+            '<span class="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;">'
+            . '&lt;img src=x onerror=alert(1)&gt;%<br>&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;'
+            . '</span>',
+            $html
+        );
+    }
 }

--- a/wwwroot/classes/TrophyRarity.php
+++ b/wwwroot/classes/TrophyRarity.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Html.php';
+
 final readonly class TrophyRarity
 {
     public function __construct(
@@ -43,15 +45,15 @@ final readonly class TrophyRarity
 
         if (!$this->unobtainable || $includePercentWhenUnobtainable) {
             if ($this->hasPercentage()) {
-                $parts[] = $this->percentage . '%';
+                $parts[] = Html::escape($this->percentage) . '%';
             }
         }
 
-        $parts[] = $this->label;
+        $parts[] = Html::escape($this->label);
 
         $classAttribute = '';
         if ($this->cssClass !== null && $this->cssClass !== '') {
-            $classAttribute = ' class="' . $this->cssClass . '"';
+            $classAttribute = ' class="' . Html::escape($this->cssClass) . '"';
         }
 
         return '<span' . $classAttribute . '>' . implode($separator, $parts) . '</span>';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`TrophyRarity::renderSpan()` emitted percentage, label, and CSS class values without escaping. When `TrophyRarityFormatter` preserves a non-numeric `rarity_percent` string from the database, that value was reflected as raw HTML on player advisor and player log pages.

This change escapes all user/DB-derived text in `renderSpan()` via the existing `Html::escape()` helper.

## Changes

- **`TrophyRarity.php`**: Escape `$percentage`, `$label`, and `$cssClass` in `renderSpan()`.
- **`TrophyRarityTest.php`**: Add regression test with malicious percentage, label, and class payloads.

The HTML separator (`<br>` by default) remains unescaped since it is intentional markup, not data.

## Test plan

- [x] `php tests/run.php` — all 858 tests pass
- [x] New test `testRenderSpanEscapesMaliciousPercentageLabelAndCssClass` verifies escaping of XSS payloads

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

