### PR TITLE
Modernize remaining PHP for 8.5-only idioms

### DIFF
--- a/wwwroot/about.php
+++ b/wwwroot/about.php
@@ -182,7 +182,7 @@ require_once("header.php");
                         </table>
                     </div>
                 </div>
-                <?php if (!empty($scanLogPlayersData)) { ?>
+                <?php if ($scanLogPlayersData !== []) { ?>
                     <link rel="stylesheet" href="<?= htmlspecialchars(StaticAsset::url('/css/scan-log-renderer.css'), ENT_QUOTES, 'UTF-8'); ?>">
                     <?php
                     $scanLogConfig = [

--- a/wwwroot/changelog.php
+++ b/wwwroot/changelog.php
@@ -25,7 +25,7 @@ require_once("header.php");
                 <div class="col-12">
                     <h2>
                         <?php if ($entries !== []) { ?>
-                            <?php $firstEntry = $entries[0]; ?>
+                            <?php $firstEntry = array_first($entries); ?>
                             <time
                                 class="js-localized-changelog-date"
                                 datetime="<?= htmlspecialchars($firstEntry->getIsoTimestamp(), ENT_QUOTES, 'UTF-8'); ?>"

--- a/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
+++ b/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
@@ -328,13 +328,15 @@ final class GameRescanCatalogUpdater
             $platforms[] = $platform->value;
         }
 
-        $platforms = array_values(array_filter($platforms, static fn(string $platform): bool => $platform !== ''));
-        $platforms = array_values(array_unique($platforms));
+        $platforms = $platforms
+            |> (fn(array $items): array => array_filter($items, static fn(string $platform): bool => $platform !== ''))
+            |> array_unique(...)
+            |> array_values(...);
 
-        $existingPlatforms = array_values(array_unique(array_filter(
-            $existingPlatforms,
-            static fn(string $platform): bool => $platform !== ''
-        )));
+        $existingPlatforms = $existingPlatforms
+            |> (fn(array $items): array => array_filter($items, static fn(string $platform): bool => $platform !== ''))
+            |> array_unique(...)
+            |> array_values(...);
 
         if (in_array('PSVR2', $existingPlatforms, true)) {
             if (!in_array('PSVR2', $platforms, true)) {

--- a/wwwroot/classes/Admin/PsnpPlusFixedGame.php
+++ b/wwwroot/classes/Admin/PsnpPlusFixedGame.php
@@ -14,7 +14,7 @@ readonly class PsnpPlusFixedGame
         private string $gameName,
         array $trophyIds
     ) {
-        $this->trophyIds = array_map('intval', $trophyIds);
+        $this->trophyIds = array_map(intval(...), $trophyIds);
     }
 
     public function getGameId(): int
@@ -47,7 +47,7 @@ readonly class PsnpPlusFixedGame
 
     public function getTrophyIdQuery(): string
     {
-        return implode(',', array_map('strval', $this->trophyIds));
+        return implode(',', array_map(strval(...), $this->trophyIds));
     }
 
     /**
@@ -55,6 +55,6 @@ readonly class PsnpPlusFixedGame
      */
     private function formatList(array $values): string
     {
-        return implode(', ', array_map('strval', $values));
+        return implode(', ', array_map(strval(...), $values));
     }
 }

--- a/wwwroot/classes/Admin/PsnpPlusGameDifference.php
+++ b/wwwroot/classes/Admin/PsnpPlusGameDifference.php
@@ -45,10 +45,10 @@ class PsnpPlusGameDifference
         $this->gameName = $gameName;
         $this->npCommunicationId = $npCommunicationId;
         $this->psnprofilesId = $psnprofilesId;
-        $this->unobtainableOrders = array_map('intval', $unobtainableOrders);
-        $this->unobtainableTrophyIds = array_map('intval', $unobtainableTrophyIds);
-        $this->obtainableOrders = array_map('intval', $obtainableOrders);
-        $this->obtainableTrophyIds = array_map('intval', $obtainableTrophyIds);
+        $this->unobtainableOrders = array_map(intval(...), $unobtainableOrders);
+        $this->unobtainableTrophyIds = array_map(intval(...), $unobtainableTrophyIds);
+        $this->obtainableOrders = array_map(intval(...), $obtainableOrders);
+        $this->obtainableTrophyIds = array_map(intval(...), $obtainableTrophyIds);
     }
 
     public function getGameId(): int
@@ -138,7 +138,7 @@ class PsnpPlusGameDifference
      */
     private function formatList(array $values): string
     {
-        return implode(', ', array_map('strval', $values));
+        return implode(', ', array_map(strval(...), $values));
     }
 
     /**
@@ -146,6 +146,6 @@ class PsnpPlusGameDifference
      */
     private function formatQuery(array $values): string
     {
-        return implode(',', array_map('strval', $values));
+        return implode(',', array_map(strval(...), $values));
     }
 }

--- a/wwwroot/classes/Admin/PsnpPlusService.php
+++ b/wwwroot/classes/Admin/PsnpPlusService.php
@@ -55,7 +55,7 @@ class PsnpPlusService
             $foundNpCommunicationIds[] = $game->getNpCommunicationId();
 
             $psnpTrophies = $trophies;
-            if ($psnpTrophies !== [] && $psnpTrophies[0] === 0) {
+            if ($psnpTrophies !== [] && array_first($psnpTrophies) === 0) {
                 $psnpTrophies = $this->findTrophyOrderNumbers($game->getNpCommunicationId(), false);
             }
 
@@ -132,7 +132,7 @@ class PsnpPlusService
 
         $rows = $statement->fetchAll(PDO::FETCH_COLUMN);
 
-        return array_map('intval', $rows === false ? [] : $rows);
+        return array_map(intval(...), $rows === false ? [] : $rows);
     }
 
     /**
@@ -188,7 +188,7 @@ class PsnpPlusService
 
         $rows = $statement->fetchAll(PDO::FETCH_COLUMN);
 
-        return array_map('strval', $rows === false ? [] : $rows);
+        return array_map(strval(...), $rows === false ? [] : $rows);
     }
 
     private function findGameByNpCommunicationId(string $npCommunicationId): ?PsnpPlusGame
@@ -274,6 +274,6 @@ class PsnpPlusService
 
         $rows = $statement->fetchAll(PDO::FETCH_COLUMN);
 
-        return array_map('intval', $rows === false ? [] : $rows);
+        return array_map(intval(...), $rows === false ? [] : $rows);
     }
 }

--- a/wwwroot/classes/Admin/TrophyStatusInputParser.php
+++ b/wwwroot/classes/Admin/TrophyStatusInputParser.php
@@ -35,7 +35,7 @@ final class TrophyStatusInputParser
             |> array_unique(...)
             |> array_values(...);
 
-        if (count($ids) === 0) {
+        if ($ids === []) {
             throw new InvalidArgumentException('No trophies were provided.');
         }
 
@@ -60,7 +60,7 @@ final class TrophyStatusInputParser
 
         $trophies = $query->fetchAll(PDO::FETCH_COLUMN);
 
-        if ($trophies === false || count($trophies) === 0) {
+        if ($trophies === false || $trophies === []) {
             throw new InvalidArgumentException('No trophies found for the selected game.');
         }
 

--- a/wwwroot/classes/Admin/TrophyStatusPage.php
+++ b/wwwroot/classes/Admin/TrophyStatusPage.php
@@ -79,16 +79,15 @@ class TrophyStatusPage
             $statusInput = (string) $status;
 
             try {
-                if (!empty($postData['game'])) {
-                    $gameValue = (string) $postData['game'];
-
+                $gameValue = trim((string) ($postData['game'] ?? ''));
+                if ($gameValue !== '') {
                     if (!ctype_digit($gameValue)) {
                         throw new \InvalidArgumentException('Game ID must be numeric.');
                     }
 
                     $gameId = (int) $gameValue;
                     $trophyIds = $this->trophyStatusInputParser->getTrophyIdsForGame($gameId);
-                    $trophyInput = implode(',', array_map('strval', $trophyIds));
+                    $trophyInput = implode(',', array_map(strval(...), $trophyIds));
                 } else {
                     $trophyInput = (string) ($postData['trophy'] ?? '');
                     $trophyIds = $this->trophyStatusInputParser->parseTrophyIds($trophyInput);

--- a/wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php
+++ b/wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php
@@ -281,7 +281,7 @@ SQL;
         $this->database->exec('DROP TEMPORARY TABLE IF EXISTS temp_impacted_accounts');
         $this->database->exec('CREATE TEMPORARY TABLE temp_impacted_accounts (account_id BIGINT UNSIGNED PRIMARY KEY)');
 
-        if (count($affectedTrophyIds) === 0) {
+        if ($affectedTrophyIds === []) {
             return;
         }
 

--- a/wwwroot/classes/Admin/TrophyStatusService.php
+++ b/wwwroot/classes/Admin/TrophyStatusService.php
@@ -26,7 +26,7 @@ class TrophyStatusService
             |> array_unique(...)
             |> array_values(...);
 
-        if (count($trophyIds) === 0) {
+        if ($trophyIds === []) {
             throw new InvalidArgumentException('No trophies were provided.');
         }
 

--- a/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
@@ -55,7 +55,7 @@ final class PlayerScanTrophyProgressSynchronizer
             foreach ($groupTrophies as $trophy) {
                 $trophyEarned = $trophy->earned();
                 $progress = (clone $trophy)->progress();
-                if ($trophyEarned || ($progress != '' && (int) $progress > 0)) {
+                if ($trophyEarned || ($progress !== '' && (int) $progress > 0)) {
                     $this->earnedTrophyPersister->persistEarnedTrophy(
                         $npCommunicationId,
                         $trophyGroup->id(),

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -311,12 +311,12 @@ class GameHeaderService
 
             $url = trim($matches['url'][0]);
             $linkText = $matches['text'][0];
-            $validatedUrl = filter_var($url, FILTER_VALIDATE_URL);
+            $scheme = Uri\Rfc3986\Uri::parse($url)?->getScheme();
 
-            if ($validatedUrl !== false && preg_match('/^https?:\/\//i', $validatedUrl) === 1) {
+            if ($scheme === 'http' || $scheme === 'https') {
                 $formatted .= sprintf(
                     '<a href="%s" target="_blank" rel="noopener">%s</a>',
-                    Html::escape($validatedUrl),
+                    Html::escape($url),
                     Html::escape($linkText)
                 );
             } else {

--- a/wwwroot/classes/GameMessageSanitizer.php
+++ b/wwwroot/classes/GameMessageSanitizer.php
@@ -25,16 +25,15 @@ final class GameMessageSanitizer
             $attributes = $matches[1][0];
             $linkContent = $matches[2][0];
             $href = self::extractHref($attributes);
-            $validatedUrl = $href !== null ? filter_var($href, FILTER_VALIDATE_URL) : false;
 
-            if ($validatedUrl !== false && preg_match('/^https?:\/\//i', (string) $validatedUrl) === 1) {
+            if ($href !== null && self::isSafeHttpUrl($href)) {
                 $targetAttributes = self::hasTargetBlank($attributes)
                     ? ' target="_blank" rel="noopener noreferrer"'
                     : '';
 
                 $sanitized .= sprintf(
                     '<a href="%s"%s>%s</a>',
-                    Html::escape((string) $validatedUrl),
+                    Html::escape($href),
                     $targetAttributes,
                     self::sanitizeLinkText($linkContent)
                 );
@@ -101,7 +100,17 @@ final class GameMessageSanitizer
 
     private static function sanitizeLinkText(string $content): string
     {
-        return Html::escape(self::decodeHtmlEntities(strip_tags($content)));
+        return $content
+            |> strip_tags(...)
+            |> self::decodeHtmlEntities(...)
+            |> Html::escape(...);
+    }
+
+    private static function isSafeHttpUrl(string $url): bool
+    {
+        $scheme = Uri\Rfc3986\Uri::parse($url)?->getScheme();
+
+        return $scheme === 'http' || $scheme === 'https';
     }
 
     private static function decodeHtmlEntities(string $value): string

--- a/wwwroot/classes/HomepageController.php
+++ b/wwwroot/classes/HomepageController.php
@@ -7,13 +7,11 @@ require_once __DIR__ . '/HomepagePage.php';
 require_once __DIR__ . '/HomepageViewModel.php';
 require_once __DIR__ . '/HomepagePopularGamesFilter.php';
 
-final class HomepageController
+final readonly class HomepageController
 {
-    private HomepagePage $homepagePage;
-
-    public function __construct(HomepagePage $homepagePage)
-    {
-        $this->homepagePage = $homepagePage;
+    public function __construct(
+        private HomepagePage $homepagePage,
+    ) {
     }
 
     public static function fromDatabase(PDO $database): self
@@ -24,39 +22,44 @@ final class HomepageController
         return new self($homepagePage);
     }
 
+    #[\NoDiscard]
     public function withTitle(string $title): self
     {
-        $this->homepagePage->setTitle($title);
-
-        return $this;
+        return clone($this, [
+            'homepagePage' => $this->homepagePage->withTitle($title),
+        ]);
     }
 
+    #[\NoDiscard]
     public function withNewGamesLimit(int $limit): self
     {
-        $this->homepagePage->setNewGamesLimit($limit);
-
-        return $this;
+        return clone($this, [
+            'homepagePage' => $this->homepagePage->withNewGamesLimit($limit),
+        ]);
     }
 
+    #[\NoDiscard]
     public function withNewDlcsLimit(int $limit): self
     {
-        $this->homepagePage->setNewDlcsLimit($limit);
-
-        return $this;
+        return clone($this, [
+            'homepagePage' => $this->homepagePage->withNewDlcsLimit($limit),
+        ]);
     }
 
+    #[\NoDiscard]
     public function withPopularGamesLimit(int $limit): self
     {
-        $this->homepagePage->setPopularGamesLimit($limit);
-
-        return $this;
+        return clone($this, [
+            'homepagePage' => $this->homepagePage->withPopularGamesLimit($limit),
+        ]);
     }
 
+    #[\NoDiscard]
     public function withPopularGamesFilter(HomepagePopularGamesFilter $filter): self
     {
-        $this->homepagePage->setPopularGamesFilter($filter);
-
-        return $this;
+        return clone($this, [
+            'homepagePage' => $this->homepagePage->withPopularGamesFilter($filter),
+        ]);
     }
 
     public function getViewModel(): HomepageViewModel

--- a/wwwroot/classes/HomepagePage.php
+++ b/wwwroot/classes/HomepagePage.php
@@ -6,12 +6,12 @@ require_once __DIR__ . '/HomepageContentService.php';
 require_once __DIR__ . '/HomepageViewModel.php';
 require_once __DIR__ . '/HomepagePopularGamesFilter.php';
 
-class HomepagePage
+final readonly class HomepagePage
 {
     private const DEFAULT_TITLE = 'PSN 100% ~ PlayStation Leaderboards & Trophies';
 
     public function __construct(
-        private readonly HomepageContentService $contentService,
+        private HomepageContentService $contentService,
         private string $title = self::DEFAULT_TITLE,
         private ?int $newGamesLimit = null,
         private ?int $newDlcsLimit = null,
@@ -20,42 +20,40 @@ class HomepagePage
     ) {
     }
 
-    public function setTitle(string $title): self
+    #[\NoDiscard]
+    public function withTitle(string $title): self
     {
-        $this->title = $title;
-
-        return $this;
+        return clone($this, ['title' => $title]);
     }
 
-    public function setNewGamesLimit(int $limit): self
+    #[\NoDiscard]
+    public function withNewGamesLimit(int $limit): self
     {
-        $this->assertPositiveLimit($limit);
-        $this->newGamesLimit = $limit;
+        self::assertPositiveLimit($limit);
 
-        return $this;
+        return clone($this, ['newGamesLimit' => $limit]);
     }
 
-    public function setNewDlcsLimit(int $limit): self
+    #[\NoDiscard]
+    public function withNewDlcsLimit(int $limit): self
     {
-        $this->assertPositiveLimit($limit);
-        $this->newDlcsLimit = $limit;
+        self::assertPositiveLimit($limit);
 
-        return $this;
+        return clone($this, ['newDlcsLimit' => $limit]);
     }
 
-    public function setPopularGamesLimit(int $limit): self
+    #[\NoDiscard]
+    public function withPopularGamesLimit(int $limit): self
     {
-        $this->assertPositiveLimit($limit);
-        $this->popularGamesLimit = $limit;
+        self::assertPositiveLimit($limit);
 
-        return $this;
+        return clone($this, ['popularGamesLimit' => $limit]);
     }
 
-    public function setPopularGamesFilter(HomepagePopularGamesFilter $filter): self
+    #[\NoDiscard]
+    public function withPopularGamesFilter(HomepagePopularGamesFilter $filter): self
     {
-        $this->popularGamesFilter = $filter;
-
-        return $this;
+        return clone($this, ['popularGamesFilter' => $filter]);
     }
 
     public function buildViewModel(): HomepageViewModel
@@ -77,7 +75,7 @@ class HomepagePage
         return new HomepageViewModel($this->title, $newGames, $newDlcs, $popularGames, $popularGamesFilter);
     }
 
-    private function assertPositiveLimit(int $limit): void
+    private static function assertPositiveLimit(int $limit): void
     {
         if ($limit < 1) {
             throw new InvalidArgumentException('Limit must be greater than or equal to 1.');

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -81,7 +81,7 @@ class PlayerGamesFilter
         if ($sort !== '' && in_array($sort, self::ALLOWED_SORTS, true)) {
             $filter->sort = $sort;
             $filter->sortProvided = true;
-        } elseif (!empty($filter->search)) {
+        } elseif ($filter->search !== '') {
             $filter->sort = self::SORT_SEARCH;
         }
 
@@ -116,7 +116,7 @@ class PlayerGamesFilter
 
     public function hasSearchTerm(): bool
     {
-        return !empty($this->search);
+        return $this->search !== '';
     }
 
     public function shouldApplyFulltextCondition(): bool

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -291,16 +291,17 @@ final class PlayerGamesService
         $formatted = $interval->format('%y years, %m months, %d days, %h hours, %i minutes, %s seconds');
         $parts = explode(', ', $formatted);
 
-        $nonZeroParts = array_values(array_filter(
-            $parts,
-            static fn(string $part): bool => $part !== '' && $part[0] !== '0'
-        ));
+        $summary = $parts
+            |> (fn(array $parts): array => array_filter(
+                $parts,
+                static fn(string $part): bool => $part !== '' && $part[0] !== '0'
+            ))
+            |> array_values(...)
+            |> (fn(array $parts): array => array_slice($parts, 0, 2));
 
-        if ($nonZeroParts === []) {
+        if ($summary === []) {
             return null;
         }
-
-        $summary = array_slice($nonZeroParts, 0, 2);
 
         return 'Completed in ' . implode(', ', $summary);
     }

--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -114,7 +114,9 @@ class PlayerRandomGamesService
             return [];
         }
 
-        return array_values(array_map('intval', $results));
+        return $results
+            |> (fn(array $ids): array => array_map(intval(...), $ids))
+            |> array_values(...);
     }
 
     /**
@@ -227,7 +229,10 @@ class PlayerRandomGamesService
             return [];
         }
 
-        $seenIds = array_values(array_unique(array_map('intval', $seenIds)));
+        $seenIds = $seenIds
+            |> (fn(array $ids): array => array_map(intval(...), $ids))
+            |> array_unique(...)
+            |> array_values(...);
 
         if ($limit <= 25) {
             return $this->fetchFallbackRowsWithRandomOrder($accountId, $filter, $limit, $seenIds);

--- a/wwwroot/classes/PlayerStatusNotice.php
+++ b/wwwroot/classes/PlayerStatusNotice.php
@@ -14,6 +14,7 @@ readonly class PlayerStatusNotice
         private string $message,
     ) {}
 
+    #[\NoDiscard]
     public static function flagged(string $onlineId, ?string $accountId): self
     {
         $disputeUrl = self::createDisputeUrl($onlineId, $accountId);
@@ -25,6 +26,7 @@ readonly class PlayerStatusNotice
         return new self(self::TYPE_FLAGGED, $message);
     }
 
+    #[\NoDiscard]
     public static function privateProfile(): self
     {
         $message = sprintf(
@@ -35,11 +37,20 @@ readonly class PlayerStatusNotice
         return new self(self::TYPE_PRIVATE, $message);
     }
 
+    #[\NoDiscard]
     public static function createDisputeUrl(string $onlineId, ?string $accountId): string
     {
-        $query = ['q' => self::buildDisputeQuery($onlineId, $accountId)];
+        $query = http_build_query(
+            ['q' => self::buildDisputeQuery($onlineId, $accountId)],
+            '',
+            '&',
+            PHP_QUERY_RFC3986
+        );
 
-        return self::DISPUTE_BASE_URL . '?' . http_build_query($query, '', '&', PHP_QUERY_RFC3986);
+        return Uri\Rfc3986\Uri::parse(self::DISPUTE_BASE_URL)
+            ?->withQuery($query)
+            ->toRawString()
+            ?? self::DISPUTE_BASE_URL . '?' . $query;
     }
 
     public function getMessage(): string

--- a/wwwroot/classes/PsnpPlusClient.php
+++ b/wwwroot/classes/PsnpPlusClient.php
@@ -47,7 +47,7 @@ class PsnpPlusClient
                 $trophies = [];
             }
 
-            $trophiesById[$psnprofilesId] = array_map('intval', $trophies);
+            $trophiesById[$psnprofilesId] = array_map(intval(...), $trophies);
         }
 
         return $trophiesById;

--- a/wwwroot/classes/SearchQueryHelper.php
+++ b/wwwroot/classes/SearchQueryHelper.php
@@ -86,7 +86,7 @@ final class SearchQueryHelper
             );
 
             if (count($scoreExpressions) === 1) {
-                $columns[] = sprintf('%s AS score', $scoreExpressions[0]);
+                $columns[] = sprintf('%s AS score', array_first($scoreExpressions));
             } else {
                 $columns[] = sprintf('GREATEST(%s) AS score', implode(', ', $scoreExpressions));
             }

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -39,7 +39,7 @@ class TrophyMergeService
 
     public function mergeSpecificTrophies(int $parentTrophyId, array $childTrophyIds): string
     {
-        if (empty($childTrophyIds)) {
+        if ($childTrophyIds === []) {
             throw new InvalidArgumentException('At least one child trophy is required.');
         }
 

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -293,7 +293,7 @@ require_once("header.php");
                                                         $first = -1;
                                                         $second = -1;
                                                         for ($i = 0; $i < count($completionTimes); $i++) {
-                                                            if ($completionTimes[$i][0] == "0") {
+                                                            if ($completionTimes[$i][0] === '0') {
                                                                 continue;
                                                             }
 

--- a/wwwroot/player_header.php
+++ b/wwwroot/player_header.php
@@ -39,7 +39,7 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
                     </blockquote>
                     <?php
                     $aboutMe = $playerHeaderViewModel->getAboutMe();
-                    if (!empty($aboutMe)) {
+                    if ($aboutMe !== '') {
                         ?>
                         <figcaption class="blockquote-footer">
                             <?= $aboutMe; ?>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The codebase already uses many PHP 8.5 features. This PR closes the remaining consistency gaps now that we target 8.5 with no backward compatibility requirement.

### Changes
- Use `array_first()` where the first array value was still indexed manually
- Prefer the pipe operator (`|>`) and first-class callables for nested `array_map` / `array_filter` / `array_unique` transforms
- Convert `HomepagePage` / `HomepageController` to immutable `readonly` types with `clone($this, [...])` and `#[\NoDiscard]`
- Validate and build URLs with `Uri\Rfc3986\Uri` in `GameMessageSanitizer`, `GameHeaderService`, and `PlayerStatusNotice`
- Add `#[\NoDiscard]` on `PlayerStatusNotice` factories
- Replace `count(...) === 0` / `empty(...)` / loose comparisons with stricter `=== []` / `!== ''` / `===` checks

## Test plan
- [x] `php tests/run.php` — all 945 tests passed
- [x] Existing coverage for URL sanitization (`GameMessageSanitizerTest`, `GameHeaderServiceTest`) and related admin/player services
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dac9ec3-2841-47a3-81e0-e52e5a9faffc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dac9ec3-2841-47a3-81e0-e52e5a9faffc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

