### PR TITLE
Clamp game list pagination to valid page range

### DIFF
--- a/tests/GameListFilterTest.php
+++ b/tests/GameListFilterTest.php
@@ -79,4 +79,21 @@ final class GameListFilterTest extends TestCase
             $filter->getQueryParametersForPagination()
         );
     }
+
+    public function testWithPageReturnsCloneWithNormalizedPage(): void
+    {
+        $filter = GameListFilter::fromArray(['page' => '3']);
+        $updated = $filter->withPage(5);
+
+        $this->assertSame(3, $filter->getPage());
+        $this->assertSame(5, $updated->getPage());
+        $this->assertSame(40, $updated->getOffset(10));
+    }
+
+    public function testWithPageFloorsToOne(): void
+    {
+        $filter = GameListFilter::fromArray(['page' => '2']);
+
+        $this->assertSame(1, $filter->withPage(0)->getPage());
+    }
 }

--- a/tests/GameListPageTest.php
+++ b/tests/GameListPageTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/GameListPage.php';
+require_once __DIR__ . '/../wwwroot/classes/GameListService.php';
+require_once __DIR__ . '/../wwwroot/classes/GameListFilter.php';
+require_once __DIR__ . '/../wwwroot/classes/SearchQueryHelper.php';
+
+final class GameListPageTest extends TestCase
+{
+    private PDO $database;
+
+    private GameListService $gameListService;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec(
+            <<<'SQL'
+            CREATE TABLE trophy_title (
+                id INTEGER PRIMARY KEY,
+                np_communication_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                icon_url TEXT NOT NULL DEFAULT '',
+                platform TEXT NOT NULL DEFAULT 'PS4',
+                platinum INTEGER NOT NULL DEFAULT 0,
+                gold INTEGER NOT NULL DEFAULT 0,
+                silver INTEGER NOT NULL DEFAULT 0,
+                bronze INTEGER NOT NULL DEFAULT 1
+            );
+
+            CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                status INTEGER NOT NULL DEFAULT 0,
+                owners INTEGER NOT NULL DEFAULT 0,
+                difficulty INTEGER NOT NULL DEFAULT 0,
+                rarity_points INTEGER NOT NULL DEFAULT 0,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE player (
+                online_id TEXT PRIMARY KEY,
+                account_id TEXT,
+                status INTEGER NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE trophy_title_player (
+                np_communication_id TEXT NOT NULL,
+                account_id TEXT NOT NULL,
+                progress INTEGER NOT NULL DEFAULT 0
+            );
+            SQL
+        );
+
+        $this->gameListService = new GameListService($this->database, new SearchQueryHelper());
+    }
+
+    public function testCurrentPageIsClampedWhenRequestedPageExceedsTotalPages(): void
+    {
+        $this->insertGame(1, 'Alpha Game');
+        $this->insertGame(2, 'Bravo Game');
+        $this->insertGame(3, 'Charlie Game');
+
+        $page = new GameListPage(
+            $this->gameListService,
+            GameListFilter::fromArray(['page' => '999'])
+        );
+
+        $this->assertSame(1, $page->getCurrentPage());
+        $this->assertSame(1, $page->getLastPage());
+        $this->assertSame(3, $page->getTotalGames());
+        $this->assertSame(1, $page->getRangeStart());
+        $this->assertSame(3, $page->getRangeEnd());
+        $this->assertCount(3, $page->getGames());
+        $this->assertSame('Charlie Game', $page->getGames()[0]->getName());
+    }
+
+    public function testOutOfRangePageReturnsLastPageResults(): void
+    {
+        for ($id = 1; $id <= 45; $id++) {
+            $this->insertGame($id, sprintf('Game %02d', $id));
+        }
+
+        $page = new GameListPage(
+            $this->gameListService,
+            GameListFilter::fromArray(['page' => '5'])
+        );
+
+        $this->assertSame(2, $page->getCurrentPage());
+        $this->assertSame(2, $page->getLastPage());
+        $this->assertSame(45, $page->getTotalGames());
+        $this->assertSame(41, $page->getRangeStart());
+        $this->assertSame(45, $page->getRangeEnd());
+        $this->assertCount(5, $page->getGames());
+        $this->assertSame('Game 05', $page->getGames()[0]->getName());
+        $this->assertSame('Game 01', $page->getGames()[4]->getName());
+    }
+
+    public function testCurrentPageDefaultsToOneWhenNoGamesExist(): void
+    {
+        $page = new GameListPage(
+            $this->gameListService,
+            GameListFilter::fromArray(['page' => '10'])
+        );
+
+        $this->assertSame(1, $page->getCurrentPage());
+        $this->assertSame(1, $page->getLastPage());
+        $this->assertSame(0, $page->getTotalGames());
+        $this->assertSame(0, $page->getRangeStart());
+        $this->assertSame(0, $page->getRangeEnd());
+        $this->assertCount(0, $page->getGames());
+    }
+
+    private function insertGame(int $id, string $name): void
+    {
+        $npCommunicationId = sprintf('NPWR%05d_00', $id);
+
+        $titleStatement = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy_title (
+                id,
+                np_communication_id,
+                name
+            ) VALUES (
+                :id,
+                :np_communication_id,
+                :name
+            )
+            SQL
+        );
+        $titleStatement->execute([
+            ':id' => $id,
+            ':np_communication_id' => $npCommunicationId,
+            ':name' => $name,
+        ]);
+
+        $metaStatement = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy_title_meta (
+                np_communication_id
+            ) VALUES (
+                :np_communication_id
+            )
+            SQL
+        );
+        $metaStatement->execute([
+            ':np_communication_id' => $npCommunicationId,
+        ]);
+    }
+}

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -104,6 +104,14 @@ class GameListFilter
         return $clone;
     }
 
+    public function withPage(int $page): self
+    {
+        $clone = clone $this;
+        $clone->page = max($page, 1);
+
+        return $clone;
+    }
+
     public function getSort(): string
     {
         return $this->sort;

--- a/wwwroot/classes/GameListPage.php
+++ b/wwwroot/classes/GameListPage.php
@@ -32,14 +32,24 @@ class GameListPage
     public function __construct(GameListService $gameListService, GameListFilter $filter)
     {
         $this->gameListService = $gameListService;
-        $this->filter = $filter->withPlayer($gameListService->resolvePlayer($filter->getPlayer()));
+        $resolvedFilter = $filter->withPlayer($gameListService->resolvePlayer($filter->getPlayer()));
         $this->limit = $this->gameListService->getLimit();
-        $this->offset = $this->gameListService->getOffset($this->filter);
-        $result = $this->gameListService->getGamesPage($this->filter);
+
+        $result = $this->gameListService->getGamesPage($resolvedFilter);
         $this->totalGames = $result->totalGames;
         $this->totalPages = $this->totalGames > 0
             ? (int) ceil($this->totalGames / $this->limit)
             : 0;
+
+        $clampedPage = $this->normalizePageNumber($resolvedFilter->getPage(), $this->totalPages);
+        $needsRefetch = $clampedPage !== $resolvedFilter->getPage();
+        $this->filter = $resolvedFilter->withPage($clampedPage);
+
+        if ($needsRefetch) {
+            $result = $this->gameListService->getGamesPage($this->filter);
+        }
+
+        $this->offset = $this->gameListService->getOffset($this->filter);
         $this->games = $result->games;
         $this->paginationParameters = $this->filter->getQueryParametersForPagination();
     }
@@ -193,5 +203,12 @@ class GameListPage
     public function getLastPageParameters(): array
     {
         return $this->getPageQueryParameters($this->getLastPage());
+    }
+
+    private function normalizePageNumber(int $requestedPage, int $totalPages): int
+    {
+        $maximumPage = $totalPages > 0 ? $totalPages : 1;
+
+        return min(max($requestedPage, 1), $maximumPage);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The game list page accepted any `?page=` value but only floored it to 1. A URL like `?page=999` produced an empty game list and broken range text (e.g. "39921–3 of 3") because offset was computed from the unclamped page.

This clamps the requested page to the valid range before loading results, consistent with `AvatarPage` and `ChangelogPaginator`.

## Changes

- **`GameListFilter`**: Add `withPage()` for immutable page updates.
- **`GameListPage`**: Compute `totalPages`, clamp the page, and refetch only when the requested page was out of range.
- **`GameListPageTest`**: Cover over-range pages, last-page fallback with multiple pages, and empty results.

## Test plan

- [x] `php tests/run.php` — all 871 tests pass
- [x] `GameListPageTest` — page 999 clamps to 1; page 5 with 45 games clamps to page 2

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

