### PR TITLE
Apply additional MySQL 8.4 SQL improvements

### DIFF
--- a/database/mysql84_drop_redundant_indexes.sql
+++ b/database/mysql84_drop_redundant_indexes.sql
@@ -4,41 +4,10 @@
 -- Idempotent: skips indexes that are already absent, so this script can be re-run on
 -- fresh installs from database/psn100.sql or databases that already ran earlier drops.
 
-DELIMITER $$
-
-DROP PROCEDURE IF EXISTS psn100_drop_index_if_exists$$
-CREATE PROCEDURE psn100_drop_index_if_exists(
-    IN p_table_name VARCHAR(64),
-    IN p_index_name VARCHAR(64)
-)
-BEGIN
-    IF EXISTS (
-        SELECT 1
-        FROM information_schema.statistics
-        WHERE table_schema = DATABASE()
-          AND table_name = p_table_name
-          AND index_name = p_index_name
-    ) THEN
-        SET @drop_sql = CONCAT(
-            'ALTER TABLE `',
-            REPLACE(p_table_name, '`', '``'),
-            '` DROP INDEX `',
-            REPLACE(p_index_name, '`', '``'),
-            '`'
-        );
-        PREPARE stmt FROM @drop_sql;
-        EXECUTE stmt;
-        DEALLOCATE PREPARE stmt;
-    END IF;
-END$$
-
-CALL psn100_drop_index_if_exists('player', 'player_idx_online_id_account_id')$$
-CALL psn100_drop_index_if_exists('player_ranking', 'idx_pr_account_id_ranking')$$
-CALL psn100_drop_index_if_exists('setting', 'setting_idx_scanning_id')$$
-CALL psn100_drop_index_if_exists('trophy_title_meta', 'idx_ttm_np_id_owners')$$
-CALL psn100_drop_index_if_exists('player_ranking', 'ranking')$$
-CALL psn100_drop_index_if_exists('player_ranking', 'rarity_ranking')$$
-
-DROP PROCEDURE psn100_drop_index_if_exists$$
-
-DELIMITER ;
+ALTER TABLE `player` DROP INDEX IF EXISTS `player_idx_online_id_account_id`;
+ALTER TABLE `player_ranking` DROP INDEX IF EXISTS `idx_pr_account_id_ranking`;
+ALTER TABLE `player_ranking` DROP INDEX IF EXISTS `ranking`;
+ALTER TABLE `player_ranking` DROP INDEX IF EXISTS `rarity_ranking`;
+ALTER TABLE `player_ranking` DROP INDEX IF EXISTS `in_game_rarity_ranking`;
+ALTER TABLE `setting` DROP INDEX IF EXISTS `setting_idx_scanning_id`;
+ALTER TABLE `trophy_title_meta` DROP INDEX IF EXISTS `idx_ttm_np_id_owners`;

--- a/database/mysql84_drop_redundant_indexes.sql
+++ b/database/mysql84_drop_redundant_indexes.sql
@@ -3,11 +3,46 @@
 --
 -- Idempotent: skips indexes that are already absent, so this script can be re-run on
 -- fresh installs from database/psn100.sql or databases that already ran earlier drops.
+--
+-- MySQL does not support DROP INDEX IF EXISTS in ALTER TABLE, so a small procedure
+-- checks information_schema before issuing each DROP.
 
-ALTER TABLE `player` DROP INDEX IF EXISTS `player_idx_online_id_account_id`;
-ALTER TABLE `player_ranking` DROP INDEX IF EXISTS `idx_pr_account_id_ranking`;
-ALTER TABLE `player_ranking` DROP INDEX IF EXISTS `ranking`;
-ALTER TABLE `player_ranking` DROP INDEX IF EXISTS `rarity_ranking`;
-ALTER TABLE `player_ranking` DROP INDEX IF EXISTS `in_game_rarity_ranking`;
-ALTER TABLE `setting` DROP INDEX IF EXISTS `setting_idx_scanning_id`;
-ALTER TABLE `trophy_title_meta` DROP INDEX IF EXISTS `idx_ttm_np_id_owners`;
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS psn100_drop_index_if_exists$$
+CREATE PROCEDURE psn100_drop_index_if_exists(
+    IN p_table_name VARCHAR(64),
+    IN p_index_name VARCHAR(64)
+)
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = p_table_name
+          AND index_name = p_index_name
+    ) THEN
+        SET @drop_sql = CONCAT(
+            'ALTER TABLE `',
+            REPLACE(p_table_name, '`', '``'),
+            '` DROP INDEX `',
+            REPLACE(p_index_name, '`', '``'),
+            '`'
+        );
+        PREPARE stmt FROM @drop_sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END IF;
+END$$
+
+CALL psn100_drop_index_if_exists('player', 'player_idx_online_id_account_id')$$
+CALL psn100_drop_index_if_exists('player_ranking', 'idx_pr_account_id_ranking')$$
+CALL psn100_drop_index_if_exists('player_ranking', 'ranking')$$
+CALL psn100_drop_index_if_exists('player_ranking', 'rarity_ranking')$$
+CALL psn100_drop_index_if_exists('player_ranking', 'in_game_rarity_ranking')$$
+CALL psn100_drop_index_if_exists('setting', 'setting_idx_scanning_id')$$
+CALL psn100_drop_index_if_exists('trophy_title_meta', 'idx_ttm_np_id_owners')$$
+
+DROP PROCEDURE psn100_drop_index_if_exists$$
+
+DELIMITER ;

--- a/database/mysql84_drop_redundant_indexes.sql
+++ b/database/mysql84_drop_redundant_indexes.sql
@@ -4,10 +4,39 @@
 -- Idempotent: skips indexes that are already absent, so this script can be re-run on
 -- fresh installs from database/psn100.sql or databases that already ran earlier drops.
 --
--- MySQL does not support DROP INDEX IF EXISTS in ALTER TABLE, so a small procedure
--- checks information_schema before issuing each DROP.
+-- MySQL does not support DROP INDEX IF EXISTS in ALTER TABLE, so small procedures
+-- check information_schema before issuing each ADD or DROP.
 
 DELIMITER $$
+
+DROP PROCEDURE IF EXISTS psn100_add_index_if_not_exists$$
+CREATE PROCEDURE psn100_add_index_if_not_exists(
+    IN p_table_name VARCHAR(64),
+    IN p_index_name VARCHAR(64),
+    IN p_index_columns VARCHAR(255)
+)
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = p_table_name
+          AND index_name = p_index_name
+    ) THEN
+        SET @add_sql = CONCAT(
+            'ALTER TABLE `',
+            REPLACE(p_table_name, '`', '``'),
+            '` ADD INDEX `',
+            REPLACE(p_index_name, '`', '``'),
+            '` (',
+            p_index_columns,
+            ')'
+        );
+        PREPARE stmt FROM @add_sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END IF;
+END$$
 
 DROP PROCEDURE IF EXISTS psn100_drop_index_if_exists$$
 CREATE PROCEDURE psn100_drop_index_if_exists(
@@ -35,6 +64,12 @@ BEGIN
     END IF;
 END$$
 
+CALL psn100_add_index_if_not_exists(
+    'player_ranking',
+    'idx_pr_in_game_rarity_ranking_account',
+    '`in_game_rarity_ranking`, `account_id`'
+)$$
+
 CALL psn100_drop_index_if_exists('player', 'player_idx_online_id_account_id')$$
 CALL psn100_drop_index_if_exists('player_ranking', 'idx_pr_account_id_ranking')$$
 CALL psn100_drop_index_if_exists('player_ranking', 'ranking')$$
@@ -43,6 +78,7 @@ CALL psn100_drop_index_if_exists('player_ranking', 'in_game_rarity_ranking')$$
 CALL psn100_drop_index_if_exists('setting', 'setting_idx_scanning_id')$$
 CALL psn100_drop_index_if_exists('trophy_title_meta', 'idx_ttm_np_id_owners')$$
 
+DROP PROCEDURE psn100_add_index_if_not_exists$$
 DROP PROCEDURE psn100_drop_index_if_exists$$
 
 DELIMITER ;

--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -506,7 +506,7 @@ ALTER TABLE `player_ranking`
   ADD KEY `rarity_ranking_country` (`rarity_ranking_country`),
   ADD KEY `idx_pr_ranking_account` (`ranking`,`account_id`),
   ADD KEY `idx_pr_rarity_ranking_account` (`rarity_ranking`,`account_id`),
-  ADD KEY `in_game_rarity_ranking` (`in_game_rarity_ranking`),
+  ADD KEY `idx_pr_in_game_rarity_ranking_account` (`in_game_rarity_ranking`,`account_id`),
   ADD KEY `in_game_rarity_ranking_country` (`in_game_rarity_ranking_country`);
 
 --

--- a/tests/AdminLoginThrottleServiceTest.php
+++ b/tests/AdminLoginThrottleServiceTest.php
@@ -106,4 +106,20 @@ final class AdminLoginThrottleServiceTest extends TestCase
         $this->assertFalse($this->service->isLocked($ipAddress));
         $this->assertSame(0, $this->service->getLockoutRemainingSeconds($ipAddress));
     }
+
+    public function testMysqlFailureUpsertEvaluatesLockoutBeforeIncrementingFailureCount(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Admin/AdminLoginThrottleService.php');
+
+        $this->assertTrue(is_string($source));
+        $this->assertStringContainsString('locked_until = IF(', $source);
+        $this->assertStringContainsString('failure_count = admin_login_throttle.failure_count + 1', $source);
+
+        $lockoutPosition = strpos($source, 'locked_until = IF(');
+        $incrementPosition = strpos($source, 'failure_count = admin_login_throttle.failure_count + 1');
+        $this->assertTrue(
+            is_int($lockoutPosition) && is_int($incrementPosition) && $lockoutPosition < $incrementPosition,
+            'MySQL evaluates ON DUPLICATE KEY UPDATE assignments left-to-right; lockout must be decided before failure_count is incremented.'
+        );
+    }
 }

--- a/tests/PlayerQueueServiceTest.php
+++ b/tests/PlayerQueueServiceTest.php
@@ -232,13 +232,14 @@ final class PlayerQueueServiceTest extends TestCase
         $this->assertSame(null, $this->service->getQueuePosition('MissingPlayer'));
     }
 
-    public function testMysqlQueuePositionSqlUsesRowNumberWindowFunction(): void
+    public function testMysqlQueuePositionSqlUsesTargetDrivenLookup(): void
     {
         $reflection = new ReflectionClass(PlayerQueueService::class);
-        $sql = $reflection->getConstant('SQL_QUEUE_POSITION');
+        $sql = $reflection->getConstant('SQL_QUEUE_POSITION_MYSQL');
 
         $this->assertTrue(is_string($sql));
-        $this->assertStringContainsString('ROW_NUMBER() OVER', $sql);
+        $this->assertStringContainsString('EXISTS', $sql);
+        $this->assertFalse(str_contains($sql, 'ROW_NUMBER() OVER'));
 
         $mysqlPdo = new PlayerQueueServiceMysqlDriverPdoStub($this->pdo);
         $service = new PlayerQueueService($mysqlPdo);

--- a/tests/PlayerQueueServiceTest.php
+++ b/tests/PlayerQueueServiceTest.php
@@ -232,13 +232,13 @@ final class PlayerQueueServiceTest extends TestCase
         $this->assertSame(null, $this->service->getQueuePosition('MissingPlayer'));
     }
 
-    public function testMysqlQueuePositionSqlReturnsNoRowWhenPlayerIsNotQueued(): void
+    public function testMysqlQueuePositionSqlUsesRowNumberWindowFunction(): void
     {
         $reflection = new ReflectionClass(PlayerQueueService::class);
-        $sql = $reflection->getConstant('SQL_QUEUE_POSITION_MYSQL');
+        $sql = $reflection->getConstant('SQL_QUEUE_POSITION');
 
         $this->assertTrue(is_string($sql));
-        $this->assertStringContainsString('EXISTS', $sql);
+        $this->assertStringContainsString('ROW_NUMBER() OVER', $sql);
 
         $mysqlPdo = new PlayerQueueServiceMysqlDriverPdoStub($this->pdo);
         $service = new PlayerQueueService($mysqlPdo);

--- a/tests/PlayerRarityLeaderboardServiceTest.php
+++ b/tests/PlayerRarityLeaderboardServiceTest.php
@@ -56,6 +56,15 @@ final class PlayerRarityLeaderboardServiceTest extends TestCase
         $this->assertSame(50, $this->service->getPageSize());
     }
 
+    public function testGetPlayersUsesPlainQueryWithoutWindowedCount(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/AbstractPlayerLeaderboardService.php');
+
+        $this->assertTrue(is_string($source));
+        $this->assertStringContainsString('fetchPlayerRows($filter, $limit, false)', $source);
+        $this->assertStringContainsString('fetchPlayerRows($filter, $limit, true)', $source);
+    }
+
     private function createSchema(): void
     {
         $this->pdo->exec(

--- a/wwwroot/classes/AbstractPlayerLeaderboardService.php
+++ b/wwwroot/classes/AbstractPlayerLeaderboardService.php
@@ -36,18 +36,50 @@ abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeader
     #[\Override]
     final public function getPlayers(PlayerLeaderboardFilter $filter, int $limit = self::PAGE_SIZE): array
     {
-        return $this->getPlayersWithTotal($filter, $limit)->players;
+        return $this->fetchPlayerRows($filter, $limit, false);
     }
 
     final public function getPlayersWithTotal(
         PlayerLeaderboardFilter $filter,
         int $limit = self::PAGE_SIZE,
     ): PlayerLeaderboardQueryResult {
+        $rows = $this->fetchPlayerRows($filter, $limit, true);
+
+        if ($rows === []) {
+            return new PlayerLeaderboardQueryResult([], null);
+        }
+
+        $firstRow = array_first($rows);
+        $totalPlayers = is_numeric($firstRow['total_rows'] ?? null)
+            ? max(0, (int) $firstRow['total_rows'])
+            : null;
+
+        $players = array_map(
+            static function (array $row): array {
+                unset($row['total_rows']);
+
+                return $row;
+            },
+            $rows
+        );
+
+        return new PlayerLeaderboardQueryResult($players, $totalPlayers);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchPlayerRows(
+        PlayerLeaderboardFilter $filter,
+        int $limit,
+        bool $includeTotalCount,
+    ): array {
+        $totalCountProjection = $includeTotalCount ? ",\n                COUNT(*) OVER() AS total_rows" : '';
+
         $sql = <<<SQL
             SELECT
                 p.*,
-                {$this->getRankingProjection()},
-                COUNT(*) OVER() AS total_rows
+                {$this->getRankingProjection()}{$totalCountProjection}
             FROM
                 player_ranking r
             JOIN player p ON p.account_id = r.account_id
@@ -71,28 +103,7 @@ abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeader
 
         $rows = $query->fetchAll(\PDO::FETCH_ASSOC);
 
-        if (!is_array($rows)) {
-            return new PlayerLeaderboardQueryResult([], null);
-        }
-
-        $totalPlayers = null;
-        if ($rows !== []) {
-            $firstRow = array_first($rows);
-            if (is_numeric($firstRow['total_rows'] ?? null)) {
-                $totalPlayers = max(0, (int) $firstRow['total_rows']);
-            }
-
-            $rows = array_map(
-                static function (array $row): array {
-                    unset($row['total_rows']);
-
-                    return $row;
-                },
-                $rows
-            );
-        }
-
-        return new PlayerLeaderboardQueryResult($rows, $totalPlayers);
+        return is_array($rows) ? $rows : [];
     }
 
     #[\Override]

--- a/wwwroot/classes/AbstractPlayerLeaderboardService.php
+++ b/wwwroot/classes/AbstractPlayerLeaderboardService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerLeaderboardDataProvider.php';
+require_once __DIR__ . '/PlayerLeaderboardQueryResult.php';
 
 abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeaderboardDataProvider
 {
@@ -32,16 +33,21 @@ abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeader
         return (int) $query->fetchColumn();
     }
 
-    /**
-     * @return array<int, array<string, mixed>>
-     */
     #[\Override]
     final public function getPlayers(PlayerLeaderboardFilter $filter, int $limit = self::PAGE_SIZE): array
     {
+        return $this->getPlayersWithTotal($filter, $limit)->players;
+    }
+
+    final public function getPlayersWithTotal(
+        PlayerLeaderboardFilter $filter,
+        int $limit = self::PAGE_SIZE,
+    ): PlayerLeaderboardQueryResult {
         $sql = <<<SQL
             SELECT
                 p.*,
-                {$this->getRankingProjection()}
+                {$this->getRankingProjection()},
+                COUNT(*) OVER() AS total_rows
             FROM
                 player_ranking r
             JOIN player p ON p.account_id = r.account_id
@@ -63,7 +69,30 @@ abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeader
         $this->bindFilterParameters($query, $filter);
         $query->execute();
 
-        return $query->fetchAll(\PDO::FETCH_ASSOC);
+        $rows = $query->fetchAll(\PDO::FETCH_ASSOC);
+
+        if (!is_array($rows)) {
+            return new PlayerLeaderboardQueryResult([], null);
+        }
+
+        $totalPlayers = null;
+        if ($rows !== []) {
+            $firstRow = array_first($rows);
+            if (is_numeric($firstRow['total_rows'] ?? null)) {
+                $totalPlayers = max(0, (int) $firstRow['total_rows']);
+            }
+
+            $rows = array_map(
+                static function (array $row): array {
+                    unset($row['total_rows']);
+
+                    return $row;
+                },
+                $rows
+            );
+        }
+
+        return new PlayerLeaderboardQueryResult($rows, $totalPlayers);
     }
 
     #[\Override]

--- a/wwwroot/classes/Admin/AdminLoginThrottleService.php
+++ b/wwwroot/classes/Admin/AdminLoginThrottleService.php
@@ -135,13 +135,13 @@ final class AdminLoginThrottleService
             VALUES (:ip_address, 1, NULL, :last_attempt_at)
             AS new_values
             ON DUPLICATE KEY UPDATE
-                failure_count = admin_login_throttle.failure_count + 1,
                 last_attempt_at = new_values.last_attempt_at,
                 locked_until = IF(
                     admin_login_throttle.failure_count + 1 >= :max_failures,
                     CURRENT_TIMESTAMP + INTERVAL :lock_seconds SECOND,
                     admin_login_throttle.locked_until
-                )
+                ),
+                failure_count = admin_login_throttle.failure_count + 1
             SQL
         );
         $statement->bindValue(':ip_address', $ipAddress, PDO::PARAM_STR);

--- a/wwwroot/classes/Admin/AdminLoginThrottleService.php
+++ b/wwwroot/classes/Admin/AdminLoginThrottleService.php
@@ -135,10 +135,10 @@ final class AdminLoginThrottleService
             VALUES (:ip_address, 1, NULL, :last_attempt_at)
             AS new_values
             ON DUPLICATE KEY UPDATE
-                failure_count = (@new_failure_count := admin_login_throttle.failure_count + 1),
+                failure_count = admin_login_throttle.failure_count + 1,
                 last_attempt_at = new_values.last_attempt_at,
                 locked_until = IF(
-                    @new_failure_count >= :max_failures,
+                    admin_login_throttle.failure_count + 1 >= :max_failures,
                     CURRENT_TIMESTAMP + INTERVAL :lock_seconds SECOND,
                     admin_login_throttle.locked_until
                 )

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -190,7 +190,7 @@ class GameListService
                 %s
             %s
             LIMIT
-                :offset, :limit
+                :limit OFFSET :offset
             SQL,
             implode(', ', $columns),
             $conditions,

--- a/wwwroot/classes/PlayerLeaderboardPage.php
+++ b/wwwroot/classes/PlayerLeaderboardPage.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/ChangelogPaginator.php';
+require_once __DIR__ . '/AbstractPlayerLeaderboardService.php';
 require_once __DIR__ . '/PlayerLeaderboardDataProvider.php';
 require_once __DIR__ . '/PlayerLeaderboardFilter.php';
 
@@ -21,18 +22,29 @@ class PlayerLeaderboardPage
     {
         $this->requestedFilter = $filter;
 
-        $totalPlayers = $service->countPlayers($filter);
-        $this->paginator = new ChangelogPaginator(
-            $filter->getPage(),
-            $totalPlayers,
-            $service->getPageSize()
-        );
+        if ($filter->getPage() === 1 && $service instanceof AbstractPlayerLeaderboardService) {
+            $result = $service->getPlayersWithTotal($filter, $service->getPageSize());
+            $totalPlayers = $result->totalPlayers ?? $service->countPlayers($filter);
+            $this->paginator = new ChangelogPaginator(
+                1,
+                $totalPlayers,
+                $service->getPageSize()
+            );
+            $this->players = $result->players;
+        } else {
+            $totalPlayers = $service->countPlayers($filter);
+            $this->paginator = new ChangelogPaginator(
+                $filter->getPage(),
+                $totalPlayers,
+                $service->getPageSize()
+            );
 
-        $resolvedFilter = $this->createFilterForPage($this->paginator->getCurrentPage());
-        $this->players = $service->getPlayers(
-            $resolvedFilter,
-            $this->paginator->getLimit()
-        );
+            $resolvedFilter = $this->createFilterForPage($this->paginator->getCurrentPage());
+            $this->players = $service->getPlayers(
+                $resolvedFilter,
+                $this->paginator->getLimit()
+            );
+        }
     }
 
     /**

--- a/wwwroot/classes/PlayerLeaderboardQueryResult.php
+++ b/wwwroot/classes/PlayerLeaderboardQueryResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+final readonly class PlayerLeaderboardQueryResult
+{
+    /**
+     * @param array<int, array<string, mixed>> $players
+     */
+    public function __construct(
+        public array $players,
+        public ?int $totalPlayers,
+    ) {
+    }
+}

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -40,7 +40,7 @@ class PlayerQueueService
         WHERE
             scanning = :online_id
         SQL;
-    private const string SQL_QUEUE_POSITION_SQLITE = <<<'SQL'
+    private const string SQL_QUEUE_POSITION = <<<'SQL'
         WITH ordered_queue AS (
             SELECT
                 online_id,
@@ -55,35 +55,6 @@ class PlayerQueueService
         WHERE
             online_id = :online_id
         LIMIT 1
-        SQL;
-    private const string SQL_QUEUE_POSITION_MYSQL = <<<'SQL'
-        SELECT
-            position
-        FROM (
-            SELECT
-                COUNT(*) + 1 AS position
-            FROM
-                player_queue pq_a
-            WHERE
-                (pq_a.request_time, pq_a.online_id) < (
-                    SELECT
-                        request_time,
-                        online_id
-                    FROM
-                        player_queue
-                    WHERE
-                        online_id = :online_id
-                )
-        ) AS counts
-        WHERE
-            EXISTS (
-                SELECT
-                    1
-                FROM
-                    player_queue
-                WHERE
-                    online_id = :online_id
-            )
         SQL;
     private const string SQL_PLAYER_IN_QUEUE = <<<'SQL'
         SELECT
@@ -117,15 +88,6 @@ class PlayerQueueService
         }
 
         return $this->database;
-    }
-
-    private function queuePositionSql(): string
-    {
-        if ($this->requireDatabase()->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
-            return self::SQL_QUEUE_POSITION_SQLITE;
-        }
-
-        return self::SQL_QUEUE_POSITION_MYSQL;
     }
 
     public function getIpSubmissionCount(string $ipAddress): int
@@ -291,7 +253,7 @@ class PlayerQueueService
         }
 
         $position = $this->fetchSingleValue(
-            $this->queuePositionSql(),
+            self::SQL_QUEUE_POSITION,
             [':online_id' => [$playerName, PDO::PARAM_STR]]
         );
 

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -40,7 +40,7 @@ class PlayerQueueService
         WHERE
             scanning = :online_id
         SQL;
-    private const string SQL_QUEUE_POSITION = <<<'SQL'
+    private const string SQL_QUEUE_POSITION_SQLITE = <<<'SQL'
         WITH ordered_queue AS (
             SELECT
                 online_id,
@@ -55,6 +55,35 @@ class PlayerQueueService
         WHERE
             online_id = :online_id
         LIMIT 1
+        SQL;
+    private const string SQL_QUEUE_POSITION_MYSQL = <<<'SQL'
+        SELECT
+            position
+        FROM (
+            SELECT
+                COUNT(*) + 1 AS position
+            FROM
+                player_queue pq_a
+            WHERE
+                (pq_a.request_time, pq_a.online_id) < (
+                    SELECT
+                        request_time,
+                        online_id
+                    FROM
+                        player_queue
+                    WHERE
+                        online_id = :online_id
+                )
+        ) AS counts
+        WHERE
+            EXISTS (
+                SELECT
+                    1
+                FROM
+                    player_queue
+                WHERE
+                    online_id = :online_id
+            )
         SQL;
     private const string SQL_PLAYER_IN_QUEUE = <<<'SQL'
         SELECT
@@ -88,6 +117,15 @@ class PlayerQueueService
         }
 
         return $this->database;
+    }
+
+    private function queuePositionSql(): string
+    {
+        if ($this->requireDatabase()->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            return self::SQL_QUEUE_POSITION_SQLITE;
+        }
+
+        return self::SQL_QUEUE_POSITION_MYSQL;
     }
 
     public function getIpSubmissionCount(string $ipAddress): int
@@ -253,7 +291,7 @@ class PlayerQueueService
         }
 
         $position = $this->fetchSingleValue(
-            self::SQL_QUEUE_POSITION,
+            $this->queuePositionSql(),
             [':online_id' => [$playerName, PDO::PARAM_STR]]
         );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up audit for MySQL 8.4 SQL improvements after the recent merge (#16151). This PR applies several remaining optimizations that leverage window functions, modern DDL syntax, and better indexing.

## Changes

### Query improvements
- **Leaderboard page 1** (`AbstractPlayerLeaderboardService`, `PlayerLeaderboardPage`): Add `COUNT(*) OVER()` only on the page-1 fast path via `getPlayersWithTotal()`; deeper pages keep a plain row query plus the existing `countPlayers()` call.
- **Admin login throttle** (`AdminLoginThrottleService`): Keep the upsert without session user variables, but evaluate `locked_until` before incrementing `failure_count` (MySQL applies `ON DUPLICATE KEY UPDATE` assignments left-to-right).
- **Game list pagination** (`GameListService`): Use `LIMIT :limit OFFSET :offset` instead of the older `LIMIT :offset, :limit` form.

### Schema / maintenance
- **`player_ranking`**: Replace single-column `in_game_rarity_ranking` index with composite `idx_pr_in_game_rarity_ranking_account (in_game_rarity_ranking, account_id)` to mirror other leaderboard indexes.
- **`mysql84_drop_redundant_indexes.sql`**: Keep the idempotent stored-procedure approach (MySQL 8.4 `ALTER TABLE` does not support `DROP INDEX IF EXISTS`). Add the composite in-game rarity index before dropping the legacy single-column index on upgraded databases.

## Review fixes

- Restored the stored-procedure index drop script after review confirmed `DROP INDEX IF EXISTS` is invalid MySQL syntax.
- Reordered throttle upsert assignments so lockout triggers on the 5th failure, not the 4th.
- Added composite index creation before dropping `in_game_rarity_ranking` on upgraded databases.
- Limited `COUNT(*) OVER()` to the page-1 leaderboard path to avoid double-counting on deeper pages.
- Kept MySQL queue position lookups target-driven (indexed tuple comparison + `EXISTS`) instead of `ROW_NUMBER()` over the full queue on every poll; SQLite tests still use `ROW_NUMBER()`.

## Deployment notes

Existing databases should run:

```bash
mysql psn100 < database/mysql84_drop_redundant_indexes.sql
```

Fresh installs from the updated `psn100.sql` already include the composite index.

## Testing

- `php tests/run.php` — all 917 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-895d6726-2a1d-4999-a7db-d41dfa867bb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-895d6726-2a1d-4999-a7db-d41dfa867bb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

