### PR TITLE
Extract TrophyMergePlayerProgressRecalculator from TrophyMergePlayerProgressUpdater

### DIFF
--- a/tests/TrophyMergePlayerProgressRecalculatorTest.php
+++ b/tests/TrophyMergePlayerProgressRecalculatorTest.php
@@ -1,0 +1,409 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMergePlayerProgressRecalculator.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMergePlayerProgressUpdater.php';
+
+final class TrophyMergePlayerProgressRecalculatorTest extends TestCase
+{
+    public function testRecalculateGroupPlayerRejectsEmptyChildren(): void
+    {
+        $recalculator = new TrophyMergePlayerProgressRecalculator(new RecordingMergeProgressPDO());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to locate child trophy titles.');
+
+        $recalculator->recalculateGroupPlayer('MERGE_000010', []);
+    }
+
+    public function testRecalculateTitlePlayerRejectsEmptyChildren(): void
+    {
+        $recalculator = new TrophyMergePlayerProgressRecalculator(new RecordingMergeProgressPDO());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to locate child trophy titles.');
+
+        $recalculator->recalculateTitlePlayer('MERGE_000010', []);
+    }
+
+    public function testRecalculateGroupPlayerBuildsProgressAndZeroInsertSql(): void
+    {
+        $database = new RecordingMergeProgressPDO(
+            groupRows: [['parent_group_id' => 'default']],
+        );
+        $recalculator = new TrophyMergePlayerProgressRecalculator($database);
+
+        $recalculator->recalculateGroupPlayer('MERGE_000010', ['NP_CHILD_1', 'NP_CHILD_2']);
+
+        $this->assertSame('MERGE_000010', $database->groupQueryParameters[':parent_np_communication_id'] ?? null);
+        $this->assertTrue(
+            str_contains($database->groupPlayerMergeSql ?? '', 'tg.max_score = 0'),
+            'Expected group progress SQL to branch when a group has no obtainable points.'
+        );
+        $this->assertTrue(
+            str_contains($database->groupPlayerMergeSql ?? '', '100,'),
+            'Expected group progress SQL to set 100% when a group has no obtainable points.'
+        );
+        $this->assertTrue(
+            str_contains($database->zeroProgressSql ?? '', 'IN (:child_np_0, :child_np_1)'),
+            'Expected zero-progress insert to use all child placeholders.'
+        );
+        $this->assertSame(
+            ['NP_CHILD_1', 'NP_CHILD_2'],
+            $database->zeroProgressChildIds,
+            'Expected zero-progress insert to bind all child np communication ids.'
+        );
+        $this->assertSame('MERGE_000010', $database->zeroProgressParameters[':np_communication_id'] ?? null);
+    }
+
+    public function testRecalculateTitlePlayerSetsFullProgressWhenMaxScoreIsZero(): void
+    {
+        $database = new RecordingMergeProgressPDO(
+            trophyTitle: ['platinum' => 0, 'max_score' => 0],
+        );
+        $recalculator = new TrophyMergePlayerProgressRecalculator($database);
+
+        $recalculator->recalculateTitlePlayer('MERGE_000010', ['NP_CHILD_1', 'NP_CHILD_2']);
+
+        $this->assertTrue(
+            str_contains($database->titlePlayerMergeSql ?? '', 'WHEN :max_score = 0 THEN 100'),
+            'Expected title progress SQL to set 100% when a title has no obtainable points.'
+        );
+        $this->assertTrue(
+            str_contains($database->titlePlayerMergeSql ?? '', 'IN (:child_np_0, :child_np_1)'),
+            'Expected title progress SQL to use all child placeholders.'
+        );
+        $this->assertTrue(
+            str_contains($database->titleZeroProgressSql ?? '', 'IN (:child_np_0, :child_np_1)'),
+            'Expected title zero-progress insert to use all child placeholders.'
+        );
+    }
+
+    public function testUpdaterDelegatesGroupRecalculation(): void
+    {
+        $recalculator = new RecordingTrophyMergePlayerProgressRecalculator();
+        $updater = new TrophyMergePlayerProgressUpdater(
+            new GameIdLookupPDO('NP_CHILD_2'),
+            new StubTrophyMergeRelationshipResolver('MERGE_000010', ['NP_CHILD_1', 'NP_CHILD_2']),
+            $recalculator,
+        );
+
+        $updater->updateTrophyGroupPlayer(42);
+
+        $this->assertSame(
+            [['MERGE_000010', ['NP_CHILD_1', 'NP_CHILD_2']]],
+            $recalculator->groupCalls,
+        );
+        $this->assertSame([], $recalculator->titleCalls);
+    }
+
+    public function testUpdaterDelegatesTitleRecalculation(): void
+    {
+        $recalculator = new RecordingTrophyMergePlayerProgressRecalculator();
+        $updater = new TrophyMergePlayerProgressUpdater(
+            new GameIdLookupPDO('NP_CHILD_2'),
+            new StubTrophyMergeRelationshipResolver('MERGE_000010', ['NP_CHILD_1', 'NP_CHILD_2']),
+            $recalculator,
+        );
+
+        $updater->updateTrophyTitlePlayer(42);
+
+        $this->assertSame([], $recalculator->groupCalls);
+        $this->assertSame(
+            [['MERGE_000010', ['NP_CHILD_1', 'NP_CHILD_2']]],
+            $recalculator->titleCalls,
+        );
+    }
+
+    public function testRecomputeByParentDelegatesBothRecalculations(): void
+    {
+        $recalculator = new RecordingTrophyMergePlayerProgressRecalculator();
+        $updater = new TrophyMergePlayerProgressUpdater(
+            new GameIdLookupPDO('NP_CHILD_2'),
+            new StubTrophyMergeRelationshipResolver('MERGE_000010', ['NP_CHILD_1', 'NP_CHILD_2']),
+            $recalculator,
+        );
+
+        $updater->recomputeByParent('MERGE_000010');
+
+        $this->assertSame(
+            [['MERGE_000010', ['NP_CHILD_1', 'NP_CHILD_2']]],
+            $recalculator->groupCalls,
+        );
+        $this->assertSame(
+            [['MERGE_000010', ['NP_CHILD_1', 'NP_CHILD_2']]],
+            $recalculator->titleCalls,
+        );
+    }
+}
+
+final class RecordingTrophyMergePlayerProgressRecalculator extends TrophyMergePlayerProgressRecalculator
+{
+    /** @var list<array{0:string,1:list<string>}> */
+    public array $groupCalls = [];
+
+    /** @var list<array{0:string,1:list<string>}> */
+    public array $titleCalls = [];
+
+    public function __construct()
+    {
+        // Parent requires a PDO, but this stub never uses it.
+        parent::__construct(new GameIdLookupPDO('unused'));
+    }
+
+    public function recalculateGroupPlayer(string $parentNpCommunicationId, array $childNpCommunicationIds): void
+    {
+        $this->groupCalls[] = [$parentNpCommunicationId, $childNpCommunicationIds];
+    }
+
+    public function recalculateTitlePlayer(string $parentNpCommunicationId, array $childNpCommunicationIds): void
+    {
+        $this->titleCalls[] = [$parentNpCommunicationId, $childNpCommunicationIds];
+    }
+}
+
+final class StubTrophyMergeRelationshipResolver extends TrophyMergeRelationshipResolver
+{
+    /**
+     * @param list<string> $childNpCommunicationIds
+     */
+    public function __construct(
+        private string $parentNpCommunicationId,
+        private array $childNpCommunicationIds,
+    ) {
+        // Parent requires a PDO, but this stub never uses it.
+        parent::__construct(new GameIdLookupPDO('unused'));
+    }
+
+    public function getMergeParentAndChildren(string $childNpCommunicationId): array
+    {
+        return [
+            'parent_np_communication_id' => $this->parentNpCommunicationId,
+            'child_np_communication_ids' => $this->childNpCommunicationIds,
+        ];
+    }
+
+    public function getMergeChildrenByParent(string $parentNpCommunicationId): array
+    {
+        return $this->childNpCommunicationIds;
+    }
+}
+
+final class GameIdLookupPDO extends PDO
+{
+    public function __construct(private string $npCommunicationId)
+    {
+    }
+
+    public function prepare(string $statement, array $options = []): PDOStatement
+    {
+        return new GameIdLookupStatement($this->npCommunicationId);
+    }
+}
+
+final class GameIdLookupStatement extends PDOStatement
+{
+    public function __construct(private string $npCommunicationId)
+    {
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchColumn(int $column = 0): string
+    {
+        return $this->npCommunicationId;
+    }
+}
+
+final class RecordingMergeProgressPDO extends PDO
+{
+    /** @var list<string> */
+    public array $zeroProgressChildIds = [];
+
+    /** @var array<string, scalar|null> */
+    public array $groupQueryParameters = [];
+
+    /** @var array<string, scalar|null> */
+    public array $zeroProgressParameters = [];
+
+    public ?string $zeroProgressSql = null;
+
+    public ?string $groupPlayerMergeSql = null;
+
+    public ?string $titlePlayerMergeSql = null;
+
+    public ?string $titleZeroProgressSql = null;
+
+    /**
+     * @param list<array{parent_group_id:string}> $groupRows
+     * @param array{platinum:int|string,max_score:int|string}|null $trophyTitle
+     */
+    public function __construct(
+        private array $groupRows = [],
+        private ?array $trophyTitle = null,
+    ) {
+    }
+
+    public function prepare(string $statement, array $options = []): PDOStatement
+    {
+        $trimmed = trim($statement);
+        $normalized = preg_replace('/\s+/', ' ', $trimmed) ?? '';
+
+        if (str_starts_with($normalized, 'SELECT DISTINCT parent_group_id FROM trophy_merge')) {
+            return new RecordingMergeGroupStatement($this, $this->groupRows);
+        }
+
+        if (str_starts_with($normalized, 'INSERT INTO trophy_group_player')) {
+            $this->groupPlayerMergeSql = $trimmed;
+
+            return new RecordingMergeExecuteStatement();
+        }
+
+        if (str_starts_with($normalized, 'INSERT IGNORE INTO trophy_group_player')) {
+            $this->zeroProgressSql = $trimmed;
+
+            return new RecordingMergeZeroProgressStatement($this);
+        }
+
+        if (str_starts_with($normalized, 'SELECT platinum, bronze * 15 + silver * 30 + gold * 90 AS max_score FROM trophy_title')) {
+            return new RecordingMergeTitleStatement($this->trophyTitle ?? ['platinum' => 0, 'max_score' => 0]);
+        }
+
+        if (str_starts_with($normalized, 'INSERT INTO trophy_title_player')) {
+            $this->titlePlayerMergeSql = $trimmed;
+
+            return new RecordingMergeExecuteStatement();
+        }
+
+        if (str_starts_with($normalized, 'INSERT IGNORE INTO trophy_title_player')) {
+            $this->titleZeroProgressSql = $trimmed;
+
+            return new RecordingMergeExecuteStatement();
+        }
+
+        throw new RuntimeException('Unexpected SQL statement: ' . $trimmed);
+    }
+
+    public function recordZeroProgress(array $parameters): void
+    {
+        $this->zeroProgressParameters = $parameters;
+        $this->zeroProgressChildIds = array_values(array_filter(
+            $parameters,
+            static fn ($value, $key): bool => str_starts_with((string) $key, ':child_np_'),
+            ARRAY_FILTER_USE_BOTH
+        ));
+    }
+
+    public function recordGroupQueryParameters(array $parameters): void
+    {
+        $this->groupQueryParameters = $parameters;
+    }
+}
+
+final class RecordingMergeGroupStatement extends PDOStatement
+{
+    /** @var list<array{parent_group_id:string}> */
+    private array $rows;
+
+    /** @var array<string, scalar|null> */
+    private array $parameters = [];
+
+    /** @param list<array{parent_group_id:string}> $rows */
+    public function __construct(private RecordingMergeProgressPDO $pdo, array $rows)
+    {
+        $this->rows = $rows;
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        $this->parameters[(string) $param] = $value;
+
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        $this->pdo->recordGroupQueryParameters($this->parameters);
+
+        return true;
+    }
+
+    public function fetch(int $mode = PDO::FETCH_DEFAULT, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0): array|false
+    {
+        if ($this->rows === []) {
+            return false;
+        }
+
+        return array_shift($this->rows);
+    }
+}
+
+final class RecordingMergeTitleStatement extends PDOStatement
+{
+    /** @param array{platinum:int|string,max_score:int|string} $row */
+    public function __construct(private array $row)
+    {
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetch(int $mode = PDO::FETCH_DEFAULT, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0): array|false
+    {
+        return $this->row;
+    }
+}
+
+final class RecordingMergeExecuteStatement extends PDOStatement
+{
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+}
+
+final class RecordingMergeZeroProgressStatement extends PDOStatement
+{
+    /** @var array<string, scalar|null> */
+    private array $parameters = [];
+
+    public function __construct(private RecordingMergeProgressPDO $pdo)
+    {
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        $this->parameters[(string) $param] = $value;
+
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        $this->pdo->recordZeroProgress($this->parameters);
+
+        return true;
+    }
+}

--- a/tests/TrophyMergePlayerProgressRecalculatorTest.php
+++ b/tests/TrophyMergePlayerProgressRecalculatorTest.php
@@ -12,20 +12,24 @@ final class TrophyMergePlayerProgressRecalculatorTest extends TestCase
     {
         $recalculator = new TrophyMergePlayerProgressRecalculator(new RecordingMergeProgressPDO());
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to locate child trophy titles.');
-
-        $recalculator->recalculateGroupPlayer('MERGE_000010', []);
+        try {
+            $recalculator->recalculateGroupPlayer('MERGE_000010', []);
+            $this->fail('Expected RuntimeException when child list is empty.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Unable to locate child trophy titles.', $exception->getMessage());
+        }
     }
 
     public function testRecalculateTitlePlayerRejectsEmptyChildren(): void
     {
         $recalculator = new TrophyMergePlayerProgressRecalculator(new RecordingMergeProgressPDO());
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to locate child trophy titles.');
-
-        $recalculator->recalculateTitlePlayer('MERGE_000010', []);
+        try {
+            $recalculator->recalculateTitlePlayer('MERGE_000010', []);
+            $this->fail('Expected RuntimeException when child list is empty.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Unable to locate child trophy titles.', $exception->getMessage());
+        }
     }
 
     public function testRecalculateGroupPlayerBuildsProgressAndZeroInsertSql(): void
@@ -85,9 +89,12 @@ final class TrophyMergePlayerProgressRecalculatorTest extends TestCase
     {
         $recalculator = new RecordingTrophyMergePlayerProgressRecalculator();
         $updater = new TrophyMergePlayerProgressUpdater(
-            new GameIdLookupPDO('NP_CHILD_2'),
-            new StubTrophyMergeRelationshipResolver('MERGE_000010', ['NP_CHILD_1', 'NP_CHILD_2']),
-            $recalculator,
+            new RelationshipLookupPDO(
+                childNpCommunicationId: 'NP_CHILD_2',
+                parentNpCommunicationId: 'MERGE_000010',
+                childNpCommunicationIds: ['NP_CHILD_1', 'NP_CHILD_2'],
+            ),
+            progressRecalculator: $recalculator,
         );
 
         $updater->updateTrophyGroupPlayer(42);
@@ -103,9 +110,12 @@ final class TrophyMergePlayerProgressRecalculatorTest extends TestCase
     {
         $recalculator = new RecordingTrophyMergePlayerProgressRecalculator();
         $updater = new TrophyMergePlayerProgressUpdater(
-            new GameIdLookupPDO('NP_CHILD_2'),
-            new StubTrophyMergeRelationshipResolver('MERGE_000010', ['NP_CHILD_1', 'NP_CHILD_2']),
-            $recalculator,
+            new RelationshipLookupPDO(
+                childNpCommunicationId: 'NP_CHILD_2',
+                parentNpCommunicationId: 'MERGE_000010',
+                childNpCommunicationIds: ['NP_CHILD_1', 'NP_CHILD_2'],
+            ),
+            progressRecalculator: $recalculator,
         );
 
         $updater->updateTrophyTitlePlayer(42);
@@ -121,9 +131,12 @@ final class TrophyMergePlayerProgressRecalculatorTest extends TestCase
     {
         $recalculator = new RecordingTrophyMergePlayerProgressRecalculator();
         $updater = new TrophyMergePlayerProgressUpdater(
-            new GameIdLookupPDO('NP_CHILD_2'),
-            new StubTrophyMergeRelationshipResolver('MERGE_000010', ['NP_CHILD_1', 'NP_CHILD_2']),
-            $recalculator,
+            new RelationshipLookupPDO(
+                childNpCommunicationId: 'NP_CHILD_2',
+                parentNpCommunicationId: 'MERGE_000010',
+                childNpCommunicationIds: ['NP_CHILD_1', 'NP_CHILD_2'],
+            ),
+            progressRecalculator: $recalculator,
         );
 
         $updater->recomputeByParent('MERGE_000010');
@@ -150,7 +163,7 @@ final class RecordingTrophyMergePlayerProgressRecalculator extends TrophyMergePl
     public function __construct()
     {
         // Parent requires a PDO, but this stub never uses it.
-        parent::__construct(new GameIdLookupPDO('unused'));
+        parent::__construct(new RelationshipLookupPDO('unused', 'unused', []));
     }
 
     public function recalculateGroupPlayer(string $parentNpCommunicationId, array $childNpCommunicationIds): void
@@ -164,48 +177,41 @@ final class RecordingTrophyMergePlayerProgressRecalculator extends TrophyMergePl
     }
 }
 
-final class StubTrophyMergeRelationshipResolver extends TrophyMergeRelationshipResolver
+final class RelationshipLookupPDO extends PDO
 {
     /**
      * @param list<string> $childNpCommunicationIds
      */
     public function __construct(
+        private string $childNpCommunicationId,
         private string $parentNpCommunicationId,
         private array $childNpCommunicationIds,
     ) {
-        // Parent requires a PDO, but this stub never uses it.
-        parent::__construct(new GameIdLookupPDO('unused'));
-    }
-
-    public function getMergeParentAndChildren(string $childNpCommunicationId): array
-    {
-        return [
-            'parent_np_communication_id' => $this->parentNpCommunicationId,
-            'child_np_communication_ids' => $this->childNpCommunicationIds,
-        ];
-    }
-
-    public function getMergeChildrenByParent(string $parentNpCommunicationId): array
-    {
-        return $this->childNpCommunicationIds;
-    }
-}
-
-final class GameIdLookupPDO extends PDO
-{
-    public function __construct(private string $npCommunicationId)
-    {
     }
 
     public function prepare(string $statement, array $options = []): PDOStatement
     {
-        return new GameIdLookupStatement($this->npCommunicationId);
+        $normalized = preg_replace('/\s+/', ' ', trim($statement)) ?? '';
+
+        if (str_starts_with($normalized, 'SELECT np_communication_id FROM trophy_title')) {
+            return new RelationshipLookupScalarStatement($this->childNpCommunicationId);
+        }
+
+        if (str_starts_with($normalized, 'SELECT DISTINCT parent_np_communication_id FROM trophy_merge')) {
+            return new RelationshipLookupColumnStatement([$this->parentNpCommunicationId]);
+        }
+
+        if (str_starts_with($normalized, 'SELECT DISTINCT child_np_communication_id FROM trophy_merge')) {
+            return new RelationshipLookupColumnStatement($this->childNpCommunicationIds);
+        }
+
+        throw new RuntimeException('Unexpected SQL statement: ' . $statement);
     }
 }
 
-final class GameIdLookupStatement extends PDOStatement
+final class RelationshipLookupScalarStatement extends PDOStatement
 {
-    public function __construct(private string $npCommunicationId)
+    public function __construct(private string $value)
     {
     }
 
@@ -221,7 +227,30 @@ final class GameIdLookupStatement extends PDOStatement
 
     public function fetchColumn(int $column = 0): string
     {
-        return $this->npCommunicationId;
+        return $this->value;
+    }
+}
+
+final class RelationshipLookupColumnStatement extends PDOStatement
+{
+    /** @param list<string> $rows */
+    public function __construct(private array $rows)
+    {
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args): array
+    {
+        return $this->rows;
     }
 }
 

--- a/wwwroot/classes/TrophyMergePlayerProgressRecalculator.php
+++ b/wwwroot/classes/TrophyMergePlayerProgressRecalculator.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * TrophyMergePlayerProgressUpdater so that updater can focus on resolving
  * parent/child relationships and orchestrating recalculation.
  */
-final class TrophyMergePlayerProgressRecalculator
+class TrophyMergePlayerProgressRecalculator
 {
     public function __construct(
         private readonly PDO $database,

--- a/wwwroot/classes/TrophyMergePlayerProgressRecalculator.php
+++ b/wwwroot/classes/TrophyMergePlayerProgressRecalculator.php
@@ -1,0 +1,367 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Recalculates trophy group/title player progress aggregates for merged titles.
+ *
+ * Encapsulates the INSERT…SELECT SQL previously embedded in
+ * TrophyMergePlayerProgressUpdater so that updater can focus on resolving
+ * parent/child relationships and orchestrating recalculation.
+ */
+final class TrophyMergePlayerProgressRecalculator
+{
+    public function __construct(
+        private readonly PDO $database,
+    ) {
+    }
+
+    /**
+     * @param list<string> $childNpCommunicationIds
+     */
+    public function recalculateGroupPlayer(string $parentNpCommunicationId, array $childNpCommunicationIds): void
+    {
+        if ($childNpCommunicationIds === []) {
+            throw new RuntimeException('Unable to locate child trophy titles.');
+        }
+
+        $childPlaceholders = [];
+        foreach (array_keys($childNpCommunicationIds) as $index) {
+            $childPlaceholders[] = ':child_np_' . $index;
+        }
+        $childListSql = implode(', ', $childPlaceholders);
+
+        $groups = $this->database->prepare(
+            <<<'SQL'
+            SELECT DISTINCT
+                parent_group_id
+            FROM
+                trophy_merge
+            WHERE
+                parent_np_communication_id = :parent_np_communication_id
+SQL
+        );
+        $groups->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+        $groups->execute();
+
+        while ($group = $groups->fetch(PDO::FETCH_ASSOC)) {
+            $query = $this->database->prepare(
+                <<<'SQL'
+                INSERT INTO trophy_group_player(
+                    np_communication_id,
+                    group_id,
+                    account_id,
+                    bronze,
+                    silver,
+                    gold,
+                    platinum,
+                    progress
+                ) WITH tg AS(
+                    SELECT
+                        platinum,
+                        bronze * 15 + silver * 30 + gold * 90 AS max_score
+                    FROM
+                        trophy_group
+                    WHERE
+                        np_communication_id = :np_communication_id AND group_id = :group_id
+                ),
+                player AS(
+                    SELECT
+                        account_id,
+                        SUM(TYPE = 'bronze') AS bronze,
+                        SUM(TYPE = 'silver') AS silver,
+                        SUM(TYPE = 'gold') AS gold,
+                        SUM(TYPE = 'platinum') AS platinum,
+                        SUM(TYPE = 'bronze') * 15 + SUM(TYPE = 'silver') * 30 + SUM(TYPE = 'gold') * 90 AS score
+                    FROM
+                        trophy_earned te
+                    JOIN trophy t ON
+                        t.np_communication_id = te.np_communication_id AND t.order_id = te.order_id
+                    JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = 0
+                    WHERE
+                        te.np_communication_id = :np_communication_id AND te.group_id = :group_id AND te.earned = 1
+                    GROUP BY
+                        account_id
+                )
+                SELECT
+                    *
+                FROM
+                    (
+                    SELECT
+                        :np_communication_id,
+                        :group_id,
+                        player.account_id,
+                        player.bronze,
+                        player.silver,
+                        player.gold,
+                        player.platinum,
+                        IF(
+                            tg.max_score = 0,
+                            100,
+                            IF(
+                                player.score = 0,
+                                0,
+                                IFNULL(
+                                    GREATEST(
+                                        FLOOR(
+                                            IF(
+                                                (player.score / tg.max_score) * 100 = 100 AND tg.platinum = 1 AND player.platinum = 0,
+                                                99,
+                                                (player.score / tg.max_score) * 100
+                                            )
+                                        ),
+                                        1
+                                    ),
+                                    0
+                                )
+                            )
+                        ) AS progress
+                    FROM
+                        tg,
+                        player
+                ) AS NEW
+                ON DUPLICATE KEY
+                UPDATE
+                    bronze = NEW.bronze,
+                    silver = NEW.silver,
+                    gold = NEW.gold,
+                    platinum = NEW.platinum,
+                    progress = NEW.progress
+SQL
+            );
+            $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+            $query->bindValue(':group_id', $group['parent_group_id'], PDO::PARAM_STR);
+            $query->execute();
+
+            $zeroProgressSql = sprintf(
+                <<<'SQL'
+                INSERT IGNORE
+                INTO trophy_group_player(
+                    np_communication_id,
+                    group_id,
+                    account_id,
+                    bronze,
+                    silver,
+                    gold,
+                    platinum,
+                    progress
+                ) WITH player AS(
+                    SELECT
+                        account_id
+                    FROM
+                        trophy_group_player tgp
+                    WHERE
+                        tgp.bronze = 0
+                        AND tgp.silver = 0
+                        AND tgp.gold = 0
+                        AND tgp.platinum = 0
+                        AND tgp.progress = 0
+                        AND tgp.np_communication_id IN (%s)
+                        AND tgp.group_id = :group_id
+                )
+                SELECT
+                    :np_communication_id,
+                    :group_id,
+                    player.account_id,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                FROM
+                    player
+SQL
+            ,
+                $childListSql
+            );
+            $query = $this->database->prepare($zeroProgressSql);
+            $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+            $query->bindValue(':group_id', $group['parent_group_id'], PDO::PARAM_STR);
+            foreach ($childNpCommunicationIds as $index => $childNpCommunicationId) {
+                $query->bindValue(':child_np_' . $index, $childNpCommunicationId, PDO::PARAM_STR);
+            }
+            $query->execute();
+        }
+    }
+
+    /**
+     * @param list<string> $childNpCommunicationIds
+     */
+    public function recalculateTitlePlayer(string $parentNpCommunicationId, array $childNpCommunicationIds): void
+    {
+        if ($childNpCommunicationIds === []) {
+            throw new RuntimeException('Unable to locate child trophy titles.');
+        }
+
+        $childPlaceholders = [];
+        foreach (array_keys($childNpCommunicationIds) as $index) {
+            $childPlaceholders[] = ':child_np_' . $index;
+        }
+        $childListSql = implode(', ', $childPlaceholders);
+
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT
+                platinum,
+                bronze * 15 + silver * 30 + gold * 90 AS max_score
+            FROM
+                trophy_title
+            WHERE
+                np_communication_id = :np_communication_id
+SQL
+        );
+        $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        $trophyTitle = $query->fetch(PDO::FETCH_ASSOC);
+
+        if ($trophyTitle === false) {
+            throw new RuntimeException('Unable to load trophy title data.');
+        }
+
+        $playerInsertSql = sprintf(
+            <<<'SQL'
+            INSERT INTO trophy_title_player(
+                np_communication_id,
+                account_id,
+                bronze,
+                silver,
+                gold,
+                platinum,
+                progress,
+                last_updated_date
+            ) WITH child_players AS(
+                SELECT
+                    ttp.account_id,
+                    MAX(ttp.last_updated_date) AS last_updated_date
+                FROM
+                    trophy_title_player ttp
+                WHERE
+                    ttp.np_communication_id IN (%s)
+                GROUP BY
+                    ttp.account_id
+            ),
+            player AS(
+                SELECT
+                    tgp.account_id,
+                    SUM(tgp.bronze) AS bronze,
+                    SUM(tgp.silver) AS silver,
+                    SUM(tgp.gold) AS gold,
+                    SUM(tgp.platinum) AS platinum,
+                    SUM(tgp.bronze) * 15 + SUM(tgp.silver) * 30 + SUM(tgp.gold) * 90 AS score,
+                    child_players.last_updated_date
+                FROM
+                    trophy_group_player tgp
+                JOIN child_players ON child_players.account_id = tgp.account_id
+                WHERE
+                    tgp.np_communication_id = :np_communication_id
+                GROUP BY
+                    tgp.account_id,
+                    child_players.last_updated_date
+            )
+            SELECT
+                *
+            FROM
+                (
+                SELECT
+                    :np_communication_id,
+                    player.account_id,
+                    player.bronze,
+                    player.silver,
+                    player.gold,
+                    player.platinum,
+                    CASE
+                        WHEN :max_score = 0 THEN 100
+                        WHEN player.score = 0 THEN 0
+                        ELSE IFNULL(
+                            GREATEST(
+                                FLOOR(
+                                    IF(
+                                        (player.score / :max_score) * 100 = 100 AND :platinum = 1 AND player.platinum = 0,
+                                        99,
+                                        (player.score / :max_score) * 100
+                                    )
+                                ),
+                                1
+                            ),
+                            0
+                        )
+                    END AS progress,
+                    player.last_updated_date
+                FROM
+                    player
+            ) AS NEW
+            ON DUPLICATE KEY
+            UPDATE
+                bronze = NEW.bronze,
+                silver = NEW.silver,
+                gold = NEW.gold,
+                platinum = NEW.platinum,
+                progress = NEW.progress,
+                last_updated_date = IF(
+                    NEW.last_updated_date > trophy_title_player.last_updated_date,
+                    NEW.last_updated_date,
+                    trophy_title_player.last_updated_date
+                )
+SQL
+        ,
+            $childListSql
+        );
+        $query = $this->database->prepare($playerInsertSql);
+        $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':max_score', $trophyTitle['max_score'], PDO::PARAM_INT);
+        $query->bindValue(':platinum', $trophyTitle['platinum'], PDO::PARAM_INT);
+        foreach ($childNpCommunicationIds as $index => $childNpCommunicationId) {
+            $query->bindValue(':child_np_' . $index, $childNpCommunicationId, PDO::PARAM_STR);
+        }
+        $query->execute();
+
+        $playerZeroSql = sprintf(
+            <<<'SQL'
+            INSERT IGNORE
+            INTO trophy_title_player(
+                np_communication_id,
+                account_id,
+                bronze,
+                silver,
+                gold,
+                platinum,
+                progress,
+                last_updated_date
+            ) WITH player AS(
+                SELECT
+                    ttp.account_id,
+                    MAX(ttp.last_updated_date) AS last_updated_date,
+                    SUM(ttp.bronze + ttp.silver + ttp.gold + ttp.platinum) AS trophy_total
+                FROM
+                    trophy_title_player ttp
+                WHERE
+                    ttp.np_communication_id IN (%s)
+                GROUP BY
+                    ttp.account_id
+                HAVING
+                    trophy_total = 0
+            )
+            SELECT
+                :np_communication_id,
+                player.account_id,
+                0,
+                0,
+                0,
+                0,
+                0,
+                player.last_updated_date
+            FROM
+                player
+SQL
+        ,
+            $childListSql
+        );
+        $query = $this->database->prepare($playerZeroSql);
+        $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+        foreach ($childNpCommunicationIds as $index => $childNpCommunicationId) {
+            $query->bindValue(':child_np_' . $index, $childNpCommunicationId, PDO::PARAM_STR);
+        }
+        $query->execute();
+    }
+}

--- a/wwwroot/classes/TrophyMergePlayerProgressUpdater.php
+++ b/wwwroot/classes/TrophyMergePlayerProgressUpdater.php
@@ -3,16 +3,26 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/TrophyMergeRelationshipResolver.php';
+require_once __DIR__ . '/TrophyMergePlayerProgressRecalculator.php';
 
+/**
+ * Orchestrates player progress updates for merged trophy titles.
+ *
+ * Resolves parent/child relationships, then delegates aggregate recalculation
+ * to TrophyMergePlayerProgressRecalculator.
+ */
 class TrophyMergePlayerProgressUpdater
 {
     private readonly TrophyMergeRelationshipResolver $relationshipResolver;
+    private readonly TrophyMergePlayerProgressRecalculator $progressRecalculator;
 
     public function __construct(
         private readonly PDO $database,
         ?TrophyMergeRelationshipResolver $relationshipResolver = null,
+        ?TrophyMergePlayerProgressRecalculator $progressRecalculator = null,
     ) {
         $this->relationshipResolver = $relationshipResolver ?? new TrophyMergeRelationshipResolver($database);
+        $this->progressRecalculator = $progressRecalculator ?? new TrophyMergePlayerProgressRecalculator($database);
     }
 
     public function updateTrophyGroupPlayer(int $childGameId): void
@@ -23,7 +33,7 @@ class TrophyMergePlayerProgressUpdater
         $parentNpCommunicationId = $mergeData['parent_np_communication_id'];
         $childNpCommunicationIds = array_values($mergeData['child_np_communication_ids']);
 
-        $this->updateTrophyGroupPlayerForMerge($parentNpCommunicationId, $childNpCommunicationIds);
+        $this->progressRecalculator->recalculateGroupPlayer($parentNpCommunicationId, $childNpCommunicationIds);
     }
 
     public function updateTrophyTitlePlayer(int $childGameId): void
@@ -34,7 +44,7 @@ class TrophyMergePlayerProgressUpdater
         $parentNpCommunicationId = $mergeData['parent_np_communication_id'];
         $childNpCommunicationIds = array_values($mergeData['child_np_communication_ids']);
 
-        $this->updateTrophyTitlePlayerForMerge($parentNpCommunicationId, $childNpCommunicationIds);
+        $this->progressRecalculator->recalculateTitlePlayer($parentNpCommunicationId, $childNpCommunicationIds);
     }
 
     public function recomputeByParent(string $parentNpCommunicationId): void
@@ -49,8 +59,8 @@ class TrophyMergePlayerProgressUpdater
             throw new RuntimeException('Unable to locate child trophy titles.');
         }
 
-        $this->updateTrophyGroupPlayerForMerge($parentNpCommunicationId, $childNpCommunicationIds);
-        $this->updateTrophyTitlePlayerForMerge($parentNpCommunicationId, $childNpCommunicationIds);
+        $this->progressRecalculator->recalculateGroupPlayer($parentNpCommunicationId, $childNpCommunicationIds);
+        $this->progressRecalculator->recalculateTitlePlayer($parentNpCommunicationId, $childNpCommunicationIds);
     }
 
     /**
@@ -59,355 +69,6 @@ class TrophyMergePlayerProgressUpdater
     public function getMergeParentAndChildren(string $childNpCommunicationId): array
     {
         return $this->relationshipResolver->getMergeParentAndChildren($childNpCommunicationId);
-    }
-
-    /**
-     * @param list<string> $childNpCommunicationIds
-     */
-    private function updateTrophyGroupPlayerForMerge(string $parentNpCommunicationId, array $childNpCommunicationIds): void
-    {
-        if ($childNpCommunicationIds === []) {
-            throw new RuntimeException('Unable to locate child trophy titles.');
-        }
-
-        $childPlaceholders = [];
-        foreach (array_keys($childNpCommunicationIds) as $index) {
-            $childPlaceholders[] = ':child_np_' . $index;
-        }
-        $childListSql = implode(', ', $childPlaceholders);
-
-        $groups = $this->database->prepare(
-            <<<'SQL'
-            SELECT DISTINCT
-                parent_group_id
-            FROM
-                trophy_merge
-            WHERE
-                parent_np_communication_id = :parent_np_communication_id
-SQL
-        );
-        $groups->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
-        $groups->execute();
-
-        while ($group = $groups->fetch(PDO::FETCH_ASSOC)) {
-            $query = $this->database->prepare(
-                <<<'SQL'
-                INSERT INTO trophy_group_player(
-                    np_communication_id,
-                    group_id,
-                    account_id,
-                    bronze,
-                    silver,
-                    gold,
-                    platinum,
-                    progress
-                ) WITH tg AS(
-                    SELECT
-                        platinum,
-                        bronze * 15 + silver * 30 + gold * 90 AS max_score
-                    FROM
-                        trophy_group
-                    WHERE
-                        np_communication_id = :np_communication_id AND group_id = :group_id
-                ),
-                player AS(
-                    SELECT
-                        account_id,
-                        SUM(TYPE = 'bronze') AS bronze,
-                        SUM(TYPE = 'silver') AS silver,
-                        SUM(TYPE = 'gold') AS gold,
-                        SUM(TYPE = 'platinum') AS platinum,
-                        SUM(TYPE = 'bronze') * 15 + SUM(TYPE = 'silver') * 30 + SUM(TYPE = 'gold') * 90 AS score
-                    FROM
-                        trophy_earned te
-                    JOIN trophy t ON
-                        t.np_communication_id = te.np_communication_id AND t.order_id = te.order_id
-                    JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = 0
-                    WHERE
-                        te.np_communication_id = :np_communication_id AND te.group_id = :group_id AND te.earned = 1
-                    GROUP BY
-                        account_id
-                )
-                SELECT
-                    *
-                FROM
-                    (
-                    SELECT
-                        :np_communication_id,
-                        :group_id,
-                        player.account_id,
-                        player.bronze,
-                        player.silver,
-                        player.gold,
-                        player.platinum,
-                        IF(
-                            tg.max_score = 0,
-                            100,
-                            IF(
-                                player.score = 0,
-                                0,
-                                IFNULL(
-                                    GREATEST(
-                                        FLOOR(
-                                            IF(
-                                                (player.score / tg.max_score) * 100 = 100 AND tg.platinum = 1 AND player.platinum = 0,
-                                                99,
-                                                (player.score / tg.max_score) * 100
-                                            )
-                                        ),
-                                        1
-                                    ),
-                                    0
-                                )
-                            )
-                        ) AS progress
-                    FROM
-                        tg,
-                        player
-                ) AS NEW
-                ON DUPLICATE KEY
-                UPDATE
-                    bronze = NEW.bronze,
-                    silver = NEW.silver,
-                    gold = NEW.gold,
-                    platinum = NEW.platinum,
-                    progress = NEW.progress
-SQL
-            );
-            $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
-            $query->bindValue(':group_id', $group['parent_group_id'], PDO::PARAM_STR);
-            $query->execute();
-
-            $zeroProgressSql = sprintf(
-                <<<'SQL'
-                INSERT IGNORE
-                INTO trophy_group_player(
-                    np_communication_id,
-                    group_id,
-                    account_id,
-                    bronze,
-                    silver,
-                    gold,
-                    platinum,
-                    progress
-                ) WITH player AS(
-                    SELECT
-                        account_id
-                    FROM
-                        trophy_group_player tgp
-                    WHERE
-                        tgp.bronze = 0
-                        AND tgp.silver = 0
-                        AND tgp.gold = 0
-                        AND tgp.platinum = 0
-                        AND tgp.progress = 0
-                        AND tgp.np_communication_id IN (%s)
-                        AND tgp.group_id = :group_id
-                )
-                SELECT
-                    :np_communication_id,
-                    :group_id,
-                    player.account_id,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
-                FROM
-                    player
-SQL
-            ,
-                $childListSql
-            );
-            $query = $this->database->prepare($zeroProgressSql);
-            $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
-            $query->bindValue(':group_id', $group['parent_group_id'], PDO::PARAM_STR);
-            foreach ($childNpCommunicationIds as $index => $childNpCommunicationId) {
-                $query->bindValue(':child_np_' . $index, $childNpCommunicationId, PDO::PARAM_STR);
-            }
-            $query->execute();
-        }
-    }
-
-    /**
-     * @param list<string> $childNpCommunicationIds
-     */
-    private function updateTrophyTitlePlayerForMerge(string $parentNpCommunicationId, array $childNpCommunicationIds): void
-    {
-        if ($childNpCommunicationIds === []) {
-            throw new RuntimeException('Unable to locate child trophy titles.');
-        }
-
-        $childPlaceholders = [];
-        foreach (array_keys($childNpCommunicationIds) as $index) {
-            $childPlaceholders[] = ':child_np_' . $index;
-        }
-        $childListSql = implode(', ', $childPlaceholders);
-
-        $query = $this->database->prepare(
-            <<<'SQL'
-            SELECT
-                platinum,
-                bronze * 15 + silver * 30 + gold * 90 AS max_score
-            FROM
-                trophy_title
-            WHERE
-                np_communication_id = :np_communication_id
-SQL
-        );
-        $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
-        $query->execute();
-
-        $trophyTitle = $query->fetch(PDO::FETCH_ASSOC);
-
-        if ($trophyTitle === false) {
-            throw new RuntimeException('Unable to load trophy title data.');
-        }
-
-        $playerInsertSql = sprintf(
-            <<<'SQL'
-            INSERT INTO trophy_title_player(
-                np_communication_id,
-                account_id,
-                bronze,
-                silver,
-                gold,
-                platinum,
-                progress,
-                last_updated_date
-            ) WITH child_players AS(
-                SELECT
-                    ttp.account_id,
-                    MAX(ttp.last_updated_date) AS last_updated_date
-                FROM
-                    trophy_title_player ttp
-                WHERE
-                    ttp.np_communication_id IN (%s)
-                GROUP BY
-                    ttp.account_id
-            ),
-            player AS(
-                SELECT
-                    tgp.account_id,
-                    SUM(tgp.bronze) AS bronze,
-                    SUM(tgp.silver) AS silver,
-                    SUM(tgp.gold) AS gold,
-                    SUM(tgp.platinum) AS platinum,
-                    SUM(tgp.bronze) * 15 + SUM(tgp.silver) * 30 + SUM(tgp.gold) * 90 AS score,
-                    child_players.last_updated_date
-                FROM
-                    trophy_group_player tgp
-                JOIN child_players ON child_players.account_id = tgp.account_id
-                WHERE
-                    tgp.np_communication_id = :np_communication_id
-                GROUP BY
-                    tgp.account_id,
-                    child_players.last_updated_date
-            )
-            SELECT
-                *
-            FROM
-                (
-                SELECT
-                    :np_communication_id,
-                    player.account_id,
-                    player.bronze,
-                    player.silver,
-                    player.gold,
-                    player.platinum,
-                    CASE
-                        WHEN :max_score = 0 THEN 100
-                        WHEN player.score = 0 THEN 0
-                        ELSE IFNULL(
-                            GREATEST(
-                                FLOOR(
-                                    IF(
-                                        (player.score / :max_score) * 100 = 100 AND :platinum = 1 AND player.platinum = 0,
-                                        99,
-                                        (player.score / :max_score) * 100
-                                    )
-                                ),
-                                1
-                            ),
-                            0
-                        )
-                    END AS progress,
-                    player.last_updated_date
-                FROM
-                    player
-            ) AS NEW
-            ON DUPLICATE KEY
-            UPDATE
-                bronze = NEW.bronze,
-                silver = NEW.silver,
-                gold = NEW.gold,
-                platinum = NEW.platinum,
-                progress = NEW.progress,
-                last_updated_date = IF(
-                    NEW.last_updated_date > trophy_title_player.last_updated_date,
-                    NEW.last_updated_date,
-                    trophy_title_player.last_updated_date
-                )
-SQL
-        ,
-            $childListSql
-        );
-        $query = $this->database->prepare($playerInsertSql);
-        $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
-        $query->bindValue(':max_score', $trophyTitle['max_score'], PDO::PARAM_INT);
-        $query->bindValue(':platinum', $trophyTitle['platinum'], PDO::PARAM_INT);
-        foreach ($childNpCommunicationIds as $index => $childNpCommunicationId) {
-            $query->bindValue(':child_np_' . $index, $childNpCommunicationId, PDO::PARAM_STR);
-        }
-        $query->execute();
-
-        $playerZeroSql = sprintf(
-            <<<'SQL'
-            INSERT IGNORE
-            INTO trophy_title_player(
-                np_communication_id,
-                account_id,
-                bronze,
-                silver,
-                gold,
-                platinum,
-                progress,
-                last_updated_date
-            ) WITH player AS(
-                SELECT
-                    ttp.account_id,
-                    MAX(ttp.last_updated_date) AS last_updated_date,
-                    SUM(ttp.bronze + ttp.silver + ttp.gold + ttp.platinum) AS trophy_total
-                FROM
-                    trophy_title_player ttp
-                WHERE
-                    ttp.np_communication_id IN (%s)
-                GROUP BY
-                    ttp.account_id
-                HAVING
-                    trophy_total = 0
-            )
-            SELECT
-                :np_communication_id,
-                player.account_id,
-                0,
-                0,
-                0,
-                0,
-                0,
-                player.last_updated_date
-            FROM
-                player
-SQL
-        ,
-            $childListSql
-        );
-        $query = $this->database->prepare($playerZeroSql);
-        $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
-        foreach ($childNpCommunicationIds as $index => $childNpCommunicationId) {
-            $query->bindValue(':child_np_' . $index, $childNpCommunicationId, PDO::PARAM_STR);
-        }
-        $query->execute();
     }
 
     private function getGameNpCommunicationId(int $gameId): string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels one concern out of `TrophyMergePlayerProgressUpdater`: the INSERT…SELECT SQL that recomputes merged title group/title player progress aggregates.

`TrophyMergePlayerProgressUpdater` already delegated relationship lookup to `TrophyMergeRelationshipResolver`. This change mirrors the recent `TrophyStatusProgressRecalculator` extraction so the updater stays as an orchestrator:

1. Resolve parent/child merge relationships
2. Delegate aggregate recalculation to `TrophyMergePlayerProgressRecalculator`

**Size:** updater `433 → 94` lines; SQL lives in the new recalculator collaborator.

## Changes

- **New** `TrophyMergePlayerProgressRecalculator` with `recalculateGroupPlayer()` / `recalculateTitlePlayer()`
- **Slimmed** `TrophyMergePlayerProgressUpdater` to inject the recalculator (optional, defaults to `new …`)
- **Tests** covering empty-child rejection, SQL shape for group/title recalculation, and updater delegation

No behavior change intended — SQL moved as-is.

## Testing

- `php tests/run.php` — all 938 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a46d408-312e-4d63-b880-f80c17b807b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a46d408-312e-4d63-b880-f80c17b807b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

