### PR TITLE
Adopt PHP 8.5 features across the codebase

### DIFF
--- a/tests/CommaSeparatedValuesTest.php
+++ b/tests/CommaSeparatedValuesTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/CommaSeparatedValues.php';
+
+final class CommaSeparatedValuesTest extends TestCase
+{
+    public function testParseTrimmedReturnsEmptyListForEmptyString(): void
+    {
+        $this->assertSame([], CommaSeparatedValues::parseTrimmed(''));
+    }
+
+    public function testParseTrimmedTrimsAndFiltersEmptySegments(): void
+    {
+        $this->assertSame(['PS4', 'PS5'], CommaSeparatedValues::parseTrimmed(' PS4 , , PS5 '));
+    }
+
+    public function testParseUppercaseTrimmedNormalizesCase(): void
+    {
+        $this->assertSame(['PS4', 'PS5'], CommaSeparatedValues::parseUppercaseTrimmed('ps4, ps5'));
+    }
+}

--- a/tests/RequestParameterTest.php
+++ b/tests/RequestParameterTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/RequestParameter.php';
+
+final class RequestParameterTest extends TestCase
+{
+    public function testFirstScalarReturnsScalarValue(): void
+    {
+        $this->assertSame('player', RequestParameter::firstScalar('player'));
+    }
+
+    public function testFirstScalarReturnsFirstArrayElement(): void
+    {
+        $this->assertSame('first', RequestParameter::firstScalar(['first', 'second']));
+    }
+
+    public function testFirstScalarReturnsNullForEmptyArray(): void
+    {
+        $this->assertSame(null, RequestParameter::firstScalar([]));
+    }
+
+    public function testLastScalarReturnsLastArrayElement(): void
+    {
+        $this->assertSame('second', RequestParameter::lastScalar(['first', 'second']));
+    }
+
+    public function testLastScalarReturnsNullForEmptyArray(): void
+    {
+        $this->assertSame(null, RequestParameter::lastScalar([]));
+    }
+}

--- a/wwwroot/classes/Admin/GameCopyHandler.php
+++ b/wwwroot/classes/Admin/GameCopyHandler.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../Html.php';
+require_once __DIR__ . '/../RequestParameter.php';
 
 class GameCopyHandler
 {
@@ -69,7 +70,7 @@ class GameCopyHandler
         $value = $postData[$key];
 
         if (is_array($value)) {
-            $value = end($value);
+            $value = RequestParameter::lastScalar($value);
         }
 
         $value = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/PlayStationWorkerAuthenticator.php';
 require_once __DIR__ . '/PsnGameLookupException.php';
 require_once __DIR__ . '/PsnTrophyApiPayloadInspector.php';
 require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
+require_once __DIR__ . '/../CommaSeparatedValues.php';
 
 use Tustin\PlayStation\Client;
 
@@ -325,10 +326,7 @@ final class PsnGameLookupService
             return null;
         }
 
-        $platforms = array_values(array_filter(array_map(
-            static fn (string $value): string => strtoupper(trim($value)),
-            explode(',', (string) $platform)
-        ), static fn (string $value): bool => $value !== ''));
+        $platforms = CommaSeparatedValues::parseUppercaseTrimmed((string) $platform);
 
         if ($platforms === []) {
             return null;

--- a/wwwroot/classes/ChangelogPage.php
+++ b/wwwroot/classes/ChangelogPage.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/ChangelogEntry.php';
 require_once __DIR__ . '/ChangelogEntryPresenter.php';
 require_once __DIR__ . '/ChangelogPaginator.php';
 require_once __DIR__ . '/ChangelogService.php';
+require_once __DIR__ . '/RequestParameter.php';
 require_once __DIR__ . '/Utility.php';
 
 class ChangelogPage
@@ -127,9 +128,7 @@ class ChangelogPage
 
     private static function resolvePageNumber(mixed $page): int
     {
-        if (is_array($page)) {
-            $page = reset($page);
-        }
+        $page = RequestParameter::firstScalar($page);
 
         if (!is_scalar($page)) {
             return 1;

--- a/wwwroot/classes/CommaSeparatedValues.php
+++ b/wwwroot/classes/CommaSeparatedValues.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+final class CommaSeparatedValues
+{
+    /**
+     * @return list<string>
+     */
+    public static function parseTrimmed(string $value): array
+    {
+        if ($value === '') {
+            return [];
+        }
+
+        return $value
+            |> (fn(string $raw): array => explode(',', $raw))
+            |> (fn(array $parts): array => array_map(trim(...), $parts))
+            |> (fn(array $parts): array => array_filter($parts, static fn(string $part): bool => $part !== ''))
+            |> array_values(...);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function parseUppercaseTrimmed(string $value): array
+    {
+        return self::parseTrimmed($value)
+            |> (fn(array $parts): array => array_map(strtoupper(...), $parts));
+    }
+}

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -86,7 +86,7 @@ final readonly class HourlyCronJob implements CronJobInterface
                     throw $exception;
                 }
 
-                $lastId = end($batchIds);
+                $lastId = array_last($batchIds);
             }
         } finally {
             $this->dropTemporaryTables();

--- a/wwwroot/classes/CsrfTokenManager.php
+++ b/wwwroot/classes/CsrfTokenManager.php
@@ -23,6 +23,7 @@ final class CsrfTokenManager
         return $token;
     }
 
+    #[\NoDiscard]
     public static function validate(string $scope, mixed $submittedToken): bool
     {
         SessionManager::ensureStarted();

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -106,10 +106,7 @@ class GameListFilter
 
     public function withPage(int $page): self
     {
-        $clone = clone $this;
-        $clone->page = max($page, 1);
-
-        return $clone;
+        return clone($this, ['page' => max($page, 1)]);
     }
 
     public function getSort(): string

--- a/wwwroot/classes/IpAddressResolver.php
+++ b/wwwroot/classes/IpAddressResolver.php
@@ -42,7 +42,7 @@ final class IpAddressResolver
     public static function resolve(mixed $remoteAddr): string
     {
         if (is_array($remoteAddr)) {
-            $remoteAddr = reset($remoteAddr);
+            $remoteAddr = array_first($remoteAddr);
         }
 
         if (is_object($remoteAddr) && method_exists($remoteAddr, '__toString')) {

--- a/wwwroot/classes/MaintenancePage.php
+++ b/wwwroot/classes/MaintenancePage.php
@@ -54,10 +54,7 @@ final class MaintenancePage
 
     public function withMessage(string $message): self
     {
-        $clone = clone $this;
-        $clone->message = $message;
-
-        return $clone;
+        return clone($this, ['message' => $message]);
     }
 
     public function getTitle(): string

--- a/wwwroot/classes/NavigationState.php
+++ b/wwwroot/classes/NavigationState.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/NavigationSection.php';
 require_once __DIR__ . '/NavigationSectionState.php';
+require_once __DIR__ . '/RequestParameter.php';
 
 final class NavigationState
 {
@@ -131,12 +132,7 @@ final class NavigationState
 
     private static function sanitizeQueryValue(mixed $value): string
     {
-        if (is_array($value)) {
-            $value = reset($value);
-            if ($value === false) {
-                $value = '';
-            }
-        }
+        $value = RequestParameter::firstScalar($value) ?? '';
 
         return htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
     }

--- a/wwwroot/classes/NotFoundPage.php
+++ b/wwwroot/classes/NotFoundPage.php
@@ -28,26 +28,17 @@ final class NotFoundPage
 
     public function withHeading(string $heading): self
     {
-        $clone = clone $this;
-        $clone->heading = $heading;
-
-        return $clone;
+        return clone($this, ['heading' => $heading]);
     }
 
     public function withMessage(string $message): self
     {
-        $clone = clone $this;
-        $clone->message = $message;
-
-        return $clone;
+        return clone($this, ['message' => $message]);
     }
 
     public function withTitle(string $title): self
     {
-        $clone = clone $this;
-        $clone->title = $title;
-
-        return $clone;
+        return clone($this, ['title' => $title]);
     }
 
     public function getTitle(): string

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -237,9 +237,6 @@ class PlayerGamesFilter
 
     public function withPageNumber(int $page): self
     {
-        $clone = clone $this;
-        $clone->page = max($page, 1);
-
-        return $clone;
+        return clone($this, ['page' => max($page, 1)]);
     }
 }

--- a/wwwroot/classes/PlayerQueueRequest.php
+++ b/wwwroot/classes/PlayerQueueRequest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/IpAddressResolver.php';
+require_once __DIR__ . '/RequestParameter.php';
 
 readonly class PlayerQueueRequest
 {
@@ -43,9 +44,7 @@ readonly class PlayerQueueRequest
 
     private static function sanitizeValue(mixed $value): string
     {
-        if (is_array($value)) {
-            $value = reset($value);
-        }
+        $value = RequestParameter::firstScalar($value);
 
         if (is_object($value)) {
             if (method_exists($value, '__toString')) {

--- a/wwwroot/classes/RequestParameter.php
+++ b/wwwroot/classes/RequestParameter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+final class RequestParameter
+{
+    public static function firstScalar(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            return array_first($value);
+        }
+
+        return $value;
+    }
+
+    public static function lastScalar(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            return array_last($value);
+        }
+
+        return $value;
+    }
+}

--- a/wwwroot/classes/RouteResult.php
+++ b/wwwroot/classes/RouteResult.php
@@ -16,16 +16,19 @@ readonly class RouteResult
     ) {
     }
 
+    #[\NoDiscard]
     public static function include(string $file, array $variables = []): self
     {
         return new self($file, null, false, $variables);
     }
 
+    #[\NoDiscard]
     public static function redirect(string $location, int $statusCode = 303): self
     {
         return new self(null, $location, false, [], $statusCode);
     }
 
+    #[\NoDiscard]
     public static function notFound(): self
     {
         return new self(null, null, true, [], 404);

--- a/wwwroot/classes/TrophyCatalogSynchronizer.php
+++ b/wwwroot/classes/TrophyCatalogSynchronizer.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
+
 /**
  * Persists trophy catalog rows shared between player scans and admin rescans.
  */
@@ -36,10 +38,7 @@ final class TrophyCatalogSynchronizer
         }
 
         $platform = isset($row['platform']) ? (string) $row['platform'] : '';
-        $platforms = array_values(array_filter(array_map(
-            'trim',
-            $platform === '' ? [] : explode(',', $platform)
-        ), static fn (string $value): bool => $value !== ''));
+        $platforms = CommaSeparatedValues::parseTrimmed($platform);
 
         return [
             'detail' => $row['detail'] === null ? null : (string) $row['detail'],

--- a/wwwroot/classes/Utility.php
+++ b/wwwroot/classes/Utility.php
@@ -15,26 +15,29 @@ class Utility
 
     public function slugify(?string $text): string
     {
-        $text = $text ?? '';
-
-        $normalizedWhitespace = preg_replace('/\s+/', ' ', $text) ?? $text;
-        $text = trim($normalizedWhitespace);
-        $text = str_replace(['&', '%', ' - '], ['and', 'percent', ' '], $text);
+        $text = ($text ?? '')
+            |> (fn(string $value): string => preg_replace('/\s+/', ' ', $value) ?? $value)
+            |> trim(...)
+            |> (fn(string $value): string => str_replace(['&', '%', ' - '], ['and', 'percent', ' '], $value));
 
         $slug = self::getSlugTransliterator()->transliterate($text);
         if (is_string($slug) && $slug !== '') {
             return $slug;
         }
 
-        $text = strtolower($text);
-        $slug = preg_replace('/[^a-z0-9]+/', '-', $text) ?? $text;
+        $slug = $text
+            |> strtolower(...)
+            |> (fn(string $value): string => preg_replace('/[^a-z0-9]+/', '-', $value) ?? $value)
+            |> (fn(string $value): string => trim($value, '-'));
 
-        return trim($slug, '-');
+        return $slug;
     }
 
     public function getCountryName(?string $countryCode): string
     {
-        $countryCode = strtoupper(trim((string) ($countryCode ?? '')));
+        $countryCode = ($countryCode ?? '')
+            |> trim(...)
+            |> strtoupper(...);
 
         if ($countryCode === '') {
             return 'Unknown';

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -74,10 +74,10 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
         if (count($replacementLinks) === 2) {
             $replacementText = implode(' and ', $replacementLinks);
         } elseif (count($replacementLinks) > 2) {
-            $lastLink = array_pop($replacementLinks);
-            $replacementText = implode(', ', $replacementLinks) . ', and ' . $lastLink;
+            $lastLink = array_last($replacementLinks);
+            $replacementText = implode(', ', array_slice($replacementLinks, 0, -1)) . ', and ' . $lastLink;
         } else {
-            $replacementText = $replacementLinks[0];
+            $replacementText = array_first($replacementLinks);
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adopts PHP 8.5 language features where they simplify existing patterns, without changing behavior.

### New helpers
- **`RequestParameter`** — wraps `array_first()` / `array_last()` for request/query sanitization
- **`CommaSeparatedValues`** — parses comma-separated platform strings using the pipe operator (`|>`)

### PHP 8.5 features applied
- **`array_first()` / `array_last()`** — replaces `reset()`, `end()`, `$arr[0]`, and `array_pop()` in request sanitizers, cron batch cursors, and template logic
- **`clone with`** — simplifies `with*` methods on `NotFoundPage`, `MaintenancePage`, `GameListFilter`, and `PlayerGamesFilter`
- **Pipe operator (`|>`)** — used in `Utility::slugify()`, `Utility::getCountryName()`, and `CommaSeparatedValues`
- **`#[\NoDiscard]`** — added to `RouteResult` factory methods and `CsrfTokenManager::validate()` to warn when return values are ignored

### Files touched
20 files across request handling, page value objects, cron jobs, platform parsing, and utilities.

## Test plan
- [x] Added `RequestParameterTest` and `CommaSeparatedValuesTest`
- [x] Full suite passes: `php tests/run.php` (913 tests)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46404993-30f9-4c80-9182-6c8e16ed295b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46404993-30f9-4c80-9182-6c8e16ed295b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

