### PR TITLE
Apply further MySQL 8.4 SQL improvements

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -21,7 +21,7 @@ Apache rules should be enabled on every production server.
 - **Apache 2.4+** with `AllowOverride` enabled for `wwwroot/` so `.htaccess` files are read
 - **`mod_auth_basic`** enabled (admin HTTP Basic authentication)
 - **PHP 8.5** with extensions used by the app (`pdo_mysql`, `curl`, `gd`, `mbstring`, `intl`, `bcmath`, `gmp`, `zip`)
-- **MySQL 8.4+** (8.0 works with the committed schema)
+- **MySQL 8.4+** (production target; the structure-only schema may import on 8.0 for local smoke tests, but `database/mysql84_histograms.sql` requires 8.4 `AUTO UPDATE` histograms)
 - Paths to password files and cron runner IP addresses decided before go-live
 
 Committed templates (safe to version):
@@ -214,4 +214,6 @@ Older databases may still carry redundant indexes dropped from the current schem
 mysql "$DB_NAME" < database/mysql84_drop_redundant_indexes.sql
 ```
 
-Each dropped index is redundant with an existing primary, unique, or composite key.
+Dropped indexes are either redundant with an existing primary/unique/composite key, or
+unused by application query predicates (country ranking indexes and
+`idx_trophy_count_npwr`). The script also adds `chk_trophy_type` when missing.

--- a/README.md
+++ b/README.md
@@ -82,14 +82,15 @@ swapped every five minutes.
 hundreds of GiB): `ANALYZE TABLE` would be extremely slow and `AUTO UPDATE` would add
 ongoing overhead with negligible benefit for partition- and PK-scoped lookups.
 
-Existing databases that still have legacy redundant indexes can apply (safe to re-run; skips
+Existing databases that still have legacy or unused indexes can apply (safe to re-run; skips
 indexes that are already absent):
 
 ```bash
 mysql psn100 < database/mysql84_drop_redundant_indexes.sql
 ```
 
-Fresh installs from the current `psn100.sql` already omit those indexes.
+Fresh installs from the current `psn100.sql` already omit those indexes and include the
+`chk_trophy_type` CHECK constraint. The drop script also adds that constraint when missing.
 
 Queue polling (`check_queue_position.php`) requires a `poll_token` from the CSRF-protected
 `add_to_queue.php` response (60 requests per IP per minute). `scan_log_poll.php` allows 30

--- a/database/mysql84_drop_redundant_indexes.sql
+++ b/database/mysql84_drop_redundant_indexes.sql
@@ -1,5 +1,10 @@
--- Drop redundant indexes for MySQL 8.4 deployments.
--- Safe on 8.4+; each index is covered by a stricter unique, primary, or composite key.
+-- Drop unused/redundant indexes for MySQL 8.4 deployments.
+-- Safe on 8.4+; each index is either covered by a stricter unique/primary/composite
+-- key, or unused by application queries (country ranking indexes are display-only
+-- columns; idx_trophy_count_npwr is only SELECTed, never filtered/ordered).
+--
+-- Dropping the three player_ranking country indexes also speeds up the every-5-minute
+-- PlayerRankingUpdater rebuild (CREATE TABLE ... LIKE copies secondary indexes).
 --
 -- Idempotent: skips indexes that are already absent, so this script can be re-run on
 -- fresh installs from database/psn100.sql or databases that already ran earlier drops.
@@ -71,10 +76,14 @@ CALL psn100_add_index_if_not_exists(
 )$$
 
 CALL psn100_drop_index_if_exists('player', 'player_idx_online_id_account_id')$$
+CALL psn100_drop_index_if_exists('player', 'idx_trophy_count_npwr')$$
 CALL psn100_drop_index_if_exists('player_ranking', 'idx_pr_account_id_ranking')$$
 CALL psn100_drop_index_if_exists('player_ranking', 'ranking')$$
 CALL psn100_drop_index_if_exists('player_ranking', 'rarity_ranking')$$
 CALL psn100_drop_index_if_exists('player_ranking', 'in_game_rarity_ranking')$$
+CALL psn100_drop_index_if_exists('player_ranking', 'ranking_country')$$
+CALL psn100_drop_index_if_exists('player_ranking', 'rarity_ranking_country')$$
+CALL psn100_drop_index_if_exists('player_ranking', 'in_game_rarity_ranking_country')$$
 CALL psn100_drop_index_if_exists('setting', 'setting_idx_scanning_id')$$
 CALL psn100_drop_index_if_exists('trophy_title_meta', 'idx_ttm_np_id_owners')$$
 
@@ -82,3 +91,23 @@ DROP PROCEDURE psn100_add_index_if_not_exists$$
 DROP PROCEDURE psn100_drop_index_if_exists$$
 
 DELIMITER ;
+
+-- Enforce trophy.type domain on upgraded databases (idempotent).
+SET @chk_trophy_type_exists := (
+    SELECT COUNT(*)
+    FROM information_schema.table_constraints
+    WHERE table_schema = DATABASE()
+      AND table_name = 'trophy'
+      AND constraint_name = 'chk_trophy_type'
+      AND constraint_type = 'CHECK'
+);
+
+SET @chk_trophy_type_sql := IF(
+    @chk_trophy_type_exists = 0,
+    'ALTER TABLE `trophy` ADD CONSTRAINT `chk_trophy_type` CHECK (`type` IN (''bronze'', ''silver'', ''gold'', ''platinum''))',
+    'DO 0'
+);
+
+PREPARE chk_trophy_type_stmt FROM @chk_trophy_type_sql;
+EXECUTE chk_trophy_type_stmt;
+DEALLOCATE PREPARE chk_trophy_type_stmt;

--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -211,7 +211,8 @@ CREATE TABLE `trophy` (
   `icon_url` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
   `progress_target_value` int UNSIGNED DEFAULT NULL,
   `reward_name` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
-  `reward_image_url` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL
+  `reward_image_url` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+  CONSTRAINT `chk_trophy_type` CHECK (`type` IN ('bronze', 'silver', 'gold', 'platinum'))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------
@@ -483,7 +484,6 @@ ALTER TABLE `player`
   ADD KEY `idx_avatar_url` (`avatar_url`),
   ADD KEY `idx_last_updated_date` (`last_updated_date`),
   ADD KEY `player_idx_status_last_date_online_id` (`status`,`last_updated_date`,`online_id`),
-  ADD KEY `idx_trophy_count_npwr` (`trophy_count_npwr`),
   ADD KEY `idx_player_ranking` (`status`,`points` DESC,`platinum` DESC,`gold` DESC,`silver` DESC),
   ADD KEY `player_idx_status_rank_last_week` (`status`,`rank_last_week`),
   ADD KEY `idx_player_status_avatar_account` (`status`,`avatar_url`,`account_id`),
@@ -502,12 +502,9 @@ ALTER TABLE `player_queue`
 --
 ALTER TABLE `player_ranking`
   ADD PRIMARY KEY (`account_id`),
-  ADD KEY `ranking_country` (`ranking_country`),
-  ADD KEY `rarity_ranking_country` (`rarity_ranking_country`),
   ADD KEY `idx_pr_ranking_account` (`ranking`,`account_id`),
   ADD KEY `idx_pr_rarity_ranking_account` (`rarity_ranking`,`account_id`),
-  ADD KEY `idx_pr_in_game_rarity_ranking_account` (`in_game_rarity_ranking`,`account_id`),
-  ADD KEY `in_game_rarity_ranking_country` (`in_game_rarity_ranking_country`);
+  ADD KEY `idx_pr_in_game_rarity_ranking_account` (`in_game_rarity_ranking`,`account_id`);
 
 --
 -- Indexes for table `player_report`

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -11,10 +11,21 @@ final class DailyCronJobTest extends TestCase
     {
         $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_QUERY');
 
-        $this->assertStringContainsString('LEFT JOIN player_ranking p', $source);
-        $this->assertStringContainsString('p.ranking <= 10000', $source);
+        $this->assertStringContainsString('JOIN player_ranking pr ON pr.ranking <= 10000', $source);
+        $this->assertStringContainsString('te.account_id = pr.account_id', $source);
         $this->assertStringContainsString('/ 10000.0) * 100 AS rarity_percent', $source);
-        $this->assertStringContainsString('WHERE t.np_communication_id = :np_communication_id', $source);
+        $this->assertStringContainsString('CAST(:np_communication_id AS CHAR(12))', $source);
+        $this->assertStringContainsString('JOIN trophy t ON t.np_communication_id = title.np_communication_id', $source);
+    }
+
+    public function testUpdateTrophyRarityQueryDrivesTrophyEarnedByAccountIdForPartitionPruning(): void
+    {
+        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_QUERY');
+
+        $this->assertStringContainsString('ranked_owners AS', $source);
+        $this->assertStringContainsString('INNER JOIN trophy_earned te', $source);
+        $this->assertStringContainsString('GROUP BY te.order_id', $source);
+        $this->assertFalse(str_contains($source, 'LEFT JOIN trophy_earned te'));
     }
 
     public function testUpdateTrophyRarityQueryAssignsRarityNamesFromThresholds(): void

--- a/tests/PlayerRarityLeaderboardServiceTest.php
+++ b/tests/PlayerRarityLeaderboardServiceTest.php
@@ -65,6 +65,19 @@ final class PlayerRarityLeaderboardServiceTest extends TestCase
         $this->assertStringContainsString('fetchPlayerRows($filter, $limit, true)', $source);
     }
 
+    public function testGetPlayersSelectsExplicitColumnsInsteadOfPlayerStar(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/AbstractPlayerLeaderboardService.php');
+        $this->assertTrue(is_string($source));
+        $this->assertStringContainsString('getPlayerProjection()', $source);
+        $this->assertFalse(str_contains($source, 'p.*,'));
+
+        $serviceSource = file_get_contents(__DIR__ . '/../wwwroot/classes/PlayerRarityLeaderboardService.php');
+        $this->assertTrue(is_string($serviceSource));
+        $this->assertStringContainsString('p.rarity_points', $serviceSource);
+        $this->assertStringContainsString('p.legendary', $serviceSource);
+    }
+
     private function createSchema(): void
     {
         $this->pdo->exec(
@@ -72,7 +85,20 @@ final class PlayerRarityLeaderboardServiceTest extends TestCase
                 account_id TEXT PRIMARY KEY,
                 status INTEGER NOT NULL,
                 country TEXT,
-                avatar_url TEXT
+                avatar_url TEXT,
+                online_id TEXT,
+                level INTEGER NOT NULL DEFAULT 1,
+                progress INTEGER NOT NULL DEFAULT 0,
+                legendary INTEGER NOT NULL DEFAULT 0,
+                epic INTEGER NOT NULL DEFAULT 0,
+                rare INTEGER NOT NULL DEFAULT 0,
+                uncommon INTEGER NOT NULL DEFAULT 0,
+                common INTEGER NOT NULL DEFAULT 0,
+                rarity_points INTEGER NOT NULL DEFAULT 0,
+                rarity_rank_last_week INTEGER NOT NULL DEFAULT 0,
+                rarity_rank_country_last_week INTEGER NOT NULL DEFAULT 0,
+                trophy_count_npwr INTEGER NOT NULL DEFAULT 0,
+                trophy_count_sony INTEGER NOT NULL DEFAULT 0
             )'
         );
 
@@ -95,7 +121,8 @@ final class PlayerRarityLeaderboardServiceTest extends TestCase
         ];
 
         $playerStatement = $this->pdo->prepare(
-            'INSERT INTO player (account_id, status, country, avatar_url) VALUES (:account_id, :status, :country, :avatar_url)'
+            'INSERT INTO player (account_id, status, country, avatar_url, online_id)
+             VALUES (:account_id, :status, :country, :avatar_url, :online_id)'
         );
         $rankingStatement = $this->pdo->prepare(
             'INSERT INTO player_ranking (account_id, rarity_ranking, rarity_ranking_country) VALUES (:account_id, :rarity_ranking, :rarity_ranking_country)'
@@ -107,6 +134,7 @@ final class PlayerRarityLeaderboardServiceTest extends TestCase
                 ':status' => $player['status'],
                 ':country' => $player['country'],
                 ':avatar_url' => $player['avatar_url'],
+                ':online_id' => 'player-' . $player['account_id'],
             ]);
 
             $rankingStatement->execute([

--- a/tests/PlayerScanQueueSelectorTest.php
+++ b/tests/PlayerScanQueueSelectorTest.php
@@ -175,6 +175,36 @@ final class PlayerScanQueueSelectorTest extends TestCase
         $this->assertSame('stale-inactive', $result['online_id']);
     }
 
+    public function testSelectNextCandidateSelectsPlayerViaRarityRankingOnlyBranch(): void
+    {
+        $selector = $this->createSelectorWithDefaultCutoffs();
+        $this->insertPlayer(920, 'rarity-only', '2024-06-15 10:00:00', 99);
+        $this->insertRanking(920, 5000, 50, 5000);
+
+        $result = $selector->selectNextCandidate(1);
+
+        $this->assertSame('rarity-only', $result['online_id']);
+    }
+
+    public function testMysqlSelectionSqlSplitsRankingOrsIntoIndexFriendlyUnions(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/PlayerScanQueueSelector.php');
+        $this->assertTrue(is_string($source));
+
+        $this->assertStringContainsString('FROM' . "\n" . '                    player_ranking pr', $source);
+        $this->assertStringContainsString('pr.ranking <= 100', $source);
+        $this->assertStringContainsString('pr.rarity_ranking <= 100', $source);
+        $this->assertStringContainsString('pr.in_game_rarity_ranking <= 100', $source);
+        $this->assertFalse(str_contains(
+            $source,
+            'pr.ranking <= 100 OR pr.rarity_ranking <= 100 OR pr.in_game_rarity_ranking <= 100'
+        ));
+        $this->assertFalse(str_contains(
+            $source,
+            'pr.ranking <= 10000 OR pr.rarity_ranking <= 10000 OR pr.in_game_rarity_ranking <= 10000'
+        ));
+    }
+
     private function createSelectorWithDefaultCutoffs(): PlayerScanQueueSelector
     {
         return $this->createSelector(

--- a/tests/TrophyServiceAchieversTest.php
+++ b/tests/TrophyServiceAchieversTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyService.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyAchiever.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyDetails.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerTrophyProgress.php';
+
+final class TrophyServiceAchieversTest extends TestCase
+{
+    private PDO $database;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->database->exec(
+            'CREATE TABLE player (
+                account_id INTEGER PRIMARY KEY,
+                online_id TEXT NOT NULL,
+                avatar_url TEXT,
+                trophy_count_npwr INTEGER NOT NULL DEFAULT 0,
+                trophy_count_sony INTEGER NOT NULL DEFAULT 0
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE player_ranking (
+                account_id INTEGER PRIMARY KEY,
+                ranking INTEGER NOT NULL
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_earned (
+                np_communication_id TEXT NOT NULL,
+                order_id INTEGER NOT NULL,
+                account_id INTEGER NOT NULL,
+                earned INTEGER NOT NULL DEFAULT 1,
+                earned_date TEXT
+            )'
+        );
+    }
+
+    public function testGetFirstAchieversOrdersByEarnedDateAscending(): void
+    {
+        $this->seedAchiever(1, 'first', 10, '2024-01-01 10:00:00');
+        $this->seedAchiever(2, 'second', 20, '2024-01-02 10:00:00');
+        $this->seedAchiever(3, 'unranked', 20000, '2023-01-01 10:00:00');
+
+        $service = new TrophyService($this->database);
+        $achievers = $service->getFirstAchievers('NPWR00001_00', 1);
+
+        $this->assertCount(2, $achievers);
+        $this->assertSame('first', $achievers[0]->getOnlineId());
+        $this->assertSame('second', $achievers[1]->getOnlineId());
+    }
+
+    public function testGetLatestAchieversOrdersByEarnedDateDescending(): void
+    {
+        $this->seedAchiever(1, 'first', 10, '2024-01-01 10:00:00');
+        $this->seedAchiever(2, 'second', 20, '2024-01-02 10:00:00');
+
+        $service = new TrophyService($this->database);
+        $achievers = $service->getLatestAchievers('NPWR00001_00', 1);
+
+        $this->assertCount(2, $achievers);
+        $this->assertSame('second', $achievers[0]->getOnlineId());
+        $this->assertSame('first', $achievers[1]->getOnlineId());
+    }
+
+    public function testAchieversQueryDrivesFromPlayerRankingForPartitionPruning(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/TrophyService.php');
+        $this->assertTrue(is_string($source));
+        $this->assertStringContainsString('FROM' . "\n" . '                player_ranking r', $source);
+        $this->assertStringContainsString('te.account_id = r.account_id', $source);
+        $this->assertStringContainsString('r.ranking <= 10000', $source);
+    }
+
+    private function seedAchiever(int $accountId, string $onlineId, int $ranking, string $earnedDate): void
+    {
+        $this->database->prepare(
+            'INSERT INTO player (account_id, online_id, avatar_url, trophy_count_npwr, trophy_count_sony)
+             VALUES (:account_id, :online_id, :avatar_url, 1, 1)'
+        )->execute([
+            ':account_id' => $accountId,
+            ':online_id' => $onlineId,
+            ':avatar_url' => $onlineId . '.png',
+        ]);
+
+        $this->database->prepare(
+            'INSERT INTO player_ranking (account_id, ranking) VALUES (:account_id, :ranking)'
+        )->execute([
+            ':account_id' => $accountId,
+            ':ranking' => $ranking,
+        ]);
+
+        $this->database->prepare(
+            'INSERT INTO trophy_earned (np_communication_id, order_id, account_id, earned, earned_date)
+             VALUES (:np, 1, :account_id, 1, :earned_date)'
+        )->execute([
+            ':np' => 'NPWR00001_00',
+            ':account_id' => $accountId,
+            ':earned_date' => $earnedDate,
+        ]);
+    }
+}

--- a/wwwroot/classes/AbstractPlayerLeaderboardService.php
+++ b/wwwroot/classes/AbstractPlayerLeaderboardService.php
@@ -78,7 +78,7 @@ abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeader
 
         $sql = <<<SQL
             SELECT
-                p.*,
+                {$this->getPlayerProjection()},
                 {$this->getRankingProjection()}{$totalCountProjection}
             FROM
                 player_ranking r
@@ -115,6 +115,12 @@ abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeader
     abstract protected function getRankingProjection(): string;
 
     abstract protected function getOrderByExpression(): string;
+
+    /**
+     * Explicit player columns used by the leaderboard row mappers.
+     * Avoid SELECT p.* so about_me and unused rarity buckets are not fetched.
+     */
+    abstract protected function getPlayerProjection(): string;
 
     final protected function buildFilterSql(PlayerLeaderboardFilter $filter): string
     {

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -6,31 +6,47 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final readonly class DailyCronJob implements CronJobInterface
 {
+    /**
+     * Recalculate rarity for one title.
+     *
+     * Owners are counted by driving from player_ranking (top 10k) into
+     * trophy_earned on account_id so HASH(account_id) partition pruning applies.
+     * The aggregated derived table is materialized once per title instead of
+     * scanning trophy_earned by np_communication_id across all 256 partitions.
+     */
     private const string UPDATE_TROPHY_RARITY_QUERY = <<<'SQL'
-        WITH rarity AS (
+        WITH title AS (
+            SELECT CAST(:np_communication_id AS CHAR(12)) AS np_communication_id
+        ),
+        ranked_owners AS (
+            SELECT
+                te.order_id,
+                COUNT(*) AS trophy_owners
+            FROM title
+            JOIN player_ranking pr ON pr.ranking <= 10000
+            INNER JOIN trophy_earned te
+                ON te.account_id = pr.account_id
+                AND te.np_communication_id = title.np_communication_id
+                AND te.earned = 1
+            GROUP BY te.order_id
+        ),
+        rarity AS (
             SELECT
                 t.id AS trophy_id,
                 tm.status AS meta_status,
                 ttm.status AS title_status,
                 ttm.owners AS title_owners,
-                COUNT(p.account_id) AS trophy_owners,
-                (COUNT(p.account_id) / 10000.0) * 100 AS rarity_percent,
+                IFNULL(owners.trophy_owners, 0) AS trophy_owners,
+                (IFNULL(owners.trophy_owners, 0) / 10000.0) * 100 AS rarity_percent,
                 CASE
                     WHEN ttm.owners = 0 THEN 0
-                    ELSE LEAST((COUNT(p.account_id) / ttm.owners) * 100, 100.0)
+                    ELSE LEAST((IFNULL(owners.trophy_owners, 0) / ttm.owners) * 100, 100.0)
                 END AS in_game_rarity_percent
-            FROM trophy t
+            FROM title
+            JOIN trophy t ON t.np_communication_id = title.np_communication_id
             JOIN trophy_meta tm ON tm.trophy_id = t.id
             JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
-            LEFT JOIN trophy_earned te
-                ON te.np_communication_id = t.np_communication_id
-                    AND te.order_id = t.order_id
-                    AND te.earned = 1
-            LEFT JOIN player_ranking p
-                ON p.account_id = te.account_id
-                    AND p.ranking <= 10000
-            WHERE t.np_communication_id = :np_communication_id
-            GROUP BY t.id, tm.status, ttm.status, ttm.owners
+            LEFT JOIN ranked_owners owners ON owners.order_id = t.order_id
         )
         UPDATE trophy_meta tm
         JOIN rarity r ON tm.trophy_id = r.trophy_id

--- a/wwwroot/classes/Cron/PlayerScanQueueSelector.php
+++ b/wwwroot/classes/Cron/PlayerScanQueueSelector.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 /**
  * Selects the next player for a worker scan from the tiered priority queue.
  *
- * Encapsulates the 9-tier UNION query that was previously embedded in
+ * Encapsulates the tiered UNION query that was previously embedded in
  * ThirtyMinuteCronJob::run() so the main scan loop can focus on PSN API
  * orchestration.
+ *
+ * Ranking tiers are split into per-index range seeks (UNION ALL) so MySQL 8.4
+ * can use idx_pr_ranking_account / idx_pr_rarity_ranking_account /
+ * idx_pr_in_game_rarity_ranking_account instead of filtering an OR across all
+ * three ranking columns.
  *
  * Stale-player cutoffs are computed with MySQL NOW() so they stay aligned with
  * the database session clock and INTERVAL month arithmetic.
@@ -77,6 +82,39 @@ final class PlayerScanQueueSelector
 
     private static function buildSelectionSql(string $nowValuesSelect): string
     {
+        $tier2 = self::rankingTierBranches(
+            tier: 2,
+            cutoffColumn: 'cutoff_1h',
+            predicates: [
+                'pr.ranking <= 100',
+                'pr.rarity_ranking <= 100',
+                'pr.in_game_rarity_ranking <= 100',
+            ],
+        );
+
+        $tier3 = self::rankingTierBranches(
+            tier: 3,
+            cutoffColumn: 'cutoff_1d',
+            predicates: [
+                'pr.ranking <= 1000',
+                'pr.rarity_ranking <= 1000',
+                'pr.in_game_rarity_ranking <= 1000',
+                'pr.ranking BETWEEN 9750 AND 10250',
+                'pr.rarity_ranking BETWEEN 9750 AND 10250',
+                'pr.in_game_rarity_ranking BETWEEN 9750 AND 10250',
+            ],
+        );
+
+        $tier4 = self::rankingTierBranches(
+            tier: 4,
+            cutoffColumn: 'cutoff_1w',
+            predicates: [
+                'pr.ranking <= 10000',
+                'pr.rarity_ranking <= 10000',
+                'pr.in_game_rarity_ranking <= 10000',
+            ],
+        );
+
         return <<<SQL
             WITH
                 now_values AS (
@@ -97,55 +135,15 @@ final class PlayerScanQueueSelector
 
                 UNION ALL
 
-                SELECT
-                    2 AS tier,
-                    p.online_id,
-                    p.last_updated_date AS priority_timestamp,
-                    p.account_id
-                FROM
-                    player p
-                    JOIN player_ranking pr ON pr.account_id = p.account_id
-                    JOIN now_values nv
-                WHERE
-                    (pr.ranking <= 100 OR pr.rarity_ranking <= 100 OR pr.in_game_rarity_ranking <= 100)
-                    AND p.last_updated_date < nv.cutoff_1h
+                {$tier2}
 
                 UNION ALL
 
-                SELECT
-                    3 AS tier,
-                    p.online_id,
-                    p.last_updated_date AS priority_timestamp,
-                    p.account_id
-                FROM
-                    player p
-                    JOIN player_ranking pr ON pr.account_id = p.account_id
-                    JOIN now_values nv
-                WHERE
-                    (
-                        pr.ranking <= 1000 OR
-                        pr.rarity_ranking <= 1000 OR
-                        pr.in_game_rarity_ranking <= 1000 OR
-                        (pr.ranking BETWEEN 9750 AND 10250) OR
-                        (pr.rarity_ranking BETWEEN 9750 AND 10250) OR
-                        (pr.in_game_rarity_ranking BETWEEN 9750 AND 10250)
-                    )
-                    AND p.last_updated_date < nv.cutoff_1d
+                {$tier3}
 
                 UNION ALL
 
-                SELECT
-                    4 AS tier,
-                    p.online_id,
-                    p.last_updated_date AS priority_timestamp,
-                    p.account_id
-                FROM
-                    player p
-                    JOIN player_ranking pr ON pr.account_id = p.account_id
-                    JOIN now_values nv
-                WHERE
-                    (pr.ranking <= 10000 OR pr.rarity_ranking <= 10000 OR pr.in_game_rarity_ranking <= 10000)
-                    AND p.last_updated_date < nv.cutoff_1w
+                {$tier4}
 
                 UNION ALL
 
@@ -231,5 +229,32 @@ final class PlayerScanQueueSelector
                 online_id
             LIMIT 1
             SQL;
+    }
+
+    /**
+     * @param list<string> $predicates
+     */
+    private static function rankingTierBranches(int $tier, string $cutoffColumn, array $predicates): string
+    {
+        $branches = [];
+
+        foreach ($predicates as $predicate) {
+            $branches[] = <<<SQL
+                SELECT
+                    {$tier} AS tier,
+                    p.online_id,
+                    p.last_updated_date AS priority_timestamp,
+                    p.account_id
+                FROM
+                    player_ranking pr
+                    JOIN player p ON p.account_id = pr.account_id
+                    JOIN now_values nv
+                WHERE
+                    {$predicate}
+                    AND p.last_updated_date < nv.{$cutoffColumn}
+                SQL;
+        }
+
+        return implode("\n\n                UNION ALL\n\n", $branches);
     }
 }

--- a/wwwroot/classes/PlayerInGameRarityLeaderboardService.php
+++ b/wwwroot/classes/PlayerInGameRarityLeaderboardService.php
@@ -17,4 +17,26 @@ final readonly class PlayerInGameRarityLeaderboardService extends AbstractPlayer
     {
         return 'r.in_game_rarity_ranking';
     }
+
+    #[\Override]
+    protected function getPlayerProjection(): string
+    {
+        return <<<'SQL'
+            p.online_id,
+            p.avatar_url,
+            p.country,
+            p.level,
+            p.progress,
+            p.in_game_legendary,
+            p.in_game_epic,
+            p.in_game_rare,
+            p.in_game_uncommon,
+            p.in_game_common,
+            p.in_game_rarity_points,
+            p.in_game_rarity_rank_last_week,
+            p.in_game_rarity_rank_country_last_week,
+            p.trophy_count_npwr,
+            p.trophy_count_sony
+            SQL;
+    }
 }

--- a/wwwroot/classes/PlayerInGameRarityLeaderboardService.php
+++ b/wwwroot/classes/PlayerInGameRarityLeaderboardService.php
@@ -22,6 +22,7 @@ final readonly class PlayerInGameRarityLeaderboardService extends AbstractPlayer
     protected function getPlayerProjection(): string
     {
         return <<<'SQL'
+            p.account_id,
             p.online_id,
             p.avatar_url,
             p.country,

--- a/wwwroot/classes/PlayerLeaderboardService.php
+++ b/wwwroot/classes/PlayerLeaderboardService.php
@@ -22,6 +22,7 @@ final readonly class PlayerLeaderboardService extends AbstractPlayerLeaderboardS
     protected function getPlayerProjection(): string
     {
         return <<<'SQL'
+            p.account_id,
             p.online_id,
             p.avatar_url,
             p.country,

--- a/wwwroot/classes/PlayerLeaderboardService.php
+++ b/wwwroot/classes/PlayerLeaderboardService.php
@@ -17,4 +17,25 @@ final readonly class PlayerLeaderboardService extends AbstractPlayerLeaderboardS
     {
         return 'r.ranking';
     }
+
+    #[\Override]
+    protected function getPlayerProjection(): string
+    {
+        return <<<'SQL'
+            p.online_id,
+            p.avatar_url,
+            p.country,
+            p.level,
+            p.progress,
+            p.platinum,
+            p.gold,
+            p.silver,
+            p.bronze,
+            p.points,
+            p.rank_last_week,
+            p.rank_country_last_week,
+            p.trophy_count_npwr,
+            p.trophy_count_sony
+            SQL;
+    }
 }

--- a/wwwroot/classes/PlayerRarityLeaderboardService.php
+++ b/wwwroot/classes/PlayerRarityLeaderboardService.php
@@ -22,6 +22,7 @@ final readonly class PlayerRarityLeaderboardService extends AbstractPlayerLeader
     protected function getPlayerProjection(): string
     {
         return <<<'SQL'
+            p.account_id,
             p.online_id,
             p.avatar_url,
             p.country,

--- a/wwwroot/classes/PlayerRarityLeaderboardService.php
+++ b/wwwroot/classes/PlayerRarityLeaderboardService.php
@@ -17,4 +17,26 @@ final readonly class PlayerRarityLeaderboardService extends AbstractPlayerLeader
     {
         return 'r.rarity_ranking';
     }
+
+    #[\Override]
+    protected function getPlayerProjection(): string
+    {
+        return <<<'SQL'
+            p.online_id,
+            p.avatar_url,
+            p.country,
+            p.level,
+            p.progress,
+            p.legendary,
+            p.epic,
+            p.rare,
+            p.uncommon,
+            p.common,
+            p.rarity_points,
+            p.rarity_rank_last_week,
+            p.rarity_rank_country_last_week,
+            p.trophy_count_npwr,
+            p.trophy_count_sony
+            SQL;
+    }
 }

--- a/wwwroot/classes/TrophyService.php
+++ b/wwwroot/classes/TrophyService.php
@@ -130,6 +130,8 @@ class TrophyService
             ? 'ORDER BY te.earned_date DESC'
             : 'ORDER BY te.earned_date IS NULL, te.earned_date';
 
+        // Drive from player_ranking so trophy_earned is probed by account_id
+        // (HASH partition key) instead of scanning all partitions by title.
         $sql = <<<SQL
             SELECT
                 p.avatar_url,
@@ -138,14 +140,15 @@ class TrophyService
                 p.trophy_count_sony,
                 IFNULL(te.earned_date, 'No Timestamp') AS earned_date
             FROM
-                trophy_earned te
-                JOIN player_ranking r ON te.account_id = r.account_id
+                player_ranking r
+                JOIN trophy_earned te
+                    ON te.account_id = r.account_id
+                    AND te.np_communication_id = :np_communication_id
+                    AND te.order_id = :order_id
+                    AND te.earned = 1
                 JOIN player p ON r.account_id = p.account_id
             WHERE
-                te.np_communication_id = :np_communication_id
-                AND te.order_id = :order_id
-                AND te.earned = 1
-                AND r.ranking <= 10000
+                r.ranking <= 10000
             %s
             LIMIT 50
         SQL;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rewrite DailyCronJob rarity updates and TrophyService achiever queries to drive `trophy_earned` from `player_ranking` via `account_id`, enabling HASH partition pruning instead of cross-partition title scans.
- Split `PlayerScanQueueSelector` ranking `OR` predicates into per-index `UNION ALL` range seeks so MySQL can use the composite ranking indexes.
- Narrow leaderboard `SELECT`s to the columns each board needs, drop unused `player_ranking` country indexes and `idx_trophy_count_npwr` (speeds the 5-minute ranking rebuild), and add `chk_trophy_type`.

## Test plan
- [x] `php tests/run.php` — all 925 tests passed
- [x] Fresh MySQL 8.0 datadir: `database/psn100.sql` imports; `mysql84_drop_redundant_indexes.sql` drops the unused indexes and re-adds `chk_trophy_type`
- [x] Behavioral smoke of the new DailyCronJob rarity SQL: unranked earners excluded; owner/rarity math matches expected values
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a44dddb-d68a-4be2-9975-b18b83da7c57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a44dddb-d68a-4be2-9975-b18b83da7c57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

