### PR TITLE
Extract player profile upsert into PlayerRepository

### DIFF
--- a/tests/PlayerRepositoryTest.php
+++ b/tests/PlayerRepositoryTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerRepository.php';
+
+final class PlayerRepositoryTest extends TestCase
+{
+    private PDO $database;
+    private PlayerRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec(
+            'CREATE TABLE player (
+                account_id TEXT PRIMARY KEY,
+                online_id TEXT NOT NULL,
+                country TEXT NOT NULL,
+                avatar_url TEXT,
+                plus INTEGER NOT NULL DEFAULT 0,
+                about_me TEXT NOT NULL DEFAULT ""
+            )'
+        );
+
+        $this->repository = new PlayerRepository($this->database);
+    }
+
+    public function testUpsertFromPsnProfileInsertsNewPlayer(): void
+    {
+        $this->repository->upsertFromPsnProfile(
+            '12345',
+            'ExampleUser',
+            'US',
+            'avatar.png',
+            true,
+            'Hello world',
+        );
+
+        $statement = $this->database->query(
+            'SELECT account_id, online_id, country, avatar_url, plus, about_me FROM player'
+        );
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertSame([
+            'account_id' => '12345',
+            'online_id' => 'ExampleUser',
+            'country' => 'us',
+            'avatar_url' => 'avatar.png',
+            'plus' => 1,
+            'about_me' => 'Hello world',
+        ], $row);
+    }
+
+    public function testUpsertFromPsnProfileUpdatesExistingPlayerWithoutChangingCountry(): void
+    {
+        $statement = $this->database->prepare(
+            'INSERT INTO player (account_id, online_id, country, avatar_url, plus, about_me)
+            VALUES (:account_id, :online_id, :country, :avatar_url, :plus, :about_me)'
+        );
+        $statement->execute([
+            ':account_id' => '12345',
+            ':online_id' => 'OldName',
+            ':country' => 'se',
+            ':avatar_url' => 'old.png',
+            ':plus' => 0,
+            ':about_me' => 'Old bio',
+        ]);
+
+        $this->repository->upsertFromPsnProfile(
+            '12345',
+            'NewName',
+            'US',
+            'new.png',
+            true,
+            'Updated bio',
+        );
+
+        $statement = $this->database->query(
+            'SELECT account_id, online_id, country, avatar_url, plus, about_me FROM player'
+        );
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertSame([
+            'account_id' => '12345',
+            'online_id' => 'NewName',
+            'country' => 'se',
+            'avatar_url' => 'new.png',
+            'plus' => 1,
+            'about_me' => 'Updated bio',
+        ], $row);
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/PlayerAvatarSynchronizer.php';
 require_once __DIR__ . '/../ImageHashCalculator.php';
 require_once __DIR__ . '/PlayerCountryResolver.php';
 require_once __DIR__ . '/PlayerScanPrivacyService.php';
+require_once __DIR__ . '/../PlayerRepository.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\PlayStation\Client;
@@ -24,6 +25,7 @@ final class PlayerScanProfileSynchronizer
     private readonly PlayerAvatarSynchronizer $avatarSynchronizer;
     private readonly PlayerCountryResolver $countryResolver;
     private readonly PlayerScanPrivacyService $privacyService;
+    private readonly PlayerRepository $playerRepository;
 
     public function __construct(
         private readonly PDO $database,
@@ -32,6 +34,7 @@ final class PlayerScanProfileSynchronizer
         ?PlayerAvatarSynchronizer $avatarSynchronizer = null,
         ?PlayerCountryResolver $countryResolver = null,
         ?PlayerScanPrivacyService $privacyService = null,
+        ?PlayerRepository $playerRepository = null,
     ) {
         $this->avatarSynchronizer = $avatarSynchronizer ?? new PlayerAvatarSynchronizer(
             $database,
@@ -42,6 +45,7 @@ final class PlayerScanProfileSynchronizer
             $database,
             $workerScanCoordinator,
         );
+        $this->playerRepository = $playerRepository ?? new PlayerRepository($database);
     }
 
     /**
@@ -77,7 +81,14 @@ final class PlayerScanProfileSynchronizer
         );
 
         $avatarFilename = $this->avatarSynchronizer->synchronizeFromPsnUser($user);
-        $this->upsertPlayerRecord($user, $country, $avatarFilename);
+        $this->playerRepository->upsertFromPsnProfile(
+            (string) $user->accountId(),
+            $user->onlineId(),
+            $country,
+            $avatarFilename,
+            (bool) $user->hasPlus(),
+            $user->aboutMe(),
+        );
 
         return PlayerScanProfileSyncResult::success($resolved->player, $user, $country);
     }
@@ -248,42 +259,6 @@ final class PlayerScanProfileSynchronizer
         }
 
         return PlayerScanProfileSyncResult::skipPlayer();
-    }
-
-    private function upsertPlayerRecord(object $user, string $country, string $avatarFilename): void
-    {
-        $plus = (bool) $user->hasPlus();
-
-        $query = $this->database->prepare(
-            'INSERT INTO player (
-                account_id,
-                online_id,
-                country,
-                avatar_url,
-                plus,
-                about_me
-            )
-            VALUES (
-                :account_id,
-                :online_id,
-                :country,
-                :avatar_url,
-                :plus,
-                :about_me
-            ) AS new ON DUPLICATE KEY
-            UPDATE
-                online_id = new.online_id,
-                avatar_url = new.avatar_url,
-                plus = new.plus,
-                about_me = new.about_me'
-        );
-        $query->bindValue(':account_id', (string) $user->accountId(), PDO::PARAM_STR);
-        $query->bindValue(':online_id', $user->onlineId(), PDO::PARAM_STR);
-        $query->bindValue(':country', strtolower($country), PDO::PARAM_STR);
-        $query->bindValue(':avatar_url', $avatarFilename, PDO::PARAM_STR);
-        $query->bindValue(':plus', $plus, PDO::PARAM_BOOL);
-        $query->bindValue(':about_me', $user->aboutMe(), PDO::PARAM_STR);
-        $query->execute();
     }
 
     private function lookupPlayerProfile(Client $client, string $onlineId): ?array

--- a/wwwroot/classes/PlayerRepository.php
+++ b/wwwroot/classes/PlayerRepository.php
@@ -4,7 +4,81 @@ declare(strict_types=1);
 
 class PlayerRepository
 {
+    private const string SQL_UPSERT_FROM_PSN_PROFILE_MYSQL = <<<'SQL'
+        INSERT INTO player (
+            account_id,
+            online_id,
+            country,
+            avatar_url,
+            plus,
+            about_me
+        )
+        VALUES (
+            :account_id,
+            :online_id,
+            :country,
+            :avatar_url,
+            :plus,
+            :about_me
+        ) AS new ON DUPLICATE KEY
+        UPDATE
+            online_id = new.online_id,
+            avatar_url = new.avatar_url,
+            plus = new.plus,
+            about_me = new.about_me
+        SQL;
+    private const string SQL_UPSERT_FROM_PSN_PROFILE_SQLITE = <<<'SQL'
+        INSERT INTO player (
+            account_id,
+            online_id,
+            country,
+            avatar_url,
+            plus,
+            about_me
+        )
+        VALUES (
+            :account_id,
+            :online_id,
+            :country,
+            :avatar_url,
+            :plus,
+            :about_me
+        )
+        ON CONFLICT(account_id) DO UPDATE SET
+            online_id = excluded.online_id,
+            avatar_url = excluded.avatar_url,
+            plus = excluded.plus,
+            about_me = excluded.about_me
+        SQL;
+
     public function __construct(private readonly \PDO $database) {}
+
+    public function upsertFromPsnProfile(
+        string $accountId,
+        string $onlineId,
+        string $country,
+        string $avatarUrl,
+        bool $hasPlus,
+        string $aboutMe,
+    ): void {
+        $query = $this->database->prepare($this->upsertFromPsnProfileSql());
+        $query->bindValue(':account_id', $accountId, \PDO::PARAM_STR);
+        $query->bindValue(':online_id', $onlineId, \PDO::PARAM_STR);
+        $query->bindValue(':country', strtolower($country), \PDO::PARAM_STR);
+        $query->bindValue(':avatar_url', $avatarUrl, \PDO::PARAM_STR);
+        $query->bindValue(':plus', $hasPlus, \PDO::PARAM_BOOL);
+        $query->bindValue(':about_me', $aboutMe, \PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    private function upsertFromPsnProfileSql(): string
+    {
+        if ($this->database->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            return self::SQL_UPSERT_FROM_PSN_PROFILE_SQLITE;
+        }
+
+        return self::SQL_UPSERT_FROM_PSN_PROFILE_MYSQL;
+    }
 
     public function findAccountIdByOnlineId(string $onlineId): ?int
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels one concern off `PlayerScanProfileSynchronizer` (~414 lines): player row persistence now lives in `PlayerRepository` instead of a private `upsertPlayerRecord()` method embedded in the cron synchronizer.

## Changes

- Add `PlayerRepository::upsertFromPsnProfile()` with MySQL and SQLite dialect support
- `PlayerScanProfileSynchronizer` delegates profile persistence to `PlayerRepository` via optional constructor injection (defaults to `new PlayerRepository($database)`)
- Add `PlayerRepositoryTest` covering insert and update-on-conflict behavior (country is preserved on update, matching existing production SQL)

## Why this first

`PlayerScanProfileSynchronizer` mixes PSN API orchestration, queue/worker coordination, privacy handling, avatar sync, and direct SQL. Moving the upsert is a small, well-bounded persistence extraction with clear ownership and no behavior change.

## Testing

- `php tests/run.php` — all 915 tests pass (2 new repository tests)

## Follow-up PRs (not in this change)

Suggested next extractions from the God-class audit:

1. Remove `PlayerQueueService::escapeHtml()` (presentation leak)
2. Extract `PlayerScanTitleCatalogSynchronizer::fetchTrophyData()` into `PlayerScanTrophyDataFetcher`
3. Move `AutomaticTrophyTitleMergeService` title-matching queries into a repository
4. Move `TrophyMergeService` inline SQL into existing repositories

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dc8838d-776b-4126-8fef-0de1ea9c7088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dc8838d-776b-4126-8fef-0de1ea9c7088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

