### PR TITLE
Rate-limit player report submissions per IP

### DIFF
--- a/tests/IpRateLimitServiceTest.php
+++ b/tests/IpRateLimitServiceTest.php
@@ -115,4 +115,31 @@ final class IpRateLimitServiceTest extends TestCase
             $this->service->checkAndRecord('192.0.2.15', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
         );
     }
+
+    public function testPlayerReportBucketAllowsFiveRequestsPerMinute(): void
+    {
+        for ($index = 0; $index < 5; $index++) {
+            $this->assertTrue(
+                $this->service->checkAndRecord('192.0.2.16', IpRateLimitService::BUCKET_PLAYER_REPORT)
+            );
+        }
+
+        $this->assertFalse(
+            $this->service->checkAndRecord('192.0.2.16', IpRateLimitService::BUCKET_PLAYER_REPORT)
+        );
+    }
+
+    public function testPlayerReportBucketTracksSeparatelyFromQueueSubmit(): void
+    {
+        for ($index = 0; $index < 5; $index++) {
+            $this->service->checkAndRecord('192.0.2.17', IpRateLimitService::BUCKET_PLAYER_REPORT);
+        }
+
+        $this->assertFalse(
+            $this->service->checkAndRecord('192.0.2.17', IpRateLimitService::BUCKET_PLAYER_REPORT)
+        );
+        $this->assertTrue(
+            $this->service->checkAndRecord('192.0.2.17', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+        );
+    }
 }

--- a/tests/PlayerReportHandlerTest.php
+++ b/tests/PlayerReportHandlerTest.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../wwwroot/classes/PlayerReportResult.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerReportService.php';
 require_once __DIR__ . '/../wwwroot/classes/SessionManager.php';
 require_once __DIR__ . '/../wwwroot/classes/CsrfTokenManager.php';
+require_once __DIR__ . '/../wwwroot/classes/IpRateLimitService.php';
 
 final class PlayerReportServiceStub extends PlayerReportService
 {
@@ -122,6 +123,92 @@ final class PlayerReportHandlerTest extends TestCase
         $this->assertTrue($result->hasMessage());
         $this->assertTrue($result->isSuccess());
         $this->assertSame('Player reported successfully.', $result->getMessage());
+    }
+
+    public function testHandleReportRequestReturnsRateLimitedErrorWhenIpLimitExceeded(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE ip_rate_limit (
+                bucket_key TEXT PRIMARY KEY,
+                window_start TEXT NOT NULL,
+                request_count INTEGER NOT NULL
+            )
+            SQL
+        );
+
+        $rateLimitService = new IpRateLimitService($pdo);
+        $service = new PlayerReportServiceStub(PlayerReportResult::success('unused'));
+        $handler = new PlayerReportHandler($service, $rateLimitService);
+
+        for ($index = 0; $index < 5; $index++) {
+            $handler->handleReportRequest(
+                789,
+                $this->createRequestWithCsrf(
+                    ['explanation' => 'Report attempt ' . $index],
+                    ['REMOTE_ADDR' => '192.0.2.88']
+                )
+            );
+        }
+
+        $service->submitReportCallCount = 0;
+        $result = $handler->handleReportRequest(
+            789,
+            $this->createRequestWithCsrf(
+                ['explanation' => 'One report too many'],
+                ['REMOTE_ADDR' => '192.0.2.88']
+            )
+        );
+
+        $this->assertTrue($result->hasMessage());
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame(
+            'Too many report submissions. Please wait a moment and try again.',
+            $result->getMessage()
+        );
+        $this->assertSame(0, $service->submitReportCallCount);
+    }
+
+    public function testHandleReportRequestDoesNotConsumeRateLimitWhenValidationFails(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE ip_rate_limit (
+                bucket_key TEXT PRIMARY KEY,
+                window_start TEXT NOT NULL,
+                request_count INTEGER NOT NULL
+            )
+            SQL
+        );
+
+        $rateLimitService = new IpRateLimitService($pdo);
+        $service = new PlayerReportServiceStub(PlayerReportResult::success('unused'));
+        $handler = new PlayerReportHandler($service, $rateLimitService);
+
+        for ($index = 0; $index < 20; $index++) {
+            $handler->handleReportRequest(
+                789,
+                PlayerReportRequest::fromArrays(
+                    ['explanation' => '   ', '_csrf_token' => 'invalid-token'],
+                    ['REMOTE_ADDR' => '192.0.2.89']
+                )
+            );
+        }
+
+        $result = $handler->handleReportRequest(
+            789,
+            $this->createRequestWithCsrf(
+                ['explanation' => 'Valid report after failed attempts'],
+                ['REMOTE_ADDR' => '192.0.2.89']
+            )
+        );
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertSame(1, $service->submitReportCallCount);
     }
 
     /**

--- a/tests/PlayerReportHandlerTest.php
+++ b/tests/PlayerReportHandlerTest.php
@@ -171,6 +171,26 @@ final class PlayerReportHandlerTest extends TestCase
         $this->assertSame(0, $service->submitReportCallCount);
     }
 
+    public function testHandleReportRequestReturnsErrorWhenExplanationIsTooLong(): void
+    {
+        $service = new PlayerReportServiceStub(PlayerReportResult::success('irrelevant'));
+        $handler = new PlayerReportHandler($service);
+        $request = $this->createRequestWithCsrf(
+            ['explanation' => str_repeat('a', PlayerReportService::MAX_EXPLANATION_LENGTH + 1)],
+            ['REMOTE_ADDR' => '192.0.2.1']
+        );
+
+        $result = $handler->handleReportRequest(456, $request);
+
+        $this->assertTrue($result->hasMessage());
+        $this->assertFalse($result->isSuccess());
+        $this->assertSame(
+            'Explanation must be ' . PlayerReportService::MAX_EXPLANATION_LENGTH . ' characters or fewer.',
+            $result->getMessage()
+        );
+        $this->assertSame(0, $service->submitReportCallCount);
+    }
+
     public function testHandleReportRequestDoesNotConsumeRateLimitWhenValidationFails(): void
     {
         $pdo = new PDO('sqlite::memory:');
@@ -204,6 +224,47 @@ final class PlayerReportHandlerTest extends TestCase
             $this->createRequestWithCsrf(
                 ['explanation' => 'Valid report after failed attempts'],
                 ['REMOTE_ADDR' => '192.0.2.89']
+            )
+        );
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertSame(1, $service->submitReportCallCount);
+    }
+
+    public function testHandleReportRequestDoesNotConsumeRateLimitWhenExplanationIsTooLong(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE ip_rate_limit (
+                bucket_key TEXT PRIMARY KEY,
+                window_start TEXT NOT NULL,
+                request_count INTEGER NOT NULL
+            )
+            SQL
+        );
+
+        $rateLimitService = new IpRateLimitService($pdo);
+        $service = new PlayerReportServiceStub(PlayerReportResult::success('unused'));
+        $handler = new PlayerReportHandler($service, $rateLimitService);
+        $oversizedExplanation = str_repeat('a', PlayerReportService::MAX_EXPLANATION_LENGTH + 1);
+
+        for ($index = 0; $index < 20; $index++) {
+            $handler->handleReportRequest(
+                789,
+                $this->createRequestWithCsrf(
+                    ['explanation' => $oversizedExplanation],
+                    ['REMOTE_ADDR' => '192.0.2.90']
+                )
+            );
+        }
+
+        $result = $handler->handleReportRequest(
+            789,
+            $this->createRequestWithCsrf(
+                ['explanation' => 'Valid report after oversized attempts'],
+                ['REMOTE_ADDR' => '192.0.2.90']
             )
         );
 

--- a/wwwroot/classes/IpRateLimitService.php
+++ b/wwwroot/classes/IpRateLimitService.php
@@ -13,6 +13,8 @@ final class IpRateLimitService
 
     public const string BUCKET_QUEUE_SUBMIT = 'queue_submit';
 
+    public const string BUCKET_PLAYER_REPORT = 'player_report';
+
     public const string BUCKET_SCAN_LOG_POLL = 'scan_log_poll';
 
     private const int QUEUE_POLL_MAX_REQUESTS = 60;
@@ -22,6 +24,10 @@ final class IpRateLimitService
     private const int QUEUE_SUBMIT_MAX_REQUESTS = 10;
 
     private const int QUEUE_SUBMIT_WINDOW_SECONDS = 60;
+
+    private const int PLAYER_REPORT_MAX_REQUESTS = 5;
+
+    private const int PLAYER_REPORT_WINDOW_SECONDS = 60;
 
     private const int SCAN_LOG_POLL_MAX_REQUESTS = 30;
 
@@ -101,6 +107,10 @@ final class IpRateLimitService
             self::BUCKET_QUEUE_SUBMIT => [
                 self::QUEUE_SUBMIT_MAX_REQUESTS,
                 self::QUEUE_SUBMIT_WINDOW_SECONDS,
+            ],
+            self::BUCKET_PLAYER_REPORT => [
+                self::PLAYER_REPORT_MAX_REQUESTS,
+                self::PLAYER_REPORT_WINDOW_SECONDS,
             ],
             default => throw new InvalidArgumentException(sprintf('Unknown rate-limit bucket "%s".', $bucket)),
         };

--- a/wwwroot/classes/PlayerReportHandler.php
+++ b/wwwroot/classes/PlayerReportHandler.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 require_once __DIR__ . '/PlayerReportService.php';
 require_once __DIR__ . '/PlayerReportResult.php';
 require_once __DIR__ . '/PlayerReportRequest.php';
+require_once __DIR__ . '/IpRateLimitService.php';
 
 class PlayerReportHandler
 {
-    private PlayerReportService $playerReportService;
-
-    public function __construct(PlayerReportService $playerReportService)
-    {
-        $this->playerReportService = $playerReportService;
+    public function __construct(
+        private readonly PlayerReportService $playerReportService,
+        private readonly ?IpRateLimitService $rateLimitService = null,
+    ) {
     }
 
     public function handleReportRequest(
@@ -30,6 +30,18 @@ class PlayerReportHandler
         $explanation = $request->getExplanation();
         if ($explanation === '') {
             return PlayerReportResult::error('Please provide an explanation for your report.');
+        }
+
+        if (
+            $this->rateLimitService !== null
+            && !$this->rateLimitService->checkAndRecord(
+                $request->getIpAddress(),
+                IpRateLimitService::BUCKET_PLAYER_REPORT
+            )
+        ) {
+            return PlayerReportResult::error(
+                'Too many report submissions. Please wait a moment and try again.'
+            );
         }
 
         return $this->playerReportService->submitReport(

--- a/wwwroot/classes/PlayerReportHandler.php
+++ b/wwwroot/classes/PlayerReportHandler.php
@@ -32,6 +32,12 @@ class PlayerReportHandler
             return PlayerReportResult::error('Please provide an explanation for your report.');
         }
 
+        if (mb_strlen($explanation) > PlayerReportService::MAX_EXPLANATION_LENGTH) {
+            return PlayerReportResult::error(
+                'Explanation must be ' . PlayerReportService::MAX_EXPLANATION_LENGTH . ' characters or fewer.'
+            );
+        }
+
         if (
             $this->rateLimitService !== null
             && !$this->rateLimitService->checkAndRecord(

--- a/wwwroot/classes/PlayerReportService.php
+++ b/wwwroot/classes/PlayerReportService.php
@@ -10,7 +10,7 @@ class PlayerReportService
 {
     private const MAX_PENDING_REPORTS_PER_IP = 10;
 
-    private const MAX_EXPLANATION_LENGTH = 256;
+    public const MAX_EXPLANATION_LENGTH = 256;
 
     private const SUBMIT_OUTCOME_SUCCESS = 'success';
 

--- a/wwwroot/player_report.php
+++ b/wwwroot/player_report.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerReportHandler.php';
 require_once __DIR__ . '/classes/PlayerReportPage.php';
 require_once __DIR__ . '/classes/PlayerReportService.php';
+require_once __DIR__ . '/classes/IpRateLimitService.php';
 require_once __DIR__ . '/classes/PlayerSummary.php';
 require_once __DIR__ . '/classes/PlayerSummaryService.php';
 require_once __DIR__ . '/classes/PlayerNavigation.php';
@@ -17,7 +18,7 @@ $playerPageAccessGuard = PlayerPageAccessGuard::fromAccountId($accountId ?? null
 $accountId = $playerPageAccessGuard->requireAccountId();
 
 $playerReportService = new PlayerReportService($database);
-$playerReportHandler = new PlayerReportHandler($playerReportService);
+$playerReportHandler = new PlayerReportHandler($playerReportService, new IpRateLimitService($database));
 $playerSummaryService = new PlayerSummaryService($database);
 $playerReportPage = new PlayerReportPage(
     $playerReportHandler,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds burst rate limiting for player report submissions, complementing the existing cumulative cap of 10 pending reports per IP in `PlayerReportService`.

## Changes

- **`IpRateLimitService`**: New `BUCKET_PLAYER_REPORT` bucket — 5 requests per 60 seconds.
- **`PlayerReportHandler`**: Accepts optional `IpRateLimitService`; enforces the limit after CSRF, empty-check, and length validation so invalid requests do not consume slots.
- **`PlayerReportService`**: `MAX_EXPLANATION_LENGTH` is now public so the handler can validate length before rate limiting.
- **`player_report.php`**: Wires in `IpRateLimitService`.
- **Tests**: Bucket limits and isolation in `IpRateLimitServiceTest`; rate-limit blocking, validation bypass, and oversized-explanation bypass in `PlayerReportHandlerTest`.

## Behavior

When an IP exceeds 5 valid report submissions within a minute, the user sees: *"Too many report submissions. Please wait a moment and try again."*

Unknown/missing client IPs share the existing `__unknown__` normalization from PR 3 (limit, not reject).

## Test plan

- [x] `php tests/run.php` — 892 tests passing (+6 new)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bd3b801-44df-41b5-b0ff-f031f6f5e29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

