### PR TITLE
Render admin merge alerts as plain text instead of innerHTML

### DIFF
--- a/wwwroot/js/admin-merge-form.js
+++ b/wwwroot/js/admin-merge-form.js
@@ -153,7 +153,7 @@ class GameMergeFormController {
                         if (finalPayload && finalPayload.success) {
                             const successMessage = finalPayload.message ?? 'The games have been merged.';
                             this.markProgressAsSuccess(successMessage);
-                            this.showAlert('success', successMessage, true);
+                            this.showAlert('success', successMessage);
 
                             return;
                         }
@@ -362,7 +362,7 @@ class GameMergeFormController {
                     this.resultContainer.replaceChildren();
                 }
 
-                showAlert(type, message, allowHtml = false) {
+                showAlert(type, message) {
                     if (!this.resultContainer) {
                         return;
                     }
@@ -370,14 +370,8 @@ class GameMergeFormController {
                     const alert = document.createElement('div');
                     alert.className = `alert alert-${type}`;
                     alert.setAttribute('role', 'alert');
-
-                    if (allowHtml) {
-                        const template = document.createElement('template');
-                        template.innerHTML = message ?? '';
-                        alert.replaceChildren(...template.content.childNodes);
-                    } else {
-                        alert.textContent = message ?? '';
-                    }
+                    alert.style.whiteSpace = 'pre-line';
+                    alert.textContent = this.toPlainText(message ?? '');
 
                     this.resultContainer.replaceChildren(alert);
                 }
@@ -399,7 +393,9 @@ class GameMergeFormController {
                         return '';
                     }
 
-                    return new DOMParser().parseFromString(value, 'text/html').body.textContent ?? '';
+                    const normalized = value.replace(/<br\s*\/?>/gi, '\n');
+
+                    return new DOMParser().parseFromString(normalized, 'text/html').body.textContent ?? '';
                 }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`admin-merge-form.js` rendered success alerts via `innerHTML` when `allowHtml` was true. Server messages are plain text today, but this was an XSS footgun if merge warnings or errors ever included user-controlled or exception content.

Alerts now always render through `textContent` and `toPlainText()`.

## Changes

- **`admin-merge-form.js`**: Remove `allowHtml` / `innerHTML` path from `showAlert()`.
- Use `toPlainText()` for all alert messages; convert `<br>` to newlines so multi-line merge warnings (e.g. unmapped trophy names) stay readable with `white-space: pre-line`.

## Test plan

- [x] `php tests/run.php` — all 866 tests pass
- [x] Manual review: success path no longer passes `allowHtml: true`; error paths were already plain text

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

