### PR TITLE
Extract TrophyStatusProgressRecalculator from TrophyStatusService

### DIFF
--- a/tests/TrophyStatusProgressRecalculatorTest.php
+++ b/tests/TrophyStatusProgressRecalculatorTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php';
+
+final class TrophyStatusProgressRecalculatorTest extends TestCase
+{
+    public function testRecalculateGroupCountsOnlyEarnedTrophiesForAllTypes(): void
+    {
+        $database = new RecordingTrophyStatusProgressPDO();
+        $recalculator = new TrophyStatusProgressRecalculator($database);
+
+        $recalculator->recalculateGroup('NPWR00001_00', 'default', [10]);
+
+        $this->assertSame(1, count($database->playerTrophyCountQueries));
+        $query = $database->playerTrophyCountQueries[0];
+        $this->assertTrue(str_contains($query, "COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'bronze' THEN 1 ELSE 0 END), 0) AS bronze"));
+        $this->assertTrue(str_contains($query, "COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'silver' THEN 1 ELSE 0 END), 0) AS silver"));
+        $this->assertTrue(str_contains($query, "COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'gold' THEN 1 ELSE 0 END), 0) AS gold"));
+        $this->assertTrue(str_contains($query, "COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'platinum' THEN 1 ELSE 0 END), 0) AS platinum"));
+        $this->assertTrue(str_contains($query, 'FROM
+            temp_impacted_accounts tia'));
+        $this->assertTrue(str_contains($query, 'LEFT JOIN trophy_earned te ON te.account_id = tia.account_id'));
+        $this->assertTrue(str_contains($query, 'AND te.earned = 1'));
+        $this->assertTrue(str_contains($query, 'AND tm.status = 0'));
+        $this->assertTrue(str_contains($query, 'AND aggregate.account_id IS NOT NULL'));
+    }
+
+    public function testRecalculateTitleAggregatesFromTrophyGroupPlayer(): void
+    {
+        $database = new RecordingTrophyStatusProgressPDO();
+        $recalculator = new TrophyStatusProgressRecalculator($database);
+
+        $recalculator->recalculateTitle('NPWR00001_00', 1, [10]);
+
+        $this->assertTrue(
+            str_contains($database->titlePlayerCountQuery ?? '', 'trophy_group_player'),
+            'Expected title-player recalculation to aggregate from trophy_group_player.'
+        );
+    }
+
+    public function testRecalculateTitleInsertsUnobtainableChangelogWhenGameExists(): void
+    {
+        $database = new RecordingTrophyStatusProgressPDO();
+        $database->gameId = 42;
+        $recalculator = new TrophyStatusProgressRecalculator($database);
+
+        $recalculator->recalculateTitle('NPWR00001_00', 1, [10]);
+
+        $this->assertSame('GAME_UNOBTAINABLE', $database->insertedChangeType);
+        $this->assertSame(42, $database->insertedChangeParam1);
+    }
+
+    public function testRecalculateTitleInsertsObtainableChangelogWhenGameExists(): void
+    {
+        $database = new RecordingTrophyStatusProgressPDO();
+        $database->gameId = 7;
+        $recalculator = new TrophyStatusProgressRecalculator($database);
+
+        $recalculator->recalculateTitle('NPWR00001_00', 0, [10]);
+
+        $this->assertSame('GAME_OBTAINABLE', $database->insertedChangeType);
+        $this->assertSame(7, $database->insertedChangeParam1);
+    }
+}
+
+final class RecordingTrophyStatusProgressPDO extends PDO
+{
+    /** @var list<string> */
+    public array $playerTrophyCountQueries = [];
+
+    public ?string $titlePlayerCountQuery = null;
+
+    public string|int|false|null $gameId = false;
+
+    public ?string $insertedChangeType = null;
+
+    public int|string|null $insertedChangeParam1 = null;
+
+    public function __construct()
+    {
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement
+    {
+        $trimmedQuery = trim($query);
+
+        if (str_starts_with($trimmedQuery, 'UPDATE') && str_contains($trimmedQuery, 'LEFT JOIN (') && str_contains($trimmedQuery, 'trophy_earned te')) {
+            $this->playerTrophyCountQueries[] = $trimmedQuery;
+
+            return new RecordingTrophyStatusProgressExecuteOnlyStatement();
+        }
+
+        if (str_contains($trimmedQuery, 'INNER JOIN player_trophy_count ptc ON ptc.account_id = ttp.account_id')) {
+            $this->titlePlayerCountQuery = $trimmedQuery;
+
+            return new RecordingTrophyStatusProgressExecuteOnlyStatement();
+        }
+
+        if (str_starts_with($trimmedQuery, 'INSERT INTO `psn100_change`')) {
+            return new RecordingTrophyStatusProgressChangeInsertStatement($this);
+        }
+
+        if (str_starts_with($trimmedQuery, 'SELECT')) {
+            if (str_contains($trimmedQuery, 'AS max_score')) {
+                return new RecordingTrophyStatusProgressFetchColumnStatement(100);
+            }
+
+            if (str_contains($trimmedQuery, 'SELECT id FROM trophy_title WHERE np_communication_id = :np_communication_id')) {
+                return new RecordingTrophyStatusProgressFetchColumnStatement($this->gameId);
+            }
+        }
+
+        return new RecordingTrophyStatusProgressExecuteOnlyStatement();
+    }
+
+    public function exec(string $statement): int|false
+    {
+        return 0;
+    }
+}
+
+final class RecordingTrophyStatusProgressExecuteOnlyStatement extends PDOStatement
+{
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+}
+
+final class RecordingTrophyStatusProgressChangeInsertStatement extends PDOStatement
+{
+    private RecordingTrophyStatusProgressPDO $database;
+
+    private ?string $changeType = null;
+
+    private int|string|null $param1 = null;
+
+    public function __construct(RecordingTrophyStatusProgressPDO $database)
+    {
+        $this->database = $database;
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        if ($param === ':change_type') {
+            $this->changeType = (string) $value;
+        }
+
+        if ($param === ':param_1') {
+            $this->param1 = $value;
+        }
+
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        $this->database->insertedChangeType = $this->changeType;
+        $this->database->insertedChangeParam1 = $this->param1;
+
+        return true;
+    }
+}
+
+final class RecordingTrophyStatusProgressFetchColumnStatement extends PDOStatement
+{
+    private string|int|bool|null $value;
+
+    public function __construct(string|int|bool|null $value)
+    {
+        $this->value = $value;
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchColumn(int $column = 0): string|int|false|null
+    {
+        return $this->value;
+    }
+}

--- a/tests/TrophyStatusServiceTest.php
+++ b/tests/TrophyStatusServiceTest.php
@@ -4,43 +4,105 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyStatusService.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyStatusUpdateResult.php';
 
 final class TrophyStatusServiceTest extends TestCase
 {
-    public function testUpdateTrophiesCountsOnlyEarnedTrophiesForAllTypes(): void
+    public function testUpdateTrophiesRejectsEmptyTrophyList(): void
     {
-        $database = new RecordingTrophyStatusPDO();
-        $service = new TrophyStatusService($database);
+        $database = new RecordingTrophyStatusServicePDO();
+        $service = new TrophyStatusService($database, new RecordingTrophyStatusProgressRecalculator());
 
-        $service->updateTrophies([10], 1);
+        try {
+            $service->updateTrophies([], 1);
+            $this->fail('Expected InvalidArgumentException for an empty trophy list.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('No trophies were provided.', $exception->getMessage());
+        }
+    }
 
-        $this->assertSame(1, count($database->playerTrophyCountQueries));
-        $query = $database->playerTrophyCountQueries[0];
-        $this->assertTrue(str_contains($query, "COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'bronze' THEN 1 ELSE 0 END), 0) AS bronze"));
-        $this->assertTrue(str_contains($query, "COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'silver' THEN 1 ELSE 0 END), 0) AS silver"));
-        $this->assertTrue(str_contains($query, "COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'gold' THEN 1 ELSE 0 END), 0) AS gold"));
-        $this->assertTrue(str_contains($query, "COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'platinum' THEN 1 ELSE 0 END), 0) AS platinum"));
-        $this->assertTrue(str_contains($query, 'FROM
-            temp_impacted_accounts tia'));
-        $this->assertTrue(str_contains($query, 'LEFT JOIN trophy_earned te ON te.account_id = tia.account_id'));
-        $this->assertTrue(str_contains($query, 'AND te.earned = 1'));
-        $this->assertTrue(str_contains($query, 'AND tm.status = 0'));
-        $this->assertTrue(str_contains($query, 'AND aggregate.account_id IS NOT NULL'));
+    public function testUpdateTrophiesDelegatesGroupAndTitleRecalculation(): void
+    {
+        $database = new RecordingTrophyStatusServicePDO();
+        $recalculator = new RecordingTrophyStatusProgressRecalculator();
+        $service = new TrophyStatusService($database, $recalculator);
 
-        $this->assertTrue(
-            str_contains($database->titlePlayerCountQuery ?? '', 'trophy_group_player'),
-            'Expected title-player recalculation to aggregate from trophy_group_player.'
+        $result = $service->updateTrophies([10, 10], 1);
+
+        $this->assertSame(['10 (Test Trophy)'], $result->getTrophyNames());
+        $this->assertSame('unobtainable', $result->getStatusText());
+
+        $this->assertSame(
+            [
+                [
+                    'np_communication_id' => 'NPWR00001_00',
+                    'group_id' => 'default',
+                    'trophy_ids' => [10],
+                ],
+            ],
+            $recalculator->groupCalls
         );
+        $this->assertSame(
+            [
+                [
+                    'np_communication_id' => 'NPWR00001_00',
+                    'status' => 1,
+                    'trophy_ids' => [10],
+                ],
+            ],
+            $recalculator->titleCalls
+        );
+    }
+
+    public function testUpdateTrophiesUsesObtainableStatusText(): void
+    {
+        $database = new RecordingTrophyStatusServicePDO();
+        $recalculator = new RecordingTrophyStatusProgressRecalculator();
+        $service = new TrophyStatusService($database, $recalculator);
+
+        $result = $service->updateTrophies([10], 0);
+
+        $this->assertSame('obtainable', $result->getStatusText());
+        $this->assertSame(0, $recalculator->titleCalls[0]['status']);
     }
 }
 
-final class RecordingTrophyStatusPDO extends PDO
+final class RecordingTrophyStatusProgressRecalculator extends TrophyStatusProgressRecalculator
 {
-    /** @var list<string> */
-    public array $playerTrophyCountQueries = [];
+    /** @var list<array{np_communication_id: string, group_id: string, trophy_ids: list<int>}> */
+    public array $groupCalls = [];
 
-    public ?string $titlePlayerCountQuery = null;
+    /** @var list<array{np_communication_id: string, status: int, trophy_ids: list<int>}> */
+    public array $titleCalls = [];
 
+    public function __construct()
+    {
+        // Parent requires a PDO, but this stub never uses it.
+        parent::__construct(new RecordingTrophyStatusServicePDO());
+    }
+
+    public function recalculateGroup(string $npCommunicationId, string $groupId, array $affectedTrophyIds): void
+    {
+        $this->groupCalls[] = [
+            'np_communication_id' => $npCommunicationId,
+            'group_id' => $groupId,
+            'trophy_ids' => $affectedTrophyIds,
+        ];
+    }
+
+    public function recalculateTitle(string $npCommunicationId, int $status, array $affectedTrophyIds): void
+    {
+        $this->titleCalls[] = [
+            'np_communication_id' => $npCommunicationId,
+            'status' => $status,
+            'trophy_ids' => $affectedTrophyIds,
+        ];
+    }
+}
+
+final class RecordingTrophyStatusServicePDO extends PDO
+{
     private bool $inTransaction = false;
 
     public function __construct()
@@ -78,49 +140,22 @@ final class RecordingTrophyStatusPDO extends PDO
         $trimmedQuery = trim($query);
 
         if (str_starts_with($trimmedQuery, 'UPDATE trophy_meta SET status = :status WHERE trophy_id = :trophy_id')) {
-            return new RecordingExecuteOnlyStatement();
+            return new RecordingTrophyStatusServiceExecuteOnlyStatement();
         }
 
         if (str_starts_with($trimmedQuery, 'SELECT np_communication_id, group_id, name FROM trophy WHERE id = :trophy_id')) {
-            return new RecordingFetchAssocStatement([
+            return new RecordingTrophyStatusServiceFetchAssocStatement([
                 'np_communication_id' => 'NPWR00001_00',
                 'group_id' => 'default',
                 'name' => 'Test Trophy',
             ]);
         }
 
-        if (str_starts_with($trimmedQuery, 'UPDATE') && str_contains($trimmedQuery, 'LEFT JOIN (') && str_contains($trimmedQuery, 'trophy_earned te')) {
-            $this->playerTrophyCountQueries[] = $trimmedQuery;
-
-            return new RecordingExecuteOnlyStatement();
-        }
-
-        if (str_contains($trimmedQuery, 'INNER JOIN player_trophy_count ptc ON ptc.account_id = ttp.account_id')) {
-            $this->titlePlayerCountQuery = $trimmedQuery;
-
-            return new RecordingExecuteOnlyStatement();
-        }
-
-        if (str_starts_with($trimmedQuery, 'SELECT')) {
-            if (str_contains($trimmedQuery, 'AS max_score')) {
-                return new RecordingFetchColumnStatement(100);
-            }
-
-            if (str_contains($trimmedQuery, 'SELECT id FROM trophy_title WHERE np_communication_id = :np_communication_id')) {
-                return new RecordingFetchColumnStatement(false);
-            }
-        }
-
-        return new RecordingExecuteOnlyStatement();
-    }
-
-    public function exec(string $statement): int|false
-    {
-        return 0;
+        return new RecordingTrophyStatusServiceExecuteOnlyStatement();
     }
 }
 
-final class RecordingExecuteOnlyStatement extends PDOStatement
+final class RecordingTrophyStatusServiceExecuteOnlyStatement extends PDOStatement
 {
     public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
     {
@@ -133,7 +168,7 @@ final class RecordingExecuteOnlyStatement extends PDOStatement
     }
 }
 
-final class RecordingFetchAssocStatement extends PDOStatement
+final class RecordingTrophyStatusServiceFetchAssocStatement extends PDOStatement
 {
     /** @var array<string, string>|null */
     private ?array $row;
@@ -164,30 +199,5 @@ final class RecordingFetchAssocStatement extends PDOStatement
         $this->row = null;
 
         return $row;
-    }
-}
-
-final class RecordingFetchColumnStatement extends PDOStatement
-{
-    private string|int|bool|null $value;
-
-    public function __construct(string|int|bool|null $value)
-    {
-        $this->value = $value;
-    }
-
-    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
-    {
-        return true;
-    }
-
-    public function execute(?array $params = null): bool
-    {
-        return true;
-    }
-
-    public function fetchColumn(int $column = 0): string|int|false|null
-    {
-        return $this->value;
     }
 }

--- a/wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php
+++ b/wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Recalculates trophy group/title aggregates and player progress after a status change.
+ *
+ * Encapsulates the SQL previously embedded in TrophyStatusService so that service can
+ * focus on flipping trophy_meta.status and collecting affected groups/titles.
+ */
+class TrophyStatusProgressRecalculator
+{
+    public function __construct(
+        private readonly PDO $database,
+    ) {
+    }
+
+    /**
+     * @param int[] $affectedTrophyIds
+     */
+    public function recalculateGroup(string $npCommunicationId, string $groupId, array $affectedTrophyIds): void
+    {
+        $this->createImpactedAccountsTempTable($npCommunicationId, $groupId, $affectedTrophyIds);
+
+        $this->executeGroupStatement(
+            <<<'SQL'
+WITH counts AS (
+    SELECT
+      COALESCE(SUM(CASE WHEN t.type = 'bronze' THEN 1 ELSE 0 END), 0) AS bronze,
+      COALESCE(SUM(CASE WHEN t.type = 'silver' THEN 1 ELSE 0 END), 0) AS silver,
+      COALESCE(SUM(CASE WHEN t.type = 'gold' THEN 1 ELSE 0 END), 0) AS gold,
+      COALESCE(SUM(CASE WHEN t.type = 'platinum' THEN 1 ELSE 0 END), 0) AS platinum
+    FROM
+      trophy t
+      JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = 0
+    WHERE
+      t.np_communication_id = :np_communication_id
+      AND t.group_id = :group_id
+  )
+  UPDATE
+    trophy_group tg
+    CROSS JOIN counts c
+  SET
+    tg.bronze = c.bronze,
+    tg.silver = c.silver,
+    tg.gold = c.gold,
+    tg.platinum = c.platinum
+  WHERE
+    tg.np_communication_id = :np_communication_id
+    AND tg.group_id = :group_id
+SQL,
+            $npCommunicationId,
+            $groupId
+        );
+
+        $this->executeGroupStatement($this->getPlayerTrophyCountSql(), $npCommunicationId, $groupId);
+
+        $this->executeGroupStatement(
+            <<<'SQL'
+WITH max_score AS (
+    SELECT
+        bronze * 15 + silver * 30 + gold * 90 AS points
+    FROM
+        trophy_group
+    WHERE
+        np_communication_id = :np_communication_id
+        AND group_id = :group_id
+    ),
+    user_score AS (
+        SELECT
+            account_id,
+            bronze * 15 + silver * 30 + gold * 90 AS points
+        FROM
+            trophy_group_player
+        WHERE
+            np_communication_id = :np_communication_id
+            AND group_id = :group_id
+        GROUP BY
+            account_id
+    )
+    UPDATE
+        trophy_group_player tgp
+        INNER JOIN user_score us ON us.account_id = tgp.account_id
+        CROSS JOIN max_score ms
+    SET
+        tgp.progress = IF(
+            ms.points = 0,
+            100,
+            IF(
+                us.points != 0
+                AND FLOOR(us.points / ms.points * 100) = 0,
+                1,
+                FLOOR(us.points / ms.points * 100)
+            )
+        )
+    WHERE
+        tgp.np_communication_id = :np_communication_id
+        AND tgp.group_id = :group_id
+SQL,
+            $npCommunicationId,
+            $groupId
+        );
+    }
+
+    /**
+     * @param int[] $affectedTrophyIds
+     */
+    public function recalculateTitle(string $npCommunicationId, int $status, array $affectedTrophyIds): void
+    {
+        $statement = $this->database->prepare(
+            <<<'SQL'
+WITH trophy_group_count AS (
+    SELECT
+      SUM(bronze) AS bronze,
+      SUM(silver) AS silver,
+      SUM(gold) AS gold,
+      SUM(platinum) AS platinum
+    FROM
+      trophy_group
+    WHERE
+      np_communication_id = :np_communication_id
+  )
+  UPDATE
+    trophy_title tt
+    CROSS JOIN trophy_group_count tgc
+  SET
+    tt.bronze = tgc.bronze,
+    tt.silver = tgc.silver,
+    tt.gold = tgc.gold,
+    tt.platinum = tgc.platinum
+  WHERE
+    tt.np_communication_id = :np_communication_id
+SQL
+        );
+        $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $statement->execute();
+
+        $statement = $this->database->prepare(
+            <<<'SQL'
+WITH player_trophy_count AS (
+    SELECT
+        account_id,
+        IFNULL(SUM(bronze), 0) AS bronze,
+        IFNULL(SUM(silver), 0) AS silver,
+        IFNULL(SUM(gold), 0) AS gold,
+        IFNULL(SUM(platinum), 0) AS platinum
+    FROM
+        trophy_group_player
+    WHERE
+        np_communication_id = :np_communication_id
+    GROUP BY
+        account_id
+    )
+    UPDATE
+        trophy_title_player ttp
+        INNER JOIN player_trophy_count ptc ON ptc.account_id = ttp.account_id
+    SET
+        ttp.bronze = ptc.bronze,
+        ttp.silver = ptc.silver,
+        ttp.gold = ptc.gold,
+        ttp.platinum = ptc.platinum
+    WHERE
+        ttp.np_communication_id = :np_communication_id
+SQL
+        );
+        $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $statement->execute();
+
+        $statement = $this->database->prepare(
+            'SELECT
+                bronze * 15 + silver * 30 + gold * 90 AS max_score
+            FROM
+                trophy_title
+            WHERE
+                np_communication_id = :np_communication_id'
+        );
+        $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $statement->execute();
+        $maxScore = $statement->fetchColumn();
+        $maxScore = $maxScore === false ? 0 : (int) $maxScore;
+
+        $statement = $this->database->prepare(
+            <<<'SQL'
+WITH user_score AS (
+    SELECT
+        account_id,
+        bronze * 15 + silver * 30 + gold * 90 AS points
+    FROM
+        trophy_title_player
+    WHERE
+        np_communication_id = :np_communication_id
+    GROUP BY
+        account_id
+    )
+    UPDATE
+        trophy_title_player ttp
+        INNER JOIN user_score us ON us.account_id = ttp.account_id
+    SET
+        ttp.progress = IF(
+            :max_score = 0,
+            100,
+            IF(
+                us.points != 0
+                AND FLOOR(us.points / :max_score * 100) = 0,
+                1,
+                FLOOR(us.points / :max_score * 100)
+            )
+        )
+    WHERE
+        ttp.np_communication_id = :np_communication_id
+SQL
+        );
+        $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(':max_score', $maxScore, PDO::PARAM_INT);
+        $statement->execute();
+
+        $gameId = $this->findGameId($npCommunicationId);
+
+        if ($gameId !== null) {
+            $changeType = $status === 1 ? 'GAME_UNOBTAINABLE' : 'GAME_OBTAINABLE';
+            $statement = $this->database->prepare(
+                'INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES (:change_type, :param_1)'
+            );
+            $statement->bindValue(':change_type', $changeType, PDO::PARAM_STR);
+            $statement->bindValue(':param_1', $gameId, PDO::PARAM_INT);
+            $statement->execute();
+        }
+    }
+
+    private function executeGroupStatement(string $sql, string $npCommunicationId, string $groupId): void
+    {
+        $statement = $this->database->prepare($sql);
+        $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(':group_id', $groupId, PDO::PARAM_STR);
+        $statement->execute();
+    }
+
+    private function getPlayerTrophyCountSql(): string
+    {
+        return <<<'SQL'
+UPDATE
+    trophy_group_player tgp
+    LEFT JOIN (
+        SELECT
+            tia.account_id,
+            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'bronze' THEN 1 ELSE 0 END), 0) AS bronze,
+            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'silver' THEN 1 ELSE 0 END), 0) AS silver,
+            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'gold' THEN 1 ELSE 0 END), 0) AS gold,
+            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'platinum' THEN 1 ELSE 0 END), 0) AS platinum
+        FROM
+            temp_impacted_accounts tia
+            LEFT JOIN trophy_earned te ON te.account_id = tia.account_id
+            AND te.np_communication_id = :np_communication_id
+            AND te.group_id = :group_id
+            AND te.earned = 1
+            LEFT JOIN trophy t ON t.np_communication_id = te.np_communication_id
+            AND t.group_id = te.group_id
+            AND t.order_id = te.order_id
+            LEFT JOIN trophy_meta tm ON tm.trophy_id = t.id
+            AND tm.status = 0
+        GROUP BY
+            tia.account_id
+    ) aggregate ON aggregate.account_id = tgp.account_id
+SET
+    tgp.bronze = COALESCE(aggregate.bronze, 0),
+    tgp.silver = COALESCE(aggregate.silver, 0),
+    tgp.gold = COALESCE(aggregate.gold, 0),
+    tgp.platinum = COALESCE(aggregate.platinum, 0)
+WHERE
+    tgp.np_communication_id = :np_communication_id
+    AND tgp.group_id = :group_id
+    AND aggregate.account_id IS NOT NULL
+SQL;
+    }
+
+    /**
+     * @param int[] $affectedTrophyIds
+     */
+    private function createImpactedAccountsTempTable(string $npCommunicationId, ?string $groupId, array $affectedTrophyIds): void
+    {
+        $this->database->exec('DROP TEMPORARY TABLE IF EXISTS temp_impacted_accounts');
+        $this->database->exec('CREATE TEMPORARY TABLE temp_impacted_accounts (account_id BIGINT UNSIGNED PRIMARY KEY)');
+
+        if (count($affectedTrophyIds) === 0) {
+            return;
+        }
+
+        $placeholders = implode(',', array_fill(0, count($affectedTrophyIds), '?'));
+        $sql = 'INSERT IGNORE INTO temp_impacted_accounts (account_id)
+            SELECT DISTINCT te.account_id
+            FROM trophy_earned te
+            INNER JOIN trophy t ON t.np_communication_id = te.np_communication_id
+                AND t.group_id = te.group_id
+                AND t.order_id = te.order_id
+            WHERE te.np_communication_id = ?
+              AND te.earned = 1';
+
+        if ($groupId !== null) {
+            $sql .= ' AND te.group_id = ?';
+        }
+
+        $sql .= ' AND t.id IN (' . $placeholders . ')';
+
+        $statement = $this->database->prepare($sql);
+        $parameterIndex = 1;
+        $statement->bindValue($parameterIndex++, $npCommunicationId, PDO::PARAM_STR);
+        if ($groupId !== null) {
+            $statement->bindValue($parameterIndex++, $groupId, PDO::PARAM_STR);
+        }
+        foreach ($affectedTrophyIds as $trophyId) {
+            $statement->bindValue($parameterIndex++, (int) $trophyId, PDO::PARAM_INT);
+        }
+        $statement->execute();
+    }
+
+    private function findGameId(string $npCommunicationId): ?int
+    {
+        $statement = $this->database->prepare('SELECT id FROM trophy_title WHERE np_communication_id = :np_communication_id');
+        $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $statement->execute();
+        $gameId = $statement->fetchColumn();
+
+        if ($gameId === false) {
+            return null;
+        }
+
+        return (int) $gameId;
+    }
+}

--- a/wwwroot/classes/Admin/TrophyStatusService.php
+++ b/wwwroot/classes/Admin/TrophyStatusService.php
@@ -3,14 +3,20 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/TrophyStatusUpdateResult.php';
+require_once __DIR__ . '/TrophyStatusProgressRecalculator.php';
 
 class TrophyStatusService
 {
     private PDO $database;
 
-    public function __construct(PDO $database)
-    {
+    private TrophyStatusProgressRecalculator $progressRecalculator;
+
+    public function __construct(
+        PDO $database,
+        ?TrophyStatusProgressRecalculator $progressRecalculator = null,
+    ) {
         $this->database = $database;
+        $this->progressRecalculator = $progressRecalculator ?? new TrophyStatusProgressRecalculator($database);
     }
 
     /**
@@ -43,11 +49,15 @@ class TrophyStatusService
         }
 
         foreach ($trophyGroups as $group) {
-            $this->recalculateGroup($group['np_communication_id'], $group['group_id'], $group['trophy_ids']);
+            $this->progressRecalculator->recalculateGroup(
+                $group['np_communication_id'],
+                $group['group_id'],
+                $group['trophy_ids'],
+            );
         }
 
         foreach ($trophyTitles as $npCommunicationId => $titleTrophyIds) {
-            $this->recalculateTitle((string) $npCommunicationId, $status, $titleTrophyIds);
+            $this->progressRecalculator->recalculateTitle((string) $npCommunicationId, $status, $titleTrophyIds);
         }
 
         $statusText = $status === 1 ? 'unobtainable' : 'obtainable';
@@ -98,309 +108,5 @@ class TrophyStatusService
             'label' => $trophyId . ' (' . $name . ')',
             'groupKey' => $npCommunicationId . ',' . $groupId,
         ];
-    }
-
-    private function recalculateGroup(string $npCommunicationId, string $groupId, array $affectedTrophyIds): void
-    {
-        $this->createImpactedAccountsTempTable($npCommunicationId, $groupId, $affectedTrophyIds);
-
-        $this->executeGroupStatement(
-            <<<'SQL'
-WITH counts AS (
-    SELECT
-      COALESCE(SUM(CASE WHEN t.type = 'bronze' THEN 1 ELSE 0 END), 0) AS bronze,
-      COALESCE(SUM(CASE WHEN t.type = 'silver' THEN 1 ELSE 0 END), 0) AS silver,
-      COALESCE(SUM(CASE WHEN t.type = 'gold' THEN 1 ELSE 0 END), 0) AS gold,
-      COALESCE(SUM(CASE WHEN t.type = 'platinum' THEN 1 ELSE 0 END), 0) AS platinum
-    FROM
-      trophy t
-      JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = 0
-    WHERE
-      t.np_communication_id = :np_communication_id
-      AND t.group_id = :group_id
-  )
-  UPDATE
-    trophy_group tg
-    CROSS JOIN counts c
-  SET
-    tg.bronze = c.bronze,
-    tg.silver = c.silver,
-    tg.gold = c.gold,
-    tg.platinum = c.platinum
-  WHERE
-    tg.np_communication_id = :np_communication_id
-    AND tg.group_id = :group_id
-SQL,
-            $npCommunicationId,
-            $groupId
-        );
-
-        $this->executeGroupStatement($this->getPlayerTrophyCountSql(), $npCommunicationId, $groupId);
-
-        $this->executeGroupStatement(
-            <<<'SQL'
-WITH max_score AS (
-    SELECT
-        bronze * 15 + silver * 30 + gold * 90 AS points
-    FROM
-        trophy_group
-    WHERE
-        np_communication_id = :np_communication_id
-        AND group_id = :group_id
-    ),
-    user_score AS (
-        SELECT
-            account_id,
-            bronze * 15 + silver * 30 + gold * 90 AS points
-        FROM
-            trophy_group_player
-        WHERE
-            np_communication_id = :np_communication_id
-            AND group_id = :group_id
-        GROUP BY
-            account_id
-    )
-    UPDATE
-        trophy_group_player tgp
-        INNER JOIN user_score us ON us.account_id = tgp.account_id
-        CROSS JOIN max_score ms
-    SET
-        tgp.progress = IF(
-            ms.points = 0,
-            100,
-            IF(
-                us.points != 0
-                AND FLOOR(us.points / ms.points * 100) = 0,
-                1,
-                FLOOR(us.points / ms.points * 100)
-            )
-        )
-    WHERE
-        tgp.np_communication_id = :np_communication_id
-        AND tgp.group_id = :group_id
-SQL,
-            $npCommunicationId,
-            $groupId
-        );
-    }
-
-    private function executeGroupStatement(string $sql, string $npCommunicationId, string $groupId): void
-    {
-        $statement = $this->database->prepare($sql);
-        $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $statement->bindValue(':group_id', $groupId, PDO::PARAM_STR);
-        $statement->execute();
-    }
-
-    private function getPlayerTrophyCountSql(): string
-    {
-        return <<<'SQL'
-UPDATE
-    trophy_group_player tgp
-    LEFT JOIN (
-        SELECT
-            tia.account_id,
-            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'bronze' THEN 1 ELSE 0 END), 0) AS bronze,
-            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'silver' THEN 1 ELSE 0 END), 0) AS silver,
-            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'gold' THEN 1 ELSE 0 END), 0) AS gold,
-            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'platinum' THEN 1 ELSE 0 END), 0) AS platinum
-        FROM
-            temp_impacted_accounts tia
-            LEFT JOIN trophy_earned te ON te.account_id = tia.account_id
-            AND te.np_communication_id = :np_communication_id
-            AND te.group_id = :group_id
-            AND te.earned = 1
-            LEFT JOIN trophy t ON t.np_communication_id = te.np_communication_id
-            AND t.group_id = te.group_id
-            AND t.order_id = te.order_id
-            LEFT JOIN trophy_meta tm ON tm.trophy_id = t.id
-            AND tm.status = 0
-        GROUP BY
-            tia.account_id
-    ) aggregate ON aggregate.account_id = tgp.account_id
-SET
-    tgp.bronze = COALESCE(aggregate.bronze, 0),
-    tgp.silver = COALESCE(aggregate.silver, 0),
-    tgp.gold = COALESCE(aggregate.gold, 0),
-    tgp.platinum = COALESCE(aggregate.platinum, 0)
-WHERE
-    tgp.np_communication_id = :np_communication_id
-    AND tgp.group_id = :group_id
-    AND aggregate.account_id IS NOT NULL
-SQL;
-    }
-
-    private function recalculateTitle(string $npCommunicationId, int $status, array $affectedTrophyIds): void
-    {
-        $statement = $this->database->prepare(
-            <<<'SQL'
-WITH trophy_group_count AS (
-    SELECT
-      SUM(bronze) AS bronze,
-      SUM(silver) AS silver,
-      SUM(gold) AS gold,
-      SUM(platinum) AS platinum
-    FROM
-      trophy_group
-    WHERE
-      np_communication_id = :np_communication_id
-  )
-  UPDATE
-    trophy_title tt
-    CROSS JOIN trophy_group_count tgc
-  SET
-    tt.bronze = tgc.bronze,
-    tt.silver = tgc.silver,
-    tt.gold = tgc.gold,
-    tt.platinum = tgc.platinum
-  WHERE
-    tt.np_communication_id = :np_communication_id
-SQL
-        );
-        $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $statement->execute();
-
-        $statement = $this->database->prepare(
-            <<<'SQL'
-WITH player_trophy_count AS (
-    SELECT
-        account_id,
-        IFNULL(SUM(bronze), 0) AS bronze,
-        IFNULL(SUM(silver), 0) AS silver,
-        IFNULL(SUM(gold), 0) AS gold,
-        IFNULL(SUM(platinum), 0) AS platinum
-    FROM
-        trophy_group_player
-    WHERE
-        np_communication_id = :np_communication_id
-    GROUP BY
-        account_id
-    )
-    UPDATE
-        trophy_title_player ttp
-        INNER JOIN player_trophy_count ptc ON ptc.account_id = ttp.account_id
-    SET
-        ttp.bronze = ptc.bronze,
-        ttp.silver = ptc.silver,
-        ttp.gold = ptc.gold,
-        ttp.platinum = ptc.platinum
-    WHERE
-        ttp.np_communication_id = :np_communication_id
-SQL
-        );
-        $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $statement->execute();
-
-        $statement = $this->database->prepare(
-            'SELECT
-                bronze * 15 + silver * 30 + gold * 90 AS max_score
-            FROM
-                trophy_title
-            WHERE
-                np_communication_id = :np_communication_id'
-        );
-        $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $statement->execute();
-        $maxScore = $statement->fetchColumn();
-        $maxScore = $maxScore === false ? 0 : (int) $maxScore;
-
-        $statement = $this->database->prepare(
-            <<<'SQL'
-WITH user_score AS (
-    SELECT
-        account_id,
-        bronze * 15 + silver * 30 + gold * 90 AS points
-    FROM
-        trophy_title_player
-    WHERE
-        np_communication_id = :np_communication_id
-    GROUP BY
-        account_id
-    )
-    UPDATE
-        trophy_title_player ttp
-        INNER JOIN user_score us ON us.account_id = ttp.account_id
-    SET
-        ttp.progress = IF(
-            :max_score = 0,
-            100,
-            IF(
-                us.points != 0
-                AND FLOOR(us.points / :max_score * 100) = 0,
-                1,
-                FLOOR(us.points / :max_score * 100)
-            )
-        )
-    WHERE
-        ttp.np_communication_id = :np_communication_id
-SQL
-        );
-        $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $statement->bindValue(':max_score', $maxScore, PDO::PARAM_INT);
-        $statement->execute();
-
-        $gameId = $this->findGameId($npCommunicationId);
-
-        if ($gameId !== null) {
-            $changeType = $status === 1 ? 'GAME_UNOBTAINABLE' : 'GAME_OBTAINABLE';
-            $statement = $this->database->prepare(
-                'INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES (:change_type, :param_1)'
-            );
-            $statement->bindValue(':change_type', $changeType, PDO::PARAM_STR);
-            $statement->bindValue(':param_1', $gameId, PDO::PARAM_INT);
-            $statement->execute();
-
-        }
-    }
-
-    private function createImpactedAccountsTempTable(string $npCommunicationId, ?string $groupId, array $affectedTrophyIds): void
-    {
-        $this->database->exec('DROP TEMPORARY TABLE IF EXISTS temp_impacted_accounts');
-        $this->database->exec('CREATE TEMPORARY TABLE temp_impacted_accounts (account_id BIGINT UNSIGNED PRIMARY KEY)');
-
-        if (count($affectedTrophyIds) === 0) {
-            return;
-        }
-
-        $placeholders = implode(',', array_fill(0, count($affectedTrophyIds), '?'));
-        $sql = 'INSERT IGNORE INTO temp_impacted_accounts (account_id)
-            SELECT DISTINCT te.account_id
-            FROM trophy_earned te
-            INNER JOIN trophy t ON t.np_communication_id = te.np_communication_id
-                AND t.group_id = te.group_id
-                AND t.order_id = te.order_id
-            WHERE te.np_communication_id = ?
-              AND te.earned = 1';
-
-        if ($groupId !== null) {
-            $sql .= ' AND te.group_id = ?';
-        }
-
-        $sql .= ' AND t.id IN (' . $placeholders . ')';
-
-        $statement = $this->database->prepare($sql);
-        $parameterIndex = 1;
-        $statement->bindValue($parameterIndex++, $npCommunicationId, PDO::PARAM_STR);
-        if ($groupId !== null) {
-            $statement->bindValue($parameterIndex++, $groupId, PDO::PARAM_STR);
-        }
-        foreach ($affectedTrophyIds as $trophyId) {
-            $statement->bindValue($parameterIndex++, (int) $trophyId, PDO::PARAM_INT);
-        }
-        $statement->execute();
-    }
-
-    private function findGameId(string $npCommunicationId): ?int
-    {
-        $statement = $this->database->prepare('SELECT id FROM trophy_title WHERE np_communication_id = :np_communication_id');
-        $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $statement->execute();
-        $gameId = $statement->fetchColumn();
-
-        if ($gameId === false) {
-            return null;
-        }
-
-        return (int) $gameId;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels aggregate recalculation out of `TrophyStatusService` into a dedicated `TrophyStatusProgressRecalculator`. This is the follow-up planned when presentation was extracted into `TrophyStatusUpdateResult` / `TrophyStatusUpdateResultPresenter` (see commit `8778406a`).

`TrophyStatusService` now owns:
- Flipping `trophy_meta.status`
- Collecting affected groups/titles
- Returning `TrophyStatusUpdateResult`

`TrophyStatusProgressRecalculator` now owns:
- Group aggregate + player progress SQL
- Title aggregate + player progress SQL
- `GAME_UNOBTAINABLE` / `GAME_OBTAINABLE` changelog inserts

Service shrunk from ~406 lines to ~112. No caller changes — `TrophyStatusPage` / `admin/unobtainable.php` still use `TrophyStatusService::updateTrophies()`.

## Why this God class

`TrophyStatusService` mixed orchestration with ~300 lines of aggregate SQL. After the presentation peel it was explicitly left as the next concern to extract.

## Test plan

- [x] `TrophyStatusProgressRecalculatorTest` — earned-trophy count SQL shape, title aggregation source, changelog inserts
- [x] `TrophyStatusServiceTest` — empty input rejection, recalculator delegation, obtainable/unobtainable status text
- [x] Full suite: `php tests/run.php` — all 924 tests passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0be1dbe-6646-4dcb-a50b-bf6e57cf9e3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0be1dbe-6646-4dcb-a50b-bf6e57cf9e3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

