### PR TITLE
Apply remaining MySQL 8.4 SQL improvements

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -195,7 +195,7 @@ mysql "$DB_NAME" < database/mysql84_histograms.sql
 ```
 
 This creates histograms with `AUTO UPDATE` on heavily filtered columns (`player.status`,
-`trophy_title_player.progress`, `trophy_title_meta.status`, and others). Histograms help the
+`trophy_title_player.progress`, `trophy_title_meta.status` and `difficulty`, and others). Histograms help the
 8.4 optimizer choose better plans for leaderboard, queue, and cron queries. Re-run after
 bulk imports; a weekly `ANALYZE TABLE` cron is optional but reasonable on busy sites.
 

--- a/database/mysql84_histograms.sql
+++ b/database/mysql84_histograms.sql
@@ -25,7 +25,7 @@ ANALYZE TABLE trophy_title_player
     WITH 256 BUCKETS AUTO UPDATE;
 
 ANALYZE TABLE trophy_title_meta
-    UPDATE HISTOGRAM ON status, recent_players, owners
+    UPDATE HISTOGRAM ON status, recent_players, owners, difficulty
     WITH 256 BUCKETS AUTO UPDATE;
 
 ANALYZE TABLE trophy_title

--- a/wwwroot/classes/Admin/MergeTrophyGroupCopier.php
+++ b/wwwroot/classes/Admin/MergeTrophyGroupCopier.php
@@ -23,14 +23,14 @@ final class MergeTrophyGroupCopier
                 np_communication_id = :child_np_communication_id
         )
         UPDATE
-            trophy_group tg,
-            tg_org
+            trophy_group tg
+            INNER JOIN tg_org ON tg.group_id = tg_org.group_id
         SET
             tg.name = tg_org.name,
             tg.detail = tg_org.detail,
             tg.icon_url = tg_org.icon_url
         WHERE
-            tg.np_communication_id = :parent_np_communication_id AND tg.group_id = tg_org.group_id
+            tg.np_communication_id = :parent_np_communication_id
         SQL;
 
     private const TROPHY_GROUP_INSERT_QUERY = <<<'SQL'

--- a/wwwroot/classes/Admin/TrophyStatusInputParser.php
+++ b/wwwroot/classes/Admin/TrophyStatusInputParser.php
@@ -46,7 +46,12 @@ final class TrophyStatusInputParser
     public function getTrophyIdsForGame(int $gameId): array
     {
         $query = $this->database->prepare(
-            'SELECT id FROM trophy WHERE np_communication_id = (SELECT np_communication_id FROM trophy_title WHERE id = :id)'
+            <<<'SQL'
+            SELECT t.id
+            FROM trophy t
+            INNER JOIN trophy_title tt ON tt.np_communication_id = t.np_communication_id
+            WHERE tt.id = :id
+            SQL
         );
         $query->bindValue(':id', $gameId, PDO::PARAM_INT);
         $query->execute();

--- a/wwwroot/classes/ChangelogPage.php
+++ b/wwwroot/classes/ChangelogPage.php
@@ -43,10 +43,19 @@ class ChangelogPage
     public static function fromService(ChangelogService $service, Utility $utility, array $queryParameters): self
     {
         $requestedPage = self::resolvePageNumber($queryParameters['page'] ?? null);
-        $totalChanges = $service->getTotalChangeCount();
-        $paginator = new ChangelogPaginator($requestedPage, $totalChanges, ChangelogService::PAGE_SIZE);
 
-        $entries = $service->getChanges($paginator);
+        if ($requestedPage === 1) {
+            // Page 1 is the common case: fetch first, then derive total from COUNT(*) OVER().
+            // Deeper pages still count first so out-of-range requests clamp before the list query.
+            $paginator = new ChangelogPaginator(1, 0, ChangelogService::PAGE_SIZE);
+            $entries = $service->getChanges($paginator);
+            $totalChanges = $service->getTotalChangeCount();
+            $paginator = new ChangelogPaginator(1, $totalChanges, ChangelogService::PAGE_SIZE);
+        } else {
+            $totalChanges = $service->getTotalChangeCount();
+            $paginator = new ChangelogPaginator($requestedPage, $totalChanges, ChangelogService::PAGE_SIZE);
+            $entries = $service->getChanges($paginator);
+        }
 
         $presenters = array_map(
             static fn(ChangelogEntry $entry): ChangelogEntryPresenter => new ChangelogEntryPresenter($entry, $utility),

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -227,11 +227,10 @@ SQL
     {
         $query = $this->database->prepare(
             <<<'SQL'
-            SELECT id
-            FROM   trophy_title
-            WHERE  np_communication_id = (SELECT np_communication_id
-                                            FROM   trophy
-                                            WHERE  id = :child_trophy_id)
+            SELECT tt.id
+            FROM trophy_title tt
+            INNER JOIN trophy t ON t.np_communication_id = tt.np_communication_id
+            WHERE t.id = :child_trophy_id
 SQL
         );
         $query->bindValue(':child_trophy_id', $trophyId, PDO::PARAM_INT);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited the codebase for MySQL 8.4 SQL opportunities. Most modernization work was already merged in recent PRs (#16138–#16145): histograms with `AUTO UPDATE`, redundant index cleanup, `INSERT … AS new ON DUPLICATE KEY UPDATE`, window functions (`RANK()`, `COUNT(*) OVER()`), CTE-based upserts, and index-friendly queue position lookup.

This PR applies the remaining safe improvements found in the audit.

## Changes

- **MergeTrophyGroupCopier**: replace legacy comma-join `UPDATE` with explicit `INNER JOIN` (matches `GameCopyService` style)
- **mysql84_histograms.sql**: add `trophy_title_meta.difficulty` to `AUTO UPDATE` histograms (used by game list completion sort)
- **ChangelogPage**: skip the standalone `COUNT(*)` on page 1; derive total from `COUNT(*) OVER()` in the list query. Deeper pages still count first so out-of-range requests clamp before fetching rows (preserves prior review feedback)
- **TrophyMergeService / TrophyStatusInputParser**: replace scalar subqueries with joins

## Already in place (no changes needed)

| Area | Status |
|------|--------|
| Histogram maintenance | `database/mysql84_histograms.sql` with `AUTO UPDATE` |
| Redundant indexes | Dropped from schema + idempotent `mysql84_drop_redundant_indexes.sql` |
| Queue position | Index-friendly tuple comparison on MySQL (ROW_NUMBER reverted — full scan on every poll) |
| DailyCronJob rarity | Per-title loop retained — full-table `trophy_earned` scan would be unsafe at production scale |
| Upsert aliases | `INSERT … AS new ON DUPLICATE KEY UPDATE` used throughout |
| Window functions | Rankings, game list totals, changelog/log pagination |

## Intentionally excluded

- **`trophy_earned` histograms / batch rarity updates** — billions of rows; per-title filtering is required
- **`player_ranking` histograms** — table swapped every 5 minutes
- **ROW_NUMBER queue position on MySQL** — forces full `player_queue` scan on each homepage poll
- **Changelog count-before-fetch on page > 1** — needed for pagination clamping

## Follow-up opportunities (not in this PR)

- Batch `TrophyMergePlayerProgressUpdater` group upserts (currently one INSERT per parent group)
- `IpRateLimitService` atomic upsert path for MySQL (needs careful concurrency semantics)
- `EXCEPT` for admin copy anti-joins (`MergeTrophyGroupCopier`, `GameCopyService`) — readability win, similar plans to `NOT EXISTS`

## Testing

- `php tests/run.php` — all 915 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9874480c-c530-43ba-bd49-85564c625eac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9874480c-c530-43ba-bd49-85564c625eac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

