### PR TITLE
Adopt remaining PHP 8.5 idioms across parsers and value objects

### DIFF
--- a/tests/NavigationStateTest.php
+++ b/tests/NavigationStateTest.php
@@ -50,4 +50,15 @@ final class NavigationStateTest extends TestCase
         $this->assertSame('', $navigationState->getFilter());
         $this->assertSame('&lt;script&gt;alert(&#039;x&#039;)&lt;/script&gt;', $navigationState->getSearch());
     }
+
+    public function testActiveSectionUsesPathAndIgnoresQueryString(): void
+    {
+        $server = ['REQUEST_URI' => '/trophy/latest?sort=date&player=example'];
+
+        $navigationState = NavigationState::fromGlobals($server, []);
+
+        $this->assertSame(' active', $navigationState->getTrophyClass());
+        $this->assertSame('', $navigationState->getHomeClass());
+        $this->assertTrue($navigationState->isSectionActive('trophy'));
+    }
 }

--- a/wwwroot/admin/detail.php
+++ b/wwwroot/admin/detail.php
@@ -6,6 +6,7 @@ require_once '../classes/Admin/GameDetail.php';
 require_once '../classes/Admin/GameDetailService.php';
 require_once '../classes/Admin/GameDetailPage.php';
 require_once '../classes/Admin/GameDetailPageResult.php';
+require_once '../classes/CommaSeparatedValues.php';
 require_once '../classes/GameStatusService.php';
 require_once '../classes/GameMessageSanitizer.php';
 
@@ -66,12 +67,7 @@ $requestedNpCommunicationId = isset($_GET['np_communication_id']) ? (string) $_G
                     <input type="text" name="icon_url" style="width: 859px;" value="<?= Html::escape($gameDetail->getIconUrl()); ?>"><br>
                     <?php
                     $selectedPlatforms = [];
-                    foreach (explode(',', $gameDetail->getPlatform()) as $platformValue) {
-                        $normalizedPlatform = $platformValue |> trim(...) |> strtoupper(...);
-                        if ($normalizedPlatform === '') {
-                            continue;
-                        }
-
+                    foreach (CommaSeparatedValues::parseUppercaseTrimmed($gameDetail->getPlatform()) as $normalizedPlatform) {
                         $selectedPlatforms[$normalizedPlatform] = true;
                     }
                     ?>

--- a/wwwroot/classes/Admin/GameDetailFormParser.php
+++ b/wwwroot/classes/Admin/GameDetailFormParser.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/GameDetail.php';
+require_once __DIR__ . '/../CommaSeparatedValues.php';
 require_once __DIR__ . '/../GameAvailabilityStatus.php';
 
 final class GameDetailFormParser
@@ -130,7 +131,7 @@ final class GameDetailFormParser
         if (is_array($value)) {
             $candidates = $value;
         } elseif (is_string($value)) {
-            $candidates = explode(',', $value);
+            $candidates = CommaSeparatedValues::parseUppercaseTrimmed($value);
         }
 
         $selected = [];
@@ -174,29 +175,18 @@ final class GameDetailFormParser
             return null;
         }
 
-        $segments = array_filter(
-            array_map(static fn(string $segment): string => trim($segment), explode(',', $value)),
-            static fn(string $segment): bool => $segment !== ''
-        );
-
-        if ($segments === []) {
-            return null;
-        }
-
-        $normalized = [];
-        foreach ($segments as $segment) {
-            if (!ctype_digit($segment)) {
-                continue;
-            }
-
-            $normalized[] = (string) (int) $segment;
-        }
+        $normalized = CommaSeparatedValues::parseTrimmed($value)
+            |> (fn(array $segments): array => array_filter($segments, ctype_digit(...)))
+            |> (fn(array $segments): array => array_map(
+                static fn(string $segment): string => (string) (int) $segment,
+                $segments
+            ))
+            |> array_unique(...)
+            |> array_values(...);
 
         if ($normalized === []) {
             return null;
         }
-
-        $normalized = array_values(array_unique($normalized));
 
         return implode(',', $normalized);
     }

--- a/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
+++ b/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
@@ -15,6 +15,17 @@ use Tustin\PlayStation\Client;
  */
 final class PlayStationWorkerAuthenticator
 {
+    private const \Closure DEFAULT_CLIENT_FACTORY = static function (): object {
+        return new Client();
+    };
+
+    private const \Closure DEFAULT_REFRESH_TOKEN_SAVER = static function (int $workerId, string $refreshToken): void {
+    };
+
+    private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
+        sleep($seconds);
+    };
+
     /**
      * @var \Closure(): iterable<Worker>
      */
@@ -48,14 +59,9 @@ final class PlayStationWorkerAuthenticator
         ?callable $refreshTokenPersistenceFailureHandler = null,
     ) {
         $this->workerFetcher = \Closure::fromCallable($workerFetcher);
-        $this->clientFactory = \Closure::fromCallable(
-            $clientFactory ?? static fn (): object => new Client()
-        );
-        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? static function (int $workerId, string $refreshToken): void {
-        });
-        $this->sleeper = \Closure::fromCallable($sleeper ?? static function (int $seconds): void {
-            sleep($seconds);
-        });
+        $this->clientFactory = \Closure::fromCallable($clientFactory ?? self::DEFAULT_CLIENT_FACTORY);
+        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? self::DEFAULT_REFRESH_TOKEN_SAVER);
+        $this->sleeper = \Closure::fromCallable($sleeper ?? self::DEFAULT_SLEEPER);
         $this->refreshTokenPersistenceFailureHandler = $refreshTokenPersistenceFailureHandler !== null
             ? \Closure::fromCallable($refreshTokenPersistenceFailureHandler)
             : null;

--- a/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
+++ b/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../CommaSeparatedValues.php';
 require_once __DIR__ . '/../Html.php';
 
 require_once __DIR__ . '/TrophyMergeProgressListener.php';
@@ -65,13 +66,8 @@ class TrophyMergeRequestHandler
     private function parseChildTrophyIds(string $childTrophies): array
     {
         $childTrophyIds = [];
-        $childTrophiesRaw = array_map('trim', explode(',', $childTrophies));
 
-        foreach ($childTrophiesRaw as $childId) {
-            if ($childId === '') {
-                continue;
-            }
-
+        foreach (CommaSeparatedValues::parseTrimmed($childTrophies) as $childId) {
             if (!$this->isNumeric($childId)) {
                 throw new InvalidArgumentException('Child trophy ids must be numeric.');
             }

--- a/wwwroot/classes/Admin/TrophyStatusInputParser.php
+++ b/wwwroot/classes/Admin/TrophyStatusInputParser.php
@@ -31,7 +31,9 @@ final class TrophyStatusInputParser
             $ids[] = (int) $value;
         }
 
-        $ids = array_values(array_unique($ids));
+        $ids = $ids
+            |> array_unique(...)
+            |> array_values(...);
 
         if (count($ids) === 0) {
             throw new InvalidArgumentException('No trophies were provided.');
@@ -62,8 +64,9 @@ final class TrophyStatusInputParser
             throw new InvalidArgumentException('No trophies found for the selected game.');
         }
 
-        $ids = array_map('intval', $trophies);
-
-        return array_values(array_unique($ids));
+        return $trophies
+            |> (fn(array $ids): array => array_map(intval(...), $ids))
+            |> array_unique(...)
+            |> array_values(...);
     }
 }

--- a/wwwroot/classes/Admin/TrophyStatusService.php
+++ b/wwwroot/classes/Admin/TrophyStatusService.php
@@ -7,15 +7,12 @@ require_once __DIR__ . '/TrophyStatusProgressRecalculator.php';
 
 class TrophyStatusService
 {
-    private PDO $database;
-
     private TrophyStatusProgressRecalculator $progressRecalculator;
 
     public function __construct(
-        PDO $database,
+        private PDO $database,
         ?TrophyStatusProgressRecalculator $progressRecalculator = null,
     ) {
-        $this->database = $database;
         $this->progressRecalculator = $progressRecalculator ?? new TrophyStatusProgressRecalculator($database);
     }
 
@@ -24,7 +21,10 @@ class TrophyStatusService
      */
     public function updateTrophies(array $trophyIds, int $status): TrophyStatusUpdateResult
     {
-        $trophyIds = array_values(array_unique(array_map('intval', $trophyIds)));
+        $trophyIds = $trophyIds
+            |> (fn(array $ids): array => array_map(intval(...), $ids))
+            |> array_unique(...)
+            |> array_values(...);
 
         if (count($trophyIds) === 0) {
             throw new InvalidArgumentException('No trophies were provided.');

--- a/wwwroot/classes/AutomaticTrophyTitleMergeService.php
+++ b/wwwroot/classes/AutomaticTrophyTitleMergeService.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/TrophyMergeService.php';
 require_once __DIR__ . '/TrophySetComparator.php';
 require_once __DIR__ . '/Cron/PlayerScanNewTitleMergeHandler.php';
@@ -418,13 +419,10 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
      */
     private function parsePlatforms(?string $platforms): array
     {
-        if ($platforms === null || trim($platforms) === '') {
+        if ($platforms === null) {
             return [];
         }
 
-        $parts = array_map('trim', explode(',', $platforms));
-        $parts = array_filter($parts, static fn(string $platform): bool => $platform !== '');
-
-        return array_values(array_map('strtoupper', $parts));
+        return CommaSeparatedValues::parseUppercaseTrimmed($platforms);
     }
 }

--- a/wwwroot/classes/ChangelogEntry.php
+++ b/wwwroot/classes/ChangelogEntry.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
+
 enum ChangelogEntryType: string
 {
     case GAME_CLONE = 'GAME_CLONE';
@@ -83,17 +85,11 @@ readonly class ChangelogEntry
      */
     private static function normalizePlatforms(?string $platforms): array
     {
-        if ($platforms === null || $platforms === '') {
+        if ($platforms === null) {
             return [];
         }
 
-        $parts = array_map('trim', explode(',', $platforms));
-        $parts = array_filter(
-            $parts,
-            static fn(string $platform): bool => $platform !== ''
-        );
-
-        return array_values($parts);
+        return CommaSeparatedValues::parseTrimmed($platforms);
     }
 
     public function getTime(): DateTimeImmutable

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -6,6 +6,10 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final readonly class DailyCronJob implements CronJobInterface
 {
+    private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
+        sleep($seconds);
+    };
+
     /**
      * Recalculate rarity for one title.
      *
@@ -102,7 +106,7 @@ final readonly class DailyCronJob implements CronJobInterface
     public function __construct(
         private PDO $database,
         private int $retryDelaySeconds = 3,
-        private ?\Closure $sleeper = null,
+        private \Closure $sleeper = self::DEFAULT_SLEEPER,
     ) {
     }
 
@@ -155,16 +159,8 @@ final readonly class DailyCronJob implements CronJobInterface
                 $operation(...$arguments);
                 return;
             } catch (Throwable $exception) {
-                ($this->getSleeper())($this->retryDelaySeconds);
+                ($this->sleeper)($this->retryDelaySeconds);
             }
         }
-    }
-
-    /** @return \Closure(int): void */
-    private function getSleeper(): \Closure
-    {
-        return $this->sleeper ?? static function (int $seconds): void {
-            sleep($seconds);
-        };
     }
 }

--- a/wwwroot/classes/Cron/PlayerRankingUpdater.php
+++ b/wwwroot/classes/Cron/PlayerRankingUpdater.php
@@ -12,6 +12,9 @@ class PlayerRankingUpdater
     private const string LOCK_NAME = 'psn100:player_ranking_recalc';
     private const int DEFAULT_RETRY_DELAY_SECONDS = 3;
     private const int DEFAULT_MAX_RETRY_DELAY_SECONDS = 60;
+    private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
+        sleep($seconds);
+    };
     private const string INSERT_TEMPLATE = <<<'SQL'
 INSERT INTO %s (
     account_id,
@@ -49,31 +52,13 @@ FROM player
 WHERE `status` = 0
 SQL;
 
-    private PDO $database;
-
-    private int $retryDelaySeconds;
-
-    private int $maxRetryDelaySeconds;
-
-    private ?Psn100Logger $logger;
-
-    /** @var callable(int): void */
-    private $sleeper;
-
     public function __construct(
-        PDO $database,
-        int $retryDelaySeconds = self::DEFAULT_RETRY_DELAY_SECONDS,
-        int $maxRetryDelaySeconds = self::DEFAULT_MAX_RETRY_DELAY_SECONDS,
-        ?Psn100Logger $logger = null,
-        ?callable $sleeper = null,
+        private PDO $database,
+        private int $retryDelaySeconds = self::DEFAULT_RETRY_DELAY_SECONDS,
+        private int $maxRetryDelaySeconds = self::DEFAULT_MAX_RETRY_DELAY_SECONDS,
+        private ?Psn100Logger $logger = null,
+        private \Closure $sleeper = self::DEFAULT_SLEEPER,
     ) {
-        $this->database = $database;
-        $this->retryDelaySeconds = $retryDelaySeconds;
-        $this->maxRetryDelaySeconds = $maxRetryDelaySeconds;
-        $this->logger = $logger;
-        $this->sleeper = $sleeper ?? static function (int $seconds): void {
-            sleep($seconds);
-        };
     }
 
     public function recalculate(): void

--- a/wwwroot/classes/Cron/PlayerScanPrivacyService.php
+++ b/wwwroot/classes/Cron/PlayerScanPrivacyService.php
@@ -13,6 +13,10 @@ require_once __DIR__ . '/PlayerScanTrophySummaryAccessResult.php';
  */
 final class PlayerScanPrivacyService
 {
+    private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
+        sleep($seconds);
+    };
+
     private readonly \Closure $sleeper;
 
     public function __construct(
@@ -20,9 +24,7 @@ final class PlayerScanPrivacyService
         private readonly WorkerScanCoordinator $workerScanCoordinator,
         ?callable $sleeper = null,
     ) {
-        $this->sleeper = \Closure::fromCallable($sleeper ?? static function (int $seconds): void {
-            sleep($seconds);
-        });
+        $this->sleeper = \Closure::fromCallable($sleeper ?? self::DEFAULT_SLEEPER);
     }
 
     public function markAsPrivateByOnlineId(string $onlineId): void

--- a/wwwroot/classes/Cron/WeeklyCronJob.php
+++ b/wwwroot/classes/Cron/WeeklyCronJob.php
@@ -6,6 +6,10 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final readonly class WeeklyCronJob implements CronJobInterface
 {
+    private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
+        sleep($seconds);
+    };
+
     private const UPDATE_PLAYER_RANKINGS_QUERY = <<<'SQL'
         UPDATE player p
         JOIN player_ranking r ON p.account_id = r.account_id
@@ -36,7 +40,7 @@ final readonly class WeeklyCronJob implements CronJobInterface
     public function __construct(
         private PDO $database,
         private int $retryDelaySeconds = 3,
-        private ?\Closure $sleeper = null,
+        private \Closure $sleeper = self::DEFAULT_SLEEPER,
     ) {
     }
 
@@ -67,16 +71,8 @@ final readonly class WeeklyCronJob implements CronJobInterface
 
                 return;
             } catch (Throwable $exception) {
-                ($this->getSleeper())($this->retryDelaySeconds);
+                ($this->sleeper)($this->retryDelaySeconds);
             }
         }
-    }
-
-    /** @return \Closure(int): void */
-    private function getSleeper(): \Closure
-    {
-        return $this->sleeper ?? static function (int $seconds): void {
-            sleep($seconds);
-        };
     }
 }

--- a/wwwroot/classes/Game/GameDetails.php
+++ b/wwwroot/classes/Game/GameDetails.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../CommaSeparatedValues.php';
+
 class GameDetails
 {
     private int $id;
@@ -122,21 +124,11 @@ class GameDetails
             return [];
         }
 
-        $segments = array_filter(
-            array_map(static fn(string $segment): string => trim($segment), explode(',', $value)),
-            static fn(string $segment): bool => $segment !== ''
-        );
-
-        $ids = [];
-        foreach ($segments as $segment) {
-            if (!ctype_digit($segment)) {
-                continue;
-            }
-
-            $ids[] = (int) $segment;
-        }
-
-        return array_values(array_unique($ids));
+        return CommaSeparatedValues::parseTrimmed($value)
+            |> (fn(array $segments): array => array_filter($segments, ctype_digit(...)))
+            |> (fn(array $segments): array => array_map(intval(...), $segments))
+            |> array_unique(...)
+            |> array_values(...);
     }
 
     public function getId(): int

--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -32,6 +32,7 @@ final readonly class GameLeaderboardFilter extends GamePlayerFilter
         return $this->page;
     }
 
+    #[\NoDiscard]
     public function withPageNumber(int $page): self
     {
         return clone($this, ['page' => max($page, 1)]);

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -91,6 +91,7 @@ readonly class GameListFilter
         return $this->player !== null;
     }
 
+    #[\NoDiscard]
     public function withPlayer(?string $player): self
     {
         if ($player !== null) {
@@ -101,6 +102,7 @@ readonly class GameListFilter
         return clone($this, ['player' => $player]);
     }
 
+    #[\NoDiscard]
     public function withPage(int $page): self
     {
         return clone($this, ['page' => max($page, 1)]);

--- a/wwwroot/classes/GameListItem.php
+++ b/wwwroot/classes/GameListItem.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/GameStatusBadge.php';
 require_once __DIR__ . '/Utility.php';
@@ -102,14 +103,7 @@ final readonly class GameListItem
      */
     public function getPlatforms(): array
     {
-        if ($this->platformValue === '') {
-            return [];
-        }
-
-        $platforms = array_map('trim', explode(',', $this->platformValue));
-        $platforms = array_filter($platforms, static fn(string $platform): bool => $platform !== '');
-
-        return array_values($platforms);
+        return CommaSeparatedValues::parseTrimmed($this->platformValue);
     }
 
     public function getOwners(): int

--- a/wwwroot/classes/GameRepository.php
+++ b/wwwroot/classes/GameRepository.php
@@ -14,8 +14,7 @@ class GameRepository
             return null;
         }
 
-        $parts = explode('-', $segment);
-        $id = (int) $parts[0];
+        $id = (int) (array_first(explode('-', $segment)) ?? 0);
 
         if ($id <= 0) {
             return null;

--- a/wwwroot/classes/Homepage/HomepageItem.php
+++ b/wwwroot/classes/Homepage/HomepageItem.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../CommaSeparatedValues.php';
+
 abstract readonly class HomepageItem
 {
     private const MISSING_PS5_ICON = '/img/missing-ps5-game-and-trophy.png';
@@ -31,18 +33,7 @@ abstract readonly class HomepageItem
      */
     public function getPlatforms(): array
     {
-        if ($this->platform === '') {
-            return [];
-        }
-
-        $platforms = array_map('trim', explode(',', $this->platform));
-
-        $platforms = array_filter(
-            $platforms,
-            static fn(string $value): bool => $value !== ''
-        );
-
-        return array_values($platforms);
+        return CommaSeparatedValues::parseTrimmed($this->platform);
     }
 
     private function isPs5Title(): bool

--- a/wwwroot/classes/IpAddressResolver.php
+++ b/wwwroot/classes/IpAddressResolver.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
+
 final class IpAddressResolver
 {
     public const string UNKNOWN_CLIENT_IDENTIFIER = '__unknown__';
@@ -76,15 +78,7 @@ final class IpAddressResolver
             return [];
         }
 
-        $proxyIps = [];
-        foreach (explode(',', $value) as $proxyIp) {
-            $proxyIp = trim($proxyIp);
-            if ($proxyIp !== '') {
-                $proxyIps[] = $proxyIp;
-            }
-        }
-
-        return $proxyIps;
+        return CommaSeparatedValues::parseTrimmed($value);
     }
 
     private static function resolveForwardedClientIp(mixed $forwardedFor): string
@@ -93,8 +87,8 @@ final class IpAddressResolver
             return '';
         }
 
-        foreach (explode(',', $forwardedFor) as $candidate) {
-            $validatedAddress = self::resolve(trim($candidate));
+        foreach (CommaSeparatedValues::parseTrimmed($forwardedFor) as $candidate) {
+            $validatedAddress = self::resolve($candidate);
             if ($validatedAddress !== '') {
                 return $validatedAddress;
             }

--- a/wwwroot/classes/MaintenancePage.php
+++ b/wwwroot/classes/MaintenancePage.php
@@ -31,6 +31,7 @@ final readonly class MaintenancePage
         );
     }
 
+    #[\NoDiscard]
     public function withMessage(string $message): self
     {
         return clone($this, ['message' => $message]);

--- a/wwwroot/classes/NavigationState.php
+++ b/wwwroot/classes/NavigationState.php
@@ -22,7 +22,7 @@ final class NavigationState
 
     public static function fromGlobals(array $server, array $queryParameters): self
     {
-        $requestUri = (string) ($server['REQUEST_URI'] ?? '/');
+        $requestPath = Uri\Rfc3986\Uri::parse((string) ($server['REQUEST_URI'] ?? '/'))?->getPath() ?? '/';
 
         $sort = self::sanitizeQueryValue($queryParameters['sort'] ?? '');
         $player = self::sanitizeQueryValue($queryParameters['player'] ?? '');
@@ -34,7 +34,7 @@ final class NavigationState
             $player,
             $filter,
             $search,
-            self::determineSectionStates($requestUri)
+            self::determineSectionStates($requestPath)
         );
     }
 
@@ -113,10 +113,10 @@ final class NavigationState
     }
 
     /**
-     * @param string $requestUri
+     * @param string $requestPath
      * @return array<string, NavigationSectionState>
      */
-    private static function determineSectionStates(string $requestUri): array
+    private static function determineSectionStates(string $requestPath): array
     {
         $states = [];
 
@@ -124,7 +124,7 @@ final class NavigationState
             $states[$section->value] = new NavigationSectionState($section, false);
         }
 
-        $activeSection = self::resolveActiveSection($requestUri);
+        $activeSection = self::resolveActiveSection($requestPath);
         $states[$activeSection->value] = new NavigationSectionState($activeSection, true);
 
         return $states;
@@ -137,15 +137,15 @@ final class NavigationState
         return htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
     }
 
-    private static function resolveActiveSection(string $requestUri): NavigationSection
+    private static function resolveActiveSection(string $requestPath): NavigationSection
     {
         return match (true) {
-            str_starts_with($requestUri, '/leaderboard') || str_starts_with($requestUri, '/player')
+            str_starts_with($requestPath, '/leaderboard') || str_starts_with($requestPath, '/player')
                 => NavigationSection::Leaderboard,
-            str_starts_with($requestUri, '/game') => NavigationSection::Game,
-            str_starts_with($requestUri, '/trophy') => NavigationSection::Trophy,
-            str_starts_with($requestUri, '/avatar') => NavigationSection::Avatar,
-            str_starts_with($requestUri, '/about') => NavigationSection::About,
+            str_starts_with($requestPath, '/game') => NavigationSection::Game,
+            str_starts_with($requestPath, '/trophy') => NavigationSection::Trophy,
+            str_starts_with($requestPath, '/avatar') => NavigationSection::Avatar,
+            str_starts_with($requestPath, '/about') => NavigationSection::About,
             default => NavigationSection::Home,
         };
     }

--- a/wwwroot/classes/NotFoundPage.php
+++ b/wwwroot/classes/NotFoundPage.php
@@ -20,16 +20,19 @@ final readonly class NotFoundPage
         );
     }
 
+    #[\NoDiscard]
     public function withHeading(string $heading): self
     {
         return clone($this, ['heading' => $heading]);
     }
 
+    #[\NoDiscard]
     public function withMessage(string $message): self
     {
         return clone($this, ['message' => $message]);
     }
 
+    #[\NoDiscard]
     public function withTitle(string $title): self
     {
         return clone($this, ['title' => $title]);

--- a/wwwroot/classes/PageMetaData.php
+++ b/wwwroot/classes/PageMetaData.php
@@ -21,6 +21,7 @@ final readonly class PageMetaData
         $this->url = self::normalize($url);
     }
 
+    #[\NoDiscard]
     public function withTitle(?string $title): self
     {
         return clone($this, ['title' => self::normalize($title)]);
@@ -31,6 +32,7 @@ final readonly class PageMetaData
         return $this->title;
     }
 
+    #[\NoDiscard]
     public function withDescription(?string $description): self
     {
         return clone($this, ['description' => self::normalize($description)]);
@@ -41,6 +43,7 @@ final readonly class PageMetaData
         return $this->description;
     }
 
+    #[\NoDiscard]
     public function withImage(?string $image): self
     {
         return clone($this, ['image' => self::normalize($image)]);
@@ -51,6 +54,7 @@ final readonly class PageMetaData
         return $this->image;
     }
 
+    #[\NoDiscard]
     public function withUrl(?string $url): self
     {
         return clone($this, ['url' => self::normalize($url)]);

--- a/wwwroot/classes/PaginationItem.php
+++ b/wwwroot/classes/PaginationItem.php
@@ -23,16 +23,19 @@ final readonly class PaginationItem
         return new self(null, '...', disabled: true);
     }
 
+    #[\NoDiscard]
     public function markAsActive(): self
     {
         return clone($this, ['active' => true]);
     }
 
+    #[\NoDiscard]
     public function markAsDisabled(): self
     {
         return clone($this, ['disabled' => true]);
     }
 
+    #[\NoDiscard]
     public function setAriaLabel(?string $ariaLabel): self
     {
         return clone($this, ['ariaLabel' => $ariaLabel]);

--- a/wwwroot/classes/PlayerAdvisableTrophy.php
+++ b/wwwroot/classes/PlayerAdvisableTrophy.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
+
 class PlayerAdvisableTrophy
 {
     private int $trophyId;
@@ -226,17 +228,7 @@ class PlayerAdvisableTrophy
 
     private function parsePlatforms(string $platformsRaw): array
     {
-        if ($platformsRaw === '') {
-            return [];
-        }
-
-        $platforms = array_map('trim', explode(',', $platformsRaw));
-        $platforms = array_filter(
-            $platforms,
-            static fn(string $value): bool => $value !== ''
-        );
-
-        return array_values($platforms);
+        return CommaSeparatedValues::parseTrimmed($platformsRaw);
     }
 
     private function usesPlayStation5Assets(): bool

--- a/wwwroot/classes/PlayerAdvisorFilter.php
+++ b/wwwroot/classes/PlayerAdvisorFilter.php
@@ -65,6 +65,7 @@ readonly class PlayerAdvisorFilter
         return $this->page;
     }
 
+    #[\NoDiscard]
     public function withPage(int $page): self
     {
         return clone($this, ['page' => max($page, 1)]);

--- a/wwwroot/classes/PlayerGame.php
+++ b/wwwroot/classes/PlayerGame.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
 
 class PlayerGame
@@ -84,12 +85,7 @@ class PlayerGame
      */
     public function getPlatforms(): array
     {
-        $platforms = array_map('trim', explode(',', $this->platform));
-
-        return array_filter(
-            $platforms,
-            static fn(string $platform): bool => $platform !== ''
-        );
+        return CommaSeparatedValues::parseTrimmed($this->platform);
     }
 
     public function getStatus(): int

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -235,6 +235,7 @@ class PlayerGamesFilter
         return $parameters;
     }
 
+    #[\NoDiscard]
     public function withPageNumber(int $page): self
     {
         return clone($this, ['page' => max($page, 1)]);

--- a/wwwroot/classes/PlayerLogEntry.php
+++ b/wwwroot/classes/PlayerLogEntry.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
+
 final readonly class PlayerLogEntry
 {
     public function __construct(
@@ -182,17 +184,7 @@ final readonly class PlayerLogEntry
      */
     public function getPlatforms(): array
     {
-        if ($this->platforms === '') {
-            return [];
-        }
-
-        $platforms = array_map('trim', explode(',', $this->platforms));
-        $platforms = array_filter(
-            $platforms,
-            static fn(string $value): bool => $value !== ''
-        );
-
-        return array_values($platforms);
+        return CommaSeparatedValues::parseTrimmed($this->platforms);
     }
 
     public function requiresWarning(): bool

--- a/wwwroot/classes/PlayerLogFilter.php
+++ b/wwwroot/classes/PlayerLogFilter.php
@@ -123,6 +123,7 @@ readonly class PlayerLogFilter
         return $parameters;
     }
 
+    #[\NoDiscard]
     public function withPageNumber(int $page): self
     {
         return clone($this, ['page' => max($page, 1)]);

--- a/wwwroot/classes/PlayerQueueResponse.php
+++ b/wwwroot/classes/PlayerQueueResponse.php
@@ -53,6 +53,7 @@ readonly class PlayerQueueResponse implements \JsonSerializable
         return new self(PlayerQueueStatus::ERROR, $message, null, null, 429);
     }
 
+    #[\NoDiscard]
     public function withPollToken(string $pollToken): self
     {
         return clone($this, ['pollToken' => $pollToken]);

--- a/wwwroot/classes/PlayerRandomGame.php
+++ b/wwwroot/classes/PlayerRandomGame.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
+
 final readonly class PlayerRandomGame
 {
     private function __construct(
@@ -107,17 +109,7 @@ final readonly class PlayerRandomGame
      */
     public function getPlatforms(): array
     {
-        if ($this->platform === '') {
-            return [];
-        }
-
-        $platforms = array_map('trim', explode(',', $this->platform));
-        $platforms = array_filter(
-            $platforms,
-            static fn(string $value): bool => $value !== ''
-        );
-
-        return array_values($platforms);
+        return CommaSeparatedValues::parseTrimmed($this->platform);
     }
 
     public function getIconUrl(): string

--- a/wwwroot/classes/PlayerTimeline.php
+++ b/wwwroot/classes/PlayerTimeline.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
+
 final readonly class PlayerTimeline
 {
     private function __construct(
@@ -107,17 +109,7 @@ final readonly class PlayerTimeline
      */
     public function getPlatforms(): array
     {
-        if ($this->platform === '') {
-            return [];
-        }
-
-        $platforms = array_map('trim', explode(',', $this->platform));
-        $platforms = array_filter(
-            $platforms,
-            static fn(string $value): bool => $value !== ''
-        );
-
-        return array_values($platforms);
+        return CommaSeparatedValues::parseTrimmed($this->platform);
     }
 
     public function getIconUrl(): string

--- a/wwwroot/classes/Routing/GameRouteHandler.php
+++ b/wwwroot/classes/Routing/GameRouteHandler.php
@@ -22,7 +22,7 @@ final readonly class GameRouteHandler implements RouteHandlerInterface
     #[\Override]
     public function handle(array $segments): RouteResult
     {
-        if (!isset($segments[0]) || $segments[0] === '') {
+        if ((array_first($segments) ?? '') === '') {
             if ($this->missingSegmentInclude !== null) {
                 return RouteResult::include($this->missingSegmentInclude);
             }
@@ -37,7 +37,7 @@ final readonly class GameRouteHandler implements RouteHandlerInterface
             return RouteResult::redirect($this->redirectPath);
         }
 
-        $playerSegment = $segments[0] ?? null;
+        $playerSegment = array_first($segments);
         $player = is_string($playerSegment) && PsnOnlineIdValidator::isValidOnlineId($playerSegment)
             ? $playerSegment
             : null;

--- a/wwwroot/classes/Routing/LeaderboardRouteHandler.php
+++ b/wwwroot/classes/Routing/LeaderboardRouteHandler.php
@@ -14,10 +14,6 @@ final readonly class LeaderboardRouteHandler implements RouteHandlerInterface
     #[\Override]
     public function handle(array $segments): RouteResult
     {
-        if (!isset($segments[0]) || $segments[0] === '') {
-            return RouteResult::redirect(self::DEFAULT_REDIRECT);
-        }
-
         $view = array_first($segments) ?? '';
 
         return match ($view) {

--- a/wwwroot/classes/Routing/PlayerRouteHandler.php
+++ b/wwwroot/classes/Routing/PlayerRouteHandler.php
@@ -17,7 +17,7 @@ final readonly class PlayerRouteHandler implements RouteHandlerInterface
     #[\Override]
     public function handle(array $segments): RouteResult
     {
-        if (!isset($segments[0]) || $segments[0] === '') {
+        if ((array_first($segments) ?? '') === '') {
             return RouteResult::redirect('/leaderboard/trophy');
         }
 

--- a/wwwroot/classes/Routing/TrophyRouteHandler.php
+++ b/wwwroot/classes/Routing/TrophyRouteHandler.php
@@ -18,7 +18,7 @@ final readonly class TrophyRouteHandler implements RouteHandlerInterface
     #[\Override]
     public function handle(array $segments): RouteResult
     {
-        if (!isset($segments[0]) || $segments[0] === '') {
+        if ((array_first($segments) ?? '') === '') {
             return RouteResult::include('trophies.php');
         }
 
@@ -29,7 +29,7 @@ final readonly class TrophyRouteHandler implements RouteHandlerInterface
             return RouteResult::redirect('/trophy/');
         }
 
-        $playerSegment = $segments[0] ?? null;
+        $playerSegment = array_first($segments);
         $player = is_string($playerSegment) && PsnOnlineIdValidator::isValidOnlineId($playerSegment)
             ? $playerSegment
             : null;

--- a/wwwroot/classes/TrophyDetails.php
+++ b/wwwroot/classes/TrophyDetails.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/Utility.php';
 
 readonly class TrophyDetails
 {
-    private const PLATFORM_SEPARATOR = ',';
     private const MISSING_PS5_ICON = '../missing-ps5-game-and-trophy.png';
     private const MISSING_PS4_GAME_ICON = '../missing-ps4-game.png';
     private const MISSING_PS4_TROPHY_ICON = '../missing-ps4-trophy.png';
@@ -154,9 +154,7 @@ readonly class TrophyDetails
      */
     public function getPlatforms(): array
     {
-        $platforms = array_map('trim', explode(self::PLATFORM_SEPARATOR, $this->platform));
-
-        return array_values(array_filter($platforms, static fn (string $platform): bool => $platform !== ''));
+        return CommaSeparatedValues::parseTrimmed($this->platform);
     }
 
     public function getGameIconPath(): string

--- a/wwwroot/classes/TrophyImageDownloader.php
+++ b/wwwroot/classes/TrophyImageDownloader.php
@@ -21,6 +21,7 @@ final readonly class TrophyImageDownloader
     ) {
     }
 
+    #[\NoDiscard]
     public function withLogger(?\Closure $logger): self
     {
         return clone($this, ['logger' => $logger]);

--- a/wwwroot/classes/TrophyListItem.php
+++ b/wwwroot/classes/TrophyListItem.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/Utility.php';
 
 class TrophyListItem
 {
-    private const PLATFORM_SEPARATOR = ',';
     private const MISSING_PS5_ICON = '../missing-ps5-game-and-trophy.png';
     private const MISSING_PS4_GAME_ICON = '../missing-ps4-game.png';
     private const MISSING_PS4_TROPHY_ICON = '../missing-ps4-trophy.png';
@@ -188,9 +188,7 @@ class TrophyListItem
      */
     public function getPlatforms(): array
     {
-        $platforms = array_map('trim', explode(self::PLATFORM_SEPARATOR, $this->platform));
-
-        return array_values(array_filter($platforms, static fn (string $platform): bool => $platform !== ''));
+        return CommaSeparatedValues::parseTrimmed($this->platform);
     }
 
     public function getGameUrl(Utility $utility): string

--- a/wwwroot/classes/TrophyMergeMetadataRepository.php
+++ b/wwwroot/classes/TrophyMergeMetadataRepository.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
 
 /**
@@ -177,10 +178,7 @@ SQL
             return [];
         }
 
-        $platforms = array_map('trim', explode(',', (string) $platforms));
-        $platforms = array_filter($platforms, static fn(string $platform): bool => $platform !== '');
-
-        return array_values($platforms);
+        return CommaSeparatedValues::parseTrimmed((string) $platforms);
     }
 
     /**

--- a/wwwroot/classes/TrophyRepository.php
+++ b/wwwroot/classes/TrophyRepository.php
@@ -14,8 +14,7 @@ class TrophyRepository
             return null;
         }
 
-        $parts = explode('-', $segment);
-        $id = (int) $parts[0];
+        $id = (int) (array_first(explode('-', $segment)) ?? 0);
 
         if ($id <= 0) {
             return null;

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/CommaSeparatedValues.php';
 require_once __DIR__ . '/classes/Html.php';
 
 require_once __DIR__ . '/classes/Game/GamePlayerProgress.php';
@@ -192,7 +193,7 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
 
                 <div>
                     <?php
-                    foreach (explode(',', $gamePlatform) as $platform) {
+                    foreach (CommaSeparatedValues::parseTrimmed($gamePlatform) as $platform) {
                         echo '<span class="badge rounded-pill text-bg-primary p-2 me-1">' . Html::escape($platform) . '</span> ';
                     }
                     ?>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Continues PHP 8.5 adoption where the previous pass left duplicated or incomplete patterns.

- Route platform/CSV parsing through `CommaSeparatedValues` (pipe-based helper) across games, trophies, players, changelog, IP proxies, and admin forms
- Prefer `array_first()` for slug ID prefixes and route segment peeks; use `Uri\Rfc3986\Uri` path extraction in `NavigationState` (ignores query strings for active nav)
- Mark immutable withers/`clone()` helpers with `#[\NoDiscard]`
- Express default sleepers and auth factories as typed `\Closure` class constants (PHP 8.5 constant-expression closures), with constructor property promotion on `PlayerRankingUpdater`
- Use the pipe operator for nested `array_map` / `array_unique` / `array_values` transforms in trophy status and obsolete-ID parsing

## Test plan
- [x] `php tests/run.php` — all 932 tests passed
- [x] New `NavigationState` coverage for query-string-safe path matching
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fec5662-edcf-4e08-90a7-ddcbceffe06e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fec5662-edcf-4e08-90a7-ddcbceffe06e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

