### PR TITLE
Extract PsnOnlineIdValidator from PlayerQueueService

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ the non-obvious steps to actually run the services.
     php -d variables_order=EGPCS -S 0.0.0.0:8000 /tmp/psn100-router.php
   ```
 - The "Update" box on the homepage submits a PSN name to `add_to_queue.php?q=<name>`
-  (param key is `q`); valid names must match `PlayerQueueService::ONLINE_ID_PATTERN`
+  (param key is `q`); valid names must match `PsnOnlineIdValidator::isValidOnlineId()`
   (`^[a-zA-Z][a-zA-Z0-9_-]{2,15}$` — 3–16 characters, starting with a letter;
   letters, numbers, hyphens, and underscores allowed) and are inserted into
   `player_queue`. This is a quick way to exercise a real DB write.

--- a/tests/PlayerQueueHandlerTest.php
+++ b/tests/PlayerQueueHandlerTest.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/../wwwroot/classes/PlayerQueueRequest.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponseFactory.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueResponse.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueueService.php';
+require_once __DIR__ . '/../wwwroot/classes/PsnOnlineIdValidator.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerQueuePollTokenManager.php';
 require_once __DIR__ . '/../wwwroot/classes/SessionManager.php';
 require_once __DIR__ . '/../wwwroot/classes/IpSubmissionLockUnavailableException.php';
@@ -293,7 +294,7 @@ final class PlayerQueueHandlerTest extends TestCase
         $response = $handler->handleAddToQueueRequest($request);
 
         $this->assertSame('error', $response->getStatus());
-        $this->assertSame(PlayerQueueService::INVALID_ONLINE_ID_MESSAGE, $response->getMessage());
+        $this->assertSame(PsnOnlineIdValidator::INVALID_MESSAGE, $response->getMessage());
     }
 
     public function testHandleAddToQueueRequestQueuesPlayerWhenValidationPasses(): void
@@ -353,7 +354,7 @@ final class PlayerQueueHandlerTest extends TestCase
         $response = $handler->handleQueuePositionRequest($request);
 
         $this->assertSame('error', $response->getStatus());
-        $this->assertSame(PlayerQueueService::INVALID_ONLINE_ID_MESSAGE, $response->getMessage());
+        $this->assertSame(PsnOnlineIdValidator::INVALID_MESSAGE, $response->getMessage());
     }
 
     public function testHandleQueuePositionRequestReturnsCheaterResponseWhenStatusMatches(): void

--- a/tests/PlayerQueueServiceTest.php
+++ b/tests/PlayerQueueServiceTest.php
@@ -142,21 +142,10 @@ final class PlayerQueueServiceTest extends TestCase
         $this->assertSame(null, $this->service->getCheaterAccountId('LegitPlayer'));
     }
 
-    public function testIsValidPlayerNameValidatesAllowedCharactersAndLength(): void
+    public function testIsValidPlayerNameDelegatesToPsnOnlineIdValidator(): void
     {
         $this->assertTrue($this->service->isValidPlayerName('Alpha-123'));
-        $this->assertTrue($this->service->isValidPlayerName('ABC'));
-        $this->assertTrue($this->service->isValidPlayerName('SixteenCharsHere'));
-        $this->assertTrue($this->service->isValidPlayerName('user_name'));
-        $this->assertTrue($this->service->isValidPlayerName('aBC'));
-
         $this->assertFalse($this->service->isValidPlayerName('ab'));
-        $this->assertFalse($this->service->isValidPlayerName('name with space'));
-        $this->assertFalse($this->service->isValidPlayerName('invalid!'));
-        $this->assertFalse($this->service->isValidPlayerName(str_repeat('a', 17)));
-        $this->assertFalse($this->service->isValidPlayerName('1Alpha'));
-        $this->assertFalse($this->service->isValidPlayerName('_Alpha'));
-        $this->assertFalse($this->service->isValidPlayerName('-Alpha'));
     }
 
     public function testEscapeHtmlEncodesSpecialCharacters(): void

--- a/tests/PsnOnlineIdValidatorTest.php
+++ b/tests/PsnOnlineIdValidatorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/PsnOnlineIdValidator.php';
+
+final class PsnOnlineIdValidatorTest extends TestCase
+{
+    public function testIsValidOnlineIdValidatesAllowedCharactersAndLength(): void
+    {
+        $this->assertTrue(PsnOnlineIdValidator::isValidOnlineId('Alpha-123'));
+        $this->assertTrue(PsnOnlineIdValidator::isValidOnlineId('ABC'));
+        $this->assertTrue(PsnOnlineIdValidator::isValidOnlineId('SixteenCharsHere'));
+        $this->assertTrue(PsnOnlineIdValidator::isValidOnlineId('user_name'));
+        $this->assertTrue(PsnOnlineIdValidator::isValidOnlineId('aBC'));
+
+        $this->assertFalse(PsnOnlineIdValidator::isValidOnlineId(''));
+        $this->assertFalse(PsnOnlineIdValidator::isValidOnlineId('ab'));
+        $this->assertFalse(PsnOnlineIdValidator::isValidOnlineId('name with space'));
+        $this->assertFalse(PsnOnlineIdValidator::isValidOnlineId('invalid!'));
+        $this->assertFalse(PsnOnlineIdValidator::isValidOnlineId(str_repeat('a', 17)));
+        $this->assertFalse(PsnOnlineIdValidator::isValidOnlineId('1Alpha'));
+        $this->assertFalse(PsnOnlineIdValidator::isValidOnlineId('_Alpha'));
+        $this->assertFalse(PsnOnlineIdValidator::isValidOnlineId('-Alpha'));
+    }
+}

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/GameListItem.php';
 require_once __DIR__ . '/GameListPageResult.php';
 require_once __DIR__ . '/SearchQueryHelper.php';
-require_once __DIR__ . '/PlayerQueueService.php';
+require_once __DIR__ . '/PsnOnlineIdValidator.php';
 
 class GameListService
 {
@@ -24,7 +24,7 @@ class GameListService
         }
 
         $onlineId = trim($onlineId);
-        if ($onlineId === '' || !PlayerQueueService::isValidOnlineId($onlineId)) {
+        if ($onlineId === '' || !PsnOnlineIdValidator::isValidOnlineId($onlineId)) {
             return null;
         }
 

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerQueueService.php';
+require_once __DIR__ . '/PsnOnlineIdValidator.php';
 require_once __DIR__ . '/PlayerQueueResponse.php';
 require_once __DIR__ . '/PlayerStatusNotice.php';
 require_once __DIR__ . '/PlayerScanProgress.php';
@@ -27,7 +28,7 @@ final class PlayerQueueResponseFactory
 
     public function createInvalidNameResponse(): PlayerQueueResponse
     {
-        return PlayerQueueResponse::error(PlayerQueueService::INVALID_ONLINE_ID_MESSAGE);
+        return PlayerQueueResponse::error(PsnOnlineIdValidator::INVALID_MESSAGE);
     }
 
     public function createQueueLimitResponse(): PlayerQueueResponse

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -7,14 +7,12 @@ require_once __DIR__ . '/PlayerScanStatus.php';
 require_once __DIR__ . '/IpSubmissionLockExecutor.php';
 require_once __DIR__ . '/IpSubmissionLockUnavailableException.php';
 require_once __DIR__ . '/Html.php';
+require_once __DIR__ . '/PsnOnlineIdValidator.php';
 
 class PlayerQueueService
 {
     public const int MAX_QUEUE_SUBMISSIONS_PER_IP = 10;
     public const int CHEATER_STATUS = 1;
-    public const string ONLINE_ID_HTML_PATTERN = '[A-Za-z][A-Za-z0-9_-]{2,15}';
-    public const string INVALID_ONLINE_ID_MESSAGE = 'PSN name must contain between three and 16 characters, start with a letter, and can consist of letters, numbers, hyphens (-) and underscores (_). Letters are not case-sensitive.';
-    private const string ONLINE_ID_PATTERN = '/^[a-zA-Z][a-zA-Z0-9_-]{2,15}$/';
     private const string SQL_IP_SUBMISSION_COUNT = <<<'SQL'
         SELECT
             COUNT(*)
@@ -234,14 +232,9 @@ class PlayerQueueService
         return new IpSubmissionLockExecutor($this->requireDatabase());
     }
 
-    public static function isValidOnlineId(string $playerName): bool
-    {
-        return $playerName !== '' && preg_match(self::ONLINE_ID_PATTERN, $playerName) === 1;
-    }
-
     public function isValidPlayerName(string $playerName): bool
     {
-        return self::isValidOnlineId($playerName);
+        return PsnOnlineIdValidator::isValidOnlineId($playerName);
     }
 
     public function escapeHtml(string $value): string

--- a/wwwroot/classes/PsnOnlineIdValidator.php
+++ b/wwwroot/classes/PsnOnlineIdValidator.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Validates PlayStation Network online IDs used for queue submissions and routing.
+ *
+ * Encapsulates validation rules that were previously embedded in PlayerQueueService.
+ */
+final class PsnOnlineIdValidator
+{
+    public const string HTML_PATTERN = '[A-Za-z][A-Za-z0-9_-]{2,15}';
+    public const string INVALID_MESSAGE = 'PSN name must contain between three and 16 characters, start with a letter, and can consist of letters, numbers, hyphens (-) and underscores (_). Letters are not case-sensitive.';
+    private const string PATTERN = '/^[a-zA-Z][a-zA-Z0-9_-]{2,15}$/';
+
+    public static function isValidOnlineId(string $onlineId): bool
+    {
+        return $onlineId !== '' && preg_match(self::PATTERN, $onlineId) === 1;
+    }
+}

--- a/wwwroot/classes/Routing/GameRouteHandler.php
+++ b/wwwroot/classes/Routing/GameRouteHandler.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../GameRepository.php';
-require_once __DIR__ . '/../PlayerQueueService.php';
+require_once __DIR__ . '/../PsnOnlineIdValidator.php';
 require_once __DIR__ . '/RouteHandlerInterface.php';
 
 final readonly class GameRouteHandler implements RouteHandlerInterface
@@ -38,7 +38,7 @@ final readonly class GameRouteHandler implements RouteHandlerInterface
         }
 
         $playerSegment = $segments[0] ?? null;
-        $player = is_string($playerSegment) && PlayerQueueService::isValidOnlineId($playerSegment)
+        $player = is_string($playerSegment) && PsnOnlineIdValidator::isValidOnlineId($playerSegment)
             ? $playerSegment
             : null;
 

--- a/wwwroot/classes/Routing/TrophyRouteHandler.php
+++ b/wwwroot/classes/Routing/TrophyRouteHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../PlayerQueueService.php';
+require_once __DIR__ . '/../PsnOnlineIdValidator.php';
 require_once __DIR__ . '/../TrophyRepository.php';
 require_once __DIR__ . '/RouteHandlerInterface.php';
 
@@ -30,7 +30,7 @@ final readonly class TrophyRouteHandler implements RouteHandlerInterface
         }
 
         $playerSegment = $segments[0] ?? null;
-        $player = is_string($playerSegment) && PlayerQueueService::isValidOnlineId($playerSegment)
+        $player = is_string($playerSegment) && PsnOnlineIdValidator::isValidOnlineId($playerSegment)
             ? $playerSegment
             : null;
 

--- a/wwwroot/games.php
+++ b/wwwroot/games.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/classes/Html.php';
-require_once __DIR__ . '/classes/PlayerQueueService.php';
+require_once __DIR__ . '/classes/PsnOnlineIdValidator.php';
 
 require_once __DIR__ . '/classes/GameListFilter.php';
 require_once __DIR__ . '/classes/GameListService.php';
@@ -37,7 +37,7 @@ require_once("header.php");
                 <div class="input-group d-flex justify-content-end">
                     <input type="hidden" name="page" value="<?= $gameListPage->getCurrentPage(); ?>">
                     <input type="hidden" name="search" value="<?= Html::escape($filter->getSearch()); ?>">
-                    <input type="text" name="player" class="form-control rounded-start" minlength="3" maxlength="16" pattern="<?= Html::escape(PlayerQueueService::ONLINE_ID_HTML_PATTERN); ?>" placeholder="View as player..." value="<?= Html::escape($filter->getPlayer() ?? ''); ?>" aria-label="Text input to show completed games for specified player">
+                    <input type="text" name="player" class="form-control rounded-start" minlength="3" maxlength="16" pattern="<?= Html::escape(PsnOnlineIdValidator::HTML_PATTERN); ?>" placeholder="View as player..." value="<?= Html::escape($filter->getPlayer() ?? ''); ?>" aria-label="Text input to show completed games for specified player">
 
                     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Filter</button>
                     <ul class="dropdown-menu p-2">

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/classes/Html.php';
-require_once __DIR__ . '/classes/PlayerQueueService.php';
+require_once __DIR__ . '/classes/PsnOnlineIdValidator.php';
 
 require_once 'classes/HomepageController.php';
 require_once 'classes/HomepagePopularGamesFilter.php';
@@ -26,7 +26,7 @@ require_once("header.php");
         <div class="row row-cols">
             <div class="col">
                 <div class="input-group mb-1">
-                    <input type="text" class="form-control" placeholder="PSN name..." id="player" minlength="3" maxlength="16" pattern="<?= Html::escape(PlayerQueueService::ONLINE_ID_HTML_PATTERN); ?>" aria-label="PSN name..." aria-describedby="player-button">
+                    <input type="text" class="form-control" placeholder="PSN name..." id="player" minlength="3" maxlength="16" pattern="<?= Html::escape(PsnOnlineIdValidator::HTML_PATTERN); ?>" aria-label="PSN name..." aria-describedby="player-button">
                     <button class="btn btn-primary" type="button" id="player-button">Update</button>
                 </div>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels PSN online ID validation out of `PlayerQueueService` — the first step in decomposing that God class.

`PlayerQueueService` mixed queue persistence, rate limiting, scan-status polling, and cross-cutting validation. Route handlers (`GameRouteHandler`, `TrophyRouteHandler`), `GameListService`, and form templates were already depending on `PlayerQueueService` only for `isValidOnlineId()` and related constants.

### New class: `PsnOnlineIdValidator`

- `isValidOnlineId()` — regex validation (`^[a-zA-Z][a-zA-Z0-9_-]{2,15}$`)
- `HTML_PATTERN` — client-side `pattern` attribute for queue/search inputs
- `INVALID_MESSAGE` — user-facing validation error text

`PlayerQueueService::isValidPlayerName()` now delegates to the validator so `PlayerQueueHandler` keeps its existing service boundary.

### Call sites updated

- `GameListService`, `GameRouteHandler`, `TrophyRouteHandler`
- `PlayerQueueResponseFactory`, `home.php`, `games.php`
- Tests moved to dedicated `PsnOnlineIdValidatorTest`

All 916 tests pass.

## Follow-up PRs (remaining God classes)

Suggested next peel-offs, one concern per PR:

1. **`PlayerQueueRepository`** — SQL/PDO helpers from `PlayerQueueService` (queue insert, position, cheater lookup)
2. **`PlayerScanStatusReader`** — `setting.scanning` decode logic from `PlayerQueueService`
3. **`PsnTrophyGroupPayloadAssembler`** from `PsnGameLookupService` (~385 lines)
4. **`PlayerScanTrophyGroupSynchronizer`** from `PlayerScanTitleCatalogSynchronizer` (~409 lines)
5. **`TrophyMergeGroupPlayerProgressUpdater`** from `TrophyMergePlayerProgressUpdater` (~433 lines)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12100e10-6413-4eb6-ba94-2f083642998e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12100e10-6413-4eb6-ba94-2f083642998e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

