### PR TITLE
Further MySQL 8.4 SQL improvements

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -186,21 +186,27 @@ Upgrades from older deployments may need these tables for abuse controls:
 
 See [README.md](README.md#schema-updates) for limits and behavior.
 
-### MySQL 8.4 optimizer statistics
+### MySQL 8.4 optimizer statistics and covering indexes
 
 After schema import or large data changes on MySQL 8.4+, run:
 
 ```bash
 mysql "$DB_NAME" < database/mysql84_histograms.sql
+mysql "$DB_NAME" < database/mysql84_covering_indexes.sql
 ```
 
-This creates histograms with `AUTO UPDATE` on heavily filtered columns (`player.status`,
-`trophy_title_player.progress`, `trophy_title_meta.status` and `difficulty`, and others). Histograms help the
-8.4 optimizer choose better plans for leaderboard, queue, and cron queries. Re-run after
-bulk imports; a weekly `ANALYZE TABLE` cron is optional but reasonable on busy sites.
+Histograms use `AUTO UPDATE` on heavily filtered columns (`player.status`,
+`trophy_title_player.progress`, `trophy_title_meta.status`/`difficulty`/`rarity_points`,
+and others). Histograms help the 8.4 optimizer choose better plans for leaderboard, queue,
+and cron queries. Re-run after bulk imports; a weekly `ANALYZE TABLE` cron is optional but
+reasonable on busy sites.
 
-`player_ranking` is excluded because `PlayerRankingUpdater` rebuilds and swaps that table
-every five minutes, which would invalidate histograms immediately.
+`mysql84_covering_indexes.sql` adds descending covering indexes for game leaderboard sorts
+and popular/game-list ordering, status CHECK constraints, and migrates
+`setting.scan_progress` to JSON. Safe to re-run on upgraded databases.
+
+`player_ranking` is excluded from histograms because `PlayerRankingUpdater` rebuilds and
+swaps that table every five minutes, which would invalidate histograms immediately.
 
 `trophy_earned` is excluded: at production scale (billions of rows, hundreds of GiB) an
 `ANALYZE TABLE` would run for hours and `AUTO UPDATE` would rebuild histograms on every

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ scripts:
 
 ```bash
 mysql psn100 < database/mysql84_histograms.sql
+mysql psn100 < database/mysql84_covering_indexes.sql
 ```
 
 Histograms use MySQL 8.4 `AUTO UPDATE` so they stay current when `ANALYZE TABLE` runs or
@@ -82,6 +83,10 @@ swapped every five minutes.
 hundreds of GiB): `ANALYZE TABLE` would be extremely slow and `AUTO UPDATE` would add
 ongoing overhead with negligible benefit for partition- and PK-scoped lookups.
 
+`mysql84_covering_indexes.sql` adds descending covering indexes for game leaderboard and
+game-list/popular sorts, status CHECK constraints, and migrates `setting.scan_progress` to
+JSON. Safe to re-run.
+
 Existing databases that still have legacy or unused indexes can apply (safe to re-run; skips
 indexes that are already absent):
 
@@ -89,8 +94,9 @@ indexes that are already absent):
 mysql psn100 < database/mysql84_drop_redundant_indexes.sql
 ```
 
-Fresh installs from the current `psn100.sql` already omit those indexes and include the
-`chk_trophy_type` CHECK constraint. The drop script also adds that constraint when missing.
+Fresh installs from the current `psn100.sql` already include the covering indexes and status
+CHECK constraints (`chk_trophy_type`, `chk_player_status`, `chk_ttm_status`, `chk_tm_status`).
+The drop script also adds `chk_trophy_type` when missing.
 
 Queue polling (`check_queue_position.php`) requires a `poll_token` from the CSRF-protected
 `add_to_queue.php` response (60 requests per IP per minute). `scan_log_poll.php` allows 30

--- a/database/mysql84_covering_indexes.sql
+++ b/database/mysql84_covering_indexes.sql
@@ -1,0 +1,171 @@
+-- Covering/sort indexes and status CHECK constraints for MySQL 8.4 deployments.
+-- Safe to re-run: adds missing indexes/constraints and drops superseded ones.
+--
+-- Hot paths covered:
+--   * Game leaderboard ORDER BY progress/platinum/gold/silver/bronze/date
+--   * Homepage popular games ORDER BY recent_players
+--   * Game list ORDER BY difficulty/owners/rarity/in-game rarity
+--
+-- idx_npcid_progress is replaced by the wider leaderboard index (same leading
+-- columns). idx_ttm_status is replaced by composites that keep status as the
+-- leftmost prefix.
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS psn100_add_index_if_not_exists$$
+CREATE PROCEDURE psn100_add_index_if_not_exists(
+    IN p_table_name VARCHAR(64),
+    IN p_index_name VARCHAR(64),
+    IN p_index_columns VARCHAR(512)
+)
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = p_table_name
+          AND index_name = p_index_name
+    ) THEN
+        SET @add_sql = CONCAT(
+            'ALTER TABLE `',
+            REPLACE(p_table_name, '`', '``'),
+            '` ADD INDEX `',
+            REPLACE(p_index_name, '`', '``'),
+            '` (',
+            p_index_columns,
+            ')'
+        );
+        PREPARE stmt FROM @add_sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END IF;
+END$$
+
+DROP PROCEDURE IF EXISTS psn100_drop_index_if_exists$$
+CREATE PROCEDURE psn100_drop_index_if_exists(
+    IN p_table_name VARCHAR(64),
+    IN p_index_name VARCHAR(64)
+)
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = p_table_name
+          AND index_name = p_index_name
+    ) THEN
+        SET @drop_sql = CONCAT(
+            'ALTER TABLE `',
+            REPLACE(p_table_name, '`', '``'),
+            '` DROP INDEX `',
+            REPLACE(p_index_name, '`', '``'),
+            '`'
+        );
+        PREPARE stmt FROM @drop_sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END IF;
+END$$
+
+DROP PROCEDURE IF EXISTS psn100_add_check_if_not_exists$$
+CREATE PROCEDURE psn100_add_check_if_not_exists(
+    IN p_table_name VARCHAR(64),
+    IN p_constraint_name VARCHAR(64),
+    IN p_check_clause VARCHAR(512)
+)
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE table_schema = DATABASE()
+          AND table_name = p_table_name
+          AND constraint_name = p_constraint_name
+          AND constraint_type = 'CHECK'
+    ) THEN
+        SET @add_sql = CONCAT(
+            'ALTER TABLE `',
+            REPLACE(p_table_name, '`', '``'),
+            '` ADD CONSTRAINT `',
+            REPLACE(p_constraint_name, '`', '``'),
+            '` CHECK (',
+            p_check_clause,
+            ')'
+        );
+        PREPARE stmt FROM @add_sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END IF;
+END$$
+
+CALL psn100_add_index_if_not_exists(
+    'trophy_title_player',
+    'idx_ttp_leaderboard',
+    '`np_communication_id`, `progress` DESC, `platinum` DESC, `gold` DESC, `silver` DESC, `bronze` DESC, `last_updated_date`'
+)$$
+CALL psn100_drop_index_if_exists('trophy_title_player', 'idx_npcid_progress')$$
+
+CALL psn100_add_index_if_not_exists(
+    'trophy_title_meta',
+    'idx_ttm_status_recent_players',
+    '`status`, `recent_players` DESC'
+)$$
+CALL psn100_add_index_if_not_exists(
+    'trophy_title_meta',
+    'idx_ttm_status_difficulty_owners',
+    '`status`, `difficulty` DESC, `owners` DESC'
+)$$
+CALL psn100_add_index_if_not_exists(
+    'trophy_title_meta',
+    'idx_ttm_status_owners',
+    '`status`, `owners` DESC'
+)$$
+CALL psn100_add_index_if_not_exists(
+    'trophy_title_meta',
+    'idx_ttm_status_rarity_owners',
+    '`status`, `rarity_points` DESC, `owners` DESC'
+)$$
+CALL psn100_add_index_if_not_exists(
+    'trophy_title_meta',
+    'idx_ttm_status_igrp_owners',
+    '`status`, `in_game_rarity_points` DESC, `owners` DESC'
+)$$
+CALL psn100_drop_index_if_exists('trophy_title_meta', 'idx_ttm_status')$$
+
+CALL psn100_add_check_if_not_exists(
+    'player',
+    'chk_player_status',
+    '`status` IN (0, 1, 3, 4, 5, 99)'
+)$$
+CALL psn100_add_check_if_not_exists(
+    'trophy_title_meta',
+    'chk_ttm_status',
+    '`status` IN (0, 1, 2)'
+)$$
+CALL psn100_add_check_if_not_exists(
+    'trophy_meta',
+    'chk_tm_status',
+    '`status` IN (0, 1)'
+)$$
+
+DROP PROCEDURE psn100_add_index_if_not_exists$$
+DROP PROCEDURE psn100_drop_index_if_exists$$
+DROP PROCEDURE psn100_add_check_if_not_exists$$
+
+DELIMITER ;
+
+-- Prefer JSON for scan_progress payloads written by WorkerScanCoordinator.
+SET @scan_progress_json := (
+    SELECT IF(
+        DATA_TYPE = 'json',
+        'DO 0',
+        'ALTER TABLE `setting` MODIFY `scan_progress` JSON'
+    )
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'setting'
+      AND column_name = 'scan_progress'
+);
+
+PREPARE scan_progress_stmt FROM @scan_progress_json;
+EXECUTE scan_progress_stmt;
+DEALLOCATE PREPARE scan_progress_stmt;

--- a/database/mysql84_covering_indexes.sql
+++ b/database/mysql84_covering_indexes.sql
@@ -185,6 +185,24 @@ DROP PROCEDURE psn100_drop_check_if_exists$$
 DELIMITER ;
 
 -- Prefer JSON for scan_progress payloads written by WorkerScanCoordinator.
+-- Null non-JSON legacy/corrupt values first: MODIFY ... JSON rejects invalid rows,
+-- and app readers already treat malformed scan_progress as null.
+SET @scan_progress_sanitize := (
+    SELECT IF(
+        DATA_TYPE = 'json',
+        'DO 0',
+        'UPDATE `setting` SET `scan_progress` = NULL WHERE `scan_progress` IS NOT NULL AND JSON_VALID(`scan_progress`) = 0'
+    )
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'setting'
+      AND column_name = 'scan_progress'
+);
+
+PREPARE scan_progress_sanitize_stmt FROM @scan_progress_sanitize;
+EXECUTE scan_progress_sanitize_stmt;
+DEALLOCATE PREPARE scan_progress_sanitize_stmt;
+
 SET @scan_progress_json := (
     SELECT IF(
         DATA_TYPE = 'json',

--- a/database/mysql84_covering_indexes.sql
+++ b/database/mysql84_covering_indexes.sql
@@ -97,6 +97,33 @@ BEGIN
     END IF;
 END$$
 
+DROP PROCEDURE IF EXISTS psn100_drop_check_if_exists$$
+CREATE PROCEDURE psn100_drop_check_if_exists(
+    IN p_table_name VARCHAR(64),
+    IN p_constraint_name VARCHAR(64)
+)
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE table_schema = DATABASE()
+          AND table_name = p_table_name
+          AND constraint_name = p_constraint_name
+          AND constraint_type = 'CHECK'
+    ) THEN
+        SET @drop_sql = CONCAT(
+            'ALTER TABLE `',
+            REPLACE(p_table_name, '`', '``'),
+            '` DROP CHECK `',
+            REPLACE(p_constraint_name, '`', '``'),
+            '`'
+        );
+        PREPARE stmt FROM @drop_sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END IF;
+END$$
+
 CALL psn100_add_index_if_not_exists(
     'trophy_title_player',
     'idx_ttp_leaderboard',
@@ -136,10 +163,13 @@ CALL psn100_add_check_if_not_exists(
     'chk_player_status',
     '`status` IN (0, 1, 3, 4, 5, 99)'
 )$$
+-- Recreate so a previously-narrow chk_ttm_status (0,1,2) is replaced.
+-- GameAvailabilityStatus also uses 3 (OBSOLETE) and 4 (DELISTED_AND_OBSOLETE).
+CALL psn100_drop_check_if_exists('trophy_title_meta', 'chk_ttm_status')$$
 CALL psn100_add_check_if_not_exists(
     'trophy_title_meta',
     'chk_ttm_status',
-    '`status` IN (0, 1, 2)'
+    '`status` IN (0, 1, 2, 3, 4)'
 )$$
 CALL psn100_add_check_if_not_exists(
     'trophy_meta',
@@ -150,6 +180,7 @@ CALL psn100_add_check_if_not_exists(
 DROP PROCEDURE psn100_add_index_if_not_exists$$
 DROP PROCEDURE psn100_drop_index_if_exists$$
 DROP PROCEDURE psn100_add_check_if_not_exists$$
+DROP PROCEDURE psn100_drop_check_if_exists$$
 
 DELIMITER ;
 

--- a/database/mysql84_histograms.sql
+++ b/database/mysql84_histograms.sql
@@ -25,7 +25,7 @@ ANALYZE TABLE trophy_title_player
     WITH 256 BUCKETS AUTO UPDATE;
 
 ANALYZE TABLE trophy_title_meta
-    UPDATE HISTOGRAM ON status, recent_players, owners, difficulty
+    UPDATE HISTOGRAM ON status, recent_players, owners, difficulty, rarity_points, in_game_rarity_points
     WITH 256 BUCKETS AUTO UPDATE;
 
 ANALYZE TABLE trophy_title

--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -417,7 +417,7 @@ CREATE TABLE `trophy_title_meta` (
   `obsolete_ids` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
   `rarity_points` int UNSIGNED NOT NULL DEFAULT '0',
   `in_game_rarity_points` int UNSIGNED NOT NULL DEFAULT '0',
-  CONSTRAINT `chk_ttm_status` CHECK (`status` IN (0, 1, 2))
+  CONSTRAINT `chk_ttm_status` CHECK (`status` IN (0, 1, 2, 3, 4))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------

--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -104,7 +104,8 @@ CREATE TABLE `player` (
   `in_game_uncommon` mediumint UNSIGNED NOT NULL DEFAULT '0',
   `in_game_rare` mediumint UNSIGNED NOT NULL DEFAULT '0',
   `in_game_epic` mediumint UNSIGNED NOT NULL DEFAULT '0',
-  `in_game_legendary` mediumint UNSIGNED NOT NULL DEFAULT '0'
+  `in_game_legendary` mediumint UNSIGNED NOT NULL DEFAULT '0',
+  CONSTRAINT `chk_player_status` CHECK (`status` IN (0, 1, 3, 4, 5, 99))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------
@@ -190,7 +191,7 @@ CREATE TABLE `setting` (
   `npsso` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
   `scanning` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
   `scan_start` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `scan_progress` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci
+  `scan_progress` json DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------
@@ -357,7 +358,8 @@ CREATE TABLE `trophy_meta` (
   `rarity_name` enum('LEGENDARY','EPIC','RARE','UNCOMMON','COMMON','NONE') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
   `in_game_rarity_percent` decimal(5,2) UNSIGNED NOT NULL DEFAULT '0.00',
   `in_game_rarity_point` mediumint UNSIGNED NOT NULL DEFAULT '0',
-  `in_game_rarity_name` enum('LEGENDARY','EPIC','RARE','UNCOMMON','COMMON','NONE') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL DEFAULT 'NONE'
+  `in_game_rarity_name` enum('LEGENDARY','EPIC','RARE','UNCOMMON','COMMON','NONE') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL DEFAULT 'NONE',
+  CONSTRAINT `chk_tm_status` CHECK (`status` IN (0, 1))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------
@@ -414,7 +416,8 @@ CREATE TABLE `trophy_title_meta` (
   `region` varchar(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
   `obsolete_ids` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
   `rarity_points` int UNSIGNED NOT NULL DEFAULT '0',
-  `in_game_rarity_points` int UNSIGNED NOT NULL DEFAULT '0'
+  `in_game_rarity_points` int UNSIGNED NOT NULL DEFAULT '0',
+  CONSTRAINT `chk_ttm_status` CHECK (`status` IN (0, 1, 2))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------
@@ -616,7 +619,11 @@ ALTER TABLE `trophy_title_history`
 --
 ALTER TABLE `trophy_title_meta`
   ADD PRIMARY KEY (`np_communication_id`),
-  ADD KEY `idx_ttm_status` (`status`),
+  ADD KEY `idx_ttm_status_recent_players` (`status`,`recent_players` DESC),
+  ADD KEY `idx_ttm_status_difficulty_owners` (`status`,`difficulty` DESC,`owners` DESC),
+  ADD KEY `idx_ttm_status_owners` (`status`,`owners` DESC),
+  ADD KEY `idx_ttm_status_rarity_owners` (`status`,`rarity_points` DESC,`owners` DESC),
+  ADD KEY `idx_ttm_status_igrp_owners` (`status`,`in_game_rarity_points` DESC,`owners` DESC),
   ADD KEY `idx_ttm_parent_np_communication_id` (`parent_np_communication_id`),
   ADD KEY `idx_ttm_psnprofiles_id` (`psnprofiles_id`);
 
@@ -625,7 +632,7 @@ ALTER TABLE `trophy_title_meta`
 --
 ALTER TABLE `trophy_title_player`
   ADD PRIMARY KEY (`np_communication_id`,`account_id`) USING BTREE,
-  ADD KEY `idx_npcid_progress` (`np_communication_id`,`progress`),
+  ADD KEY `idx_ttp_leaderboard` (`np_communication_id`,`progress` DESC,`platinum` DESC,`gold` DESC,`silver` DESC,`bronze` DESC,`last_updated_date`),
   ADD KEY `idx_npcid_lupdate` (`np_communication_id`,`last_updated_date`),
   ADD KEY `idx_ttp_account_id_progress_updated` (`account_id`,`progress`,`last_updated_date`);
 

--- a/tests/PlatformSqlTest.php
+++ b/tests/PlatformSqlTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/PlatformSql.php';
+
+final class PlatformSqlTest extends TestCase
+{
+    public function testBuildOrExpressionReturnsNullForUnknownPlatforms(): void
+    {
+        $this->assertNull(PlatformSql::buildOrExpression(['unknown']));
+    }
+
+    public function testBuildOrClausePrefixesAndForKnownPlatforms(): void
+    {
+        $clause = PlatformSql::buildOrClause(['ps4', 'psvr']);
+
+        $this->assertStringStartsWith(' AND (', $clause);
+        $this->assertStringContainsString("tt.platform LIKE '%PS4%'", $clause);
+        $this->assertStringContainsString(PlatformSql::PSVR_TOKEN_MATCH, $clause);
+        $this->assertStringNotContainsString('REGEXP_LIKE', $clause);
+    }
+
+    public function testPsvrPredicateDoesNotSubstringMatchPsvr2(): void
+    {
+        $psvr = PlatformSql::conditionFor('psvr');
+        $this->assertNotNull($psvr);
+        $this->assertStringContainsString("LIKE '%,PSVR,%'", $psvr);
+        $this->assertStringNotContainsString('%PSVR%', $psvr);
+    }
+}

--- a/tests/PlatformSqlTest.php
+++ b/tests/PlatformSqlTest.php
@@ -9,24 +9,24 @@ final class PlatformSqlTest extends TestCase
 {
     public function testBuildOrExpressionReturnsNullForUnknownPlatforms(): void
     {
-        $this->assertNull(PlatformSql::buildOrExpression(['unknown']));
+        $this->assertSame(null, PlatformSql::buildOrExpression(['unknown']));
     }
 
     public function testBuildOrClausePrefixesAndForKnownPlatforms(): void
     {
         $clause = PlatformSql::buildOrClause(['ps4', 'psvr']);
 
-        $this->assertStringStartsWith(' AND (', $clause);
+        $this->assertTrue(str_starts_with($clause, ' AND ('));
         $this->assertStringContainsString("tt.platform LIKE '%PS4%'", $clause);
         $this->assertStringContainsString(PlatformSql::PSVR_TOKEN_MATCH, $clause);
-        $this->assertStringNotContainsString('REGEXP_LIKE', $clause);
+        $this->assertFalse(str_contains($clause, 'REGEXP_LIKE'));
     }
 
     public function testPsvrPredicateDoesNotSubstringMatchPsvr2(): void
     {
         $psvr = PlatformSql::conditionFor('psvr');
-        $this->assertNotNull($psvr);
-        $this->assertStringContainsString("LIKE '%,PSVR,%'", $psvr);
-        $this->assertStringNotContainsString('%PSVR%', $psvr);
+        $this->assertTrue($psvr !== null);
+        $this->assertStringContainsString("LIKE '%,PSVR,%'", (string) $psvr);
+        $this->assertFalse(str_contains((string) $psvr, "LIKE '%PSVR%'"));
     }
 }

--- a/tests/PlayerAdvisorServiceTest.php
+++ b/tests/PlayerAdvisorServiceTest.php
@@ -265,10 +265,10 @@ final class PlayerAdvisorServiceTest extends TestCase
 
     public function testAdvisorQueriesUseNotExistsAntiJoinForUnearnedTrophies(): void
     {
-        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/PlayerAdvisorService.php');
+        $source = (string) file_get_contents(__DIR__ . '/../wwwroot/classes/PlayerAdvisorService.php');
 
         $this->assertStringContainsString('AND NOT EXISTS (', $source);
         $this->assertStringContainsString('FROM trophy_title_player ttp', $source);
-        $this->assertStringNotContainsString('LEFT JOIN trophy_earned te_completed', $source);
+        $this->assertFalse(str_contains($source, 'LEFT JOIN trophy_earned te_completed'));
     }
 }

--- a/tests/PlayerAdvisorServiceTest.php
+++ b/tests/PlayerAdvisorServiceTest.php
@@ -262,4 +262,13 @@ final class PlayerAdvisorServiceTest extends TestCase
         );
         $this->assertSame(25.0, $trophies[0]->getInGameRarityPercent());
     }
+
+    public function testAdvisorQueriesUseNotExistsAntiJoinForUnearnedTrophies(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/PlayerAdvisorService.php');
+
+        $this->assertStringContainsString('AND NOT EXISTS (', $source);
+        $this->assertStringContainsString('FROM trophy_title_player ttp', $source);
+        $this->assertStringNotContainsString('LEFT JOIN trophy_earned te_completed', $source);
+    }
 }

--- a/tests/PlayerGamesServiceTest.php
+++ b/tests/PlayerGamesServiceTest.php
@@ -135,6 +135,28 @@ final class PlayerGamesServiceTest extends TestCase
         $this->assertSame(1, $count);
     }
 
+    public function testCountPlayerGamesSkipsBaseGroupJoinWhenBaseFilterIsOff(): void
+    {
+        $this->insertGame(
+            id: 4,
+            npCommunicationId: 'NPWR004',
+            name: 'Orphan Title Progress',
+            platform: 'PS5',
+            status: 0,
+            accountId: 42,
+            progress: 40,
+            baseProgress: 0
+        );
+        $this->pdo->exec("DELETE FROM trophy_group_player WHERE np_communication_id = 'NPWR004'");
+
+        $filter = PlayerGamesFilter::fromArray([]);
+
+        $this->assertSame(1, $this->service->countPlayerGames(42, $filter));
+
+        $baseOnly = PlayerGamesFilter::fromArray(['base' => '1']);
+        $this->assertSame(0, $this->service->countPlayerGames(42, $baseOnly));
+    }
+
     public function testGetPlayerGamesHydratesResultsAndCompletionLabel(): void
     {
         $this->insertGame(

--- a/tests/TrophyMergePlayerProgressRecalculatorTest.php
+++ b/tests/TrophyMergePlayerProgressRecalculatorTest.php
@@ -51,6 +51,16 @@ final class TrophyMergePlayerProgressRecalculatorTest extends TestCase
             'Expected group progress SQL to set 100% when a group has no obtainable points.'
         );
         $this->assertTrue(
+            str_contains($database->groupPlayerMergeSql ?? '', 'accounts AS')
+                && str_contains($database->groupPlayerMergeSql ?? '', 'trophy_title_player')
+                && str_contains($database->groupPlayerMergeSql ?? '', 'te.account_id = a.account_id'),
+            'Expected group progress SQL to drive trophy_earned by account_id for partition pruning.'
+        );
+        $this->assertTrue(
+            str_contains($database->groupPlayerMergeSql ?? '', 'IN (:child_np_0, :child_np_1)'),
+            'Expected group progress SQL to scope accounts to all child titles.'
+        );
+        $this->assertTrue(
             str_contains($database->zeroProgressSql ?? '', 'IN (:child_np_0, :child_np_1)'),
             'Expected zero-progress insert to use all child placeholders.'
         );

--- a/tests/TrophyMergeServiceCopyMergedTrophiesTest.php
+++ b/tests/TrophyMergeServiceCopyMergedTrophiesTest.php
@@ -30,6 +30,11 @@ final class TrophyMergeServiceCopyMergedTrophiesTest extends TestCase
                 && str_contains($insertStatements[0], 'FROM merge_source AS source'),
             'Insert statement should use the merge_source CTE.'
         );
+        $this->assertTrue(
+            str_contains($insertStatements[0], 'JOIN trophy_title_player AS ttp')
+                && str_contains($insertStatements[0], 'child.account_id = ttp.account_id'),
+            'Insert statement should drive trophy_earned by account_id for partition pruning.'
+        );
 
         $updateStatements = array_values(array_filter(
             $pdo->executedSql,
@@ -42,6 +47,11 @@ final class TrophyMergeServiceCopyMergedTrophiesTest extends TestCase
             str_contains($updateStatements[0], 'WITH merge_source AS (')
                 && str_contains($updateStatements[0], 'JOIN merge_source AS source ON'),
             'Update statement should join from the merge_source CTE.'
+        );
+        $this->assertTrue(
+            str_contains($updateStatements[0], 'JOIN trophy_title_player AS ttp')
+                && str_contains($updateStatements[0], 'child.account_id = ttp.account_id'),
+            'Update statement should drive trophy_earned by account_id for partition pruning.'
         );
 
         $expectedParameters = [':child_np_communication_id' => 'NP_CHILD'];

--- a/tests/TrophyMergeServiceGroupPlayerMergeTest.php
+++ b/tests/TrophyMergeServiceGroupPlayerMergeTest.php
@@ -45,6 +45,16 @@ final class TrophyMergeServiceGroupPlayerMergeTest extends TestCase
             str_contains($pdo->groupPlayerMergeSql ?? '', '100,'),
             'Expected merge progress SQL to set 100% when a group has no obtainable points.'
         );
+        $this->assertTrue(
+            str_contains($pdo->groupPlayerMergeSql ?? '', 'accounts AS')
+                && str_contains($pdo->groupPlayerMergeSql ?? '', 'trophy_title_player')
+                && str_contains($pdo->groupPlayerMergeSql ?? '', 'te.account_id = a.account_id'),
+            'Expected merge progress SQL to drive trophy_earned by account_id for partition pruning.'
+        );
+        $this->assertTrue(
+            str_contains($pdo->groupPlayerMergeSql ?? '', 'IN (:child_np_0, :child_np_1)'),
+            'Expected merge progress SQL to scope accounts to all child titles.'
+        );
     }
 }
 

--- a/wwwroot/classes/ChangelogService.php
+++ b/wwwroot/classes/ChangelogService.php
@@ -40,7 +40,11 @@ final class ChangelogService
         $query = $this->database->prepare(
             <<<'SQL'
             SELECT
-                c.*,
+                c.time,
+                c.change_type,
+                c.param_1,
+                c.param_2,
+                c.extra,
                 COUNT(*) OVER() AS total_rows,
                 tt1.name AS param_1_name,
                 tt1.platform AS param_1_platform,

--- a/wwwroot/classes/Cron/PlayerScanCompletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionService.php
@@ -66,7 +66,11 @@ final class PlayerScanCompletionService
         $ourTotalTrophies = $query->fetchColumn();
 
         if ($ourTotalTrophies > $totalTrophiesSony) {
-            $query = $this->database->prepare("UPDATE `player` SET trophy_count_npwr = (SELECT COUNT(*) FROM `trophy_earned` WHERE account_id = :account_id AND earned = 1 AND np_communication_id LIKE 'N%') WHERE account_id = :account_id");
+            // Prefer NPWR% over N%: same rows today (ids are NPWR… or MERGE…), matches
+            // trophy_earned triggers, and documents that MERGE titles are excluded.
+            // On (account_id, np_communication_id, …) both are prefix ranges with no
+            // meaningful speed difference when every N* value is NPWR*.
+            $query = $this->database->prepare("UPDATE `player` SET trophy_count_npwr = (SELECT COUNT(*) FROM `trophy_earned` WHERE account_id = :account_id AND earned = 1 AND np_communication_id LIKE 'NPWR%') WHERE account_id = :account_id");
             $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
             $query->execute();
 
@@ -86,7 +90,7 @@ final class PlayerScanCompletionService
 
         $query = $this->database->prepare("SELECT
                 IF(
-                MAX(last_updated_date) >= DATE(NOW()) - INTERVAL 1 YEAR,
+                MAX(last_updated_date) >= (NOW() - INTERVAL 1 YEAR),
                 TRUE,
                 FALSE
                 ) AS within_a_year

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/GameListItem.php';
 require_once __DIR__ . '/GameListPageResult.php';
+require_once __DIR__ . '/PlatformSql.php';
 require_once __DIR__ . '/SearchQueryHelper.php';
 require_once __DIR__ . '/PsnOnlineIdValidator.php';
 
@@ -257,21 +258,6 @@ class GameListService
             return null;
         }
 
-        $conditions = array_map(
-            static function (string $platform): string {
-                if ($platform === GameListFilter::PLATFORM_PSVR) {
-                    return "REGEXP_LIKE(tt.platform, '(^|,)PSVR(,|$)')";
-                }
-
-                return sprintf("tt.platform LIKE '%%%s%%'", strtoupper($platform));
-            },
-            $filter->getSelectedPlatforms()
-        );
-
-        if ($conditions === []) {
-            return null;
-        }
-
-        return '(' . implode(' OR ', $conditions) . ')';
+        return PlatformSql::buildOrExpression($filter->getSelectedPlatforms());
     }
 }

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -8,22 +8,13 @@ require_once __DIR__ . '/Homepage/HomepageNewGame.php';
 require_once __DIR__ . '/Homepage/HomepageDlc.php';
 require_once __DIR__ . '/Homepage/HomepagePopularGame.php';
 require_once __DIR__ . '/HomepagePopularGamesFilter.php';
+require_once __DIR__ . '/PlatformSql.php';
 
 class HomepageContentService
 {
     private const DEFAULT_NEW_GAME_LIMIT = 8;
     private const DEFAULT_NEW_DLCS_LIMIT = 8;
     private const DEFAULT_POPULAR_GAME_LIMIT = 10;
-
-    private const PLATFORM_CONDITIONS = [
-        HomepagePopularGamesFilter::PLATFORM_PC => "tt.platform LIKE '%PC%'",
-        HomepagePopularGamesFilter::PLATFORM_PS3 => "tt.platform LIKE '%PS3%'",
-        HomepagePopularGamesFilter::PLATFORM_PS4 => "tt.platform LIKE '%PS4%'",
-        HomepagePopularGamesFilter::PLATFORM_PS5 => "tt.platform LIKE '%PS5%'",
-        HomepagePopularGamesFilter::PLATFORM_PSVITA => "tt.platform LIKE '%PSVITA%'",
-        HomepagePopularGamesFilter::PLATFORM_PSVR => "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'",
-        HomepagePopularGamesFilter::PLATFORM_PSVR2 => "tt.platform LIKE '%PSVR2%'",
-    ];
 
     public function __construct(private readonly PDO $database)
     {
@@ -160,7 +151,7 @@ class HomepageContentService
         } elseif ($filter->isExclusiveOnly()) {
             $conditions[] = "tt.platform NOT LIKE '%,%'";
         } elseif ($filter->hasPlatformFilter()) {
-            $platformCondition = self::PLATFORM_CONDITIONS[$filter->getPlatform()] ?? null;
+            $platformCondition = PlatformSql::conditionFor($filter->getPlatform());
             if ($platformCondition !== null) {
                 $conditions[] = $platformCondition;
             }

--- a/wwwroot/classes/PlatformSql.php
+++ b/wwwroot/classes/PlatformSql.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Shared SQL fragments for filtering trophy_title.platform.
+ *
+ * Platform values are comma-separated (often with spaces). PSVR must not match
+ * PSVR2, so its predicate tokenizes after stripping spaces rather than using a
+ * plain LIKE / REGEXP against the raw column.
+ */
+final class PlatformSql
+{
+    public const string PSVR_TOKEN_MATCH =
+        "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'";
+
+    /**
+     * @var array<string, string>
+     */
+    public const array CONDITIONS = [
+        'pc' => "tt.platform LIKE '%PC%'",
+        'ps3' => "tt.platform LIKE '%PS3%'",
+        'ps4' => "tt.platform LIKE '%PS4%'",
+        'ps5' => "tt.platform LIKE '%PS5%'",
+        'psvita' => "tt.platform LIKE '%PSVITA%'",
+        'psvr' => self::PSVR_TOKEN_MATCH,
+        'psvr2' => "tt.platform LIKE '%PSVR2%'",
+    ];
+
+    /**
+     * @param list<string> $platformKeys
+     * @return non-empty-string|null Parenthesized OR expression, or null when empty.
+     */
+    public static function buildOrExpression(array $platformKeys): ?string
+    {
+        $clauses = [];
+
+        foreach ($platformKeys as $platformKey) {
+            $condition = self::CONDITIONS[$platformKey] ?? null;
+            if ($condition !== null) {
+                $clauses[] = $condition;
+            }
+        }
+
+        if ($clauses === []) {
+            return null;
+        }
+
+        return '(' . implode(' OR ', $clauses) . ')';
+    }
+
+    /**
+     * @param list<string> $platformKeys
+     */
+    public static function buildOrClause(array $platformKeys): string
+    {
+        $expression = self::buildOrExpression($platformKeys);
+
+        return $expression === null ? '' : ' AND ' . $expression;
+    }
+
+    public static function conditionFor(string $platformKey): ?string
+    {
+        return self::CONDITIONS[$platformKey] ?? null;
+    }
+}

--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -3,21 +3,12 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerAdvisableTrophy.php';
+require_once __DIR__ . '/PlatformSql.php';
 require_once __DIR__ . '/Utility.php';
 
 class PlayerAdvisorService
 {
     public const PAGE_SIZE = 50;
-
-    private const PLATFORM_FILTERS = [
-        'pc' => "tt.platform LIKE '%PC%'",
-        'ps3' => "tt.platform LIKE '%PS3%'",
-        'ps4' => "tt.platform LIKE '%PS4%'",
-        'ps5' => "tt.platform LIKE '%PS5%'",
-        'psvita' => "tt.platform LIKE '%PSVITA%'",
-        'psvr' => "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'",
-        'psvr2' => "tt.platform LIKE '%PSVR2%'",
-    ];
 
     private PDO $database;
 
@@ -33,21 +24,22 @@ class PlayerAdvisorService
     {
         $sql = <<<'SQL'
             SELECT COUNT(*)
-            FROM trophy t
+            FROM trophy_title_player ttp
+            JOIN trophy t ON t.np_communication_id = ttp.np_communication_id
             JOIN trophy_meta tm ON tm.trophy_id = t.id
-            JOIN trophy_title tt USING (np_communication_id)
-            JOIN trophy_title_meta ttm USING (np_communication_id)
-            JOIN trophy_title_player ttp ON
-                t.np_communication_id = ttp.np_communication_id
-                AND ttp.account_id = :account_id
-            LEFT JOIN trophy_earned te_completed ON
-                te_completed.np_communication_id = t.np_communication_id
-                AND te_completed.order_id = t.order_id
-                AND te_completed.account_id = :account_id
-                AND te_completed.earned = 1
-            WHERE te_completed.account_id IS NULL
+            JOIN trophy_title tt ON tt.np_communication_id = t.np_communication_id
+            JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
+            WHERE ttp.account_id = :account_id
                 AND ttm.status = 0
                 AND tm.status = 0
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM trophy_earned te_completed
+                    WHERE te_completed.account_id = :account_id
+                        AND te_completed.np_communication_id = t.np_communication_id
+                        AND te_completed.order_id = t.order_id
+                        AND te_completed.earned = 1
+                )
         SQL;
 
         $sql .= $this->buildPlatformClause($filter);
@@ -81,26 +73,27 @@ class PlayerAdvisorService
                 tt.icon_url AS game_icon,
                 tt.platform,
                 te_progress.progress
-            FROM trophy t
+            FROM trophy_title_player ttp
+            JOIN trophy t ON t.np_communication_id = ttp.np_communication_id
             JOIN trophy_meta tm ON tm.trophy_id = t.id
-            JOIN trophy_title tt USING (np_communication_id)
-            JOIN trophy_title_meta ttm USING (np_communication_id)
+            JOIN trophy_title tt ON tt.np_communication_id = t.np_communication_id
+            JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
             LEFT JOIN trophy_earned te_progress ON
-                t.np_communication_id = te_progress.np_communication_id
-                AND t.order_id = te_progress.order_id
-                AND te_progress.account_id = :account_id
+                te_progress.account_id = :account_id
+                AND te_progress.np_communication_id = t.np_communication_id
+                AND te_progress.order_id = t.order_id
                 AND te_progress.earned = 0
-            JOIN trophy_title_player ttp ON
-                t.np_communication_id = ttp.np_communication_id
-                AND ttp.account_id = :account_id
-            LEFT JOIN trophy_earned te_completed ON
-                te_completed.np_communication_id = t.np_communication_id
-                AND te_completed.order_id = t.order_id
-                AND te_completed.account_id = :account_id
-                AND te_completed.earned = 1
-            WHERE te_completed.account_id IS NULL
+            WHERE ttp.account_id = :account_id
                 AND ttm.status = 0
                 AND tm.status = 0
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM trophy_earned te_completed
+                    WHERE te_completed.account_id = :account_id
+                        AND te_completed.np_communication_id = t.np_communication_id
+                        AND te_completed.order_id = t.order_id
+                        AND te_completed.earned = 1
+                )
         SQL;
 
         $sql .= $this->buildPlatformClause($filter);
@@ -132,19 +125,7 @@ class PlayerAdvisorService
             return '';
         }
 
-        $clauses = [];
-
-        foreach ($filter->getPlatforms() as $platform) {
-            if (isset(self::PLATFORM_FILTERS[$platform])) {
-                $clauses[] = self::PLATFORM_FILTERS[$platform];
-            }
-        }
-
-        if ($clauses === []) {
-            return '';
-        }
-
-        return ' AND (' . implode(' OR ', $clauses) . ')';
+        return PlatformSql::buildOrClause($filter->getPlatforms());
     }
 
     private function buildOrderByClause(PlayerAdvisorFilter $filter): string

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -4,20 +4,11 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerGame.php';
 require_once __DIR__ . '/PlayerGamesFilter.php';
+require_once __DIR__ . '/PlatformSql.php';
 require_once __DIR__ . '/SearchQueryHelper.php';
 
 final class PlayerGamesService
 {
-    private const array PLATFORM_CONDITIONS = [
-        PlayerGamesFilter::PLATFORM_PC => "tt.platform LIKE '%PC%'",
-        PlayerGamesFilter::PLATFORM_PS3 => "tt.platform LIKE '%PS3%'",
-        PlayerGamesFilter::PLATFORM_PS4 => "tt.platform LIKE '%PS4%'",
-        PlayerGamesFilter::PLATFORM_PS5 => "tt.platform LIKE '%PS5%'",
-        PlayerGamesFilter::PLATFORM_PSVITA => "tt.platform LIKE '%PSVITA%'",
-        PlayerGamesFilter::PLATFORM_PSVR => "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'",
-        PlayerGamesFilter::PLATFORM_PSVR2 => "tt.platform LIKE '%PSVR2%'",
-    ];
-
     public function __construct(
         private readonly PDO $database,
         private readonly SearchQueryHelper $searchQueryHelper
@@ -31,8 +22,9 @@ final class PlayerGamesService
             FROM trophy_title_player ttp
                 JOIN trophy_title tt USING (np_communication_id)
                 JOIN trophy_title_meta ttm USING (np_communication_id)
-                JOIN trophy_group_player tgp USING (account_id, np_communication_id)
+                %s
             WHERE %s',
+            $this->buildBaseGameJoin($filter),
             $this->buildWhereClause($filter)
         );
 
@@ -81,11 +73,12 @@ final class PlayerGamesService
             FROM trophy_title_player ttp
                 JOIN trophy_title tt USING (np_communication_id)
                 JOIN trophy_title_meta ttm USING (np_communication_id)
-                JOIN trophy_group_player tgp USING (account_id, np_communication_id)
+                %s
             WHERE %s
             %s
             LIMIT :offset, :limit',
             implode(', ', $columns),
+            $this->buildBaseGameJoin($filter),
             $this->buildWhereClause($filter),
             $this->buildOrderByClause($filter)
         );
@@ -113,12 +106,22 @@ final class PlayerGamesService
         return $games;
     }
 
+    private function buildBaseGameJoin(PlayerGamesFilter $filter): string
+    {
+        if (!$filter->isBaseSelected()) {
+            return '';
+        }
+
+        return "JOIN trophy_group_player tgp ON tgp.account_id = ttp.account_id
+                AND tgp.np_communication_id = ttp.np_communication_id
+                AND tgp.group_id = 'default'";
+    }
+
     private function buildWhereClause(PlayerGamesFilter $filter): string
     {
         $conditions = [
             'ttm.status != 2',
             'ttp.account_id = :account_id',
-            "tgp.group_id = 'default'",
         ];
 
         $conditions = $this->searchQueryHelper->appendFulltextCondition(
@@ -141,16 +144,9 @@ final class PlayerGamesService
         }
 
         if ($filter->hasPlatformFilters()) {
-            $platformConditions = [];
-            foreach ($filter->getPlatforms() as $platformKey) {
-                $condition = self::PLATFORM_CONDITIONS[$platformKey] ?? null;
-                if ($condition !== null) {
-                    $platformConditions[] = $condition;
-                }
-            }
-
-            if ($platformConditions !== []) {
-                $conditions[] = '(' . implode(' OR ', $platformConditions) . ')';
+            $platformExpression = PlatformSql::buildOrExpression($filter->getPlatforms());
+            if ($platformExpression !== null) {
+                $conditions[] = $platformExpression;
             }
         }
 

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -3,20 +3,11 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerLogEntry.php';
+require_once __DIR__ . '/PlatformSql.php';
 
 class PlayerLogService
 {
     public const PAGE_SIZE = 50;
-
-    private const PLATFORM_FILTERS = [
-        'pc' => "tt.platform LIKE '%PC%'",
-        'ps3' => "tt.platform LIKE '%PS3%'",
-        'ps4' => "tt.platform LIKE '%PS4%'",
-        'ps5' => "tt.platform LIKE '%PS5%'",
-        'psvita' => "tt.platform LIKE '%PSVITA%'",
-        'psvr' => "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'",
-        'psvr2' => "tt.platform LIKE '%PSVR2%'",
-    ];
 
     public function __construct(private readonly PDO $database)
     {
@@ -53,7 +44,9 @@ class PlayerLogService
     {
         $sql = <<<'SQL'
             SELECT
-                te.*,
+                te.earned,
+                te.progress,
+                te.earned_date,
                 t.id AS trophy_id,
                 t.type AS trophy_type,
                 t.name AS trophy_name,
@@ -108,17 +101,7 @@ class PlayerLogService
             return '';
         }
 
-        $platforms = array_intersect($filter->getPlatforms(), array_keys(self::PLATFORM_FILTERS));
-        $clauses = array_map(
-            static fn(string $platform): string => self::PLATFORM_FILTERS[$platform],
-            $platforms
-        );
-
-        if ($clauses === []) {
-            return '';
-        }
-
-        return PHP_EOL . '                AND (' . implode(' OR ', $clauses) . ')';
+        return PlatformSql::buildOrClause($filter->getPlatforms());
     }
 
     private function buildOrderByClause(PlayerLogFilter $filter): string

--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -4,18 +4,10 @@ declare(strict_types=1);
 
 use Random\Randomizer;
 
+require_once __DIR__ . '/PlatformSql.php';
+
 class PlayerRandomGamesService
 {
-    private const PLATFORM_FILTERS = [
-        'pc' => "tt.platform LIKE '%PC%'",
-        'ps3' => "tt.platform LIKE '%PS3%'",
-        'ps4' => "tt.platform LIKE '%PS4%'",
-        'ps5' => "tt.platform LIKE '%PS5%'",
-        'psvita' => "tt.platform LIKE '%PSVITA%'",
-        'psvr' => "CONCAT(',', REPLACE(tt.platform, ' ', ''), ',') LIKE '%,PSVR,%'",
-        'psvr2' => "tt.platform LIKE '%PSVR2%'",
-    ];
-
     private readonly PDO $database;
 
     private readonly Utility $utility;
@@ -96,18 +88,14 @@ class PlayerRandomGamesService
 
     private function buildPlatformFilter(PlayerRandomGamesFilter $filter): string
     {
-        $conditions = [];
-        foreach (self::PLATFORM_FILTERS as $filterKey => $condition) {
+        $selected = [];
+        foreach (array_keys(PlatformSql::CONDITIONS) as $filterKey) {
             if ($filter->isPlatformSelected($filterKey)) {
-                $conditions[] = $condition;
+                $selected[] = $filterKey;
             }
         }
 
-        if ($conditions === []) {
-            return '';
-        }
-
-        return ' AND (' . implode(' OR ', $conditions) . ')';
+        return PlatformSql::buildOrClause($selected);
     }
 
     /**

--- a/wwwroot/classes/TrophyMergeEarnedCopier.php
+++ b/wwwroot/classes/TrophyMergeEarnedCopier.php
@@ -66,14 +66,17 @@ final class TrophyMergeEarnedCopier
                         ELSE COALESCE(existing.earned, 0)
                     END AS earned
                 FROM
-                    trophy_earned AS child
+                    trophy_title_player AS ttp
+                JOIN trophy_earned AS child
+                    ON child.account_id = ttp.account_id
+                    AND child.np_communication_id = :child_np_communication_id
+                    AND child.order_id = :child_order_id
                 LEFT JOIN trophy_earned AS existing ON existing.np_communication_id = :parent_np_communication_id
                     AND existing.group_id = :parent_group_id
                     AND existing.order_id = :parent_order_id
                     AND existing.account_id = child.account_id
                 WHERE
-                    child.np_communication_id = :child_np_communication_id
-                    AND child.order_id = :child_order_id
+                    ttp.np_communication_id = :child_np_communication_id
             ) AS new
             ON DUPLICATE KEY
             UPDATE
@@ -121,6 +124,8 @@ SQL
             sprintf('Found %d merged trophies to copy…', $total)
         );
 
+        // Drive child trophy_earned via trophy_title_player.account_id so
+        // HASH(account_id) partition pruning applies on the large earned table.
         $mergeSourceCte = <<<'SQL'
             WITH merge_source AS (
                 SELECT
@@ -132,7 +137,11 @@ SQL
                     child.progress,
                     child.earned
                 FROM trophy_merge AS tm
-                JOIN trophy_earned AS child ON child.np_communication_id = tm.child_np_communication_id
+                JOIN trophy_title_player AS ttp
+                    ON ttp.np_communication_id = tm.child_np_communication_id
+                JOIN trophy_earned AS child
+                    ON child.account_id = ttp.account_id
+                    AND child.np_communication_id = tm.child_np_communication_id
                     AND child.group_id = tm.child_group_id
                     AND child.order_id = tm.child_order_id
                 WHERE tm.child_np_communication_id = :child_np_communication_id

--- a/wwwroot/classes/TrophyMergePlayerProgressRecalculator.php
+++ b/wwwroot/classes/TrophyMergePlayerProgressRecalculator.php
@@ -45,7 +45,9 @@ SQL
         $groups->execute();
 
         while ($group = $groups->fetch(PDO::FETCH_ASSOC)) {
-            $query = $this->database->prepare(
+            // Drive trophy_earned from child title accounts so HASH(account_id)
+            // partition pruning applies instead of scanning all 256 partitions by title.
+            $mergeSql = sprintf(
                 <<<'SQL'
                 INSERT INTO trophy_group_player(
                     np_communication_id,
@@ -65,23 +67,34 @@ SQL
                     WHERE
                         np_communication_id = :np_communication_id AND group_id = :group_id
                 ),
+                accounts AS(
+                    SELECT DISTINCT
+                        account_id
+                    FROM
+                        trophy_title_player
+                    WHERE
+                        np_communication_id IN (%s)
+                ),
                 player AS(
                     SELECT
-                        account_id,
-                        SUM(TYPE = 'bronze') AS bronze,
-                        SUM(TYPE = 'silver') AS silver,
-                        SUM(TYPE = 'gold') AS gold,
-                        SUM(TYPE = 'platinum') AS platinum,
-                        SUM(TYPE = 'bronze') * 15 + SUM(TYPE = 'silver') * 30 + SUM(TYPE = 'gold') * 90 AS score
+                        te.account_id,
+                        SUM(t.type = 'bronze') AS bronze,
+                        SUM(t.type = 'silver') AS silver,
+                        SUM(t.type = 'gold') AS gold,
+                        SUM(t.type = 'platinum') AS platinum,
+                        SUM(t.type = 'bronze') * 15 + SUM(t.type = 'silver') * 30 + SUM(t.type = 'gold') * 90 AS score
                     FROM
-                        trophy_earned te
+                        accounts a
+                    JOIN trophy_earned te ON
+                        te.account_id = a.account_id
+                        AND te.np_communication_id = :np_communication_id
+                        AND te.group_id = :group_id
+                        AND te.earned = 1
                     JOIN trophy t ON
                         t.np_communication_id = te.np_communication_id AND t.order_id = te.order_id
                     JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = 0
-                    WHERE
-                        te.np_communication_id = :np_communication_id AND te.group_id = :group_id AND te.earned = 1
                     GROUP BY
-                        account_id
+                        te.account_id
                 )
                 SELECT
                     *
@@ -128,9 +141,15 @@ SQL
                     platinum = NEW.platinum,
                     progress = NEW.progress
 SQL
+                ,
+                $childListSql
             );
+            $query = $this->database->prepare($mergeSql);
             $query->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
             $query->bindValue(':group_id', $group['parent_group_id'], PDO::PARAM_STR);
+            foreach ($childNpCommunicationIds as $index => $childNpCommunicationId) {
+                $query->bindValue(':child_np_' . $index, $childNpCommunicationId, PDO::PARAM_STR);
+            }
             $query->execute();
 
             $zeroProgressSql = sprintf(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the MySQL 8.4 SQL modernization work with covering indexes, status domain constraints, partition-friendly merge queries, and leaner read paths.

Rebased onto latest `master` (includes the `TrophyMergePlayerProgressRecalculator` extraction).

### Schema / ops
- Add descending covering indexes for game leaderboard (`trophy_title_player`) and popular/game-list sorts (`trophy_title_meta`)
- Add CHECK constraints for `player.status`, `trophy_title_meta.status`, and `trophy_meta.status`
- Store `setting.scan_progress` as JSON
- New idempotent upgrade script: `database/mysql84_covering_indexes.sql`
- Extend histograms with `trophy_title_meta.rarity_points` / `in_game_rarity_points`

### Query rewrites
- Drive merge `trophy_earned` work from `trophy_title_player.account_id` so `HASH(account_id)` partition pruning applies (`TrophyMergePlayerProgressRecalculator`, `TrophyMergeEarnedCopier`)
- Advisor anti-join uses `NOT EXISTS` and starts from the player’s titles
- Player games skips `trophy_group_player` unless the base-completed filter is on
- Narrow `PlayerLogService` / `ChangelogService` projections (no `te.*` / `c.*`)
- Align inactive-player cutoff to `NOW() - INTERVAL 1 YEAR`
- Keep `LIKE 'NPWR%'` for `trophy_count_npwr` recount (matches `trophy_earned` triggers; equivalent to `N%` under the NPWR/MERGE domain, no meaningful speed difference)
- Unify platform filters via `PlatformSql` (fixes GameList PSVR matching against spaced comma lists; SQLite-safe)

### Docs
- README / DEPLOYMENT document the new covering-index script

## Test plan
- [x] `php tests/run.php` — all 944 tests passed after rebase
- [ ] Apply `database/mysql84_covering_indexes.sql` on a staging MySQL 8.4 DB and confirm indexes/CHECKs
- [ ] Spot-check game leaderboard, homepage popular games, player advisor, and admin merge after deploy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00508af5-f855-4956-a47a-8f828e51f61e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00508af5-f855-4956-a47a-8f828e51f61e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

