### PR TITLE
Escape platform badges in game header template

### DIFF
--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -193,7 +193,7 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
                 <div>
                     <?php
                     foreach (explode(',', $gamePlatform) as $platform) {
-                        echo "<span class=\"badge rounded-pill text-bg-primary p-2 me-1\">" . $platform . "</span> ";
+                        echo '<span class="badge rounded-pill text-bg-primary p-2 me-1">' . Html::escape($platform) . '</span> ';
                     }
                     ?>
                 </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Platform badges on the game header were echoed without escaping. The region badge on the same page already uses `Html::escape()`.

This wraps each platform label in `Html::escape()` so any unexpected database value is rendered as text, not HTML.

## Changes

- **`game_header.php`**: Escape platform badge text in the foreach loop.

## Test plan

- [x] `php tests/run.php` — all 866 tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

