### PR TITLE
Apply shared abuse limits when client IP is unknown

### DIFF
--- a/tests/IpAddressResolverTest.php
+++ b/tests/IpAddressResolverTest.php
@@ -88,4 +88,13 @@ final class IpAddressResolverTest extends TestCase
 
         $this->assertSame('198.51.100.44', $ipAddress);
     }
+
+    public function testNormalizeForAbuseControlsMapsEmptyIpToSharedIdentifier(): void
+    {
+        $this->assertSame(
+            IpAddressResolver::UNKNOWN_CLIENT_IDENTIFIER,
+            IpAddressResolver::normalizeForAbuseControls('')
+        );
+        $this->assertSame('192.0.2.1', IpAddressResolver::normalizeForAbuseControls('192.0.2.1'));
+    }
 }

--- a/tests/IpRateLimitServiceTest.php
+++ b/tests/IpRateLimitServiceTest.php
@@ -88,4 +88,31 @@ final class IpRateLimitServiceTest extends TestCase
             $this->service->checkAndRecord('192.0.2.14', IpRateLimitService::BUCKET_QUEUE_POLL)
         );
     }
+
+    public function testEmptyIpSharesUnknownClientRateLimitBucket(): void
+    {
+        for ($index = 0; $index < 10; $index++) {
+            $this->assertTrue(
+                $this->service->checkAndRecord('', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+            );
+        }
+
+        $this->assertFalse(
+            $this->service->checkAndRecord('', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+        );
+    }
+
+    public function testUnknownClientBucketIsSeparateFromKnownIp(): void
+    {
+        for ($index = 0; $index < 10; $index++) {
+            $this->service->checkAndRecord('', IpRateLimitService::BUCKET_QUEUE_SUBMIT);
+        }
+
+        $this->assertFalse(
+            $this->service->checkAndRecord('', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+        );
+        $this->assertTrue(
+            $this->service->checkAndRecord('192.0.2.15', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+        );
+    }
 }

--- a/tests/PlayerQueueControllerTest.php
+++ b/tests/PlayerQueueControllerTest.php
@@ -171,4 +171,33 @@ final class PlayerQueueControllerTest extends TestCase
         );
         $this->assertSame(null, $handler->getHandledMethod());
     }
+
+    public function testHandleAddToQueueRateLimitsSharedUnknownIpSubmissions(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE ip_rate_limit (
+                bucket_key TEXT PRIMARY KEY,
+                window_start TEXT NOT NULL,
+                request_count INTEGER NOT NULL
+            )
+            SQL
+        );
+
+        $rateLimitService = new IpRateLimitService($pdo);
+        $handler = new PlayerQueueHandlerSpy(PlayerQueueResponse::queued('unused'));
+        $controller = new PlayerQueueController($handler, $rateLimitService);
+
+        for ($index = 0; $index < 10; $index++) {
+            $controller->handleAddToQueue(['q' => 'QueueUser'], ['REMOTE_ADDR' => '']);
+        }
+
+        $handler->resetCapturedState();
+        $result = $controller->handleAddToQueue(['q' => 'QueueUser'], ['REMOTE_ADDR' => '']);
+
+        $this->assertSame(429, $result->getHttpStatusCode());
+        $this->assertSame(null, $handler->getHandledMethod());
+    }
 }

--- a/tests/PlayerQueueServiceTest.php
+++ b/tests/PlayerQueueServiceTest.php
@@ -59,9 +59,33 @@ final class PlayerQueueServiceTest extends TestCase
         }
     }
 
-    public function testGetIpSubmissionCountReturnsZeroWhenIpEmpty(): void
+    public function testGetIpSubmissionCountCountsSharedEmptyIpSubmissions(): void
     {
-        $this->assertSame(0, $this->service->getIpSubmissionCount(''));
+        $this->pdo->exec(
+            "INSERT INTO player_queue (online_id, ip_address, request_time) VALUES" .
+            " ('PlayerA', '', '2024-01-01T00:00:00')," .
+            " ('PlayerB', '', '2024-01-01T00:01:00')," .
+            " ('PlayerC', '10.0.0.1', '2024-01-01T00:02:00')"
+        );
+
+        $this->assertSame(2, $this->service->getIpSubmissionCount(''));
+        $this->assertSame(1, $this->service->getIpSubmissionCount('10.0.0.1'));
+    }
+
+    public function testHasReachedIpSubmissionLimitAppliesToSharedEmptyIpSubmissions(): void
+    {
+        $values = [];
+
+        for ($i = 0; $i < PlayerQueueService::MAX_QUEUE_SUBMISSIONS_PER_IP; $i++) {
+            $values[] = sprintf("('Player%d', '', '2024-01-01T00:%02d:00')", $i, $i);
+        }
+
+        $this->pdo->exec(
+            'INSERT INTO player_queue (online_id, ip_address, request_time) VALUES ' .
+            implode(', ', $values)
+        );
+
+        $this->assertTrue($this->service->hasReachedIpSubmissionLimit(''));
     }
 
     public function testGetIpSubmissionCountReturnsNumberOfMatches(): void

--- a/wwwroot/classes/IpAddressResolver.php
+++ b/wwwroot/classes/IpAddressResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 final class IpAddressResolver
 {
+    public const string UNKNOWN_CLIENT_IDENTIFIER = '__unknown__';
+
     /**
      * @param array<string, mixed> $serverParameters
      */
@@ -57,6 +59,11 @@ final class IpAddressResolver
         $validatedAddress = filter_var($ipAddress, FILTER_VALIDATE_IP);
 
         return is_string($validatedAddress) ? $validatedAddress : '';
+    }
+
+    public static function normalizeForAbuseControls(string $ipAddress): string
+    {
+        return $ipAddress !== '' ? $ipAddress : self::UNKNOWN_CLIENT_IDENTIFIER;
     }
 
     /**

--- a/wwwroot/classes/IpRateLimitService.php
+++ b/wwwroot/classes/IpRateLimitService.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/IpAddressResolver.php';
+
 /**
  * Fixed-window IP rate limiting backed by the ip_rate_limit table.
  */
@@ -31,10 +33,6 @@ final class IpRateLimitService
 
     public function isAllowed(string $ipAddress, string $bucket): bool
     {
-        if ($ipAddress === '') {
-            return true;
-        }
-
         [$maxRequests, $windowSeconds] = $this->resolveLimits($bucket);
         $bucketKey = $this->buildBucketKey($ipAddress, $bucket);
         $row = $this->fetchBucketRow($bucketKey);
@@ -60,10 +58,6 @@ final class IpRateLimitService
 
     public function checkAndRecord(string $ipAddress, string $bucket): bool
     {
-        if ($ipAddress === '') {
-            return true;
-        }
-
         [$maxRequests, $windowSeconds] = $this->resolveLimits($bucket);
         $bucketKey = $this->buildBucketKey($ipAddress, $bucket);
 
@@ -114,7 +108,9 @@ final class IpRateLimitService
 
     private function buildBucketKey(string $ipAddress, string $bucket): string
     {
-        return hash('sha256', $bucket . '|' . $ipAddress);
+        $normalizedIpAddress = IpAddressResolver::normalizeForAbuseControls($ipAddress);
+
+        return hash('sha256', $bucket . '|' . $normalizedIpAddress);
     }
 
     private function consumeSlotIfAvailable(string $bucketKey, int $maxRequests, int $windowSeconds): bool

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -92,10 +92,6 @@ class PlayerQueueService
 
     public function getIpSubmissionCount(string $ipAddress): int
     {
-        if ($ipAddress === '') {
-            return 0;
-        }
-
         $count = $this->fetchSingleValue(
             self::SQL_IP_SUBMISSION_COUNT,
             [':ip_address' => [$ipAddress, PDO::PARAM_STR]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the resolved client IP was empty, abuse controls were effectively disabled:

- `IpRateLimitService` skipped rate limiting entirely
- `PlayerQueueService::getIpSubmissionCount('')` always returned 0, bypassing the cumulative 10-row cap

Unknown clients are now subject to the **same limits** as known IPs, via a shared bucket — not rejected outright.

## Changes

- **`IpAddressResolver`**: Add `UNKNOWN_CLIENT_IDENTIFIER` and `normalizeForAbuseControls()` to map empty IPs to a shared key.
- **`IpRateLimitService`**: Remove empty-IP bypass; normalize before building bucket keys so unknown clients share one rate-limit window per bucket.
- **`PlayerQueueService`**: Count `player_queue` rows with `ip_address = ''` toward the shared cumulative cap.

Known IPs are unaffected. Unknown clients can still submit and poll until they hit the same thresholds (10 submissions/min burst, 10 cumulative queue rows, etc.).

## Test plan

- [x] `php tests/run.php` — all 866 tests pass
- [x] `IpAddressResolverTest` — normalize mapping
- [x] `IpRateLimitServiceTest` — shared unknown-client bucket and separation from known IPs
- [x] `PlayerQueueServiceTest` — empty-IP row counting and limit enforcement
- [x] `PlayerQueueControllerTest` — 429 on 11th unknown-IP submission within the window

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

