### PR TITLE
Adopt PHP 8.5 language features across the codebase

### DIFF
--- a/wwwroot/classes/Admin/LogService.php
+++ b/wwwroot/classes/Admin/LogService.php
@@ -50,7 +50,7 @@ final class LogService
             return [];
         }
 
-        $totalRows = $rows[0]['total_rows'] ?? null;
+        $totalRows = array_first($rows)['total_rows'] ?? null;
         if (is_numeric($totalRows)) {
             $this->cachedEntryCount = max(0, (int) $totalRows);
         }

--- a/wwwroot/classes/Admin/PsnTrophyLookupGroupDataProvider.php
+++ b/wwwroot/classes/Admin/PsnTrophyLookupGroupDataProvider.php
@@ -22,6 +22,7 @@ final class PsnTrophyLookupGroupDataProvider implements GameRescanGroupDataFetch
     /**
      * @return array<int, array{group: PsnTrophyGroupApiAdapter, trophies: array<int, PsnTrophyApiAdapter>}>
      */
+    #[\Override]
     public function fetchGroupData(Client $client, string $npCommunicationId): array
     {
         $trophyData = $this->psnGameLookupService->fetchTrophyDataForNpCommunicationId($npCommunicationId, $client);

--- a/wwwroot/classes/AutomaticTrophyTitleMergeService.php
+++ b/wwwroot/classes/AutomaticTrophyTitleMergeService.php
@@ -30,6 +30,7 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
     /**
      * @return list<string> Merge parent NP communication IDs to recompute.
      */
+    #[\Override]
     public function handleNewTitle(string $npCommunicationId): array
     {
         $newTitle = $this->getTitleByNpCommunicationId($npCommunicationId);
@@ -299,7 +300,7 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
             }
         }
 
-        return $eligibleGames[0] ?? null;
+        return array_first($eligibleGames);
     }
 
     /**

--- a/wwwroot/classes/ChangelogService.php
+++ b/wwwroot/classes/ChangelogService.php
@@ -68,8 +68,11 @@ final class ChangelogService
             return [];
         }
 
-        if ($rows !== [] && is_numeric($rows[0]['total_rows'] ?? null)) {
-            $this->cachedTotalChangeCount = max(0, (int) $rows[0]['total_rows']);
+        if ($rows !== []) {
+            $firstRow = array_first($rows);
+            if (is_numeric($firstRow['total_rows'] ?? null)) {
+                $this->cachedTotalChangeCount = max(0, (int) $firstRow['total_rows']);
+            }
         }
 
         return array_map(

--- a/wwwroot/classes/Cron/PlayerScanCompletionResult.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionResult.php
@@ -14,11 +14,13 @@ final class PlayerScanCompletionResult
     {
     }
 
+    #[\NoDiscard]
     public static function completed(): self
     {
         return new self(self::STATUS_COMPLETED);
     }
 
+    #[\NoDiscard]
     public static function continueScan(): self
     {
         return new self(self::STATUS_CONTINUE_SCAN);

--- a/wwwroot/classes/Cron/PlayerScanProfileSyncResult.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSyncResult.php
@@ -24,11 +24,13 @@ final class PlayerScanProfileSyncResult
     /**
      * @param array<string, mixed> $player
      */
+    #[\NoDiscard]
     public static function success(array $player, object $user, string $country): self
     {
         return new self(self::STATUS_SUCCESS, $player, $user, $country);
     }
 
+    #[\NoDiscard]
     public static function skipPlayer(): self
     {
         return new self(self::STATUS_SKIP_PLAYER);

--- a/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php
@@ -17,16 +17,19 @@ final class PlayerScanTrophySummaryAccessResult
     ) {
     }
 
+    #[\NoDiscard]
     public static function accessible(int $level): self
     {
         return new self(self::STATUS_ACCESSIBLE, $level);
     }
 
+    #[\NoDiscard]
     public static function privateProfile(): self
     {
         return new self(self::STATUS_PRIVATE);
     }
 
+    #[\NoDiscard]
     public static function abortScan(): self
     {
         return new self(self::STATUS_ABORT_SCAN);

--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -34,7 +34,7 @@ final readonly class GameLeaderboardFilter extends GamePlayerFilter
 
     public function withPageNumber(int $page): self
     {
-        return new self($this->getCountry(), $this->getAvatar(), $page);
+        return clone($this, ['page' => max($page, 1)]);
     }
 
     public function getOffset(int $limit): int

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -93,15 +93,12 @@ class GameListFilter
 
     public function withPlayer(?string $player): self
     {
-        $clone = clone $this;
         if ($player !== null) {
             $player = trim($player);
             $player = $player === '' ? null : $player;
         }
 
-        $clone->player = $player;
-
-        return $clone;
+        return clone($this, ['player' => $player]);
     }
 
     public function withPage(int $page): self

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -90,7 +90,7 @@ class GameListService
 
         $totalGames = 0;
         if ($games !== []) {
-            $totalGames = (int) ($games[0]['total_games'] ?? 0);
+            $totalGames = (int) (array_first($games)['total_games'] ?? 0);
         } elseif ($this->getOffset($filter) > 0) {
             $totalGames = $this->fetchCount($filter);
         }

--- a/wwwroot/classes/PageMetaData.php
+++ b/wwwroot/classes/PageMetaData.php
@@ -23,7 +23,7 @@ final readonly class PageMetaData
 
     public function withTitle(?string $title): self
     {
-        return new self($title, $this->description, $this->image, $this->url);
+        return clone($this, ['title' => self::normalize($title)]);
     }
 
     public function getTitle(): ?string
@@ -33,7 +33,7 @@ final readonly class PageMetaData
 
     public function withDescription(?string $description): self
     {
-        return new self($this->title, $description, $this->image, $this->url);
+        return clone($this, ['description' => self::normalize($description)]);
     }
 
     public function getDescription(): ?string
@@ -43,7 +43,7 @@ final readonly class PageMetaData
 
     public function withImage(?string $image): self
     {
-        return new self($this->title, $this->description, $image, $this->url);
+        return clone($this, ['image' => self::normalize($image)]);
     }
 
     public function getImage(): ?string
@@ -53,7 +53,7 @@ final readonly class PageMetaData
 
     public function withUrl(?string $url): self
     {
-        return new self($this->title, $this->description, $this->image, $url);
+        return clone($this, ['url' => self::normalize($url)]);
     }
 
     public function getUrl(): ?string

--- a/wwwroot/classes/PlayerAdvisorFilter.php
+++ b/wwwroot/classes/PlayerAdvisorFilter.php
@@ -73,7 +73,7 @@ class PlayerAdvisorFilter
 
     public function withPage(int $page): self
     {
-        return new self(max($page, 1), $this->sort, $this->platforms);
+        return clone($this, ['page' => max($page, 1)]);
     }
 
     public function getOffset(int $limit): int

--- a/wwwroot/classes/PlayerLogFilter.php
+++ b/wwwroot/classes/PlayerLogFilter.php
@@ -127,7 +127,7 @@ class PlayerLogFilter
 
     public function withPageNumber(int $page): self
     {
-        return new self($this->sort, $page, $this->platforms);
+        return clone($this, ['page' => max($page, 1)]);
     }
 
     private function normaliseSort(string $sort): string

--- a/wwwroot/classes/PlayerQueueResponse.php
+++ b/wwwroot/classes/PlayerQueueResponse.php
@@ -50,13 +50,7 @@ readonly class PlayerQueueResponse implements \JsonSerializable
 
     public function withPollToken(string $pollToken): self
     {
-        return new self(
-            $this->status,
-            $this->message,
-            $this->messageParts,
-            $pollToken,
-            $this->httpStatusCode,
-        );
+        return clone($this, ['pollToken' => $pollToken]);
     }
 
     public function getStatusEnum(): PlayerQueueStatus

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -164,8 +164,7 @@ final class PlayerQueueResponseFactory
                 && !$this->isErrorProgressTitle($title)
                 && preg_match('/^(Updating|Fetching)\b/i', $title) !== 1
             ) {
-                $normalizedTitle = preg_replace('/\s+for\s+[^.]+\.?$/i', '', trim($title)) ?? '';
-                $normalizedTitle = rtrim($normalizedTitle, " .\t\n\r\0\v");
+                $normalizedTitle = $this->normalizeProgressTitle($title);
                 $builder->text(' Working on ');
                 $builder->emphasis($normalizedTitle);
             } else {
@@ -188,8 +187,7 @@ final class PlayerQueueResponseFactory
 
     private function formatProgressTitle(string $title): string
     {
-        $normalizedTitle = preg_replace('/\s+for\s+[^.]+\.?$/i', '', trim($title)) ?? '';
-        $normalizedTitle = rtrim($normalizedTitle, " .\t\n\r\0\v");
+        $normalizedTitle = $this->normalizeProgressTitle($title);
 
         if ($normalizedTitle === '') {
             return '';
@@ -204,6 +202,14 @@ final class PlayerQueueResponseFactory
         }
 
         return 'Working on ' . $normalizedTitle;
+    }
+
+    private function normalizeProgressTitle(string $title): string
+    {
+        return $title
+            |> trim(...)
+            |> (fn(string $value): string => preg_replace('/\s+for\s+[^.]+\.?$/i', '', $value) ?? $value)
+            |> (fn(string $value): string => rtrim($value, " .\t\n\r\0\v"));
     }
 
     private function isErrorProgressTitle(string $title): bool

--- a/wwwroot/classes/PlayerTimelineService.php
+++ b/wwwroot/classes/PlayerTimelineService.php
@@ -53,8 +53,8 @@ class PlayerTimelineService
             return null;
         }
 
-        $timelineStart = new DateTimeImmutable((string) $rows[0]['timeline_start']);
-        $timelineEnd = new DateTimeImmutable((string) $rows[0]['timeline_end']);
+        $timelineStart = new DateTimeImmutable((string) array_first($rows)['timeline_start']);
+        $timelineEnd = new DateTimeImmutable((string) array_first($rows)['timeline_end']);
         $startDate = $timelineStart->modify('first day of this month');
         $endDate = $timelineEnd->modify('first day of next month');
 

--- a/wwwroot/classes/Router.php
+++ b/wwwroot/classes/Router.php
@@ -43,6 +43,7 @@ class Router
         ];
     }
 
+    #[\NoDiscard]
     public function dispatch(string $requestUri): RouteResult
     {
         $path = parse_url($requestUri, PHP_URL_PATH);
@@ -54,7 +55,7 @@ class Router
         }
 
         $segments = explode('/', $normalizedPath);
-        $route = $segments[0];
+        $route = array_first($segments);
         $routeSegments = array_slice($segments, 1);
 
         $handler = $this->routeHandlers[$route] ?? null;

--- a/wwwroot/classes/TrophyImageDownloader.php
+++ b/wwwroot/classes/TrophyImageDownloader.php
@@ -23,7 +23,7 @@ final class TrophyImageDownloader
 
     public function withLogger(?\Closure $logger): self
     {
-        return new self($this->imageHashCalculator, $logger, $this->remoteFileFetcher);
+        return clone($this, ['logger' => $logger]);
     }
 
     /**
@@ -154,7 +154,7 @@ final class TrophyImageDownloader
 
             $contents = @file_get_contents($url, false, $context);
             if ($contents !== false) {
-                $statusLine = $http_response_header[0] ?? '';
+                $statusLine = array_first($http_response_header) ?? '';
                 if ($statusLine === '' || preg_match('/^HTTP\/\S+\s+2\d\d\b/', $statusLine)) {
                     return $contents;
                 }

--- a/wwwroot/classes/TrophyMergeMappingService.php
+++ b/wwwroot/classes/TrophyMergeMappingService.php
@@ -63,7 +63,7 @@ SQL
             $parentTrophy = $parentTrophyByName[$childName] ?? [];
 
             if (count($parentTrophy) === 1) {
-                $this->insertDirectMapping($childTrophy, $parentTrophy[0]);
+                $this->insertDirectMapping($childTrophy, array_first($parentTrophy));
             } else {
                 $message .= $childTrophy['name'] . " couldn't be merged.<br>";
             }
@@ -132,7 +132,7 @@ SQL
             $parentTrophy = $parentTrophiesByIcon[(string) $childTrophy['icon_url']] ?? [];
 
             if ((int) $childTrophy['counter'] === 1 && count($parentTrophy) === 1) {
-                $this->insertDirectMapping($childTrophy, $parentTrophy[0]);
+                $this->insertDirectMapping($childTrophy, array_first($parentTrophy));
             } else {
                 $message .= $childTrophy['name'] . " couldn't be merged.<br>";
             }

--- a/wwwroot/classes/TrophyMergeRelationshipResolver.php
+++ b/wwwroot/classes/TrophyMergeRelationshipResolver.php
@@ -37,7 +37,7 @@ SQL
         }
 
         if (count($parentIds) === 1) {
-            $parentNpCommunicationId = $parentIds[0];
+            $parentNpCommunicationId = array_first($parentIds);
         } else {
             $parentNpCommunicationId = $this->resolveMergeParent($childNpCommunicationId, $parentIds);
         }
@@ -86,7 +86,7 @@ SQL
 
         sort($parentIds, SORT_STRING);
 
-        return $parentIds[0];
+        return array_first($parentIds);
     }
 
     private function getParentFromMeta(string $childNpCommunicationId): ?string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Modernizes production PHP to use PHP 8.5 features already required by `composer.json` (`^8.5`). No backward-compatibility constraints apply.

## Changes

### `clone with` (PHP 8.5)
Replaces manual `new self(...)` / `$clone = clone $this` patterns with `clone($this, [...])` on immutable/with-er types:
- `PageMetaData` (all four `with*` methods, preserving normalization)
- `PlayerQueueResponse::withPollToken`
- `GameListFilter::withPlayer` (last remaining manual clone-and-mutate)
- `GameLeaderboardFilter`, `PlayerLogFilter`, `PlayerAdvisorFilter`, `TrophyImageDownloader` `with*` methods

### `array_first()` (PHP 8.5)
Uses the built-in helper where the first row/element is semantically intended:
- Paginated SQL totals in `GameListService`, `ChangelogService`, `Admin/LogService`, `PlayerTimelineService`
- Single-element list access in `TrophyMergeRelationshipResolver`, `TrophyMergeMappingService`, `AutomaticTrophyTitleMergeService`, `Router`, `TrophyImageDownloader`

### Pipe operator (`|>`)
Extracts duplicated progress-title normalization in `PlayerQueueResponseFactory` into `normalizeProgressTitle()`, matching the style already used in `Utility.php` and `CommaSeparatedValues.php`.

### `#[\NoDiscard]`
Extends usage beyond `RouteResult` and `CsrfTokenManager` to cron scan result factories (`PlayerScanProfileSyncResult`, `PlayerScanCompletionResult`, `PlayerScanTrophySummaryAccessResult`) and `Router::dispatch`, where ignoring the return value is a logic bug.

### `#[\Override]`
Adds missing attributes on `AutomaticTrophyTitleMergeService::handleNewTitle` and `PsnTrophyLookupGroupDataProvider::fetchGroupData`.

## Testing

- `php tests/run.php` — all 915 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fecab3dd-3ee9-4dec-a3ec-5594290ca314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fecab3dd-3ee9-4dec-a3ec-5594290ca314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

