### PR TITLE
Apply PHP 8.5 improvements to immutable value objects and formatters

### DIFF
--- a/tests/AboutPageScanLogControllerTest.php
+++ b/tests/AboutPageScanLogControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPageScanLogController.php';
+require_once __DIR__ . '/../wwwroot/classes/AboutPageDataProviderInterface.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPageService.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPageScanSummary.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPagePlayer.php';
@@ -12,7 +13,7 @@ require_once __DIR__ . '/../wwwroot/classes/Utility.php';
 require_once __DIR__ . '/../wwwroot/classes/JsonResponseEmitter.php';
 require_once __DIR__ . '/../wwwroot/classes/IpRateLimitService.php';
 
-final class FakeAboutPageService extends AboutPageService
+final class FakeAboutPageService implements AboutPageDataProviderInterface
 {
     private AboutPageScanSummary $summary;
 
@@ -53,15 +54,16 @@ final class FakeAboutPageService extends AboutPageService
     }
 }
 
-final class FailingAboutPageService extends AboutPageService
+final class FailingAboutPageService implements AboutPageDataProviderInterface
 {
-    public function __construct()
-    {
-    }
-
     public function getScanSummary(): AboutPageScanSummary
     {
         throw new \RuntimeException('Failed to load summary');
+    }
+
+    public function getScanLogPlayers(int $limit): array
+    {
+        throw new \RuntimeException('Failed to load scan log players');
     }
 }
 

--- a/tests/PlayerScanTrophyTitleRefresherTest.php
+++ b/tests/PlayerScanTrophyTitleRefresherTest.php
@@ -192,7 +192,7 @@ final class PlayerScanTrophyTitleRefresherTestUser
 
     public function trophyTitles(): PlayerScanTrophyTitleRefresherTestTrophyTitleCollection
     {
-        $titles = $this->fetchResults[$this->fetchCount] ?? $this->fetchResults[array_key_last($this->fetchResults)] ?? [];
+        $titles = $this->fetchResults[$this->fetchCount] ?? array_last($this->fetchResults) ?? [];
         $this->fetchCount++;
 
         return new PlayerScanTrophyTitleRefresherTestTrophyTitleCollection($titles);

--- a/tests/TrophyCalculatorTest.php
+++ b/tests/TrophyCalculatorTest.php
@@ -333,9 +333,7 @@ final class FakePDOStatement extends PDOStatement
             return false;
         }
 
-        $row = reset($this->result);
-
-        return $row === false ? false : $row;
+        return array_first($this->result) ?? false;
     }
 
     private function executeSelectTrophyCounts(): void

--- a/wwwroot/classes/AboutPageScanLogController.php
+++ b/wwwroot/classes/AboutPageScanLogController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/AboutPageService.php';
+require_once __DIR__ . '/AboutPageDataProviderInterface.php';
 require_once __DIR__ . '/AboutPageScanSummary.php';
 require_once __DIR__ . '/AboutPagePlayerArraySerializer.php';
 require_once __DIR__ . '/JsonResponseEmitter.php';
@@ -15,7 +15,7 @@ final class AboutPageScanLogController
     private const MIN_LIMIT = 1;
     private const MAX_LIMIT = 100;
 
-    private AboutPageService $aboutPageService;
+    private AboutPageDataProviderInterface $aboutPageService;
     private JsonResponseEmitter $jsonResponder;
     private ?IpRateLimitService $rateLimitService;
     private int $defaultLimit;
@@ -23,7 +23,7 @@ final class AboutPageScanLogController
     private int $maxLimit;
 
     public function __construct(
-        AboutPageService $aboutPageService,
+        AboutPageDataProviderInterface $aboutPageService,
         JsonResponseEmitter $jsonResponder,
         ?IpRateLimitService $rateLimitService = null,
         int $defaultLimit = self::DEFAULT_LIMIT,
@@ -39,7 +39,7 @@ final class AboutPageScanLogController
     }
 
     public static function create(
-        AboutPageService $aboutPageService,
+        AboutPageDataProviderInterface $aboutPageService,
         JsonResponseEmitter $jsonResponder,
         ?IpRateLimitService $rateLimitService = null,
     ): self {

--- a/wwwroot/classes/AboutPageService.php
+++ b/wwwroot/classes/AboutPageService.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/AboutPageDataProviderInterface.php';
 require_once __DIR__ . '/AboutPagePlayer.php';
 require_once __DIR__ . '/AboutPageScanSummary.php';
 
-class AboutPageService implements AboutPageDataProviderInterface
+final readonly class AboutPageService implements AboutPageDataProviderInterface
 {
     private const DEFAULT_SCAN_LOG_LIMIT = 10;
 

--- a/wwwroot/classes/Admin/WorkerSortDirection.php
+++ b/wwwroot/classes/Admin/WorkerSortDirection.php
@@ -13,7 +13,7 @@ enum WorkerSortDirection: string
             return self::Asc;
         }
 
-        return self::tryFrom(strtolower(trim($value))) ?? self::Asc;
+        return self::tryFrom($value |> trim(...) |> strtolower(...)) ?? self::Asc;
     }
 
     public function toSqlKeyword(): string

--- a/wwwroot/classes/Admin/WorkerSortField.php
+++ b/wwwroot/classes/Admin/WorkerSortField.php
@@ -13,7 +13,7 @@ enum WorkerSortField: string
             return self::ScanStart;
         }
 
-        return self::tryFrom(strtolower(trim($value))) ?? self::ScanStart;
+        return self::tryFrom($value |> trim(...) |> strtolower(...)) ?? self::ScanStart;
     }
 
     public function toSqlColumn(): string

--- a/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
@@ -55,7 +55,7 @@ final class PlayerScanTrophyProgressSynchronizer
             foreach ($groupTrophies as $trophy) {
                 $trophyEarned = $trophy->earned();
                 $progress = (clone $trophy)->progress();
-                if ($trophyEarned || ($progress != '' && intval($progress) > 0)) {
+                if ($trophyEarned || ($progress != '' && (int) $progress > 0)) {
                     $this->earnedTrophyPersister->persistEarnedTrophy(
                         $npCommunicationId,
                         $trophyGroup->id(),

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/PlayerScanTrophyTitleLoopResult.php';
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\Haste\Exception\UnauthorizedHttpException;
 
-final class ThirtyMinuteCronJob implements CronJobInterface
+final readonly class ThirtyMinuteCronJob implements CronJobInterface
 {
     private readonly AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService;
 

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-class GameListFilter
+readonly class GameListFilter
 {
     public const SORT_ADDED = 'added';
     public const SORT_COMPLETION = 'completion';
@@ -300,7 +300,7 @@ class GameListFilter
 
     private static function normalizeSort(mixed $value, string $search, bool $sortSpecified): string
     {
-        $sort = is_string($value) ? strtolower(trim($value)) : '';
+        $sort = is_string($value) ? ($value |> trim(...) |> strtolower(...)) : '';
 
         return match ($sort) {
             self::SORT_ADDED,
@@ -328,7 +328,7 @@ class GameListFilter
         }
 
         if (is_string($value)) {
-            $value = strtolower(trim($value));
+            $value = $value |> trim(...) |> strtolower(...);
 
             if ($value === '' || $value === 'false' || $value === '0') {
                 return false;

--- a/wwwroot/classes/GameListItem.php
+++ b/wwwroot/classes/GameListItem.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/GameStatusBadge.php';
 require_once __DIR__ . '/Utility.php';
 
-final class GameListItem
+final readonly class GameListItem
 {
     private const int COMPLETION_PERCENTAGE = 100;
     private const string MISSING_PS5_ICON = '../missing-ps5-game-and-trophy.png';

--- a/wwwroot/classes/GameTrophyFilter.php
+++ b/wwwroot/classes/GameTrophyFilter.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 require_once __DIR__ . '/Game/GameTrophyGroupPlayer.php';
 require_once __DIR__ . '/Game/GameTrophyRow.php';
 
-class GameTrophyFilter
+readonly class GameTrophyFilter
 {
-    private bool $unearnedOnly;
-
-    private function __construct(bool $unearnedOnly)
+    private function __construct(private bool $unearnedOnly)
     {
-        $this->unearnedOnly = $unearnedOnly;
     }
 
     /**
@@ -75,7 +72,7 @@ class GameTrophyFilter
         }
 
         if (is_string($value)) {
-            $normalized = strtolower(trim($value));
+            $normalized = $value |> trim(...) |> strtolower(...);
 
             if ($normalized === '' || in_array($normalized, ['0', 'false', 'off', 'no'], true)) {
                 return false;

--- a/wwwroot/classes/HomepagePopularGamesFilter.php
+++ b/wwwroot/classes/HomepagePopularGamesFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-final class HomepagePopularGamesFilter
+final readonly class HomepagePopularGamesFilter
 {
     public const PLATFORM_ALL = '';
     public const PLATFORM_PC = 'pc';
@@ -114,7 +114,7 @@ final class HomepagePopularGamesFilter
             return self::PLATFORM_ALL;
         }
 
-        $platform = strtolower(trim((string) $value));
+        $platform = ((string) $value) |> trim(...) |> strtolower(...);
 
         if ($platform === '' || !in_array($platform, self::PLATFORM_KEYS, true)) {
             return self::PLATFORM_ALL;
@@ -138,7 +138,7 @@ final class HomepagePopularGamesFilter
         }
 
         if (is_string($value)) {
-            $value = strtolower(trim($value));
+            $value = $value |> trim(...) |> strtolower(...);
 
             if ($value === '' || $value === 'false' || $value === '0') {
                 return false;

--- a/wwwroot/classes/Leaderboard/InGameRarityLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/InGameRarityLeaderboardPageContext.php
@@ -10,11 +10,13 @@ class InGameRarityLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
     private const TITLE = 'PSN Rarity (Game) Leaderboard ~ PSN 100%';
 
+    #[\Override]
     public function getTitle(): string
     {
         return self::TITLE;
     }
 
+    #[\Override]
     protected static function createDataProvider(PDO $database): PlayerLeaderboardDataProvider
     {
         return new PlayerInGameRarityLeaderboardService($database);
@@ -23,6 +25,7 @@ class InGameRarityLeaderboardPageContext extends AbstractLeaderboardPageContext
     /**
      * @param array<string, mixed> $player
      */
+    #[\Override]
     protected function createRow(
         array $player,
         PlayerLeaderboardFilter $filter,

--- a/wwwroot/classes/Leaderboard/InGameRarityLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/InGameRarityLeaderboardRow.php
@@ -10,6 +10,7 @@ class InGameRarityLeaderboardRow extends AbstractLeaderboardRow
      * @param array<string, mixed> $player
      * @param array<string, int|string> $filterParameters
      */
+    #[\Override]
     public function __construct(
         array $player,
         PlayerLeaderboardFilter $filter,

--- a/wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
@@ -10,11 +10,13 @@ class RarityLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
     private const TITLE = 'PSN Rarity Leaderboard ~ PSN 100%';
 
+    #[\Override]
     public function getTitle(): string
     {
         return self::TITLE;
     }
 
+    #[\Override]
     protected static function createDataProvider(PDO $database): PlayerLeaderboardDataProvider
     {
         return new PlayerRarityLeaderboardService($database);
@@ -23,6 +25,7 @@ class RarityLeaderboardPageContext extends AbstractLeaderboardPageContext
     /**
      * @param array<string, mixed> $player
      */
+    #[\Override]
     protected function createRow(
         array $player,
         PlayerLeaderboardFilter $filter,

--- a/wwwroot/classes/Leaderboard/RarityLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/RarityLeaderboardRow.php
@@ -10,6 +10,7 @@ class RarityLeaderboardRow extends AbstractLeaderboardRow
      * @param array<string, mixed> $player
      * @param array<string, int|string> $filterParameters
      */
+    #[\Override]
     public function __construct(
         array $player,
         PlayerLeaderboardFilter $filter,

--- a/wwwroot/classes/Leaderboard/TrophyLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/TrophyLeaderboardPageContext.php
@@ -10,11 +10,13 @@ class TrophyLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
     private const TITLE = 'PSN Trophy Leaderboard ~ PSN 100%';
 
+    #[\Override]
     public function getTitle(): string
     {
         return self::TITLE;
     }
 
+    #[\Override]
     protected static function createDataProvider(PDO $database): PlayerLeaderboardDataProvider
     {
         return new PlayerLeaderboardService($database);
@@ -23,6 +25,7 @@ class TrophyLeaderboardPageContext extends AbstractLeaderboardPageContext
     /**
      * @param array<string, mixed> $player
      */
+    #[\Override]
     protected function createRow(
         array $player,
         PlayerLeaderboardFilter $filter,

--- a/wwwroot/classes/Leaderboard/TrophyLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/TrophyLeaderboardRow.php
@@ -10,6 +10,7 @@ class TrophyLeaderboardRow extends AbstractLeaderboardRow
      * @param array<string, mixed> $player
      * @param array<string, int|string> $filterParameters
      */
+    #[\Override]
     public function __construct(
         array $player,
         PlayerLeaderboardFilter $filter,

--- a/wwwroot/classes/MaintenancePage.php
+++ b/wwwroot/classes/MaintenancePage.php
@@ -4,40 +4,19 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/MaintenancePageStylesheet.php';
 
-final class MaintenancePage
+final readonly class MaintenancePage
 {
-    private string $title;
-
-    private string $heading;
-
-    private string $description;
-
-    private string $author;
-
-    private string $message;
-
-    /**
-     * @var MaintenancePageStylesheet[]
-     */
-    private array $stylesheets;
-
     /**
      * @param MaintenancePageStylesheet[] $stylesheets
      */
     private function __construct(
-        string $title,
-        string $heading,
-        string $description,
-        string $author,
-        string $message,
-        array $stylesheets
+        private string $title,
+        private string $heading,
+        private string $description,
+        private string $author,
+        private string $message,
+        private array $stylesheets,
     ) {
-        $this->title = $title;
-        $this->heading = $heading;
-        $this->description = $description;
-        $this->author = $author;
-        $this->message = $message;
-        $this->stylesheets = $stylesheets;
     }
 
     public static function createDefault(): self

--- a/wwwroot/classes/NotFoundPage.php
+++ b/wwwroot/classes/NotFoundPage.php
@@ -2,19 +2,13 @@
 
 declare(strict_types=1);
 
-final class NotFoundPage
+final readonly class NotFoundPage
 {
-    private string $title;
-
-    private string $heading;
-
-    private string $message;
-
-    private function __construct(string $title, string $heading, string $message)
-    {
-        $this->title = $title;
-        $this->heading = $heading;
-        $this->message = $message;
+    private function __construct(
+        private string $title,
+        private string $heading,
+        private string $message,
+    ) {
     }
 
     public static function createDefault(): self

--- a/wwwroot/classes/PlayerAdvisorFilter.php
+++ b/wwwroot/classes/PlayerAdvisorFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-class PlayerAdvisorFilter
+readonly class PlayerAdvisorFilter
 {
     public const SORT_RARITY = 'rarity';
     public const SORT_IN_GAME_RARITY = 'in_game_rarity';
@@ -25,20 +25,14 @@ class PlayerAdvisorFilter
         'psvr2',
     ];
 
-    private int $page;
-
-    private string $sort;
-
-    /**
-     * @var array<int, string>
-     */
-    private array $platforms;
-
-    private function __construct(int $page, string $sort, array $platforms)
-    {
-        $this->page = $page;
-        $this->sort = $sort;
-        $this->platforms = $platforms;
+    private function __construct(
+        private int $page,
+        private string $sort,
+        /**
+         * @var array<int, string>
+         */
+        private array $platforms,
+    ) {
     }
 
     /**

--- a/wwwroot/classes/PlayerLogFilter.php
+++ b/wwwroot/classes/PlayerLogFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-class PlayerLogFilter
+readonly class PlayerLogFilter
 {
     public const SORT_DATE = 'date';
     public const SORT_RARITY = 'rarity';
@@ -19,18 +19,12 @@ class PlayerLogFilter
         'psvr2',
     ];
 
-    /** @var array<int, string> */
-    private array $platforms;
-
-    private string $sort;
-
-    private int $page;
-
-    private function __construct(string $sort, int $page, array $platforms)
-    {
-        $this->sort = $this->normaliseSort($sort);
-        $this->page = max($page, 1);
-        $this->platforms = array_values(array_unique($platforms));
+    private function __construct(
+        private string $sort,
+        private int $page,
+        /** @var array<int, string> */
+        private array $platforms,
+    ) {
     }
 
     public static function fromArray(array $parameters): self
@@ -49,7 +43,11 @@ class PlayerLogFilter
             }
         }
 
-        return new self($sort, $page, $platforms);
+        return new self(
+            self::normaliseSort($sort),
+            max($page, 1),
+            array_values(array_unique($platforms)),
+        );
     }
 
     public function getSort(): string
@@ -59,7 +57,7 @@ class PlayerLogFilter
 
     public function isSort(string $sort): bool
     {
-        return $this->sort === $this->normaliseSort($sort);
+        return $this->sort === self::normaliseSort($sort);
     }
 
     public function getPage(): int
@@ -130,7 +128,7 @@ class PlayerLogFilter
         return clone($this, ['page' => max($page, 1)]);
     }
 
-    private function normaliseSort(string $sort): string
+    private static function normaliseSort(string $sort): string
     {
         if ($sort === self::SORT_RARITY) {
             return self::SORT_RARITY;

--- a/wwwroot/classes/TrophyImageDownloader.php
+++ b/wwwroot/classes/TrophyImageDownloader.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/ImageHashCalculator.php';
  * Encapsulates the remote fetch, filename hashing, and persistence rules that
  * were previously duplicated in ThirtyMinuteCronJob and GameRescanService.
  */
-final class TrophyImageDownloader
+final readonly class TrophyImageDownloader
 {
     public const string PLACEHOLDER_FILENAME = '.png';
 

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -22,15 +22,11 @@ final class TrophyTitleNameFormatter
             return $name;
         }
 
-        $name = str_replace(['™', '®', '©'], '', $name);
-
-        // Normalize en dash to hyphen-minus to keep downstream handling consistent.
-        $name = str_replace('–', '-', $name);
-
-        // Normalize apostrophe formatting in title names
-        $name = str_replace(['’', '´', '`'], '\'', $name);
-
-        $name = preg_replace('/\s*:\s*/', ': ', $name) ?? $name;
+        $name = $name
+            |> (fn(string $value): string => str_replace(['™', '®', '©'], '', $value))
+            |> (fn(string $value): string => str_replace('–', '-', $value))
+            |> (fn(string $value): string => str_replace(['’', '´', '`'], '\'', $value))
+            |> (fn(string $value): string => preg_replace('/\s*:\s*/', ': ', $value) ?? $value);
 
         if ($name === '') {
             return $name;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited the codebase for PHP 8.5 modernization opportunities and applied focused improvements where they add real value. The project was already in good shape (pipe operator in `Utility`, `clone(with:)` patterns, widespread `str_contains`, etc.); this PR closes the remaining gaps.

### PHP 8.5 language features

- **Pipe operator (`|>`)** for string normalization chains in `TrophyTitleNameFormatter`, `GameListFilter`, `GameTrophyFilter`, `HomepagePopularGamesFilter`, and admin worker sort enums
- **`array_first()` / `array_last()`** in test fakes (replacing `reset()` and `array_key_last()` index lookups)

### Immutability (`readonly class`)

Applied to value objects that are only mutated via `clone(with:)`:

- `GameListFilter`, `PlayerAdvisorFilter`, `PlayerLogFilter`, `GameTrophyFilter`, `HomepagePopularGamesFilter`
- `GameListItem`, `NotFoundPage`, `MaintenancePage`
- `AboutPageService`, `TrophyImageDownloader`, `ThirtyMinuteCronJob`

### Other improvements

- **`#[\Override]`** on leaderboard page context and row subclasses (12 methods) for safer refactoring
- **`(int)` cast** instead of `intval()` in `PlayerScanTrophyProgressSynchronizer`
- **`AboutPageScanLogController`** now depends on `AboutPageDataProviderInterface` instead of the concrete service, enabling `final` on `AboutPageService`

### Not changed (already modern)

- `clone($obj, with: [...])` is used throughout filters and page objects
- No `array()` syntax, no `PHP_VERSION_ID` guards, no `strpos !== false` candidates that could become `str_contains` without losing position data

## Test plan

- [x] `php tests/run.php` — all 915 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4e92b58-5247-44a9-b8f0-81c0c9d39111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4e92b58-5247-44a9-b8f0-81c0c9d39111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

