### PR TITLE
Clamp game leaderboard pagination to valid page range

### DIFF
--- a/tests/GameLeaderboardFilterTest.php
+++ b/tests/GameLeaderboardFilterTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/GamePlayerFilter.php';
+require_once __DIR__ . '/../wwwroot/classes/GameLeaderboardFilter.php';
+
+final class GameLeaderboardFilterTest extends TestCase
+{
+    public function testWithPageNumberReturnsNewFilterInstance(): void
+    {
+        $filter = GameLeaderboardFilter::fromArray(['page' => '2', 'country' => 'us']);
+
+        $updated = $filter->withPageNumber(4);
+
+        $this->assertSame(2, $filter->getPage());
+        $this->assertSame(4, $updated->getPage());
+        $this->assertSame('us', $updated->getCountry());
+        $this->assertSame(150, $updated->getOffset(50));
+    }
+}

--- a/tests/GameLeaderboardPageTest.php
+++ b/tests/GameLeaderboardPageTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/GameLeaderboardPage.php';
+require_once __DIR__ . '/../wwwroot/classes/GameLeaderboardService.php';
+require_once __DIR__ . '/../wwwroot/classes/GameHeaderService.php';
+require_once __DIR__ . '/../wwwroot/classes/Game/GameHeaderData.php';
+
+final class GameLeaderboardPageTest extends TestCase
+{
+    private PDO $database;
+
+    private GameLeaderboardService $leaderboardService;
+
+    private GameHeaderService $headerService;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec(
+            <<<'SQL'
+            CREATE TABLE trophy_title (
+                id INTEGER PRIMARY KEY,
+                np_communication_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                detail TEXT NOT NULL DEFAULT '',
+                icon_url TEXT NOT NULL DEFAULT '',
+                platform TEXT NOT NULL DEFAULT 'PS4',
+                bronze INTEGER NOT NULL DEFAULT 0,
+                silver INTEGER NOT NULL DEFAULT 0,
+                gold INTEGER NOT NULL DEFAULT 0,
+                platinum INTEGER NOT NULL DEFAULT 0,
+                set_version TEXT NOT NULL DEFAULT '01.00'
+            );
+
+            CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                message TEXT,
+                status INTEGER NOT NULL DEFAULT 0,
+                recent_players INTEGER NOT NULL DEFAULT 0,
+                owners_completed INTEGER NOT NULL DEFAULT 0,
+                owners INTEGER NOT NULL DEFAULT 0,
+                difficulty INTEGER NOT NULL DEFAULT 0,
+                psnprofiles_id TEXT,
+                parent_np_communication_id TEXT,
+                region TEXT,
+                rarity_points INTEGER NOT NULL DEFAULT 0,
+                in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
+                obsolete_ids TEXT
+            );
+
+            CREATE TABLE player (
+                account_id TEXT PRIMARY KEY,
+                online_id TEXT NOT NULL,
+                avatar_url TEXT NOT NULL DEFAULT '',
+                country TEXT NOT NULL DEFAULT 'us',
+                status INTEGER NOT NULL DEFAULT 0,
+                trophy_count_npwr INTEGER NOT NULL DEFAULT 0,
+                trophy_count_sony INTEGER NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE player_ranking (
+                account_id TEXT PRIMARY KEY,
+                ranking INTEGER NOT NULL
+            );
+
+            CREATE TABLE trophy_title_player (
+                np_communication_id TEXT NOT NULL,
+                account_id TEXT NOT NULL,
+                bronze INTEGER NOT NULL DEFAULT 0,
+                silver INTEGER NOT NULL DEFAULT 0,
+                gold INTEGER NOT NULL DEFAULT 0,
+                platinum INTEGER NOT NULL DEFAULT 0,
+                progress INTEGER NOT NULL DEFAULT 0,
+                last_updated_date TEXT NOT NULL DEFAULT '2024-01-01'
+            );
+            SQL
+        );
+
+        $this->insertGame(1, 'NPWR00001_00', 'Example Game');
+        $this->leaderboardService = new GameLeaderboardService($this->database);
+        $this->headerService = new class extends GameHeaderService {
+            public function __construct()
+            {
+            }
+
+            public function buildHeaderData(GameDetails $game): GameHeaderData
+            {
+                return new GameHeaderData(null, [], 0, [], null);
+            }
+        };
+    }
+
+    public function testPageIsClampedWhenRequestedPageExceedsTotalPages(): void
+    {
+        $this->insertLeaderboardPlayer('player-1', 'PlayerOne', 100);
+        $this->insertLeaderboardPlayer('player-2', 'PlayerTwo', 90);
+        $this->insertLeaderboardPlayer('player-3', 'PlayerThree', 80);
+
+        $page = GameLeaderboardPage::create(
+            $this->leaderboardService,
+            $this->headerService,
+            1,
+            null,
+            ['page' => '999']
+        );
+
+        $this->assertSame(1, $page->getPage());
+        $this->assertSame(1, $page->getTotalPagesCount());
+        $this->assertSame(0, $page->getOffset());
+        $this->assertSame(3, $page->getTotalPlayers());
+        $this->assertCount(3, $page->getRows());
+        $this->assertSame('PlayerOne', $page->getRows()[0]->getOnlineId());
+    }
+
+    public function testOutOfRangePageReturnsLastPageResults(): void
+    {
+        for ($index = 1; $index <= 55; $index++) {
+            $this->insertLeaderboardPlayer(
+                sprintf('player-%02d', $index),
+                sprintf('Player%02d', $index),
+                $index
+            );
+        }
+
+        $page = GameLeaderboardPage::create(
+            $this->leaderboardService,
+            $this->headerService,
+            1,
+            null,
+            ['page' => '5']
+        );
+
+        $this->assertSame(2, $page->getPage());
+        $this->assertSame(2, $page->getTotalPagesCount());
+        $this->assertSame(50, $page->getOffset());
+        $this->assertSame(55, $page->getTotalPlayers());
+        $this->assertCount(5, $page->getRows());
+        $this->assertSame('Player05', $page->getRows()[0]->getOnlineId());
+        $this->assertSame('Player01', $page->getRows()[4]->getOnlineId());
+    }
+
+    public function testPageDefaultsToOneWhenLeaderboardIsEmpty(): void
+    {
+        $page = GameLeaderboardPage::create(
+            $this->leaderboardService,
+            $this->headerService,
+            1,
+            null,
+            ['page' => '10']
+        );
+
+        $this->assertSame(1, $page->getPage());
+        $this->assertSame(0, $page->getTotalPagesCount());
+        $this->assertSame(0, $page->getOffset());
+        $this->assertSame(0, $page->getTotalPlayers());
+        $this->assertCount(0, $page->getRows());
+    }
+
+    private function insertGame(int $id, string $npCommunicationId, string $name): void
+    {
+        $titleStatement = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy_title (
+                id,
+                np_communication_id,
+                name
+            ) VALUES (
+                :id,
+                :np_communication_id,
+                :name
+            )
+            SQL
+        );
+        $titleStatement->execute([
+            ':id' => $id,
+            ':np_communication_id' => $npCommunicationId,
+            ':name' => $name,
+        ]);
+
+        $metaStatement = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy_title_meta (
+                np_communication_id
+            ) VALUES (
+                :np_communication_id
+            )
+            SQL
+        );
+        $metaStatement->execute([
+            ':np_communication_id' => $npCommunicationId,
+        ]);
+    }
+
+    private function insertLeaderboardPlayer(string $accountId, string $onlineId, int $progress): void
+    {
+        $playerStatement = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO player (
+                account_id,
+                online_id
+            ) VALUES (
+                :account_id,
+                :online_id
+            )
+            SQL
+        );
+        $playerStatement->execute([
+            ':account_id' => $accountId,
+            ':online_id' => $onlineId,
+        ]);
+
+        $rankingStatement = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO player_ranking (
+                account_id,
+                ranking
+            ) VALUES (
+                :account_id,
+                :ranking
+            )
+            SQL
+        );
+        $rankingStatement->execute([
+            ':account_id' => $accountId,
+            ':ranking' => 1,
+        ]);
+
+        $progressStatement = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy_title_player (
+                np_communication_id,
+                account_id,
+                progress
+            ) VALUES (
+                :np_communication_id,
+                :account_id,
+                :progress
+            )
+            SQL
+        );
+        $progressStatement->execute([
+            ':np_communication_id' => 'NPWR00001_00',
+            ':account_id' => $accountId,
+            ':progress' => $progress,
+        ]);
+    }
+}

--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -32,6 +32,11 @@ final readonly class GameLeaderboardFilter extends GamePlayerFilter
         return $this->page;
     }
 
+    public function withPageNumber(int $page): self
+    {
+        return new self($this->getCountry(), $this->getAvatar(), $page);
+    }
+
     public function getOffset(int $limit): int
     {
         return ($this->page - 1) * $limit;

--- a/wwwroot/classes/GameLeaderboardPage.php
+++ b/wwwroot/classes/GameLeaderboardPage.php
@@ -92,18 +92,21 @@ class GameLeaderboardPage
 
         $filter = GameLeaderboardFilter::fromArray($queryParameters);
         $limit = GameLeaderboardService::PAGE_SIZE;
-        $offset = $filter->getOffset($limit);
         $npCommunicationId = $game->getNpCommunicationId();
         $totalPlayers = $leaderboardService->getLeaderboardPlayerCount(
             $npCommunicationId,
             $filter
         );
+        $totalPagesCount = $limit > 0 ? (int) ceil($totalPlayers / $limit) : 0;
+
+        $clampedPage = self::normalizePageNumber($filter->getPage(), $totalPagesCount);
+        $filter = $filter->withPageNumber($clampedPage);
+        $offset = $filter->getOffset($limit);
         $rows = $leaderboardService->getLeaderboardRows(
             $npCommunicationId,
             $filter,
             $limit
         );
-        $totalPagesCount = $limit > 0 ? (int) ceil($totalPlayers / $limit) : 0;
 
         $gameHeaderData = $headerService->buildHeaderData($game);
 
@@ -181,5 +184,12 @@ class GameLeaderboardPage
     public function getGameSlug(Utility $utility): string
     {
         return $this->game->getId() . '-' . $utility->slugify($this->game->getName());
+    }
+
+    private static function normalizePageNumber(int $requestedPage, int $totalPages): int
+    {
+        $maximumPage = $totalPages > 0 ? $totalPages : 1;
+
+        return min(max($requestedPage, 1), $maximumPage);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The game leaderboard accepted any `?page=` value but only floored it to 1. Out-of-range pages returned empty leaderboards while pagination still reflected the invalid page number.

This clamps the requested page to the valid range before loading rows, consistent with the game list pagination fix in PR 13.

## Changes

- **`GameLeaderboardFilter`**: Add `withPageNumber()` for immutable page updates.
- **`GameLeaderboardPage`**: Count players, clamp page, then fetch rows with the normalized filter.
- **Tests**: `GameLeaderboardPageTest` and `GameLeaderboardFilterTest`.

## Test plan

- [x] `php tests/run.php` — all 875 tests pass
- [x] `GameLeaderboardPageTest` — page 999 clamps to 1; page 5 with 55 players clamps to page 2

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

