### PR TITLE
Extract PlayerCountryResolver from PlayerScanProfileSynchronizer

### DIFF
--- a/tests/PlayerCountryResolverTest.php
+++ b/tests/PlayerCountryResolverTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerCountryResolver.php';
+
+if (!class_exists('Tustin\\PlayStation\\Client')) {
+    eval('namespace Tustin\\PlayStation; final class Client {}');
+}
+
+final class PlayerCountryResolverTest extends TestCase
+{
+    private PlayerCountryResolver $resolver;
+    private PDO $database;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec(
+            'CREATE TABLE player (
+                account_id TEXT PRIMARY KEY,
+                online_id TEXT NOT NULL,
+                country TEXT
+            )'
+        );
+
+        $this->resolver = new PlayerCountryResolver($this->database);
+    }
+
+    public function testExtractCountryFromNpIdDecodesTrailingCountryCode(): void
+    {
+        $npId = base64_encode('ExamplePlayerUS');
+
+        $result = $this->resolver->extractCountryFromNpId($npId);
+
+        $this->assertSame('us', $result);
+    }
+
+    public function testExtractCountryFromNpIdReturnsNullForInvalidValues(): void
+    {
+        $this->assertSame(null, $this->resolver->extractCountryFromNpId(''));
+        $this->assertSame(null, $this->resolver->extractCountryFromNpId(null));
+        $this->assertSame(null, $this->resolver->extractCountryFromNpId('not-valid-base64!!!'));
+    }
+
+    public function testFetchStoredCountryByAccountIdReturnsStoredValue(): void
+    {
+        $largeAccountId = '9223372036854775808';
+        $statement = $this->database->prepare(
+            'INSERT INTO player (account_id, online_id, country) VALUES (:account_id, :online_id, :country)'
+        );
+        $statement->bindValue(':account_id', $largeAccountId, PDO::PARAM_STR);
+        $statement->bindValue(':online_id', 'large-id-player', PDO::PARAM_STR);
+        $statement->bindValue(':country', 'se', PDO::PARAM_STR);
+        $statement->execute();
+
+        $this->assertSame('se', $this->resolver->fetchStoredCountryByAccountId($largeAccountId));
+    }
+
+    public function testUpdatePlayerCountryPersistsLowercaseCountryCode(): void
+    {
+        $largeAccountId = '9223372036854775808';
+        $statement = $this->database->prepare(
+            'INSERT INTO player (account_id, online_id, country) VALUES (:account_id, :online_id, :country)'
+        );
+        $statement->bindValue(':account_id', $largeAccountId, PDO::PARAM_STR);
+        $statement->bindValue(':online_id', 'large-id-player', PDO::PARAM_STR);
+        $statement->bindValue(':country', 'se', PDO::PARAM_STR);
+        $statement->execute();
+
+        $this->resolver->updatePlayerCountry($largeAccountId, 'NO');
+
+        $country = $this->database
+            ->query("SELECT country FROM player WHERE account_id = '{$largeAccountId}'")
+            ->fetchColumn();
+        $this->assertSame('no', $country);
+    }
+
+    public function testResolveCountryUsesNpIdHintWithoutQueryingStoredCountry(): void
+    {
+        $accountId = '12345';
+        $statement = $this->database->prepare(
+            'INSERT INTO player (account_id, online_id, country) VALUES (:account_id, :online_id, :country)'
+        );
+        $statement->bindValue(':account_id', $accountId, PDO::PARAM_STR);
+        $statement->bindValue(':online_id', 'player-one', PDO::PARAM_STR);
+        $statement->bindValue(':country', 'zz', PDO::PARAM_STR);
+        $statement->execute();
+
+        $client = new \Tustin\PlayStation\Client();
+
+        $country = $this->resolver->resolveCountry($client, $accountId, 'player-one', 'us');
+
+        $this->assertSame('us', $country);
+
+        $storedCountry = $this->database
+            ->query("SELECT country FROM player WHERE account_id = '{$accountId}'")
+            ->fetchColumn();
+        $this->assertSame('us', $storedCountry);
+    }
+
+    public function testResolveCountryFallsBackToStoredCountry(): void
+    {
+        $accountId = '12345';
+        $statement = $this->database->prepare(
+            'INSERT INTO player (account_id, online_id, country) VALUES (:account_id, :online_id, :country)'
+        );
+        $statement->bindValue(':account_id', $accountId, PDO::PARAM_STR);
+        $statement->bindValue(':online_id', 'player-one', PDO::PARAM_STR);
+        $statement->bindValue(':country', 'fi', PDO::PARAM_STR);
+        $statement->execute();
+
+        $client = new \Tustin\PlayStation\Client();
+
+        $country = $this->resolver->resolveCountry($client, $accountId, 'player-one');
+
+        $this->assertSame('fi', $country);
+    }
+}

--- a/tests/PlayerScanProfileSynchronizerTest.php
+++ b/tests/PlayerScanProfileSynchronizerTest.php
@@ -69,28 +69,6 @@ final class PlayerScanProfileSynchronizerTest extends TestCase
         $this->assertSame('FallbackName', $result);
     }
 
-    public function testExtractCountryFromNpIdDecodesTrailingCountryCode(): void
-    {
-        $npId = base64_encode('ExamplePlayerUS');
-
-        $result = $this->synchronizer->extractCountryFromNpId($npId);
-
-        $this->assertSame('us', $result);
-    }
-
-    public function testExtractCountryFromNpIdReturnsNullForInvalidValues(): void
-    {
-        $this->assertSame(null, $this->synchronizer->extractCountryFromNpId(''));
-        $this->assertSame(null, $this->synchronizer->extractCountryFromNpId(null));
-        $this->assertSame(null, $this->synchronizer->extractCountryFromNpId('not-valid-base64!!!'));
-    }
-
-    public function testNormalizeAccountIdValueAcceptsIntegersAndDigitStrings(): void
-    {
-        $this->assertSame('12345', $this->synchronizer->normalizeAccountIdValue(12345));
-        $this->assertSame('12345', $this->synchronizer->normalizeAccountIdValue(' 12345 '));
-    }
-
     public function testNormalizeAccountIdValueRejectsNonNumericValues(): void
     {
         $this->assertSame(null, $this->synchronizer->normalizeAccountIdValue(''));
@@ -109,40 +87,9 @@ final class PlayerScanProfileSynchronizerTest extends TestCase
         $this->assertTrue($skip->shouldSkipPlayer());
     }
 
-    public function testCountryHelpersAcceptStringAccountIds(): void
+    public function testNormalizeAccountIdValueAcceptsIntegersAndDigitStrings(): void
     {
-        $largeAccountId = '9223372036854775808';
-        $statement = $this->synchronizerDatabase()->prepare(
-            'INSERT INTO player (account_id, online_id, country, status) VALUES (:account_id, :online_id, :country, :status)'
-        );
-        $statement->bindValue(':account_id', $largeAccountId, PDO::PARAM_STR);
-        $statement->bindValue(':online_id', 'large-id-player', PDO::PARAM_STR);
-        $statement->bindValue(':country', 'se', PDO::PARAM_STR);
-        $statement->bindValue(':status', 0, PDO::PARAM_INT);
-        $statement->execute();
-
-        $fetchStoredCountry = new ReflectionMethod(PlayerScanProfileSynchronizer::class, 'fetchStoredCountryByAccountId');
-        $fetchStoredCountry->setAccessible(true);
-        $this->assertSame('se', $fetchStoredCountry->invoke($this->synchronizer, $largeAccountId));
-
-        $updatePlayerCountry = new ReflectionMethod(PlayerScanProfileSynchronizer::class, 'updatePlayerCountry');
-        $updatePlayerCountry->setAccessible(true);
-        $updatePlayerCountry->invoke($this->synchronizer, $largeAccountId, 'no');
-
-        $country = $this->synchronizerDatabase()
-            ->query("SELECT country FROM player WHERE account_id = '{$largeAccountId}'")
-            ->fetchColumn();
-        $this->assertSame('no', $country);
-    }
-
-    private function synchronizerDatabase(): PDO
-    {
-        $property = new ReflectionProperty(PlayerScanProfileSynchronizer::class, 'database');
-        $property->setAccessible(true);
-
-        /** @var PDO $database */
-        $database = $property->getValue($this->synchronizer);
-
-        return $database;
+        $this->assertSame('12345', $this->synchronizer->normalizeAccountIdValue(12345));
+        $this->assertSame('12345', $this->synchronizer->normalizeAccountIdValue(' 12345 '));
     }
 }

--- a/wwwroot/classes/Cron/PlayerCountryResolver.php
+++ b/wwwroot/classes/Cron/PlayerCountryResolver.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use Tustin\PlayStation\Client;
+
+/**
+ * Resolves and persists player country codes during PSN profile scans.
+ *
+ * Encapsulates npId decoding, stored-country lookup, live PSN search, and
+ * country persistence that were previously embedded in PlayerScanProfileSynchronizer.
+ */
+final class PlayerCountryResolver
+{
+    public function __construct(
+        private readonly PDO $database,
+    ) {
+    }
+
+    public function extractCountryFromNpId(mixed $npId): ?string
+    {
+        if (!is_string($npId) || $npId === '') {
+            return null;
+        }
+
+        $decoded = base64_decode($npId, true);
+        if ($decoded === false || $decoded === '') {
+            return null;
+        }
+
+        $trimmed = trim($decoded);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (strlen($trimmed) < 2) {
+            return null;
+        }
+
+        return strtolower(substr($trimmed, -2));
+    }
+
+    public function resolveCountry(
+        Client $client,
+        string $accountId,
+        string $onlineId,
+        ?string $countryFromNpId = null,
+    ): string {
+        $country = $countryFromNpId;
+
+        if ($country === null || strtolower($country) === 'zz') {
+            $storedCountry = $this->fetchStoredCountryByAccountId($accountId);
+
+            if (is_string($storedCountry) && $storedCountry !== '') {
+                $country = $storedCountry;
+            } else {
+                $country = 'zz';
+            }
+
+            if (strtolower($country) === 'zz') {
+                $resolvedCountry = $this->findPlayerCountry($client, $onlineId);
+
+                if ($resolvedCountry !== null) {
+                    $country = $resolvedCountry;
+                    $this->updatePlayerCountry($accountId, $resolvedCountry);
+                }
+            }
+        } else {
+            $this->updatePlayerCountry($accountId, $country);
+        }
+
+        if (!is_string($country) || $country === '') {
+            return 'zz';
+        }
+
+        return $country;
+    }
+
+    public function fetchStoredCountryByAccountId(string $accountId): ?string
+    {
+        $query = $this->database->prepare('SELECT country FROM player WHERE account_id = :account_id');
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
+        $query->execute();
+
+        $country = $query->fetchColumn();
+
+        if (!is_string($country) || $country === '') {
+            return null;
+        }
+
+        return $country;
+    }
+
+    public function findPlayerCountry(Client $client, string $onlineId): ?string
+    {
+        $normalizedOnlineId = strtolower($onlineId);
+        $userCounter = 0;
+
+        try {
+            foreach ($client->users()->search($onlineId) as $result) {
+                if (strtolower($result->onlineId()) === $normalizedOnlineId) {
+                    $country = $result->country();
+
+                    if (!is_string($country) || $country === '') {
+                        return null;
+                    }
+
+                    $normalizedCountry = strtolower($country);
+
+                    if ($normalizedCountry === 'zz') {
+                        return null;
+                    }
+
+                    return $normalizedCountry;
+                }
+
+                $userCounter++;
+
+                if ($userCounter >= 50) {
+                    break;
+                }
+            }
+        } catch (Throwable) {
+            return null;
+        }
+
+        return null;
+    }
+
+    public function updatePlayerCountry(string $accountId, string $country): void
+    {
+        $query = $this->database->prepare(
+            'UPDATE player SET country = :country WHERE account_id = :account_id'
+        );
+        $query->bindValue(':country', strtolower($country), PDO::PARAM_STR);
+        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
+        $query->execute();
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
 require_once __DIR__ . '/PlayerAvatarSynchronizer.php';
 require_once __DIR__ . '/../ImageHashCalculator.php';
+require_once __DIR__ . '/PlayerCountryResolver.php';
 require_once __DIR__ . '/PlayerScanPrivacyService.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
@@ -21,6 +22,7 @@ final class PlayerScanProfileSynchronizer
     private const MAX_INVALID_API_RESPONSE_ATTEMPTS = 2;
 
     private readonly PlayerAvatarSynchronizer $avatarSynchronizer;
+    private readonly PlayerCountryResolver $countryResolver;
     private readonly PlayerScanPrivacyService $privacyService;
 
     public function __construct(
@@ -28,12 +30,14 @@ final class PlayerScanProfileSynchronizer
         private readonly Psn100Logger $logger,
         private readonly WorkerScanCoordinator $workerScanCoordinator,
         ?PlayerAvatarSynchronizer $avatarSynchronizer = null,
+        ?PlayerCountryResolver $countryResolver = null,
         ?PlayerScanPrivacyService $privacyService = null,
     ) {
         $this->avatarSynchronizer = $avatarSynchronizer ?? new PlayerAvatarSynchronizer(
             $database,
             new ImageHashCalculator(),
         );
+        $this->countryResolver = $countryResolver ?? new PlayerCountryResolver($database);
         $this->privacyService = $privacyService ?? new PlayerScanPrivacyService(
             $database,
             $workerScanCoordinator,
@@ -94,29 +98,6 @@ final class PlayerScanProfileSynchronizer
         }
 
         return $fallbackOnlineId;
-    }
-
-    public function extractCountryFromNpId(mixed $npId): ?string
-    {
-        if (!is_string($npId) || $npId === '') {
-            return null;
-        }
-
-        $decoded = base64_decode($npId, true);
-        if ($decoded === false || $decoded === '') {
-            return null;
-        }
-
-        $trimmed = trim($decoded);
-        if ($trimmed === '') {
-            return null;
-        }
-
-        if (strlen($trimmed) < 2) {
-            return null;
-        }
-
-        return strtolower(substr($trimmed, -2));
     }
 
     public function normalizeAccountIdValue(mixed $accountId): ?string
@@ -199,29 +180,12 @@ final class PlayerScanProfileSynchronizer
                     $player['account_id'] = $profileAccountId;
                     $user = $client->users()->find($profileAccountId);
 
-                    $countryFromProfile = $this->extractCountryFromNpId($profile['npId'] ?? null);
-                    $country = $countryFromProfile;
-
-                    if ($country === null || strtolower($country) === 'zz') {
-                        $storedCountry = $this->fetchStoredCountryByAccountId($profileAccountId);
-
-                        if (is_string($storedCountry) && $storedCountry !== '') {
-                            $country = $storedCountry;
-                        } else {
-                            $country = 'zz';
-                        }
-
-                        if (strtolower($country) === 'zz') {
-                            $resolvedCountry = $this->findPlayerCountry($client, $user->onlineId());
-
-                            if ($resolvedCountry !== null) {
-                                $country = $resolvedCountry;
-                                $this->updatePlayerCountry($profileAccountId, $resolvedCountry);
-                            }
-                        }
-                    } else {
-                        $this->updatePlayerCountry($profileAccountId, $country);
-                    }
+                    $country = $this->countryResolver->resolveCountry(
+                        $client,
+                        $profileAccountId,
+                        $user->onlineId(),
+                        $this->countryResolver->extractCountryFromNpId($profile['npId'] ?? null),
+                    );
                 } else {
                     if ($existingAccountId === null) {
                         $this->privacyService->markAsPrivateByOnlineId($originalOnlineId);
@@ -241,24 +205,11 @@ final class PlayerScanProfileSynchronizer
                         $player['online_id'] = $originalOnlineId;
                     }
 
-                    $storedCountry = $this->fetchStoredCountryByAccountId($existingAccountId);
-
-                    if (is_string($storedCountry) && $storedCountry !== '') {
-                        $country = $storedCountry;
-                    }
-
-                    if (strtolower($country) === 'zz') {
-                        $resolvedCountry = $this->findPlayerCountry($client, $user->onlineId());
-
-                        if ($resolvedCountry !== null) {
-                            $country = $resolvedCountry;
-                            $this->updatePlayerCountry($existingAccountId, $resolvedCountry);
-                        }
-                    }
-                }
-
-                if (!is_string($country) || $country === '') {
-                    $country = 'zz';
+                    $country = $this->countryResolver->resolveCountry(
+                        $client,
+                        $existingAccountId,
+                        $user->onlineId(),
+                    );
                 }
 
                 $user->aboutMe();
@@ -375,67 +326,6 @@ final class PlayerScanProfileSynchronizer
         );
         $query->bindValue(':scanning', $newOnlineId, PDO::PARAM_STR);
         $query->bindValue(':worker_id', $workerId, PDO::PARAM_INT);
-        $query->execute();
-    }
-
-    private function fetchStoredCountryByAccountId(string $accountId): ?string
-    {
-        $query = $this->database->prepare('SELECT country FROM player WHERE account_id = :account_id');
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
-        $query->execute();
-
-        $country = $query->fetchColumn();
-
-        if (!is_string($country) || $country === '') {
-            return null;
-        }
-
-        return $country;
-    }
-
-    private function findPlayerCountry(Client $client, string $onlineId): ?string
-    {
-        $normalizedOnlineId = strtolower($onlineId);
-        $userCounter = 0;
-
-        try {
-            foreach ($client->users()->search($onlineId) as $result) {
-                if (strtolower($result->onlineId()) === $normalizedOnlineId) {
-                    $country = $result->country();
-
-                    if (!is_string($country) || $country === '') {
-                        return null;
-                    }
-
-                    $normalizedCountry = strtolower($country);
-
-                    if ($normalizedCountry === 'zz') {
-                        return null;
-                    }
-
-                    return $normalizedCountry;
-                }
-
-                $userCounter++;
-
-                if ($userCounter >= 50) {
-                    break;
-                }
-            }
-        } catch (Throwable) {
-            return null;
-        }
-
-        return null;
-    }
-
-    private function updatePlayerCountry(string $accountId, string $country): void
-    {
-        $query = $this->database->prepare(
-            'UPDATE player SET country = :country WHERE account_id = :account_id'
-        );
-        $query->bindValue(':country', strtolower($country), PDO::PARAM_STR);
-        $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`PlayerScanProfileSynchronizer` (~524 lines) was handling profile lookup, country resolution, avatar sync, privacy marking, and player persistence. This PR peels off the **country resolution** concern into a new `PlayerCountryResolver` class.

## Changes

- **New `PlayerCountryResolver`** — owns npId decoding, stored-country lookup, live PSN search, DB persistence, and a `resolveCountry()` orchestration method that unifies the two code paths in `resolvePlayerForScan()`.
- **`PlayerScanProfileSynchronizer` slimmed** — delegates country work to the resolver; constructor accepts an optional `PlayerCountryResolver` for testing.
- **Tests moved/added** — country-specific tests now live in `PlayerCountryResolverTest`; synchronizer tests focus on online-ID and account-ID helpers.

## Why this class first

Country resolution was the smallest, clearest boundary in the largest remaining God class in the player-scan pipeline. It follows the same extraction pattern already used for `PlayerAvatarSynchronizer` and `PlayerScanPrivacyService`.

## Follow-up PR candidates

1. Extract `PlayerProfileResolver` from `resolvePlayerForScan()` (profile lookup + retry loop)
2. Extract trophy-group catalog sync from `PlayerScanTitleCatalogSynchronizer` (shared with `GameRescanCatalogUpdater`)
3. Extract `TrophyTitleMatchFinder` from `AutomaticTrophyTitleMergeService`

## Testing

- All 900 tests pass (`php tests/run.php`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4987106-fbae-4651-b8cd-05616ad361af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4987106-fbae-4651-b8cd-05616ad361af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

