### PR TITLE
Extract PlayStationTrophyLevelCalculator from PlayerScanCompletionService

### DIFF
--- a/tests/PlayStationTrophyLevelCalculatorTest.php
+++ b/tests/PlayStationTrophyLevelCalculatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayStationTrophyLevelCalculator.php';
+
+final class PlayStationTrophyLevelCalculatorTest extends TestCase
+{
+    public function testCalculateUsesFirstTierFormula(): void
+    {
+        $result = PlayStationTrophyLevelCalculator::calculate(120);
+
+        $this->assertSame(3, $result['level']);
+        $this->assertSame(0, $result['progress']);
+    }
+
+    public function testCalculateUsesSecondTierFormula(): void
+    {
+        $result = PlayStationTrophyLevelCalculator::calculate(6030);
+
+        $this->assertSame(101, $result['level']);
+        $this->assertSame(0, $result['progress']);
+    }
+
+    public function testCalculateUsesThirdTierFormula(): void
+    {
+        $result = PlayStationTrophyLevelCalculator::calculate(20000);
+
+        $this->assertSame(211, $result['level']);
+        $this->assertSame(24, $result['progress']);
+    }
+}

--- a/tests/PlayerScanCompletionServiceTest.php
+++ b/tests/PlayerScanCompletionServiceTest.php
@@ -97,30 +97,6 @@ final class PlayerScanCompletionServiceTest extends TestCase
         $this->service = new PlayerScanCompletionService($this->database);
     }
 
-    public function testCalculateLevelAndProgressUsesFirstTierFormula(): void
-    {
-        $result = $this->service->calculateLevelAndProgress(120);
-
-        $this->assertSame(3, $result['level']);
-        $this->assertSame(0, $result['progress']);
-    }
-
-    public function testCalculateLevelAndProgressUsesSecondTierFormula(): void
-    {
-        $result = $this->service->calculateLevelAndProgress(6030);
-
-        $this->assertSame(101, $result['level']);
-        $this->assertSame(0, $result['progress']);
-    }
-
-    public function testCalculateLevelAndProgressUsesThirdTierFormula(): void
-    {
-        $result = $this->service->calculateLevelAndProgress(20000);
-
-        $this->assertSame(211, $result['level']);
-        $this->assertSame(24, $result['progress']);
-    }
-
     public function testRecalculatePlayerTrophyStatsAndStatusRequestsRescanWhenNpwrCountExceedsSonyTotal(): void
     {
         $this->seedActiveTitle('NPWR00003_00');

--- a/wwwroot/classes/Cron/PlayerScanCompletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionService.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../PlayStationTrophyLevelCalculator.php';
+
 /**
  * Recalculates player trophy totals, PSN level/progress, status, and rarity rollups
  * after a scan completes.
@@ -12,38 +14,6 @@ final class PlayerScanCompletionService
 {
     public function __construct(private readonly PDO $database)
     {
-    }
-
-    /**
-     * @return array{level: int, progress: int}
-     */
-    public function calculateLevelAndProgress(int $points): array
-    {
-        if ($points <= 5940) {
-            return [
-                'level' => (int) floor($points / 60) + 1,
-                'progress' => (int) (floor($points / 60 * 100) % 100),
-            ];
-        }
-
-        if ($points <= 14940) {
-            return [
-                'level' => (int) floor(($points - 5940) / 90) + 100,
-                'progress' => (int) (floor(($points - 5940) / 90 * 100) % 100),
-            ];
-        }
-
-        $stage = 1;
-        $leftovers = $points - 14940;
-        while ($leftovers > 45000 * $stage) {
-            $leftovers -= 45000 * $stage;
-            $stage++;
-        }
-
-        return [
-            'level' => (int) floor($leftovers / (450 * $stage)) + (100 + 100 * $stage),
-            'progress' => (int) (floor($leftovers / (450 * $stage) * 100) % 100),
-        ];
     }
 
     public function recalculatePlayerTrophyStatsAndStatus(
@@ -67,7 +37,7 @@ final class PlayerScanCompletionService
             + $trophies['silver'] * 30
             + $trophies['gold'] * 90
             + $trophies['platinum'] * 300;
-        $levelAndProgress = $this->calculateLevelAndProgress($points);
+        $levelAndProgress = PlayStationTrophyLevelCalculator::calculate($points);
 
         $query = $this->database->prepare("UPDATE player
             SET    bronze = :bronze,

--- a/wwwroot/classes/PlayStationTrophyLevelCalculator.php
+++ b/wwwroot/classes/PlayStationTrophyLevelCalculator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Converts PlayStation Network trophy points into PSN level and progress percentage.
+ */
+final class PlayStationTrophyLevelCalculator
+{
+    /**
+     * @return array{level: int, progress: int}
+     */
+    public static function calculate(int $points): array
+    {
+        if ($points <= 5940) {
+            return [
+                'level' => (int) floor($points / 60) + 1,
+                'progress' => (int) (floor($points / 60 * 100) % 100),
+            ];
+        }
+
+        if ($points <= 14940) {
+            return [
+                'level' => (int) floor(($points - 5940) / 90) + 100,
+                'progress' => (int) (floor(($points - 5940) / 90 * 100) % 100),
+            ];
+        }
+
+        $stage = 1;
+        $leftovers = $points - 14940;
+        while ($leftovers > 45000 * $stage) {
+            $leftovers -= 45000 * $stage;
+            $stage++;
+        }
+
+        return [
+            'level' => (int) floor($leftovers / (450 * $stage)) + (100 + 100 * $stage),
+            'progress' => (int) (floor($leftovers / (450 * $stage) * 100) % 100),
+        ];
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`PlayerScanCompletionService` mixed several post-scan concerns: PSN level/progress math, trophy stat rollups, queue cleanup, and rarity aggregation. This PR peels off the first concern — the pure tier formula that converts trophy points into PSN level and progress.

## Changes

- Add `PlayStationTrophyLevelCalculator` with the existing three-tier level/progress logic.
- Delegate from `PlayerScanCompletionService::recalculatePlayerTrophyStatsAndStatus()` instead of keeping the formula inline.
- Move the three level-calculation unit tests into `PlayStationTrophyLevelCalculatorTest`.

## Why this first

The calculator is stateless, has no database dependency, and was already tested in isolation. Extracting it shrinks `PlayerScanCompletionService` without changing behavior and sets up reuse if the same formula is needed elsewhere later.

## Follow-up candidates (separate PRs)

- `PlayerScanCompletionService`: rarity rollup SQL / deadlock retry helper
- `PlayerQueueService`: move `escapeHtml()` to the HTTP/view layer
- `PsnGameLookupService`: extract trophy API transport (`PsnTrophyApiClient`)
- `TrophyStatusService`: extract group-level recalculation
- `TrophyMergePlayerProgressUpdater`: split group vs title player rollup SQL

## Testing

- `php tests/run.php PlayStationTrophyLevelCalculatorTest PlayerScanCompletionServiceTest`
- Full suite: `php tests/run.php` (passes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-375c3df5-d2de-48ee-a6c2-6309cf649d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-375c3df5-d2de-48ee-a6c2-6309cf649d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

