### PR TITLE
Extract title header sync from PlayerScanTitleCatalogSynchronizer

### DIFF
--- a/tests/PlayerScanTitleHeaderSynchronizerTest.php
+++ b/tests/PlayerScanTitleHeaderSynchronizerTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/ImageHashCalculatorTest.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyCatalogSynchronizer.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyImageDirectories.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyImageDownloader.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php';
+require_once __DIR__ . '/../wwwroot/classes/Cron/PlayerScanTitleHeaderSyncResult.php';
+
+final class PlayerScanTitleHeaderSynchronizerTest extends TestCase
+{
+    private PDO $database;
+    private string $titleIconDirectory;
+    private PlayerScanTitleHeaderSynchronizer $synchronizer;
+
+    protected function setUp(): void
+    {
+        $this->database = new PlayerScanTitleHeaderSynchronizerTestPDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec(
+            'CREATE TABLE trophy_title (
+                np_communication_id TEXT PRIMARY KEY,
+                name TEXT,
+                detail TEXT,
+                icon_url TEXT,
+                platform TEXT,
+                set_version TEXT
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                message TEXT NOT NULL
+            )'
+        );
+
+        $this->titleIconDirectory = sys_get_temp_dir() . '/psn100-title-header-sync-' . uniqid('', true) . '/';
+        mkdir($this->titleIconDirectory, 0777, true);
+
+        $imageDownloader = new TrophyImageDownloader(
+            new ImageHashCalculator(new FakeImageProcessor(supported: false)),
+            null,
+            static fn (string $url): ?string => $url === 'https://example.test/icon.png' ? 'icon-bytes' : null,
+        );
+
+        $this->synchronizer = new PlayerScanTitleHeaderSynchronizer(
+            $this->database,
+            new TrophyCatalogSynchronizer($this->database),
+            new TrophyImageDirectories($this->titleIconDirectory, '/tmp/group', '/tmp/trophy', '/tmp/reward'),
+            $imageDownloader,
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->titleIconDirectory);
+    }
+
+    public function testFormatPlatformListFromTitleMapsPspcToPc(): void
+    {
+        $platforms = $this->synchronizer->formatPlatformListFromTitle(new PlayerScanTitleHeaderTestTrophyTitle(
+            'NPWR12345_00',
+            [
+                new PlayerScanTitleHeaderTestPlatform('PS5'),
+                new PlayerScanTitleHeaderTestPlatform('PSPC'),
+            ],
+        ));
+
+        $this->assertSame('PS5,PC', $platforms);
+    }
+
+    public function testSyncInsertsTrophyTitleMetaRowWhenTitleAlreadyExists(): void
+    {
+        file_put_contents($this->titleIconDirectory . 'existing.png', 'icon-bytes');
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, name, detail, icon_url, platform, set_version)
+            VALUES ('NPWR12345_00', 'Example Game', 'Details', 'existing.png', 'PS5', '01.00')"
+        );
+
+        $result = $this->synchronizer->sync(new PlayerScanTitleHeaderTestTrophyTitle('NPWR12345_00'));
+
+        $this->assertFalse($result->titleDataChanged);
+        $this->assertFalse($result->titleNeedsUpdate);
+        $this->assertFalse($result->isNewTitle);
+
+        $query = $this->database->prepare(
+            'SELECT message FROM trophy_title_meta WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', 'NPWR12345_00', PDO::PARAM_STR);
+        $query->execute();
+
+        $this->assertSame('', $query->fetchColumn());
+    }
+
+    public function testSyncSkipsTitleUpdateWhenIncomingSetVersionIsOlder(): void
+    {
+        file_put_contents($this->titleIconDirectory . 'existing.png', 'icon-bytes');
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, name, detail, icon_url, platform, set_version)
+            VALUES ('NPWR12345_00', 'Example Game', 'Stored detail', 'existing.png', 'PS5', '02.00')"
+        );
+
+        $result = $this->synchronizer->sync(new PlayerScanTitleHeaderTestTrophyTitle(
+            'NPWR12345_00',
+            detail: 'Incoming detail',
+            trophySetVersion: '01.00',
+        ));
+
+        $this->assertFalse($result->titleDataChanged);
+        $this->assertFalse($result->titleNeedsUpdate);
+        $this->assertFalse($result->isNewTitle);
+
+        $query = $this->database->prepare(
+            'SELECT detail, set_version FROM trophy_title WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', 'NPWR12345_00', PDO::PARAM_STR);
+        $query->execute();
+        $row = $query->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertSame('Stored detail', $row['detail']);
+        $this->assertSame('02.00', $row['set_version']);
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $entries = scandir($directory);
+        if ($entries === false) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $directory . $entry;
+            if (is_dir($path)) {
+                $this->removeDirectory($path . '/');
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($directory);
+    }
+}
+
+final class PlayerScanTitleHeaderTestPlatform
+{
+    public function __construct(public readonly string $value)
+    {
+    }
+}
+
+final class PlayerScanTitleHeaderTestTrophyTitle
+{
+    /**
+     * @param list<PlayerScanTitleHeaderTestPlatform> $platforms
+     */
+    public function __construct(
+        private readonly string $npCommunicationId,
+        private readonly array $platforms = [new PlayerScanTitleHeaderTestPlatform('PS5')],
+        private readonly string $detail = 'Details',
+        private readonly string $trophySetVersion = '01.00',
+    ) {
+    }
+
+    public function npCommunicationId(): string
+    {
+        return $this->npCommunicationId;
+    }
+
+    public function name(): string
+    {
+        return 'Example Game';
+    }
+
+    public function detail(): string
+    {
+        return $this->detail;
+    }
+
+    public function iconUrl(): string
+    {
+        return 'https://example.test/icon.png';
+    }
+
+    /**
+     * @return list<PlayerScanTitleHeaderTestPlatform>
+     */
+    public function platform(): array
+    {
+        return $this->platforms;
+    }
+
+    public function trophySetVersion(): string
+    {
+        return $this->trophySetVersion;
+    }
+}
+
+final class PlayerScanTitleHeaderSynchronizerTestPDO extends PDO
+{
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        return parent::prepare(
+            str_replace('INSERT IGNORE', 'INSERT OR IGNORE', $query),
+            $options,
+        );
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
@@ -12,6 +12,7 @@ require_once __DIR__ . '/../TrophyMetaRepository.php';
 require_once __DIR__ . '/../TrophyTitleNameFormatter.php';
 require_once __DIR__ . '/PlayerScanCatalogSideEffects.php';
 require_once __DIR__ . '/PlayerScanTitleCatalogSyncResult.php';
+require_once __DIR__ . '/PlayerScanTitleHeaderSynchronizer.php';
 require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
 
 /**
@@ -36,6 +37,7 @@ final class PlayerScanTitleCatalogSynchronizer
         private readonly ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
         private readonly ?TrophyMetaRepository $trophyMetaRepository = null,
         private readonly ?PlayerScanCatalogSideEffects $catalogSideEffects = null,
+        private readonly ?PlayerScanTitleHeaderSynchronizer $titleHeaderSynchronizer = null,
         private readonly mixed $trophyDataFetcher = null,
     ) {
     }
@@ -44,78 +46,15 @@ final class PlayerScanTitleCatalogSynchronizer
     {
         $npid = (string) $trophyTitle->npCommunicationId();
         $newTrophies = false;
-        $titleDataChanged = false;
         $groupDataChanged = false;
         $trophyDataChanged = false;
         $titleId = null;
-
-        $platforms = $this->formatPlatformListFromTitle($trophyTitle);
-
-        $sanitizedTitleName = $this->titleFormatter()->format($trophyTitle->name());
-
-        $existingTitle = $this->catalogSynchronizer()->fetchExistingTrophyTitleRow($npid);
-        $isNewTitle = $existingTitle === null;
-        $incomingSetVersion = $trophyTitle->trophySetVersion();
-        $setVersionForUpdate = $this->metadataHelper()->resolveSetVersionForUpdate(
-            $incomingSetVersion,
-            is_array($existingTitle) ? ($existingTitle['set_version'] ?? null) : null
-        );
-        $incomingVersionIsOlderThanStored = $this->metadataHelper()->isIncomingSetVersionOlderThanStored(
-            $incomingSetVersion,
-            is_array($existingTitle) ? ($existingTitle['set_version'] ?? null) : null
-        );
-
-        $previousTitleIconFilename = $existingTitle['icon_url'] ?? null;
-        $titleIconFilename = $previousTitleIconFilename;
         $directories = $this->directories();
-        $titleIconMissing = $titleIconFilename === null
-            || !file_exists($directories->title . $titleIconFilename);
 
-        $titleNeedsUpdate = $existingTitle === null
-            || (
-                !$incomingVersionIsOlderThanStored
-                && (
-                    $existingTitle['detail'] !== $trophyTitle->detail()
-                    || $existingTitle['set_version'] !== $setVersionForUpdate
-                )
-            );
-
-        if ($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) {
-            $titleIconFilename = $this->downloader()->downloadMandatoryForScan(
-                $trophyTitle->iconUrl(),
-                $directories->title,
-                sprintf('title icon for "%s" (%s)', $trophyTitle->name(), $npid),
-                $previousTitleIconFilename
-            );
-        }
-
-        if ($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) {
-            $titleAffectedRows = $this->catalogSynchronizer()->upsertTrophyTitle(
-                $npid,
-                $sanitizedTitleName,
-                $trophyTitle->detail(),
-                $titleIconFilename,
-                $platforms,
-                $setVersionForUpdate,
-                $incomingVersionIsOlderThanStored,
-            );
-
-            if ($titleAffectedRows > 0) {
-                $titleDataChanged = true;
-            }
-        }
-
-        $metaQuery = $this->database->prepare('INSERT IGNORE INTO trophy_title_meta (
-                np_communication_id,
-                message
-            )
-            VALUES (
-                :np_communication_id,
-                :message
-            )');
-        $metaQuery->bindValue(':np_communication_id', $npid, PDO::PARAM_STR);
-        $metaQuery->bindValue(':message', '', PDO::PARAM_STR);
-        $metaQuery->execute();
+        $headerSyncResult = $this->titleHeaderSynchronizer()->sync($trophyTitle);
+        $titleDataChanged = $headerSyncResult->titleDataChanged;
+        $titleNeedsUpdate = $headerSyncResult->titleNeedsUpdate;
+        $isNewTitle = $headerSyncResult->isNewTitle;
 
         try {
             $trophyData = $this->fetchTrophyData($npid, $client);
@@ -406,17 +345,7 @@ final class PlayerScanTitleCatalogSynchronizer
 
     public function formatPlatformListFromTitle(object $trophyTitle): string
     {
-        $platforms = '';
-        foreach ($trophyTitle->platform() as $platform) {
-            $platformValue = $platform->value;
-            if ($platformValue === 'PSPC') {
-                $platformValue = 'PC';
-            }
-
-            $platforms .= $platformValue . ',';
-        }
-
-        return rtrim($platforms, ',');
+        return $this->titleHeaderSynchronizer()->formatPlatformListFromTitle($trophyTitle);
     }
 
     /**
@@ -451,19 +380,21 @@ final class PlayerScanTitleCatalogSynchronizer
         );
     }
 
-    private function titleFormatter(): TrophyTitleNameFormatter
+    private function titleHeaderSynchronizer(): PlayerScanTitleHeaderSynchronizer
     {
-        return $this->trophyTitleNameFormatter ?? new TrophyTitleNameFormatter();
+        return $this->titleHeaderSynchronizer ?? new PlayerScanTitleHeaderSynchronizer(
+            $this->database,
+            $this->catalogSynchronizer(),
+            $this->directories(),
+            $this->downloader(),
+            $this->trophyTitleNameFormatter,
+            $this->titleMetadataHelper,
+        );
     }
 
     private function catalogSynchronizer(): TrophyCatalogSynchronizer
     {
         return $this->trophyCatalogSynchronizer ?? new TrophyCatalogSynchronizer($this->database);
-    }
-
-    private function metadataHelper(): PlayerScanTitleMetadataHelper
-    {
-        return $this->titleMetadataHelper ?? new PlayerScanTitleMetadataHelper();
     }
 
     private function trophyMetaRepository(): TrophyMetaRepository

--- a/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
@@ -37,8 +37,8 @@ final class PlayerScanTitleCatalogSynchronizer
         private readonly ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
         private readonly ?TrophyMetaRepository $trophyMetaRepository = null,
         private readonly ?PlayerScanCatalogSideEffects $catalogSideEffects = null,
-        private readonly ?PlayerScanTitleHeaderSynchronizer $titleHeaderSynchronizer = null,
         private readonly mixed $trophyDataFetcher = null,
+        private readonly ?PlayerScanTitleHeaderSynchronizer $titleHeaderSynchronizer = null,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanTitleHeaderSyncResult.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleHeaderSyncResult.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Outcome of synchronizing a trophy title header row during player scans.
+ */
+final class PlayerScanTitleHeaderSyncResult
+{
+    public function __construct(
+        public readonly bool $titleDataChanged,
+        public readonly bool $titleNeedsUpdate,
+        public readonly bool $isNewTitle,
+    ) {
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../TrophyCatalogSynchronizer.php';
+require_once __DIR__ . '/../TrophyImageDirectories.php';
+require_once __DIR__ . '/../TrophyImageDownloader.php';
+require_once __DIR__ . '/../TrophyTitleNameFormatter.php';
+require_once __DIR__ . '/PlayerScanTitleHeaderSyncResult.php';
+require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
+
+/**
+ * Synchronizes trophy title header rows and ensures trophy_title_meta exists.
+ *
+ * Extracted from PlayerScanTitleCatalogSynchronizer so per-title catalog sync can
+ * delegate title-row persistence separately from group and trophy iteration.
+ */
+final class PlayerScanTitleHeaderSynchronizer
+{
+    public function __construct(
+        private readonly PDO $database,
+        private readonly TrophyCatalogSynchronizer $catalogSynchronizer,
+        private readonly TrophyImageDirectories $imageDirectories,
+        private readonly TrophyImageDownloader $imageDownloader,
+        private readonly ?TrophyTitleNameFormatter $trophyTitleNameFormatter = null,
+        private readonly ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
+    ) {
+    }
+
+    public function sync(object $trophyTitle): PlayerScanTitleHeaderSyncResult
+    {
+        $npid = (string) $trophyTitle->npCommunicationId();
+        $titleDataChanged = false;
+
+        $platforms = $this->formatPlatformListFromTitle($trophyTitle);
+        $sanitizedTitleName = $this->titleFormatter()->format($trophyTitle->name());
+
+        $existingTitle = $this->catalogSynchronizer->fetchExistingTrophyTitleRow($npid);
+        $isNewTitle = $existingTitle === null;
+        $incomingSetVersion = $trophyTitle->trophySetVersion();
+        $setVersionForUpdate = $this->metadataHelper()->resolveSetVersionForUpdate(
+            $incomingSetVersion,
+            is_array($existingTitle) ? ($existingTitle['set_version'] ?? null) : null
+        );
+        $incomingVersionIsOlderThanStored = $this->metadataHelper()->isIncomingSetVersionOlderThanStored(
+            $incomingSetVersion,
+            is_array($existingTitle) ? ($existingTitle['set_version'] ?? null) : null
+        );
+
+        $previousTitleIconFilename = $existingTitle['icon_url'] ?? null;
+        $titleIconFilename = $previousTitleIconFilename;
+        $titleIconMissing = $titleIconFilename === null
+            || !file_exists($this->imageDirectories->title . $titleIconFilename);
+
+        $titleNeedsUpdate = $existingTitle === null
+            || (
+                !$incomingVersionIsOlderThanStored
+                && (
+                    $existingTitle['detail'] !== $trophyTitle->detail()
+                    || $existingTitle['set_version'] !== $setVersionForUpdate
+                )
+            );
+
+        if ($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) {
+            $titleIconFilename = $this->imageDownloader->downloadMandatoryForScan(
+                $trophyTitle->iconUrl(),
+                $this->imageDirectories->title,
+                sprintf('title icon for "%s" (%s)', $trophyTitle->name(), $npid),
+                $previousTitleIconFilename
+            );
+        }
+
+        if ($existingTitle === null || $titleNeedsUpdate || $titleIconMissing) {
+            $titleAffectedRows = $this->catalogSynchronizer->upsertTrophyTitle(
+                $npid,
+                $sanitizedTitleName,
+                $trophyTitle->detail(),
+                $titleIconFilename,
+                $platforms,
+                $setVersionForUpdate,
+                $incomingVersionIsOlderThanStored,
+            );
+
+            if ($titleAffectedRows > 0) {
+                $titleDataChanged = true;
+            }
+        }
+
+        $metaQuery = $this->database->prepare('INSERT IGNORE INTO trophy_title_meta (
+                np_communication_id,
+                message
+            )
+            VALUES (
+                :np_communication_id,
+                :message
+            )');
+        $metaQuery->bindValue(':np_communication_id', $npid, PDO::PARAM_STR);
+        $metaQuery->bindValue(':message', '', PDO::PARAM_STR);
+        $metaQuery->execute();
+
+        return new PlayerScanTitleHeaderSyncResult(
+            $titleDataChanged,
+            $titleNeedsUpdate,
+            $isNewTitle,
+        );
+    }
+
+    public function formatPlatformListFromTitle(object $trophyTitle): string
+    {
+        $platforms = '';
+        foreach ($trophyTitle->platform() as $platform) {
+            $platformValue = $platform->value;
+            if ($platformValue === 'PSPC') {
+                $platformValue = 'PC';
+            }
+
+            $platforms .= $platformValue . ',';
+        }
+
+        return rtrim($platforms, ',');
+    }
+
+    private function titleFormatter(): TrophyTitleNameFormatter
+    {
+        return $this->trophyTitleNameFormatter ?? new TrophyTitleNameFormatter();
+    }
+
+    private function metadataHelper(): PlayerScanTitleMetadataHelper
+    {
+        return $this->titleMetadataHelper ?? new PlayerScanTitleMetadataHelper();
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels one concern off `PlayerScanTitleCatalogSynchronizer` (~479 lines), which still owns the full per-title catalog pipeline during player scans.

**Extracted:** title-header synchronization — `trophy_title` upsert, icon download, set-version handling, and `trophy_title_meta` bootstrap.

**New classes:**
- `PlayerScanTitleHeaderSynchronizer` — performs header sync
- `PlayerScanTitleHeaderSyncResult` — returns `titleDataChanged`, `titleNeedsUpdate`, and `isNewTitle` flags consumed by the group/trophy loops

`synchronizeCatalog()` now delegates header work, then continues with PSN fetch and group/trophy iteration unchanged.

## Review feedback addressed

- Moved `titleHeaderSynchronizer` **after** `trophyDataFetcher` in the constructor so callers that inject the fetcher as the final positional argument are not broken.

## Why this slice first

The header block (lines 52–118) is self-contained: no nested loops, clear inputs/outputs, and it produces flags (`titleNeedsUpdate`) that downstream group/trophy sync already depends on. Lower risk than extracting the ~230-line group/trophy loop in one go.

## Tests

- Added `PlayerScanTitleHeaderSynchronizerTest` covering platform formatting, meta row insertion, and skipping title updates when the incoming set version is older.
- Existing `PlayerScanTitleCatalogSynchronizerTest` still passes (delegation preserved for `formatPlatformListFromTitle`).
- Full suite: 904 tests passing.

## Follow-up PRs (not in this change)

1. Extract group + trophy iteration → `PlayerScanTrophyGroupSynchronizer`
2. Share logic with `GameRescanCatalogUpdater` (~368 lines, near-duplicate)
3. Other God-class candidates: `TrophyMergePlayerProgressUpdater`, `PsnGameLookupService`, `TrophyStatusService`, `PlayerQueueService`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cab2bed-de73-4418-b5d3-cc006b3e7ca0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cab2bed-de73-4418-b5d3-cc006b3e7ca0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

