### PR TITLE
Fix PHP 8.5 $http_response_header deprecation in TrophyImageDownloader

### DIFF
--- a/tests/TrophyImageDownloaderTest.php
+++ b/tests/TrophyImageDownloaderTest.php
@@ -217,6 +217,17 @@ final class TrophyImageDownloaderTest extends TestCase
         $this->assertSame('/home/psn100/public_html/img/reward/', $directories->reward);
     }
 
+    public function testFetchRemoteFileUsesHttpGetLastResponseHeadersApi(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../wwwroot/classes/TrophyImageDownloader.php');
+        $this->assertTrue(is_string($source));
+        $this->assertStringContainsString('http_get_last_response_headers()', $source);
+        $this->assertStringContainsString('http_clear_last_response_headers()', $source);
+        if (str_contains($source, '$http_response_header')) {
+            $this->fail('TrophyImageDownloader must not use deprecated $http_response_header.');
+        }
+    }
+
     private function createDownloader(?\Closure $remoteFileFetcher): TrophyImageDownloader
     {
         return new TrophyImageDownloader(

--- a/wwwroot/classes/TrophyImageDownloader.php
+++ b/wwwroot/classes/TrophyImageDownloader.php
@@ -153,9 +153,10 @@ final readonly class TrophyImageDownloader
                 ],
             ]);
 
+            http_clear_last_response_headers();
             $contents = @file_get_contents($url, false, $context);
             if ($contents !== false) {
-                $statusLine = array_first($http_response_header) ?? '';
+                $statusLine = array_first(http_get_last_response_headers() ?? []) ?? '';
                 if ($statusLine === '' || preg_match('/^HTTP\/\S+\s+2\d\d\b/', $statusLine)) {
                     return $contents;
                 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace deprecated `$http_response_header` with `http_get_last_response_headers()` when validating HTTP status after image downloads.
- Clear prior response headers with `http_clear_last_response_headers()` before each fetch attempt.
- Add a regression test that locks in the PHP 8.5 HTTP header API usage.

## Test plan
- [x] Run `php tests/run.php` — all 945 tests passed
- [ ] Deploy/cron path that downloads trophy images no longer emits the `$http_response_header` deprecation notice

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-302039e0-c84e-4ddc-8798-0b116d2f6260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-302039e0-c84e-4ddc-8798-0b116d2f6260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

