### PR TITLE
Extract post-catalog side effects from PlayerScanTitleCatalogSynchronizer

### DIFF
--- a/tests/PlayerScanCatalogSideEffectsTest.php
+++ b/tests/PlayerScanCatalogSideEffectsTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyHistoryRecorder.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanNewTitleMergeHandler.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanCatalogSideEffects.php';
+
+final class PlayerScanCatalogSideEffectsTest extends TestCase
+{
+    private PDO $database;
+
+    /** @var RecordingPlayerScanCatalogHistoryRecorder */
+    private RecordingPlayerScanCatalogHistoryRecorder $historyRecorder;
+
+    /** @var RecordingPlayerScanCatalogMergeService */
+    private RecordingPlayerScanCatalogMergeService $mergeService;
+
+    private PlayerScanCatalogSideEffects $sideEffects;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->database->exec('CREATE TABLE trophy_title (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            np_communication_id TEXT NOT NULL
+        )');
+        $this->database->exec('CREATE TABLE psn100_change (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            change_type TEXT NOT NULL,
+            param_1 INTEGER NOT NULL
+        )');
+
+        $this->historyRecorder = new RecordingPlayerScanCatalogHistoryRecorder();
+        $this->mergeService = new RecordingPlayerScanCatalogMergeService(['NPWR_PARENT_00']);
+
+        $this->sideEffects = new PlayerScanCatalogSideEffects(
+            $this->database,
+            $this->historyRecorder,
+            $this->mergeService,
+        );
+    }
+
+    public function testDoesNothingWhenNoCatalogChangesOrTriggers(): void
+    {
+        $result = $this->sideEffects->applyAfterCatalogSync(
+            npCommunicationId: 'NPWR12345_00',
+            titleDataChanged: false,
+            groupDataChanged: false,
+            trophyDataChanged: false,
+            isNewTitle: false,
+            newTrophies: false,
+        );
+
+        $this->assertSame(null, $result->titleId);
+        $this->assertSame([], $result->mergeParentsToRecompute);
+        $this->assertSame([], $this->historyRecorder->recordedTitleIds);
+        $this->assertSame([], $this->mergeService->handledNpIds);
+        $this->assertSame(0, $this->countChangelogRows());
+    }
+
+    public function testRecordsHistoryWhenCatalogDataChanged(): void
+    {
+        $this->insertTitle('NPWR12345_00', 42);
+
+        $result = $this->sideEffects->applyAfterCatalogSync(
+            npCommunicationId: 'NPWR12345_00',
+            titleDataChanged: true,
+            groupDataChanged: false,
+            trophyDataChanged: false,
+            isNewTitle: false,
+            newTrophies: false,
+        );
+
+        $this->assertSame(42, $result->titleId);
+        $this->assertSame([42], $this->historyRecorder->recordedTitleIds);
+        $this->assertSame(0, $this->countChangelogRows());
+    }
+
+    public function testTriggersAutomaticMergeForNewTitles(): void
+    {
+        $result = $this->sideEffects->applyAfterCatalogSync(
+            npCommunicationId: 'NPWR12345_00',
+            titleDataChanged: false,
+            groupDataChanged: false,
+            trophyDataChanged: false,
+            isNewTitle: true,
+            newTrophies: false,
+        );
+
+        $this->assertSame(['NPWR12345_00'], $this->mergeService->handledNpIds);
+        $this->assertSame(['NPWR_PARENT_00'], $result->mergeParentsToRecompute);
+    }
+
+    public function testInsertsGameVersionChangelogWhenNewTrophiesAppear(): void
+    {
+        $this->insertTitle('NPWR12345_00', 7);
+
+        $result = $this->sideEffects->applyAfterCatalogSync(
+            npCommunicationId: 'NPWR12345_00',
+            titleDataChanged: false,
+            groupDataChanged: false,
+            trophyDataChanged: false,
+            isNewTitle: false,
+            newTrophies: true,
+        );
+
+        $this->assertSame(7, $result->titleId);
+        $this->assertSame(1, $this->countChangelogRows());
+
+        $query = $this->database->query('SELECT change_type, param_1 FROM psn100_change');
+        $row = $query->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertSame('GAME_VERSION', $row['change_type']);
+        $this->assertSame(7, (int) $row['param_1']);
+    }
+
+    public function testReusesProvidedTitleIdWithoutLookup(): void
+    {
+        $result = $this->sideEffects->applyAfterCatalogSync(
+            npCommunicationId: 'NPWR12345_00',
+            titleDataChanged: true,
+            groupDataChanged: false,
+            trophyDataChanged: false,
+            isNewTitle: false,
+            newTrophies: true,
+            titleId: 99,
+        );
+
+        $this->assertSame(99, $result->titleId);
+        $this->assertSame([99], $this->historyRecorder->recordedTitleIds);
+        $this->assertSame(1, $this->countChangelogRows());
+    }
+
+    private function insertTitle(string $npCommunicationId, int $id): void
+    {
+        $query = $this->database->prepare(
+            'INSERT INTO trophy_title (id, np_communication_id) VALUES (:id, :np_communication_id)'
+        );
+        $query->bindValue(':id', $id, PDO::PARAM_INT);
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    private function countChangelogRows(): int
+    {
+        return (int) $this->database->query('SELECT COUNT(*) FROM psn100_change')->fetchColumn();
+    }
+}
+
+final class RecordingPlayerScanCatalogHistoryRecorder extends TrophyHistoryRecorder
+{
+    /** @var list<int> */
+    public array $recordedTitleIds = [];
+
+    public function __construct()
+    {
+    }
+
+    public function recordByTitleId(int $titleId): void
+    {
+        $this->recordedTitleIds[] = $titleId;
+    }
+}
+
+final class RecordingPlayerScanCatalogMergeService implements PlayerScanNewTitleMergeHandler
+{
+    /** @var list<string> */
+    public array $handledNpIds = [];
+
+    /**
+     * @param list<string> $parentsToReturn
+     */
+    public function __construct(private readonly array $parentsToReturn)
+    {
+    }
+
+    public function handleNewTitle(string $npCommunicationId): array
+    {
+        $this->handledNpIds[] = $npCommunicationId;
+
+        return $this->parentsToReturn;
+    }
+}

--- a/tests/PlayerScanTrophyTitleLoopTest.php
+++ b/tests/PlayerScanTrophyTitleLoopTest.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/../wwwroot/classes/AutomaticTrophyTitleMergeService.php
 require_once __DIR__ . '/../wwwroot/classes/Cron/WorkerScanCoordinator.php';
 require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanTitleMetadataHelper.php';
 require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerEarnedTrophyPersister.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanCatalogSideEffects.php';
 require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php';
 require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php';
 require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanStaleGameDeletionService.php';
@@ -52,8 +53,11 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
             new PlayerScanTitleCatalogSynchronizer(
                 $this->database,
                 $logger,
-                historyRecorder: $historyRecorder,
-                automaticTrophyTitleMergeService: $automaticTrophyTitleMergeService,
+                catalogSideEffects: new PlayerScanCatalogSideEffects(
+                    $this->database,
+                    $historyRecorder,
+                    $automaticTrophyTitleMergeService,
+                ),
             ),
             new PlayerScanTrophyProgressSynchronizer(
                 $this->database,

--- a/wwwroot/classes/AutomaticTrophyTitleMergeService.php
+++ b/wwwroot/classes/AutomaticTrophyTitleMergeService.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/TrophyMergeService.php';
 require_once __DIR__ . '/TrophySetComparator.php';
+require_once __DIR__ . '/Cron/PlayerScanNewTitleMergeHandler.php';
 
-final class AutomaticTrophyTitleMergeService
+final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeHandler
 {
     private PDO $database;
 

--- a/wwwroot/classes/Cron/PlayerScanCatalogSideEffectResult.php
+++ b/wwwroot/classes/Cron/PlayerScanCatalogSideEffectResult.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Outcome of post-catalog side effects during a player scan.
+ */
+final class PlayerScanCatalogSideEffectResult
+{
+    /**
+     * @param list<string> $mergeParentsToRecompute
+     */
+    private function __construct(
+        public readonly ?int $titleId,
+        public readonly array $mergeParentsToRecompute,
+    ) {
+    }
+
+    /**
+     * @param list<string> $mergeParentsToRecompute
+     */
+    public static function create(?int $titleId, array $mergeParentsToRecompute): self
+    {
+        return new self($titleId, $mergeParentsToRecompute);
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanCatalogSideEffects.php
+++ b/wwwroot/classes/Cron/PlayerScanCatalogSideEffects.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../AutomaticTrophyTitleMergeService.php';
+require_once __DIR__ . '/../TrophyHistoryRecorder.php';
+require_once __DIR__ . '/../TrophyMergeService.php';
+require_once __DIR__ . '/PlayerScanCatalogSideEffectResult.php';
+require_once __DIR__ . '/PlayerScanNewTitleMergeHandler.php';
+
+/**
+ * Applies post-catalog side effects after trophy rows are synchronized during player scans.
+ *
+ * Encapsulates history recording, automatic merge triggers, and changelog insertion that
+ * were previously embedded in PlayerScanTitleCatalogSynchronizer.
+ */
+final class PlayerScanCatalogSideEffects
+{
+    public function __construct(
+        private readonly PDO $database,
+        private readonly ?TrophyHistoryRecorder $historyRecorder = null,
+        private readonly ?PlayerScanNewTitleMergeHandler $newTitleMergeHandler = null,
+    ) {
+    }
+
+    public function applyAfterCatalogSync(
+        string $npCommunicationId,
+        bool $titleDataChanged,
+        bool $groupDataChanged,
+        bool $trophyDataChanged,
+        bool $isNewTitle,
+        bool $newTrophies,
+        ?int $titleId = null,
+    ): PlayerScanCatalogSideEffectResult {
+        if ($titleDataChanged || $groupDataChanged || $trophyDataChanged) {
+            $titleId = $this->resolveTitleId($npCommunicationId, $titleId);
+
+            if ($titleId !== null) {
+                $this->historyRecorder()->recordByTitleId($titleId);
+            }
+        }
+
+        $mergeParentsToRecompute = [];
+        if ($isNewTitle) {
+            $mergeParentsToRecompute = $this->newTitleMergeHandler()->handleNewTitle($npCommunicationId);
+        }
+
+        if ($newTrophies) {
+            $titleId = $this->resolveTitleId($npCommunicationId, $titleId);
+
+            if ($titleId !== null) {
+                $this->insertGameVersionChangelog($titleId);
+            }
+        }
+
+        return PlayerScanCatalogSideEffectResult::create($titleId, $mergeParentsToRecompute);
+    }
+
+    private function resolveTitleId(string $npCommunicationId, ?int $titleId): ?int
+    {
+        if ($titleId !== null) {
+            return $titleId;
+        }
+
+        return $this->findTrophyTitleId($npCommunicationId);
+    }
+
+    private function findTrophyTitleId(string $npCommunicationId): ?int
+    {
+        $query = $this->database->prepare(
+            'SELECT id FROM trophy_title WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        $id = $query->fetchColumn();
+
+        if ($id === false) {
+            return null;
+        }
+
+        return (int) $id;
+    }
+
+    private function insertGameVersionChangelog(int $titleId): void
+    {
+        $query = $this->database->prepare(
+            "INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES ('GAME_VERSION', :param_1)"
+        );
+        $query->bindValue(':param_1', $titleId, PDO::PARAM_INT);
+        $query->execute();
+    }
+
+    private function historyRecorder(): TrophyHistoryRecorder
+    {
+        return $this->historyRecorder ?? new TrophyHistoryRecorder($this->database);
+    }
+
+    private function newTitleMergeHandler(): PlayerScanNewTitleMergeHandler
+    {
+        return $this->newTitleMergeHandler
+            ?? new AutomaticTrophyTitleMergeService($this->database, new TrophyMergeService($this->database));
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanNewTitleMergeHandler.php
+++ b/wwwroot/classes/Cron/PlayerScanNewTitleMergeHandler.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Triggers automatic trophy-title merges when a new title appears during player scans.
+ */
+interface PlayerScanNewTitleMergeHandler
+{
+    /**
+     * @return list<string> Merge parent NP communication IDs to recompute.
+     */
+    public function handleNewTitle(string $npCommunicationId): array;
+}

--- a/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
@@ -3,16 +3,14 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../Admin/PsnGameLookupService.php';
-require_once __DIR__ . '/../AutomaticTrophyTitleMergeService.php';
 require_once __DIR__ . '/../ImageHashCalculator.php';
 require_once __DIR__ . '/../Psn100Logger.php';
-require_once __DIR__ . '/../TrophyMergeService.php';
 require_once __DIR__ . '/../TrophyCatalogSynchronizer.php';
-require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../TrophyImageDirectories.php';
 require_once __DIR__ . '/../TrophyImageDownloader.php';
 require_once __DIR__ . '/../TrophyMetaRepository.php';
 require_once __DIR__ . '/../TrophyTitleNameFormatter.php';
+require_once __DIR__ . '/PlayerScanCatalogSideEffects.php';
 require_once __DIR__ . '/PlayerScanTitleCatalogSyncResult.php';
 require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
 
@@ -37,8 +35,7 @@ final class PlayerScanTitleCatalogSynchronizer
         private readonly ?TrophyCatalogSynchronizer $trophyCatalogSynchronizer = null,
         private readonly ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
         private readonly ?TrophyMetaRepository $trophyMetaRepository = null,
-        private readonly ?TrophyHistoryRecorder $historyRecorder = null,
-        private readonly ?AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService = null,
+        private readonly ?PlayerScanCatalogSideEffects $catalogSideEffects = null,
         private readonly mixed $trophyDataFetcher = null,
     ) {
     }
@@ -389,45 +386,21 @@ final class PlayerScanTitleCatalogSynchronizer
             }
         }
 
-        if ($titleDataChanged || $groupDataChanged || $trophyDataChanged) {
-            if ($titleId === null) {
-                $titleId = $this->findTrophyTitleId($npid);
-            }
-
-            if ($titleId !== null) {
-                $this->historyRecorder()->recordByTitleId($titleId);
-            }
-        }
-
-        $mergeParentsToRecompute = [];
-        if ($isNewTitle) {
-            $mergeParentsToRecompute = $this->automaticMergeService()->handleNewTitle($npid);
-        }
-
-        if ($newTrophies) {
-            if ($titleId === null) {
-                $titleId = $this->findTrophyTitleId($npid);
-            }
-
-            if ($titleId === null) {
-                return PlayerScanTitleCatalogSyncResult::synced(
-                    $newTrophies,
-                    $isNewTitle,
-                    null,
-                    $mergeParentsToRecompute,
-                );
-            }
-
-            $query = $this->database->prepare("INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES ('GAME_VERSION', :param_1)");
-            $query->bindValue(':param_1', $titleId, PDO::PARAM_INT);
-            $query->execute();
-        }
+        $sideEffectResult = $this->catalogSideEffects()->applyAfterCatalogSync(
+            $npid,
+            $titleDataChanged,
+            $groupDataChanged,
+            $trophyDataChanged,
+            $isNewTitle,
+            $newTrophies,
+            $titleId,
+        );
 
         return PlayerScanTitleCatalogSyncResult::synced(
             $newTrophies,
             $isNewTitle,
-            $titleId,
-            $mergeParentsToRecompute,
+            $sideEffectResult->titleId,
+            $sideEffectResult->mergeParentsToRecompute,
         );
     }
 
@@ -461,23 +434,6 @@ final class PlayerScanTitleCatalogSynchronizer
     private function psnGameLookup(): PsnGameLookupService
     {
         return $this->psnGameLookupService ?? PsnGameLookupService::fromDatabase($this->database);
-    }
-
-    private function findTrophyTitleId(string $npCommunicationId): ?int
-    {
-        $query = $this->database->prepare(
-            'SELECT id FROM trophy_title WHERE np_communication_id = :np_communication_id'
-        );
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->execute();
-
-        $id = $query->fetchColumn();
-
-        if ($id === false) {
-            return null;
-        }
-
-        return (int) $id;
     }
 
     private function directories(): TrophyImageDirectories
@@ -515,14 +471,8 @@ final class PlayerScanTitleCatalogSynchronizer
         return $this->trophyMetaRepository ?? new TrophyMetaRepository($this->database);
     }
 
-    private function historyRecorder(): TrophyHistoryRecorder
+    private function catalogSideEffects(): PlayerScanCatalogSideEffects
     {
-        return $this->historyRecorder ?? new TrophyHistoryRecorder($this->database);
-    }
-
-    private function automaticMergeService(): AutomaticTrophyTitleMergeService
-    {
-        return $this->automaticTrophyTitleMergeService
-            ?? new AutomaticTrophyTitleMergeService($this->database, new TrophyMergeService($this->database));
+        return $this->catalogSideEffects ?? new PlayerScanCatalogSideEffects($this->database);
     }
 }

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -22,6 +22,7 @@ require_once __DIR__ . '/PlayerScanCompletionService.php';
 require_once __DIR__ . '/PlayerEarnedTrophyPersister.php';
 require_once __DIR__ . '/PlayerScanStaleGameDeletionService.php';
 require_once __DIR__ . '/PlayerScanTitleCatalogSynchronizer.php';
+require_once __DIR__ . '/PlayerScanCatalogSideEffects.php';
 require_once __DIR__ . '/PlayerScanTitleCatalogSyncResult.php';
 require_once __DIR__ . '/PlayerScanTrophyProgressSynchronizer.php';
 require_once __DIR__ . '/PlayerScanPrivacyService.php';
@@ -111,8 +112,11 @@ final class ThirtyMinuteCronJob implements CronJobInterface
         $this->titleCatalogSynchronizer = $titleCatalogSynchronizer ?? new PlayerScanTitleCatalogSynchronizer(
             $database,
             $logger,
-            historyRecorder: $historyRecorder,
-            automaticTrophyTitleMergeService: $this->automaticTrophyTitleMergeService,
+            catalogSideEffects: new PlayerScanCatalogSideEffects(
+                $database,
+                $historyRecorder,
+                $this->automaticTrophyTitleMergeService,
+            ),
         );
         $this->trophyProgressSynchronizer = $trophyProgressSynchronizer ?? new PlayerScanTrophyProgressSynchronizer(
             $database,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`PlayerScanTitleCatalogSynchronizer` was a god class: a ~530-line method mixed catalog persistence (API fetch, image downloads, upserts) with unrelated post-sync side effects (history snapshots, automatic merges, changelog rows).

This PR peels off the **post-catalog side effects** into a focused `PlayerScanCatalogSideEffects` class — one concern, no behavior change.

## What moved

`PlayerScanCatalogSideEffects::applyAfterCatalogSync()` now owns:

- Trophy history recording when catalog data changed
- Automatic merge triggers for newly discovered titles
- `GAME_VERSION` changelog insertion when new trophies appear
- Title ID resolution for the above

`PlayerScanTitleCatalogSynchronizer` now ends with a single delegation call and returns the existing `PlayerScanTitleCatalogSyncResult`.

## Supporting changes

- Added `PlayerScanCatalogSideEffectResult` DTO
- Added `PlayerScanNewTitleMergeHandler` interface so the final `AutomaticTrophyTitleMergeService` can be injected/tested without subclassing
- Wired shared dependencies through `ThirtyMinuteCronJob`

## Tests

Added `PlayerScanCatalogSideEffectsTest` with five cases covering:
- no-op when nothing changed
- history recording on catalog changes
- merge trigger on new titles
- changelog on new trophies
- reuse of a pre-resolved title ID

All 897 tests pass.

## Follow-up candidates (future PRs)

Other god-class extractions identified but intentionally deferred:

1. **PlayerScanTitleCatalogSynchronizer** — extract the per-group trophy sync loop (~230 lines)
2. **PlayerScanProfileSynchronizer** — extract country resolution
3. **TrophyStatusService** — extract obtainability recalculation SQL
4. **PsnGameLookupService** — extract response normalizer
5. Unify catalog refresh logic shared with `GameRescanCatalogUpdater`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5639ced-252f-4899-8d97-f3646b2b588c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5639ced-252f-4899-8d97-f3646b2b588c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

