### PR TITLE
Clamp player advisor pagination to valid page range

### DIFF
--- a/tests/PlayerAdvisorFilterTest.php
+++ b/tests/PlayerAdvisorFilterTest.php
@@ -80,4 +80,23 @@ final class PlayerAdvisorFilterTest extends TestCase
             'sort' => PlayerAdvisorFilter::SORT_IN_GAME_RARITY,
         ], $filter->getFilterParameters());
     }
+
+    public function testWithPageReturnsCloneWithNormalizedPage(): void
+    {
+        $filter = PlayerAdvisorFilter::fromArray(['page' => '2', 'ps5' => '1']);
+
+        $updated = $filter->withPage(4);
+
+        $this->assertSame(2, $filter->getPage());
+        $this->assertSame(4, $updated->getPage());
+        $this->assertTrue($updated->isPlatformSelected('ps5'));
+        $this->assertSame(60, $updated->getOffset(20));
+    }
+
+    public function testWithPageFloorsToOne(): void
+    {
+        $filter = PlayerAdvisorFilter::fromArray(['page' => '3']);
+
+        $this->assertSame(1, $filter->withPage(0)->getPage());
+    }
 }

--- a/tests/PlayerAdvisorPageTest.php
+++ b/tests/PlayerAdvisorPageTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerAdvisorPage.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerAdvisorService.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerAdvisorFilter.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerSummaryService.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerStatus.php';
+require_once __DIR__ . '/../wwwroot/classes/Utility.php';
+
+final class PlayerAdvisorPageTest extends TestCase
+{
+    private PDO $database;
+
+    private PlayerAdvisorService $advisorService;
+
+    private PlayerSummaryService $summaryService;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->database->exec(
+            <<<'SQL'
+            CREATE TABLE trophy_title (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                np_communication_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                icon_url TEXT NOT NULL,
+                platform TEXT NOT NULL
+            );
+
+            CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                status INTEGER NOT NULL
+            );
+
+            CREATE TABLE trophy (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                np_communication_id TEXT NOT NULL,
+                order_id INTEGER NOT NULL,
+                type TEXT NOT NULL,
+                name TEXT NOT NULL,
+                detail TEXT NOT NULL,
+                icon_url TEXT NOT NULL,
+                progress_target_value INTEGER,
+                reward_name TEXT,
+                reward_image_url TEXT
+            );
+
+            CREATE TABLE trophy_meta (
+                trophy_id INTEGER PRIMARY KEY,
+                rarity_percent REAL NOT NULL,
+                in_game_rarity_percent REAL NOT NULL DEFAULT 0,
+                status INTEGER NOT NULL
+            );
+
+            CREATE TABLE trophy_title_player (
+                np_communication_id TEXT NOT NULL,
+                account_id INTEGER NOT NULL,
+                last_updated_date TEXT NOT NULL
+            );
+
+            CREATE TABLE trophy_earned (
+                np_communication_id TEXT NOT NULL,
+                order_id INTEGER NOT NULL,
+                account_id INTEGER NOT NULL,
+                earned INTEGER NOT NULL,
+                progress REAL
+            );
+            SQL
+        );
+
+        $this->advisorService = new PlayerAdvisorService($this->database, new Utility());
+        $this->summaryService = new class($this->database) extends PlayerSummaryService {
+            public function getSummary(int $accountId): PlayerSummary
+            {
+                return new PlayerSummary(0, 0, null, 0);
+            }
+        };
+    }
+
+    public function testCurrentPageIsClampedWhenRequestedPageExceedsTotalPages(): void
+    {
+        $this->insertAdvisableTrophy(42, 1, 'Trophy One', 30.0);
+        $this->insertAdvisableTrophy(42, 2, 'Trophy Two', 20.0);
+        $this->insertAdvisableTrophy(42, 3, 'Trophy Three', 10.0);
+
+        $page = new PlayerAdvisorPage(
+            $this->advisorService,
+            $this->summaryService,
+            PlayerAdvisorFilter::fromArray(['page' => '999']),
+            42,
+            PlayerStatus::NORMAL
+        );
+
+        $this->assertSame(1, $page->getCurrentPage());
+        $this->assertSame(1, $page->getTotalPages());
+        $this->assertSame(0, $page->getOffset());
+        $this->assertSame(3, $page->getTotalTrophies());
+        $this->assertCount(3, $page->getAdvisableTrophies());
+        $this->assertSame('Trophy One', $page->getAdvisableTrophies()[0]->getTrophyName());
+    }
+
+    public function testOutOfRangePageReturnsLastPageResults(): void
+    {
+        for ($index = 1; $index <= 55; $index++) {
+            $this->insertAdvisableTrophy(42, $index, sprintf('Trophy %02d', $index), (float) $index);
+        }
+
+        $page = new PlayerAdvisorPage(
+            $this->advisorService,
+            $this->summaryService,
+            PlayerAdvisorFilter::fromArray(['page' => '5']),
+            42,
+            PlayerStatus::NORMAL
+        );
+
+        $this->assertSame(2, $page->getCurrentPage());
+        $this->assertSame(2, $page->getTotalPages());
+        $this->assertSame(50, $page->getOffset());
+        $this->assertSame(55, $page->getTotalTrophies());
+        $this->assertCount(5, $page->getAdvisableTrophies());
+        $this->assertSame('Trophy 05', $page->getAdvisableTrophies()[0]->getTrophyName());
+        $this->assertSame('Trophy 01', $page->getAdvisableTrophies()[4]->getTrophyName());
+    }
+
+    public function testCurrentPageDefaultsToOneWhenNoAdvisableTrophiesExist(): void
+    {
+        $page = new PlayerAdvisorPage(
+            $this->advisorService,
+            $this->summaryService,
+            PlayerAdvisorFilter::fromArray(['page' => '10']),
+            42,
+            PlayerStatus::NORMAL
+        );
+
+        $this->assertSame(1, $page->getCurrentPage());
+        $this->assertSame(0, $page->getTotalPages());
+        $this->assertSame(0, $page->getOffset());
+        $this->assertSame(0, $page->getTotalTrophies());
+        $this->assertCount(0, $page->getAdvisableTrophies());
+    }
+
+    private function insertAdvisableTrophy(int $accountId, int $trophyId, string $name, float $rarityPercent): void
+    {
+        $npCommunicationId = 'NPWR-ADVISOR-1';
+
+        if ($trophyId === 1) {
+            $this->database->exec(
+                "INSERT INTO trophy_title (np_communication_id, name, icon_url, platform)
+                VALUES ('{$npCommunicationId}', 'Advisor Game', 'game.png', 'PS5')"
+            );
+            $this->database->exec(
+                "INSERT INTO trophy_title_meta (np_communication_id, status)
+                VALUES ('{$npCommunicationId}', 0)"
+            );
+            $this->database->exec(
+                "INSERT INTO trophy_title_player (np_communication_id, account_id, last_updated_date)
+                VALUES ('{$npCommunicationId}', {$accountId}, '2024-01-01 00:00:00')"
+            );
+        }
+
+        $statement = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy (
+                id,
+                np_communication_id,
+                order_id,
+                type,
+                name,
+                detail,
+                icon_url
+            ) VALUES (
+                :id,
+                :np_communication_id,
+                :order_id,
+                'bronze',
+                :name,
+                'Detail',
+                'trophy.png'
+            )
+            SQL
+        );
+        $statement->execute([
+            ':id' => $trophyId,
+            ':np_communication_id' => $npCommunicationId,
+            ':order_id' => $trophyId,
+            ':name' => $name,
+        ]);
+
+        $metaStatement = $this->database->prepare(
+            <<<'SQL'
+            INSERT INTO trophy_meta (
+                trophy_id,
+                rarity_percent,
+                status
+            ) VALUES (
+                :trophy_id,
+                :rarity_percent,
+                0
+            )
+            SQL
+        );
+        $metaStatement->execute([
+            ':trophy_id' => $trophyId,
+            ':rarity_percent' => $rarityPercent,
+        ]);
+    }
+}

--- a/wwwroot/classes/PlayerAdvisorFilter.php
+++ b/wwwroot/classes/PlayerAdvisorFilter.php
@@ -71,6 +71,11 @@ class PlayerAdvisorFilter
         return $this->page;
     }
 
+    public function withPage(int $page): self
+    {
+        return new self(max($page, 1), $this->sort, $this->platforms);
+    }
+
     public function getOffset(int $limit): int
     {
         return ($this->page - 1) * $limit;

--- a/wwwroot/classes/PlayerAdvisorPage.php
+++ b/wwwroot/classes/PlayerAdvisorPage.php
@@ -34,9 +34,23 @@ class PlayerAdvisorPage
     ) {
         $this->playerAdvisorService = $playerAdvisorService;
         $this->playerSummaryService = $playerSummaryService;
-        $this->filter = $filter;
         $this->accountId = $accountId;
         $this->playerStatus = $playerStatus;
+
+        if ($this->shouldDisplayAdvisor()) {
+            $this->totalTrophies = $this->playerAdvisorService->countAdvisableTrophies(
+                $this->accountId,
+                $filter
+            );
+            $this->filter = $filter->withPage(
+                $this->normalizePageNumber(
+                    $filter->getPage(),
+                    $this->calculateTotalPages($this->totalTrophies)
+                )
+            );
+        } else {
+            $this->filter = $filter->withPage($this->normalizePageNumber($filter->getPage(), 0));
+        }
     }
 
     public function getPlayerSummary(): PlayerSummary
@@ -112,13 +126,7 @@ class PlayerAdvisorPage
 
     public function getTotalPages(): int
     {
-        $pageSize = $this->getPageSize();
-
-        if ($pageSize === 0) {
-            return 0;
-        }
-
-        return (int) ceil($this->getTotalTrophies() / $pageSize);
+        return $this->calculateTotalPages($this->getTotalTrophies());
     }
 
     /**
@@ -127,5 +135,23 @@ class PlayerAdvisorPage
     public function getFilterParameters(): array
     {
         return $this->filter->getFilterParameters();
+    }
+
+    private function calculateTotalPages(int $totalTrophies): int
+    {
+        $pageSize = $this->getPageSize();
+
+        if ($pageSize === 0) {
+            return 0;
+        }
+
+        return (int) ceil($totalTrophies / $pageSize);
+    }
+
+    private function normalizePageNumber(int $requestedPage, int $totalPages): int
+    {
+        $maximumPage = $totalPages > 0 ? $totalPages : 1;
+
+        return min(max($requestedPage, 1), $maximumPage);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The player advisor page accepted any `?page=` value but only floored it to 1. Out-of-range pages returned empty trophy lists while `getTotalPages()` was computed but never used to clamp the active page.

This normalizes the requested page against `totalPages` before loading advisable trophies, consistent with the game list and game leaderboard pagination fixes.

## Changes

- **`PlayerAdvisorFilter`**: Add `withPage()` for immutable page updates.
- **`PlayerAdvisorPage`**: Count advisable trophies in the constructor, clamp the page, and use the normalized filter for offset and trophy queries.
- **Tests**: `PlayerAdvisorPageTest` and `PlayerAdvisorFilterTest` coverage for page clamping.

## Test plan

- [x] `php tests/run.php` — all 880 tests pass
- [x] `PlayerAdvisorPageTest` — page 999 clamps to 1; page 5 with 55 trophies clamps to page 2

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

