### PR TITLE
Further MySQL 8.4 SQL improvements for cron jobs and schema

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -185,3 +185,27 @@ Upgrades from older deployments may need these tables for abuse controls:
 - `admin_login_throttle` — admin login lockouts
 
 See [README.md](README.md#schema-updates) for limits and behavior.
+
+### MySQL 8.4 optimizer statistics
+
+After schema import or large data changes on MySQL 8.4+, run:
+
+```bash
+mysql "$DB_NAME" < database/mysql84_histograms.sql
+```
+
+This creates histograms with `AUTO UPDATE` on heavily filtered columns (`player.status`,
+`trophy_title_player.progress`, `trophy_title_meta.status`, and others). Histograms help the
+8.4 optimizer choose better plans for leaderboard, queue, and cron queries. Re-run after
+bulk imports; a weekly `ANALYZE TABLE` cron is optional but reasonable on busy sites.
+
+`player_ranking` is excluded because `PlayerRankingUpdater` rebuilds and swaps that table
+every five minutes, which would invalidate histograms immediately.
+
+Older databases may still carry redundant indexes dropped from the current schema. Apply:
+
+```bash
+mysql "$DB_NAME" < database/mysql84_drop_redundant_indexes.sql
+```
+
+Each dropped index is redundant with an existing primary or unique key.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -202,6 +202,11 @@ bulk imports; a weekly `ANALYZE TABLE` cron is optional but reasonable on busy s
 `player_ranking` is excluded because `PlayerRankingUpdater` rebuilds and swaps that table
 every five minutes, which would invalidate histograms immediately.
 
+`trophy_earned` is excluded: at production scale (billions of rows, hundreds of GiB) an
+`ANALYZE TABLE` would run for hours and `AUTO UPDATE` would rebuild histograms on every
+InnoDB stats refresh. Existing queries filter by `account_id` (partition key) or
+`np_communication_id` (leading primary-key column), so histograms would add little value.
+
 Older databases may still carry redundant indexes dropped from the current schema. Apply:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ InnoDB recalculates persistent statistics. Re-run after large bulk imports or ma
 migrations. `player_ranking` is intentionally excluded because that table is rebuilt and
 swapped every five minutes.
 
+`trophy_earned` is intentionally excluded at production scale (billions of rows,
+hundreds of GiB): `ANALYZE TABLE` would be extremely slow and `AUTO UPDATE` would add
+ongoing overhead with negligible benefit for partition- and PK-scoped lookups.
+
 Existing databases that still have legacy redundant indexes can apply:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ for abuse controls:
 - `ip_rate_limit` — fixed-window IP rate limits for public JSON endpoints
 - `admin_login_throttle` — failed admin login tracking and temporary lockouts
 
+On MySQL 8.4+, after importing or upgrading the schema, run the optimizer maintenance
+scripts:
+
+```bash
+mysql psn100 < database/mysql84_histograms.sql
+```
+
+Histograms use MySQL 8.4 `AUTO UPDATE` so they stay current when `ANALYZE TABLE` runs or
+InnoDB recalculates persistent statistics. Re-run after large bulk imports or major data
+migrations. `player_ranking` is intentionally excluded because that table is rebuilt and
+swapped every five minutes.
+
+Existing databases that still have legacy redundant indexes can apply:
+
+```bash
+mysql psn100 < database/mysql84_drop_redundant_indexes.sql
+```
+
+Fresh installs from the current `psn100.sql` already omit those indexes.
+
 Queue polling (`check_queue_position.php`) requires a `poll_token` from the CSRF-protected
 `add_to_queue.php` response (60 requests per IP per minute). `scan_log_poll.php` allows 30
 per IP per minute. Admin login locks an IP for 15 minutes after five failed attempts.

--- a/database/mysql84_drop_redundant_indexes.sql
+++ b/database/mysql84_drop_redundant_indexes.sql
@@ -1,0 +1,16 @@
+-- Drop redundant indexes for MySQL 8.4 deployments.
+-- Safe on 8.4+; each index is covered by a stricter unique or primary key.
+--
+-- Fresh installs already omit these from database/psn100.sql.
+
+ALTER TABLE player
+    DROP INDEX player_idx_online_id_account_id;
+
+ALTER TABLE player_ranking
+    DROP INDEX idx_pr_account_id_ranking;
+
+ALTER TABLE setting
+    DROP INDEX setting_idx_scanning_id;
+
+ALTER TABLE trophy_title_meta
+    DROP INDEX idx_ttm_np_id_owners;

--- a/database/mysql84_histograms.sql
+++ b/database/mysql84_histograms.sql
@@ -6,6 +6,11 @@
 -- player_ranking is intentionally omitted: the table is fully rebuilt and
 -- swapped every 5 minutes (see PlayerRankingUpdater), so histograms would be
 -- stale immediately and AUTO UPDATE would rebuild them on every stats refresh.
+--
+-- trophy_earned is intentionally omitted: the table is billions of rows and
+-- hundreds of GiB. ANALYZE TABLE would run for hours and AUTO UPDATE would
+-- rebuild histograms on every InnoDB stats refresh. Queries already filter by
+-- account_id (partition key) or np_communication_id (leading PK column).
 
 ANALYZE TABLE player
     UPDATE HISTOGRAM ON status, last_updated_date, country, points, rarity_points, in_game_rarity_points
@@ -26,10 +31,6 @@ ANALYZE TABLE trophy_title_meta
 ANALYZE TABLE trophy_title
     UPDATE HISTOGRAM ON platform
     WITH 32 BUCKETS AUTO UPDATE;
-
-ANALYZE TABLE trophy_earned
-    UPDATE HISTOGRAM ON earned
-    WITH 4 BUCKETS AUTO UPDATE;
 
 ANALYZE TABLE trophy_meta
     UPDATE HISTOGRAM ON status

--- a/database/mysql84_histograms.sql
+++ b/database/mysql84_histograms.sql
@@ -8,7 +8,7 @@
 -- stale immediately and AUTO UPDATE would rebuild them on every stats refresh.
 
 ANALYZE TABLE player
-    UPDATE HISTOGRAM ON status, last_updated_date, country
+    UPDATE HISTOGRAM ON status, last_updated_date, country, points, rarity_points, in_game_rarity_points
     WITH 256 BUCKETS AUTO UPDATE;
 
 ANALYZE TABLE player_queue
@@ -26,3 +26,19 @@ ANALYZE TABLE trophy_title_meta
 ANALYZE TABLE trophy_title
     UPDATE HISTOGRAM ON platform
     WITH 32 BUCKETS AUTO UPDATE;
+
+ANALYZE TABLE trophy_earned
+    UPDATE HISTOGRAM ON earned
+    WITH 4 BUCKETS AUTO UPDATE;
+
+ANALYZE TABLE trophy_meta
+    UPDATE HISTOGRAM ON status
+    WITH 8 BUCKETS AUTO UPDATE;
+
+ANALYZE TABLE psn100_change
+    UPDATE HISTOGRAM ON change_type, time
+    WITH 64 BUCKETS AUTO UPDATE;
+
+ANALYZE TABLE log
+    UPDATE HISTOGRAM ON time
+    WITH 64 BUCKETS AUTO UPDATE;

--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -482,7 +482,6 @@ ALTER TABLE `player`
   ADD UNIQUE KEY `u_online_id` (`online_id`),
   ADD KEY `idx_avatar_url` (`avatar_url`),
   ADD KEY `idx_last_updated_date` (`last_updated_date`),
-  ADD KEY `player_idx_online_id_account_id` (`online_id`,`account_id`),
   ADD KEY `player_idx_status_last_date_online_id` (`status`,`last_updated_date`,`online_id`),
   ADD KEY `idx_trophy_count_npwr` (`trophy_count_npwr`),
   ADD KEY `idx_player_ranking` (`status`,`points` DESC,`platinum` DESC,`gold` DESC,`silver` DESC),
@@ -507,7 +506,6 @@ ALTER TABLE `player_ranking`
   ADD KEY `ranking_country` (`ranking_country`),
   ADD KEY `rarity_ranking` (`rarity_ranking`),
   ADD KEY `rarity_ranking_country` (`rarity_ranking_country`),
-  ADD KEY `idx_pr_account_id_ranking` (`account_id`,`ranking`),
   ADD KEY `idx_pr_ranking_account` (`ranking`,`account_id`),
   ADD KEY `idx_pr_rarity_ranking_account` (`rarity_ranking`,`account_id`),
   ADD KEY `in_game_rarity_ranking` (`in_game_rarity_ranking`),
@@ -540,8 +538,7 @@ ALTER TABLE `psn100_change`
 --
 ALTER TABLE `setting`
   ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `scanning` (`scanning`),
-  ADD KEY `setting_idx_scanning_id` (`scanning`,`id`);
+  ADD UNIQUE KEY `scanning` (`scanning`);
 
 --
 -- Indexes for table `trophy`
@@ -626,8 +623,7 @@ ALTER TABLE `trophy_title_meta`
   ADD PRIMARY KEY (`np_communication_id`),
   ADD KEY `idx_ttm_status` (`status`),
   ADD KEY `idx_ttm_parent_np_communication_id` (`parent_np_communication_id`),
-  ADD KEY `idx_ttm_psnprofiles_id` (`psnprofiles_id`),
-  ADD KEY `idx_ttm_np_id_owners` (`np_communication_id`,`owners`);
+  ADD KEY `idx_ttm_psnprofiles_id` (`psnprofiles_id`);
 
 --
 -- Indexes for table `trophy_title_player`

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -9,7 +9,7 @@ final class DailyCronJobTest extends TestCase
 {
     public function testUpdateTrophyRarityQueryUsesTopTenThousandRankingFilter(): void
     {
-        $source = $this->readMethodSource('updateTrophyRarityForGame');
+        $source = $this->readPrivateConstant('UPDATE_ALL_TROPHY_RARITY_QUERY');
 
         $this->assertStringContainsString('LEFT JOIN player_ranking p', $source);
         $this->assertStringContainsString('p.ranking <= 10000', $source);
@@ -18,7 +18,7 @@ final class DailyCronJobTest extends TestCase
 
     public function testUpdateTrophyRarityQueryAssignsRarityNamesFromThresholds(): void
     {
-        $source = $this->readMethodSource('updateTrophyRarityForGame');
+        $source = $this->readPrivateConstant('UPDATE_ALL_TROPHY_RARITY_QUERY');
 
         $this->assertStringContainsString("WHEN r.rarity_percent > 10 THEN 'COMMON'", $source);
         $this->assertStringContainsString("WHEN r.rarity_percent > 2 THEN 'UNCOMMON'", $source);
@@ -28,9 +28,18 @@ final class DailyCronJobTest extends TestCase
         $this->assertStringContainsString("WHEN r.in_game_rarity_percent <= 1 THEN 'LEGENDARY'", $source);
     }
 
+    public function testUpdateTrophyRarityQueryRecalculatesAllTitlesInOneStatement(): void
+    {
+        $source = $this->readClassSource();
+
+        $this->assertStringContainsString('UPDATE_ALL_TROPHY_RARITY_QUERY', $source);
+        $this->assertFalse(str_contains($source, 'np_communication_id = :np_communication_id'));
+        $this->assertFalse(str_contains($source, 'SELECT np_communication_id FROM trophy_title'));
+    }
+
     public function testUpdateTrophyTitleRarityPointsAggregatesPerGame(): void
     {
-        $source = $this->readMethodSource('updateTrophyTitleRarityPoints');
+        $source = $this->readPrivateConstant('UPDATE_TITLE_RARITY_POINTS_QUERY');
 
         $this->assertStringContainsString('IFNULL(SUM(tm.rarity_point), 0) AS rarity_sum', $source);
         $this->assertStringContainsString('IFNULL(SUM(tm.in_game_rarity_point), 0) AS in_game_rarity_sum', $source);
@@ -41,13 +50,12 @@ final class DailyCronJobTest extends TestCase
 
     public function testExecuteWithRetryUsesInfiniteLoopWithoutMaxAttemptCap(): void
     {
-        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/DailyCronJob.php');
-        $this->assertTrue(is_string($source));
+        $source = $this->readClassSource();
 
         $this->assertStringContainsString('while (true)', $source);
         $this->assertFalse(str_contains($source, 'maxAttempt'));
         $this->assertStringContainsString(
-            '$this->executeWithRetry([$this, \'updateTrophyRarityForGame\'], $npCommunicationId);',
+            '$this->executeWithRetry([$this, \'updateAllTrophyRarity\']);',
             $source
         );
         $this->assertStringContainsString(
@@ -56,9 +64,9 @@ final class DailyCronJobTest extends TestCase
         );
     }
 
-    public function testRunRetriesPerGameRarityUpdateUntilItSucceeds(): void
+    public function testRunRetriesBatchRarityUpdateUntilItSucceeds(): void
     {
-        $database = new DailyCronJobPerGameRetryTestDatabase();
+        $database = new DailyCronJobBatchRetryTestDatabase();
         $sleepCalls = [];
 
         $job = new DailyCronJob(
@@ -72,7 +80,7 @@ final class DailyCronJobTest extends TestCase
         $job->run();
 
         $this->assertSame([1, 1], $sleepCalls);
-        $this->assertSame(3, $database->getPerGameUpdateCount());
+        $this->assertSame(3, $database->getBatchRarityUpdateCount());
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
     }
 
@@ -92,8 +100,27 @@ final class DailyCronJobTest extends TestCase
         $job->run();
 
         $this->assertSame([1, 1], $sleepCalls);
-        $this->assertSame(0, $database->getPerGameUpdateCount());
+        $this->assertSame(1, $database->getBatchRarityUpdateCount());
         $this->assertSame(3, $database->getTitlePointsUpdateCount());
+    }
+
+    private function readClassSource(): string
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/DailyCronJob.php');
+        $this->assertTrue(is_string($source));
+
+        return $source;
+    }
+
+    private function readPrivateConstant(string $name): string
+    {
+        $class = new ReflectionClass(DailyCronJob::class);
+        $constant = $class->getReflectionConstant($name);
+        $this->assertTrue($constant instanceof ReflectionClassConstant);
+        $value = $constant->getValue();
+        $this->assertTrue(is_string($value));
+
+        return $value;
     }
 
     private function readMethodSource(string $methodName): string
@@ -111,9 +138,9 @@ final class DailyCronJobTest extends TestCase
     }
 }
 
-final class DailyCronJobPerGameRetryTestDatabase extends PDO
+final class DailyCronJobBatchRetryTestDatabase extends PDO
 {
-    private int $perGameUpdateCount = 0;
+    private int $batchRarityUpdateCount = 0;
 
     private int $titlePointsUpdateCount = 0;
 
@@ -121,9 +148,9 @@ final class DailyCronJobPerGameRetryTestDatabase extends PDO
     {
     }
 
-    public function getPerGameUpdateCount(): int
+    public function getBatchRarityUpdateCount(): int
     {
-        return $this->perGameUpdateCount;
+        return $this->batchRarityUpdateCount;
     }
 
     public function getTitlePointsUpdateCount(): int
@@ -133,18 +160,12 @@ final class DailyCronJobPerGameRetryTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
-        if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
-            return new DailyCronJobTestStatement(static function (): array {
-                return ['NPWR00001_00'];
-            }, isSelect: true);
-        }
-
         if (str_contains($query, 'UPDATE trophy_meta tm')) {
             return new DailyCronJobTestStatement(function (): void {
-                $this->perGameUpdateCount++;
+                $this->batchRarityUpdateCount++;
 
-                if ($this->perGameUpdateCount < 3) {
-                    throw new RuntimeException('Simulated per-game rarity update failure.');
+                if ($this->batchRarityUpdateCount < 3) {
+                    throw new RuntimeException('Simulated batch rarity update failure.');
                 }
             });
         }
@@ -161,7 +182,7 @@ final class DailyCronJobPerGameRetryTestDatabase extends PDO
 
 final class DailyCronJobTitleRetryTestDatabase extends PDO
 {
-    private int $perGameUpdateCount = 0;
+    private int $batchRarityUpdateCount = 0;
 
     private int $titlePointsUpdateCount = 0;
 
@@ -169,9 +190,9 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
     {
     }
 
-    public function getPerGameUpdateCount(): int
+    public function getBatchRarityUpdateCount(): int
     {
-        return $this->perGameUpdateCount;
+        return $this->batchRarityUpdateCount;
     }
 
     public function getTitlePointsUpdateCount(): int
@@ -181,15 +202,9 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
-        if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
-            return new DailyCronJobTestStatement(static function (): array {
-                return [];
-            }, isSelect: true);
-        }
-
         if (str_contains($query, 'UPDATE trophy_meta tm')) {
             return new DailyCronJobTestStatement(function (): void {
-                $this->perGameUpdateCount++;
+                $this->batchRarityUpdateCount++;
             });
         }
 
@@ -212,15 +227,12 @@ final class DailyCronJobTestStatement extends PDOStatement
     /** @var callable(): mixed */
     private $callback;
 
-    private bool $isSelect;
-
     /**
      * @param callable(): mixed $callback
      */
-    public function __construct(callable $callback, bool $isSelect = false)
+    public function __construct(callable $callback)
     {
         $this->callback = $callback;
-        $this->isSelect = $isSelect;
     }
 
     public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
@@ -230,21 +242,8 @@ final class DailyCronJobTestStatement extends PDOStatement
 
     public function execute(?array $params = null): bool
     {
-        if (!$this->isSelect) {
-            ($this->callback)();
-        }
+        ($this->callback)();
 
         return true;
-    }
-
-    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args): array
-    {
-        if (!$this->isSelect) {
-            return [];
-        }
-
-        $result = ($this->callback)();
-
-        return is_array($result) ? $result : [];
     }
 }

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -9,16 +9,17 @@ final class DailyCronJobTest extends TestCase
 {
     public function testUpdateTrophyRarityQueryUsesTopTenThousandRankingFilter(): void
     {
-        $source = $this->readPrivateConstant('UPDATE_ALL_TROPHY_RARITY_QUERY');
+        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_QUERY');
 
         $this->assertStringContainsString('LEFT JOIN player_ranking p', $source);
         $this->assertStringContainsString('p.ranking <= 10000', $source);
         $this->assertStringContainsString('/ 10000.0) * 100 AS rarity_percent', $source);
+        $this->assertStringContainsString('WHERE t.np_communication_id = :np_communication_id', $source);
     }
 
     public function testUpdateTrophyRarityQueryAssignsRarityNamesFromThresholds(): void
     {
-        $source = $this->readPrivateConstant('UPDATE_ALL_TROPHY_RARITY_QUERY');
+        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_QUERY');
 
         $this->assertStringContainsString("WHEN r.rarity_percent > 10 THEN 'COMMON'", $source);
         $this->assertStringContainsString("WHEN r.rarity_percent > 2 THEN 'UNCOMMON'", $source);
@@ -28,13 +29,15 @@ final class DailyCronJobTest extends TestCase
         $this->assertStringContainsString("WHEN r.in_game_rarity_percent <= 1 THEN 'LEGENDARY'", $source);
     }
 
-    public function testUpdateTrophyRarityQueryRecalculatesAllTitlesInOneStatement(): void
+    public function testUpdateTrophyRarityQueryScopesTrophyEarnedByTitle(): void
     {
         $source = $this->readClassSource();
 
-        $this->assertStringContainsString('UPDATE_ALL_TROPHY_RARITY_QUERY', $source);
-        $this->assertFalse(str_contains($source, 'np_communication_id = :np_communication_id'));
-        $this->assertFalse(str_contains($source, 'SELECT np_communication_id FROM trophy_title'));
+        $this->assertStringContainsString('SELECT np_communication_id FROM trophy_title', $source);
+        $this->assertStringContainsString(
+            '$this->executeWithRetry([$this, \'updateTrophyRarityForGame\'], $npCommunicationId);',
+            $source
+        );
     }
 
     public function testUpdateTrophyTitleRarityPointsAggregatesPerGame(): void
@@ -55,7 +58,7 @@ final class DailyCronJobTest extends TestCase
         $this->assertStringContainsString('while (true)', $source);
         $this->assertFalse(str_contains($source, 'maxAttempt'));
         $this->assertStringContainsString(
-            '$this->executeWithRetry([$this, \'updateAllTrophyRarity\']);',
+            '$this->executeWithRetry([$this, \'updateTrophyRarityForGame\'], $npCommunicationId);',
             $source
         );
         $this->assertStringContainsString(
@@ -64,9 +67,9 @@ final class DailyCronJobTest extends TestCase
         );
     }
 
-    public function testRunRetriesBatchRarityUpdateUntilItSucceeds(): void
+    public function testRunRetriesPerGameRarityUpdateUntilItSucceeds(): void
     {
-        $database = new DailyCronJobBatchRetryTestDatabase();
+        $database = new DailyCronJobPerGameRetryTestDatabase();
         $sleepCalls = [];
 
         $job = new DailyCronJob(
@@ -80,7 +83,7 @@ final class DailyCronJobTest extends TestCase
         $job->run();
 
         $this->assertSame([1, 1], $sleepCalls);
-        $this->assertSame(3, $database->getBatchRarityUpdateCount());
+        $this->assertSame(3, $database->getPerGameUpdateCount());
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
     }
 
@@ -100,7 +103,7 @@ final class DailyCronJobTest extends TestCase
         $job->run();
 
         $this->assertSame([1, 1], $sleepCalls);
-        $this->assertSame(1, $database->getBatchRarityUpdateCount());
+        $this->assertSame(0, $database->getPerGameUpdateCount());
         $this->assertSame(3, $database->getTitlePointsUpdateCount());
     }
 
@@ -122,25 +125,11 @@ final class DailyCronJobTest extends TestCase
 
         return $value;
     }
-
-    private function readMethodSource(string $methodName): string
-    {
-        $class = new ReflectionClass(DailyCronJob::class);
-        $method = $class->getMethod($methodName);
-        $source = file_get_contents((string) $class->getFileName());
-        $this->assertTrue(is_string($source));
-
-        $lines = explode("\n", $source);
-        $startLine = $method->getStartLine() - 1;
-        $lineCount = $method->getEndLine() - $method->getStartLine() + 1;
-
-        return implode("\n", array_slice($lines, $startLine, $lineCount));
-    }
 }
 
-final class DailyCronJobBatchRetryTestDatabase extends PDO
+final class DailyCronJobPerGameRetryTestDatabase extends PDO
 {
-    private int $batchRarityUpdateCount = 0;
+    private int $perGameUpdateCount = 0;
 
     private int $titlePointsUpdateCount = 0;
 
@@ -148,9 +137,9 @@ final class DailyCronJobBatchRetryTestDatabase extends PDO
     {
     }
 
-    public function getBatchRarityUpdateCount(): int
+    public function getPerGameUpdateCount(): int
     {
-        return $this->batchRarityUpdateCount;
+        return $this->perGameUpdateCount;
     }
 
     public function getTitlePointsUpdateCount(): int
@@ -160,12 +149,18 @@ final class DailyCronJobBatchRetryTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
+            return new DailyCronJobTestStatement(static function (): array {
+                return ['NPWR00001_00'];
+            }, isSelect: true);
+        }
+
         if (str_contains($query, 'UPDATE trophy_meta tm')) {
             return new DailyCronJobTestStatement(function (): void {
-                $this->batchRarityUpdateCount++;
+                $this->perGameUpdateCount++;
 
-                if ($this->batchRarityUpdateCount < 3) {
-                    throw new RuntimeException('Simulated batch rarity update failure.');
+                if ($this->perGameUpdateCount < 3) {
+                    throw new RuntimeException('Simulated per-game rarity update failure.');
                 }
             });
         }
@@ -182,7 +177,7 @@ final class DailyCronJobBatchRetryTestDatabase extends PDO
 
 final class DailyCronJobTitleRetryTestDatabase extends PDO
 {
-    private int $batchRarityUpdateCount = 0;
+    private int $perGameUpdateCount = 0;
 
     private int $titlePointsUpdateCount = 0;
 
@@ -190,9 +185,9 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
     {
     }
 
-    public function getBatchRarityUpdateCount(): int
+    public function getPerGameUpdateCount(): int
     {
-        return $this->batchRarityUpdateCount;
+        return $this->perGameUpdateCount;
     }
 
     public function getTitlePointsUpdateCount(): int
@@ -202,9 +197,15 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
+            return new DailyCronJobTestStatement(static function (): array {
+                return [];
+            }, isSelect: true);
+        }
+
         if (str_contains($query, 'UPDATE trophy_meta tm')) {
             return new DailyCronJobTestStatement(function (): void {
-                $this->batchRarityUpdateCount++;
+                $this->perGameUpdateCount++;
             });
         }
 
@@ -227,12 +228,15 @@ final class DailyCronJobTestStatement extends PDOStatement
     /** @var callable(): mixed */
     private $callback;
 
+    private bool $isSelect;
+
     /**
      * @param callable(): mixed $callback
      */
-    public function __construct(callable $callback)
+    public function __construct(callable $callback, bool $isSelect = false)
     {
         $this->callback = $callback;
+        $this->isSelect = $isSelect;
     }
 
     public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
@@ -242,8 +246,21 @@ final class DailyCronJobTestStatement extends PDOStatement
 
     public function execute(?array $params = null): bool
     {
-        ($this->callback)();
+        if (!$this->isSelect) {
+            ($this->callback)();
+        }
 
         return true;
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args): array
+    {
+        if (!$this->isSelect) {
+            return [];
+        }
+
+        $result = ($this->callback)();
+
+        return is_array($result) ? $result : [];
     }
 }

--- a/tests/HourlyCronJobTest.php
+++ b/tests/HourlyCronJobTest.php
@@ -12,18 +12,18 @@ final class HourlyCronJobTest extends TestCase
         $class = new ReflectionClass(HourlyCronJob::class);
         $createBatchTableQuery = $this->readPrivateConstantValue($class, 'CREATE_BATCH_TEMP_TABLE_QUERY');
         $createStatsTableQuery = $this->readPrivateConstantValue($class, 'CREATE_STATS_TEMP_TABLE_QUERY');
-        $populateAllStatsQuery = $this->readPrivateConstantValue($class, 'POPULATE_ALL_STATS_QUERY');
+        $populateBatchStatsQuery = $this->readPrivateConstantValue($class, 'POPULATE_BATCH_STATS_QUERY');
         $updateMetaQuery = $this->readPrivateConstantValue($class, 'UPDATE_META_QUERY');
 
         $this->assertStringContainsString('COLLATE utf8mb4_0900_ai_ci', $createBatchTableQuery);
         $this->assertStringContainsString('COLLATE utf8mb4_0900_ai_ci', $createStatsTableQuery);
-        $this->assertStringContainsString('INSERT INTO tmp_hourly_stats', $populateAllStatsQuery);
-        $this->assertStringContainsString('FROM trophy_title_player ttp', $populateAllStatsQuery);
-        $this->assertStringContainsString('JOIN player_ranking pr ON pr.account_id = ttp.account_id AND pr.ranking <= 10000', $populateAllStatsQuery);
-        $this->assertStringContainsString('COUNT(*) AS owners', $populateAllStatsQuery);
-        $this->assertStringContainsString('SUM(ttp.progress = 100) AS owners_completed', $populateAllStatsQuery);
-        $this->assertStringContainsString('SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players', $populateAllStatsQuery);
-        $this->assertFalse(str_contains($populateAllStatsQuery, 'tmp_hourly_batch'));
+        $this->assertStringContainsString('INSERT INTO tmp_hourly_stats', $populateBatchStatsQuery);
+        $this->assertStringContainsString('FROM trophy_title_player ttp', $populateBatchStatsQuery);
+        $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id', $populateBatchStatsQuery);
+        $this->assertStringContainsString('JOIN player_ranking pr ON pr.account_id = ttp.account_id AND pr.ranking <= 10000', $populateBatchStatsQuery);
+        $this->assertStringContainsString('COUNT(*) AS owners', $populateBatchStatsQuery);
+        $this->assertStringContainsString('SUM(ttp.progress = 100) AS owners_completed', $populateBatchStatsQuery);
+        $this->assertStringContainsString('SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players', $populateBatchStatsQuery);
 
         $this->assertStringContainsString('UPDATE trophy_title_meta ttm', $updateMetaQuery);
         $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttm.np_communication_id', $updateMetaQuery);
@@ -42,36 +42,30 @@ final class HourlyCronJobTest extends TestCase
         $this->assertStringContainsString('(COALESCE(s.owners_completed, 0) / COALESCE(s.owners, 0)) * 100', $updateMetaQuery);
     }
 
-
     public function testUsesDeleteInsteadOfTruncateInBatchUpdateFlow(): void
     {
         $class = new ReflectionClass(HourlyCronJob::class);
         $source = file_get_contents((string) $class->getFileName());
         $this->assertTrue(is_string($source));
 
-        $this->assertStringContainsString("DELETE FROM tmp_hourly_batch", $source);
-        $this->assertFalse(str_contains($source, 'DELETE FROM tmp_hourly_stats'));
+        $this->assertStringContainsString('DELETE FROM tmp_hourly_batch', $source);
+        $this->assertStringContainsString('DELETE FROM tmp_hourly_stats', $source);
         $this->assertFalse(str_contains($source, 'TRUNCATE TABLE tmp_hourly_batch'));
         $this->assertFalse(str_contains($source, 'TRUNCATE TABLE tmp_hourly_stats'));
     }
 
-    public function testPopulatesAllStatisticsOnceBeforeBatchUpdates(): void
+    public function testPopulatesStatisticsPerBatch(): void
     {
         $class = new ReflectionClass(HourlyCronJob::class);
 
-        $this->assertTrue($class->hasMethod('populateAllStatistics'));
-        $this->assertFalse(str_contains(
-            $this->readMethodSource($class, 'updateStatisticsForBatch'),
-            'POPULATE_ALL_STATS_QUERY'
-        ));
+        $this->assertFalse($class->hasMethod('populateAllStatistics'));
+
+        $batchSource = $this->readMethodSource($class, 'updateStatisticsForBatch');
+        $this->assertStringContainsString('POPULATE_BATCH_STATS_QUERY', $batchSource);
+        $this->assertStringContainsString('DELETE FROM tmp_hourly_stats', $batchSource);
 
         $updateSource = $this->readMethodSource($class, 'updateTrophyTitleStatistics');
-        $this->assertStringContainsString('$this->populateAllStatistics();', $updateSource);
-        $populatePosition = strpos($updateSource, '$this->populateAllStatistics();');
-        $loopPosition = strpos($updateSource, 'while (true)');
-        $this->assertTrue(is_int($populatePosition));
-        $this->assertTrue(is_int($loopPosition));
-        $this->assertTrue($populatePosition < $loopPosition);
+        $this->assertFalse(str_contains($updateSource, 'populateAllStatistics'));
     }
 
     public function testNoDynamicUnionAllSelectBatchPathExists(): void

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final readonly class DailyCronJob implements CronJobInterface
 {
-    private const string UPDATE_ALL_TROPHY_RARITY_QUERY = <<<'SQL'
+    private const string UPDATE_TROPHY_RARITY_QUERY = <<<'SQL'
         WITH rarity AS (
             SELECT
                 t.id AS trophy_id,
@@ -29,6 +29,7 @@ final readonly class DailyCronJob implements CronJobInterface
             LEFT JOIN player_ranking p
                 ON p.account_id = te.account_id
                     AND p.ranking <= 10000
+            WHERE t.np_communication_id = :np_communication_id
             GROUP BY t.id, tm.status, ttm.status, ttm.owners
         )
         UPDATE trophy_meta tm
@@ -92,18 +93,31 @@ final readonly class DailyCronJob implements CronJobInterface
     #[\Override]
     public function run(): void
     {
-        $this->recalculateTrophyRarity();
+        $this->recalculateTrophyRarityForGames();
         $this->recalculateTitleRarityPoints();
     }
 
-    private function recalculateTrophyRarity(): void
+    private function recalculateTrophyRarityForGames(): void
     {
-        $this->executeWithRetry([$this, 'updateAllTrophyRarity']);
+        $query = $this->database->prepare(
+            'SELECT np_communication_id FROM trophy_title ORDER BY id DESC'
+        );
+        $query->execute();
+        $games = $query->fetchAll(PDO::FETCH_COLUMN);
+
+        foreach ($games as $npCommunicationId) {
+            if (!is_string($npCommunicationId)) {
+                continue;
+            }
+
+            $this->executeWithRetry([$this, 'updateTrophyRarityForGame'], $npCommunicationId);
+        }
     }
 
-    private function updateAllTrophyRarity(): void
+    private function updateTrophyRarityForGame(string $npCommunicationId): void
     {
-        $query = $this->database->prepare(self::UPDATE_ALL_TROPHY_RARITY_QUERY);
+        $query = $this->database->prepare(self::UPDATE_TROPHY_RARITY_QUERY);
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->execute();
     }
 

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -6,6 +6,82 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final readonly class DailyCronJob implements CronJobInterface
 {
+    private const string UPDATE_ALL_TROPHY_RARITY_QUERY = <<<'SQL'
+        WITH rarity AS (
+            SELECT
+                t.id AS trophy_id,
+                tm.status AS meta_status,
+                ttm.status AS title_status,
+                ttm.owners AS title_owners,
+                COUNT(p.account_id) AS trophy_owners,
+                (COUNT(p.account_id) / 10000.0) * 100 AS rarity_percent,
+                CASE
+                    WHEN ttm.owners = 0 THEN 0
+                    ELSE LEAST((COUNT(p.account_id) / ttm.owners) * 100, 100.0)
+                END AS in_game_rarity_percent
+            FROM trophy t
+            JOIN trophy_meta tm ON tm.trophy_id = t.id
+            JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
+            LEFT JOIN trophy_earned te
+                ON te.np_communication_id = t.np_communication_id
+                    AND te.order_id = t.order_id
+                    AND te.earned = 1
+            LEFT JOIN player_ranking p
+                ON p.account_id = te.account_id
+                    AND p.ranking <= 10000
+            GROUP BY t.id, tm.status, ttm.status, ttm.owners
+        )
+        UPDATE trophy_meta tm
+        JOIN rarity r ON tm.trophy_id = r.trophy_id
+        SET
+            tm.rarity_percent = r.rarity_percent,
+            tm.owners = r.trophy_owners,
+            tm.rarity_point = IF(
+                r.meta_status = 0 AND r.title_status = 0,
+                IF(r.rarity_percent = 0, 10000, FLOOR(1 / (r.rarity_percent / 100) - 1)),
+                0
+            ),
+            tm.rarity_name = CASE
+                WHEN r.meta_status != 0 OR r.title_status != 0 THEN 'NONE'
+                WHEN r.rarity_percent > 10 THEN 'COMMON'
+                WHEN r.rarity_percent > 2 THEN 'UNCOMMON'
+                WHEN r.rarity_percent > 0.2 THEN 'RARE'
+                WHEN r.rarity_percent > 0.02 THEN 'EPIC'
+                ELSE 'LEGENDARY'
+            END,
+            tm.in_game_rarity_percent = r.in_game_rarity_percent,
+            tm.in_game_rarity_point = IF(
+                r.meta_status = 0 AND r.title_status = 0 AND r.title_owners > 0,
+                IF(r.in_game_rarity_percent = 0, 0, FLOOR(1 / (r.in_game_rarity_percent / 100) - 1)),
+                0
+            ),
+            tm.in_game_rarity_name = CASE
+                WHEN r.meta_status != 0 OR r.title_status != 0 THEN 'NONE'
+                WHEN r.in_game_rarity_percent <= 1 THEN 'LEGENDARY'
+                WHEN r.in_game_rarity_percent <= 5 THEN 'EPIC'
+                WHEN r.in_game_rarity_percent <= 20 THEN 'RARE'
+                WHEN r.in_game_rarity_percent <= 60 THEN 'UNCOMMON'
+                ELSE 'COMMON'
+            END
+        SQL;
+
+    private const string UPDATE_TITLE_RARITY_POINTS_QUERY = <<<'SQL'
+        WITH rarity AS (
+            SELECT
+                t.np_communication_id,
+                IFNULL(SUM(tm.rarity_point), 0) AS rarity_sum,
+                IFNULL(SUM(tm.in_game_rarity_point), 0) AS in_game_rarity_sum
+            FROM trophy t
+            JOIN trophy_meta tm ON tm.trophy_id = t.id
+            GROUP BY t.np_communication_id
+        )
+        UPDATE trophy_title_meta ttm
+        JOIN rarity r USING (np_communication_id)
+        SET
+            ttm.rarity_points = r.rarity_sum,
+            ttm.in_game_rarity_points = r.in_game_rarity_sum
+        SQL;
+
     public function __construct(
         private PDO $database,
         private int $retryDelaySeconds = 3,
@@ -16,90 +92,18 @@ final readonly class DailyCronJob implements CronJobInterface
     #[\Override]
     public function run(): void
     {
-        $this->recalculateTrophyRarityForGames();
+        $this->recalculateTrophyRarity();
         $this->recalculateTitleRarityPoints();
     }
 
-    private function recalculateTrophyRarityForGames(): void
+    private function recalculateTrophyRarity(): void
     {
-        $query = $this->database->prepare(
-            'SELECT np_communication_id FROM trophy_title ORDER BY id DESC'
-        );
-        $query->execute();
-        $games = $query->fetchAll(PDO::FETCH_COLUMN);
-
-        foreach ($games as $npCommunicationId) {
-            if (!is_string($npCommunicationId)) {
-                continue;
-            }
-
-            $this->executeWithRetry([$this, 'updateTrophyRarityForGame'], $npCommunicationId);
-        }
+        $this->executeWithRetry([$this, 'updateAllTrophyRarity']);
     }
 
-    private function updateTrophyRarityForGame(string $npCommunicationId): void
+    private function updateAllTrophyRarity(): void
     {
-        $query = $this->database->prepare(
-            "WITH rarity AS (
-                SELECT
-                    t.id AS trophy_id,
-                    tm.status AS meta_status,
-                    ttm.status AS title_status,
-                    ttm.owners AS title_owners,
-                    COUNT(p.account_id) AS trophy_owners,
-                    (COUNT(p.account_id) / 10000.0) * 100 AS rarity_percent,
-                    CASE
-                        WHEN ttm.owners = 0 THEN 0
-                        ELSE LEAST((COUNT(p.account_id) / ttm.owners) * 100, 100.0)
-                    END AS in_game_rarity_percent
-                FROM trophy t
-                JOIN trophy_meta tm ON tm.trophy_id = t.id
-                JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
-                LEFT JOIN trophy_earned te
-                    ON te.np_communication_id = t.np_communication_id
-                        AND te.order_id = t.order_id
-                        AND te.earned = 1
-                LEFT JOIN player_ranking p
-                    ON p.account_id = te.account_id
-                        AND p.ranking <= 10000
-                WHERE t.np_communication_id = :np_communication_id
-                GROUP BY t.id, tm.status, ttm.status, ttm.owners
-            )
-            UPDATE trophy_meta tm
-            JOIN rarity r ON tm.trophy_id = r.trophy_id
-            SET
-                tm.rarity_percent = r.rarity_percent,
-                tm.owners = r.trophy_owners,
-                tm.rarity_point = IF(
-                    r.meta_status = 0 AND r.title_status = 0,
-                    IF(r.rarity_percent = 0, 10000, FLOOR(1 / (r.rarity_percent / 100) - 1)),
-                    0
-                ),
-                tm.rarity_name = CASE
-                    WHEN r.meta_status != 0 OR r.title_status != 0 THEN 'NONE'
-                    WHEN r.rarity_percent > 10 THEN 'COMMON'
-                    WHEN r.rarity_percent > 2 THEN 'UNCOMMON'
-                    WHEN r.rarity_percent > 0.2 THEN 'RARE'
-                    WHEN r.rarity_percent > 0.02 THEN 'EPIC'
-                    ELSE 'LEGENDARY'
-                END,
-                tm.in_game_rarity_percent = r.in_game_rarity_percent,
-                tm.in_game_rarity_point = IF(
-                    r.meta_status = 0 AND r.title_status = 0 AND r.title_owners > 0,
-                    IF(r.in_game_rarity_percent = 0, 0, FLOOR(1 / (r.in_game_rarity_percent / 100) - 1)),
-                    0
-                ),
-                tm.in_game_rarity_name = CASE
-                    WHEN r.meta_status != 0 OR r.title_status != 0 THEN 'NONE'
-                    WHEN r.in_game_rarity_percent <= 1 THEN 'LEGENDARY'
-                    WHEN r.in_game_rarity_percent <= 5 THEN 'EPIC'
-                    WHEN r.in_game_rarity_percent <= 20 THEN 'RARE'
-                    WHEN r.in_game_rarity_percent <= 60 THEN 'UNCOMMON'
-                    ELSE 'COMMON'
-                END"
-        );
-
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query = $this->database->prepare(self::UPDATE_ALL_TROPHY_RARITY_QUERY);
         $query->execute();
     }
 
@@ -110,23 +114,7 @@ final readonly class DailyCronJob implements CronJobInterface
 
     private function updateTrophyTitleRarityPoints(): void
     {
-            $query = $this->database->prepare(
-                "WITH rarity AS (
-                    SELECT
-                        t.np_communication_id,
-                    IFNULL(SUM(tm.rarity_point), 0) AS rarity_sum,
-                    IFNULL(SUM(tm.in_game_rarity_point), 0) AS in_game_rarity_sum
-                FROM trophy t
-                JOIN trophy_meta tm ON tm.trophy_id = t.id
-                GROUP BY t.np_communication_id
-            )
-            UPDATE trophy_title_meta ttm
-            JOIN rarity r USING(np_communication_id)
-            SET
-                ttm.rarity_points = r.rarity_sum,
-                ttm.in_game_rarity_points = r.in_game_rarity_sum"
-        );
-
+        $query = $this->database->prepare(self::UPDATE_TITLE_RARITY_POINTS_QUERY);
         $query->execute();
     }
 

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -23,7 +23,7 @@ final readonly class HourlyCronJob implements CronJobInterface
         )
         SQL;
 
-    private const POPULATE_ALL_STATS_QUERY = <<<'SQL'
+    private const POPULATE_BATCH_STATS_QUERY = <<<'SQL'
         INSERT INTO tmp_hourly_stats (np_communication_id, owners, owners_completed, recent_players)
         SELECT
             ttp.np_communication_id,
@@ -31,6 +31,7 @@ final readonly class HourlyCronJob implements CronJobInterface
             SUM(ttp.progress = 100) AS owners_completed,
             SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players
         FROM trophy_title_player ttp
+        JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id
         JOIN player_ranking pr ON pr.account_id = ttp.account_id AND pr.ranking <= 10000
         GROUP BY ttp.np_communication_id
         SQL;
@@ -67,8 +68,6 @@ final readonly class HourlyCronJob implements CronJobInterface
         $this->initializeTemporaryTables();
 
         try {
-            $this->populateAllStatistics();
-
             while (true) {
                 $batchIds = $this->getBatchNpCommunicationIds($lastId, self::BATCH_SIZE);
 
@@ -94,12 +93,6 @@ final readonly class HourlyCronJob implements CronJobInterface
         }
     }
 
-    private function populateAllStatistics(): void
-    {
-        $query = $this->database->prepare(self::POPULATE_ALL_STATS_QUERY);
-        $query->execute();
-    }
-
     private function getBatchNpCommunicationIds(?string $lastId, int $limit): array
     {
         $baseQuery = 'SELECT np_communication_id FROM trophy_title_meta %s ORDER BY np_communication_id LIMIT :limit';
@@ -120,7 +113,11 @@ final readonly class HourlyCronJob implements CronJobInterface
     private function updateStatisticsForBatch(array $batchIds): void
     {
         $this->database->exec('DELETE FROM tmp_hourly_batch');
+        $this->database->exec('DELETE FROM tmp_hourly_stats');
         $this->insertBatchIdsIntoTemporaryTable($batchIds);
+
+        $populateStatsQuery = $this->database->prepare(self::POPULATE_BATCH_STATS_QUERY);
+        $populateStatsQuery->execute();
 
         $updateMetaQuery = $this->database->prepare(self::UPDATE_META_QUERY);
         $updateMetaQuery->execute();

--- a/wwwroot/classes/Cron/PlayerScanQueueSelector.php
+++ b/wwwroot/classes/Cron/PlayerScanQueueSelector.php
@@ -173,7 +173,7 @@ final class PlayerScanQueueSelector
                     LEFT JOIN player_ranking pr ON pr.account_id = p.account_id
                     JOIN now_values nv
                 WHERE
-                    p.status NOT IN (1, 3, 4, 5)
+                    p.status IN (0, 99)
                     AND p.last_updated_date < nv.cutoff_1w
                     AND (
                         pr.account_id IS NULL


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Builds on the recent MySQL 8.4 work (histograms, queue upserts, CTE updates) with additional performance and maintenance improvements targeting MySQL 8.4 only.

### Cron job SQL

- **HourlyCronJob**: Aggregate `trophy_title_player` statistics per 500-title batch via `tmp_hourly_batch`, instead of scanning the full table once before batching updates. Does **not** touch `trophy_earned`.
- **DailyCronJob**: Keeps **per-title** rarity recalculation (`WHERE np_communication_id = ?`) because `trophy_earned` is ~2.7B rows / ~448 GiB — a single batch `UPDATE` joining the full table would risk hours of I/O and site freeze. SQL is refactored into constants only.

### MySQL 8.4 optimizer maintenance

- Extended `database/mysql84_histograms.sql` with `AUTO UPDATE` histograms for ranking columns, `trophy_meta.status`, `psn100_change`, and `log`.
- **`trophy_earned` explicitly excluded** from histograms (scale + `AUTO UPDATE` overhead; queries already use partition/PK filters).
- Documented when and how to run histogram maintenance in `README.md` and `DEPLOYMENT.md`.

### Schema cleanup

- Removed four redundant indexes from `database/psn100.sql` (each covered by an existing PK/unique key). None on `trophy_earned`.
- Added `database/mysql84_drop_redundant_indexes.sql` for existing production databases.

### Query clarity

- **PlayerScanQueueSelector** tier 6 now uses `status IN (0, 99)` instead of `NOT IN (1, 3, 4, 5)`.

## Testing

- `php tests/run.php` — all 902 tests pass.

## Deployment notes

After deploy on MySQL 8.4+:

```bash
mysql psn100 < database/mysql84_histograms.sql
mysql psn100 < database/mysql84_drop_redundant_indexes.sql   # existing DBs only
```

Do **not** add histograms or batch full-table scans on `trophy_earned` at current scale.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aba5d9b0-183d-4e0a-a7cf-32831adb3a2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aba5d9b0-183d-4e0a-a7cf-32831adb3a2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

