### PR TITLE
Rate-limit queue submissions per IP

### DIFF
--- a/tests/IpRateLimitServiceTest.php
+++ b/tests/IpRateLimitServiceTest.php
@@ -61,4 +61,31 @@ final class IpRateLimitServiceTest extends TestCase
             $this->service->checkAndRecord('192.0.2.12', IpRateLimitService::BUCKET_QUEUE_POLL)
         );
     }
+
+    public function testQueueSubmitBucketAllowsTenRequestsPerMinute(): void
+    {
+        for ($index = 0; $index < 10; $index++) {
+            $this->assertTrue(
+                $this->service->checkAndRecord('192.0.2.13', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+            );
+        }
+
+        $this->assertFalse(
+            $this->service->checkAndRecord('192.0.2.13', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+        );
+    }
+
+    public function testQueueSubmitBucketTracksSeparatelyFromQueuePoll(): void
+    {
+        for ($index = 0; $index < 10; $index++) {
+            $this->service->checkAndRecord('192.0.2.14', IpRateLimitService::BUCKET_QUEUE_SUBMIT);
+        }
+
+        $this->assertFalse(
+            $this->service->checkAndRecord('192.0.2.14', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+        );
+        $this->assertTrue(
+            $this->service->checkAndRecord('192.0.2.14', IpRateLimitService::BUCKET_QUEUE_POLL)
+        );
+    }
 }

--- a/tests/PlayerQueueControllerTest.php
+++ b/tests/PlayerQueueControllerTest.php
@@ -138,4 +138,37 @@ final class PlayerQueueControllerTest extends TestCase
         $this->assertSame(429, $result->getHttpStatusCode());
         $this->assertSame(null, $handler->getHandledMethod());
     }
+
+    public function testHandleAddToQueueReturnsRateLimitedResponseWhenIpLimitExceeded(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE ip_rate_limit (
+                bucket_key TEXT PRIMARY KEY,
+                window_start TEXT NOT NULL,
+                request_count INTEGER NOT NULL
+            )
+            SQL
+        );
+
+        $rateLimitService = new IpRateLimitService($pdo);
+        $handler = new PlayerQueueHandlerSpy(PlayerQueueResponse::queued('unused'));
+        $controller = new PlayerQueueController($handler, $rateLimitService);
+
+        for ($index = 0; $index < 10; $index++) {
+            $controller->handleAddToQueue(['q' => 'QueueUser'], ['REMOTE_ADDR' => '192.0.2.55']);
+        }
+
+        $handler->resetCapturedState();
+        $result = $controller->handleAddToQueue(['q' => 'QueueUser'], ['REMOTE_ADDR' => '192.0.2.55']);
+
+        $this->assertSame(429, $result->getHttpStatusCode());
+        $this->assertSame(
+            'Too many queue submissions. Please wait a moment and try again.',
+            $result->getMessage()
+        );
+        $this->assertSame(null, $handler->getHandledMethod());
+    }
 }

--- a/wwwroot/classes/IpRateLimitService.php
+++ b/wwwroot/classes/IpRateLimitService.php
@@ -9,11 +9,17 @@ final class IpRateLimitService
 {
     public const string BUCKET_QUEUE_POLL = 'queue_poll';
 
+    public const string BUCKET_QUEUE_SUBMIT = 'queue_submit';
+
     public const string BUCKET_SCAN_LOG_POLL = 'scan_log_poll';
 
     private const int QUEUE_POLL_MAX_REQUESTS = 60;
 
     private const int QUEUE_POLL_WINDOW_SECONDS = 60;
+
+    private const int QUEUE_SUBMIT_MAX_REQUESTS = 10;
+
+    private const int QUEUE_SUBMIT_WINDOW_SECONDS = 60;
 
     private const int SCAN_LOG_POLL_MAX_REQUESTS = 30;
 
@@ -97,6 +103,10 @@ final class IpRateLimitService
             self::BUCKET_QUEUE_POLL => [
                 self::QUEUE_POLL_MAX_REQUESTS,
                 self::QUEUE_POLL_WINDOW_SECONDS,
+            ],
+            self::BUCKET_QUEUE_SUBMIT => [
+                self::QUEUE_SUBMIT_MAX_REQUESTS,
+                self::QUEUE_SUBMIT_WINDOW_SECONDS,
             ],
             default => throw new InvalidArgumentException(sprintf('Unknown rate-limit bucket "%s".', $bucket)),
         };

--- a/wwwroot/classes/PlayerQueueController.php
+++ b/wwwroot/classes/PlayerQueueController.php
@@ -34,6 +34,18 @@ class PlayerQueueController
     {
         $request = PlayerQueueRequest::fromArrays($requestData, $serverData);
 
+        if (
+            $this->rateLimitService !== null
+            && !$this->rateLimitService->checkAndRecord(
+                $request->getIpAddress(),
+                IpRateLimitService::BUCKET_QUEUE_SUBMIT
+            )
+        ) {
+            return PlayerQueueResponse::rateLimited(
+                'Too many queue submissions. Please wait a moment and try again.'
+            );
+        }
+
         return $this->handler->handleAddToQueueRequest($request);
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Queue status polling was already rate-limited (60 requests/minute per IP via `queue_poll`), but submitting a player to the update queue had no burst protection — only the cumulative cap of 10 rows per IP in `player_queue`.

This adds a dedicated `queue_submit` bucket (10 submissions per 60 seconds per IP) enforced in `PlayerQueueController::handleAddToQueue()`.

## Changes

- **`IpRateLimitService`**: Add `BUCKET_QUEUE_SUBMIT` with a 10/minute fixed window.
- **`PlayerQueueController`**: Call `checkAndRecord()` before handling add-to-queue requests; return HTTP 429 when exceeded.
- **Tests**: Cover the new bucket limits and controller behavior.

Submit and poll buckets are tracked independently, so a user who hits the submission cap can still poll queue status.

## Test plan

- [x] `php tests/run.php` — all 861 tests pass
- [x] `IpRateLimitServiceTest` — submit bucket limit and separation from poll bucket
- [x] `PlayerQueueControllerTest` — 429 returned on 11th submission within the window

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

