### PR TITLE
Fix leaderboard HTTP 500 caused by invalid #[\Override] on row constructors

### DIFF
--- a/wwwroot/classes/Leaderboard/InGameRarityLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/InGameRarityLeaderboardRow.php
@@ -10,7 +10,6 @@ class InGameRarityLeaderboardRow extends AbstractLeaderboardRow
      * @param array<string, mixed> $player
      * @param array<string, int|string> $filterParameters
      */
-    #[\Override]
     public function __construct(
         array $player,
         PlayerLeaderboardFilter $filter,

--- a/wwwroot/classes/Leaderboard/RarityLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/RarityLeaderboardRow.php
@@ -10,7 +10,6 @@ class RarityLeaderboardRow extends AbstractLeaderboardRow
      * @param array<string, mixed> $player
      * @param array<string, int|string> $filterParameters
      */
-    #[\Override]
     public function __construct(
         array $player,
         PlayerLeaderboardFilter $filter,

--- a/wwwroot/classes/Leaderboard/TrophyLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/TrophyLeaderboardRow.php
@@ -10,7 +10,6 @@ class TrophyLeaderboardRow extends AbstractLeaderboardRow
      * @param array<string, mixed> $player
      * @param array<string, int|string> $filterParameters
      */
-    #[\Override]
     public function __construct(
         array $player,
         PlayerLeaderboardFilter $filter,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

All leaderboard pages (`/leaderboard/trophy`, `/leaderboard/rarity`, `/leaderboard/in-game-rarity`) returned HTTP 500 after the recent PHP 8.5 improvements merge.

Production error log:

```
PHP Fatal error: TrophyLeaderboardRow::__construct() has #[\Override] attribute, but no matching parent method exists
```

## Root cause

`TrophyLeaderboardRow`, `RarityLeaderboardRow`, and `InGameRarityLeaderboardRow` each define a narrowed constructor (5 parameters) that forwards fixed ranking field names to `AbstractLeaderboardRow::__construct()` (9 parameters). PHP 8.5's `#[\Override]` attribute requires an exact parent method match, so the attribute is invalid on these constructors and triggers a fatal error at class load time.

## Fix

Remove the erroneous `#[\Override]` attributes from the three leaderboard row constructors. The `#[\Override]` attributes on `getTitle()`, `createDataProvider()`, and `createRow()` in the page context classes are unchanged and remain valid.

## Testing

- Instantiated `TrophyLeaderboardRow` successfully after the change
- `php tests/run.php` — all 918 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a93a149-ea4f-4fa2-b17c-fe9abe9ee298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a93a149-ea4f-4fa2-b17c-fe9abe9ee298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

