### PR TITLE
Improve MySQL 8.4 SQL for trophy_earned at production scale

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -193,6 +193,7 @@ After schema import or large data changes on MySQL 8.4+, run:
 ```bash
 mysql "$DB_NAME" < database/mysql84_histograms.sql
 mysql "$DB_NAME" < database/mysql84_covering_indexes.sql
+mysql "$DB_NAME" < database/mysql84_trophy_earned_triggers.sql
 ```
 
 Histograms use `AUTO UPDATE` on heavily filtered columns (`player.status`,
@@ -202,7 +203,8 @@ and cron queries. Re-run after bulk imports; a weekly `ANALYZE TABLE` cron is op
 reasonable on busy sites.
 
 `mysql84_covering_indexes.sql` adds descending covering indexes for game leaderboard sorts
-and popular/game-list ordering, status CHECK constraints, and migrates
+and popular/game-list ordering, replaces `trophy_group_player.idx_account_id` with
+`(account_id, np_communication_id)`, status CHECK constraints, and migrates
 `setting.scan_progress` to JSON. Safe to re-run on upgraded databases.
 
 `player_ranking` is excluded from histograms because `PlayerRankingUpdater` rebuilds and
@@ -212,6 +214,11 @@ swaps that table every five minutes, which would invalidate histograms immediate
 `ANALYZE TABLE` would run for hours and `AUTO UPDATE` would rebuild histograms on every
 InnoDB stats refresh. Existing queries filter by `account_id` (partition key) or
 `np_communication_id` (leading primary-key column), so histograms would add little value.
+
+`mysql84_trophy_earned_triggers.sql` recreates the three `trophy_earned` triggers so that
+`earned` flips from `1` → `0` decrement `player.trophy_count_npwr`, and so bulk deletes can
+set `@psn100_skip_trophy_count = 1` to skip per-row counter updates (fresh installs from
+`psn100.sql` already include this). Safe to re-run; it only replaces trigger definitions.
 
 Older databases may still carry redundant indexes dropped from the current schema. Apply
 (safe to re-run; skips indexes that are already absent):

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -203,9 +203,18 @@ and cron queries. Re-run after bulk imports; a weekly `ANALYZE TABLE` cron is op
 reasonable on busy sites.
 
 `mysql84_covering_indexes.sql` adds descending covering indexes for game leaderboard sorts
-and popular/game-list ordering, replaces `trophy_group_player.idx_account_id` with
-`(account_id, np_communication_id)`, status CHECK constraints, and migrates
+and popular/game-list ordering, status CHECK constraints, and migrates
 `setting.scan_progress` to JSON. Safe to re-run on upgraded databases.
+
+`trophy_group_player` (~227M rows / ~24 GiB) and `trophy_title_player` (~123M rows /
+~33 GiB) are large enough that index builds are scheduled ops, not routine deploys.
+Fresh installs from `psn100.sql` already use `trophy_group_player.idx_tgp_account_np`
+`(account_id, np_communication_id)`. Upgrades that still have `idx_account_id` can apply
+the optional online swap when disk/IO allow:
+
+```bash
+mysql "$DB_NAME" < database/mysql84_trophy_group_player_index.sql
+```
 
 `player_ranking` is excluded from histograms because `PlayerRankingUpdater` rebuilds and
 swaps that table every five minutes, which would invalidate histograms immediately.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -215,10 +215,10 @@ swaps that table every five minutes, which would invalidate histograms immediate
 InnoDB stats refresh. Existing queries filter by `account_id` (partition key) or
 `np_communication_id` (leading primary-key column), so histograms would add little value.
 
-`mysql84_trophy_earned_triggers.sql` recreates the three `trophy_earned` triggers so that
-`earned` flips from `1` → `0` decrement `player.trophy_count_npwr`, and so bulk deletes can
-set `@psn100_skip_trophy_count = 1` to skip per-row counter updates (fresh installs from
-`psn100.sql` already include this). Safe to re-run; it only replaces trigger definitions.
+`mysql84_trophy_earned_triggers.sql` recreates the three `trophy_earned` triggers so bulk
+deletes can set `@psn100_skip_trophy_count = 1` to skip per-row counter updates (fresh
+installs from `psn100.sql` already include this). Safe to re-run; it only replaces trigger
+definitions. (`earned` only transitions `0` → `1`, never `1` → `0`.)
 
 Older databases may still carry redundant indexes dropped from the current schema. Apply
 (safe to re-run; skips indexes that are already absent):

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ scripts:
 ```bash
 mysql psn100 < database/mysql84_histograms.sql
 mysql psn100 < database/mysql84_covering_indexes.sql
+mysql psn100 < database/mysql84_trophy_earned_triggers.sql
 ```
 
 Histograms use MySQL 8.4 `AUTO UPDATE` so they stay current when `ANALYZE TABLE` runs or
@@ -86,6 +87,11 @@ ongoing overhead with negligible benefit for partition- and PK-scoped lookups.
 `mysql84_covering_indexes.sql` adds descending covering indexes for game leaderboard and
 game-list/popular sorts, status CHECK constraints, and migrates `setting.scan_progress` to
 JSON. Safe to re-run.
+
+`mysql84_trophy_earned_triggers.sql` recreates the `trophy_earned` triggers so `earned`
+`1` → `0` flips decrement `player.trophy_count_npwr`, and bulk deletes can set
+`@psn100_skip_trophy_count = 1` to skip per-row counter updates. Safe to re-run; does not
+alter the multi-billion-row table itself.
 
 Existing databases that still have legacy or unused indexes can apply (safe to re-run; skips
 indexes that are already absent):

--- a/README.md
+++ b/README.md
@@ -88,10 +88,9 @@ ongoing overhead with negligible benefit for partition- and PK-scoped lookups.
 game-list/popular sorts, status CHECK constraints, and migrates `setting.scan_progress` to
 JSON. Safe to re-run.
 
-`mysql84_trophy_earned_triggers.sql` recreates the `trophy_earned` triggers so `earned`
-`1` → `0` flips decrement `player.trophy_count_npwr`, and bulk deletes can set
-`@psn100_skip_trophy_count = 1` to skip per-row counter updates. Safe to re-run; does not
-alter the multi-billion-row table itself.
+`mysql84_trophy_earned_triggers.sql` recreates the `trophy_earned` triggers so bulk deletes
+can set `@psn100_skip_trophy_count = 1` to skip per-row counter updates. Safe to re-run;
+does not alter the multi-billion-row table itself. (`earned` only transitions `0` → `1`.)
 
 Existing databases that still have legacy or unused indexes can apply (safe to re-run; skips
 indexes that are already absent):

--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ JSON. Safe to re-run.
 can set `@psn100_skip_trophy_count = 1` to skip per-row counter updates. Safe to re-run;
 does not alter the multi-billion-row table itself. (`earned` only transitions `0` → `1`.)
 
+`trophy_group_player` / `trophy_title_player` are large (~227M / ~24 GiB and ~123M / ~33 GiB).
+The optional `mysql84_trophy_group_player_index.sql` swaps `idx_account_id` for
+`idx_tgp_account_np`; schedule that online ALTER separately (fresh `psn100.sql` installs
+already have it).
+
 Existing databases that still have legacy or unused indexes can apply (safe to re-run; skips
 indexes that are already absent):
 

--- a/database/mysql84_covering_indexes.sql
+++ b/database/mysql84_covering_indexes.sql
@@ -158,13 +158,9 @@ CALL psn100_add_index_if_not_exists(
 )$$
 CALL psn100_drop_index_if_exists('trophy_title_meta', 'idx_ttm_status')$$
 
--- Scan/stale-delete paths filter trophy_group_player by (account_id, np_communication_id).
-CALL psn100_add_index_if_not_exists(
-    'trophy_group_player',
-    'idx_tgp_account_np',
-    '`account_id`, `np_communication_id`'
-)$$
-CALL psn100_drop_index_if_exists('trophy_group_player', 'idx_account_id')$$
+-- trophy_group_player index swap is intentionally NOT here: at production scale
+-- (~200M+ rows / tens of GiB) that online ALTER should be scheduled separately.
+-- See database/mysql84_trophy_group_player_index.sql.
 
 CALL psn100_add_check_if_not_exists(
     'player',

--- a/database/mysql84_covering_indexes.sql
+++ b/database/mysql84_covering_indexes.sql
@@ -158,6 +158,14 @@ CALL psn100_add_index_if_not_exists(
 )$$
 CALL psn100_drop_index_if_exists('trophy_title_meta', 'idx_ttm_status')$$
 
+-- Scan/stale-delete paths filter trophy_group_player by (account_id, np_communication_id).
+CALL psn100_add_index_if_not_exists(
+    'trophy_group_player',
+    'idx_tgp_account_np',
+    '`account_id`, `np_communication_id`'
+)$$
+CALL psn100_drop_index_if_exists('trophy_group_player', 'idx_account_id')$$
+
 CALL psn100_add_check_if_not_exists(
     'player',
     'chk_player_status',

--- a/database/mysql84_trophy_earned_triggers.sql
+++ b/database/mysql84_trophy_earned_triggers.sql
@@ -1,0 +1,49 @@
+-- Recreate trophy_earned triggers for MySQL 8.4 deployments.
+-- Safe to re-run: drops and recreates all three triggers.
+--
+-- Changes vs older definitions:
+--   * after_update also decrements player.trophy_count_npwr on earned 1→0
+--   * all three triggers honor @psn100_skip_trophy_count so bulk deletes
+--     (e.g. DeletePlayerService) can skip per-row player counter updates
+--
+-- trophy_earned is ~billions of rows / hundreds of GiB. This script only
+-- replaces trigger definitions; it does not ALTER the table or rebuild indexes.
+
+DROP TRIGGER IF EXISTS `after_delete_trophy_earned`;
+DROP TRIGGER IF EXISTS `after_insert_trophy_earned`;
+DROP TRIGGER IF EXISTS `after_update_trophy_earned`;
+
+DELIMITER $$
+CREATE TRIGGER `after_delete_trophy_earned` AFTER DELETE ON `trophy_earned` FOR EACH ROW BEGIN
+    IF IFNULL(@psn100_skip_trophy_count, 0) = 0
+        AND OLD.earned = 1
+        AND OLD.np_communication_id LIKE 'NPWR%' THEN
+        UPDATE player SET trophy_count_npwr = trophy_count_npwr - 1 WHERE account_id = OLD.account_id;
+    END IF;
+END
+$$
+DELIMITER ;
+
+DELIMITER $$
+CREATE TRIGGER `after_insert_trophy_earned` AFTER INSERT ON `trophy_earned` FOR EACH ROW BEGIN
+    IF IFNULL(@psn100_skip_trophy_count, 0) = 0
+        AND NEW.earned = 1
+        AND NEW.np_communication_id LIKE 'NPWR%' THEN
+        UPDATE player SET trophy_count_npwr = trophy_count_npwr + 1 WHERE account_id = NEW.account_id;
+    END IF;
+END
+$$
+DELIMITER ;
+
+DELIMITER $$
+CREATE TRIGGER `after_update_trophy_earned` AFTER UPDATE ON `trophy_earned` FOR EACH ROW BEGIN
+    IF IFNULL(@psn100_skip_trophy_count, 0) = 0 THEN
+        IF OLD.earned = 0 AND NEW.earned = 1 AND NEW.np_communication_id LIKE 'NPWR%' THEN
+            UPDATE player SET trophy_count_npwr = trophy_count_npwr + 1 WHERE account_id = NEW.account_id;
+        ELSEIF OLD.earned = 1 AND NEW.earned = 0 AND OLD.np_communication_id LIKE 'NPWR%' THEN
+            UPDATE player SET trophy_count_npwr = trophy_count_npwr - 1 WHERE account_id = OLD.account_id;
+        END IF;
+    END IF;
+END
+$$
+DELIMITER ;

--- a/database/mysql84_trophy_earned_triggers.sql
+++ b/database/mysql84_trophy_earned_triggers.sql
@@ -2,9 +2,11 @@
 -- Safe to re-run: drops and recreates all three triggers.
 --
 -- Changes vs older definitions:
---   * after_update also decrements player.trophy_count_npwr on earned 1→0
 --   * all three triggers honor @psn100_skip_trophy_count so bulk deletes
 --     (e.g. DeletePlayerService) can skip per-row player counter updates
+--
+-- earned never transitions 1→0 (only insert as 0/1, or update 0→1), so
+-- after_update only increments on 0→1.
 --
 -- trophy_earned is ~billions of rows / hundreds of GiB. This script only
 -- replaces trigger definitions; it does not ALTER the table or rebuild indexes.
@@ -37,12 +39,12 @@ DELIMITER ;
 
 DELIMITER $$
 CREATE TRIGGER `after_update_trophy_earned` AFTER UPDATE ON `trophy_earned` FOR EACH ROW BEGIN
-    IF IFNULL(@psn100_skip_trophy_count, 0) = 0 THEN
-        IF OLD.earned = 0 AND NEW.earned = 1 AND NEW.np_communication_id LIKE 'NPWR%' THEN
-            UPDATE player SET trophy_count_npwr = trophy_count_npwr + 1 WHERE account_id = NEW.account_id;
-        ELSEIF OLD.earned = 1 AND NEW.earned = 0 AND OLD.np_communication_id LIKE 'NPWR%' THEN
-            UPDATE player SET trophy_count_npwr = trophy_count_npwr - 1 WHERE account_id = OLD.account_id;
-        END IF;
+    -- earned only transitions 0→1 (never 1→0); inserts handle the initial value.
+    IF IFNULL(@psn100_skip_trophy_count, 0) = 0
+        AND OLD.earned = 0
+        AND NEW.earned = 1
+        AND NEW.np_communication_id LIKE 'NPWR%' THEN
+        UPDATE player SET trophy_count_npwr = trophy_count_npwr + 1 WHERE account_id = NEW.account_id;
     END IF;
 END
 $$

--- a/database/mysql84_trophy_group_player_index.sql
+++ b/database/mysql84_trophy_group_player_index.sql
@@ -1,0 +1,79 @@
+-- Optional / scheduled: replace trophy_group_player.idx_account_id with a composite
+-- that covers (account_id, np_communication_id) deletes used by scan stale-cleanup.
+--
+-- Production scale (approx): ~227M rows / ~24 GiB. This is an online InnoDB secondary
+-- index build (ALGORITHM=INPLACE, LOCK=NONE when possible) but still hours of IO and
+-- temporary disk for the new index before idx_account_id is dropped. Do NOT bundle this
+-- with routine post-deploy scripts; run during a maintenance window with disk headroom.
+--
+-- Fresh installs from database/psn100.sql already have idx_tgp_account_np.
+-- Safe to re-run: skips work when the target index already exists / old index is gone.
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS psn100_add_index_if_not_exists$$
+CREATE PROCEDURE psn100_add_index_if_not_exists(
+    IN p_table_name VARCHAR(64),
+    IN p_index_name VARCHAR(64),
+    IN p_index_columns VARCHAR(512)
+)
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = p_table_name
+          AND index_name = p_index_name
+    ) THEN
+        SET @add_sql = CONCAT(
+            'ALTER TABLE `',
+            REPLACE(p_table_name, '`', '``'),
+            '` ADD INDEX `',
+            REPLACE(p_index_name, '`', '``'),
+            '` (',
+            p_index_columns,
+            '), ALGORITHM=INPLACE, LOCK=NONE'
+        );
+        PREPARE stmt FROM @add_sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END IF;
+END$$
+
+DROP PROCEDURE IF EXISTS psn100_drop_index_if_exists$$
+CREATE PROCEDURE psn100_drop_index_if_exists(
+    IN p_table_name VARCHAR(64),
+    IN p_index_name VARCHAR(64)
+)
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = p_table_name
+          AND index_name = p_index_name
+    ) THEN
+        SET @drop_sql = CONCAT(
+            'ALTER TABLE `',
+            REPLACE(p_table_name, '`', '``'),
+            '` DROP INDEX `',
+            REPLACE(p_index_name, '`', '``'),
+            '`, ALGORITHM=INPLACE, LOCK=NONE'
+        );
+        PREPARE stmt FROM @drop_sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END IF;
+END$$
+
+CALL psn100_add_index_if_not_exists(
+    'trophy_group_player',
+    'idx_tgp_account_np',
+    '`account_id`, `np_communication_id`'
+)$$
+CALL psn100_drop_index_if_exists('trophy_group_player', 'idx_account_id')$$
+
+DROP PROCEDURE psn100_add_index_if_not_exists$$
+DROP PROCEDURE psn100_drop_index_if_exists$$
+
+DELIMITER ;

--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -259,12 +259,12 @@ $$
 DELIMITER ;
 DELIMITER $$
 CREATE TRIGGER `after_update_trophy_earned` AFTER UPDATE ON `trophy_earned` FOR EACH ROW BEGIN
-    IF IFNULL(@psn100_skip_trophy_count, 0) = 0 THEN
-        IF OLD.earned = 0 AND NEW.earned = 1 AND NEW.np_communication_id LIKE 'NPWR%' THEN
-            UPDATE player SET trophy_count_npwr = trophy_count_npwr + 1 WHERE account_id = NEW.account_id;
-        ELSEIF OLD.earned = 1 AND NEW.earned = 0 AND OLD.np_communication_id LIKE 'NPWR%' THEN
-            UPDATE player SET trophy_count_npwr = trophy_count_npwr - 1 WHERE account_id = OLD.account_id;
-        END IF;
+    -- earned only transitions 0→1 (never 1→0); inserts handle the initial value.
+    IF IFNULL(@psn100_skip_trophy_count, 0) = 0
+        AND OLD.earned = 0
+        AND NEW.earned = 1
+        AND NEW.np_communication_id LIKE 'NPWR%' THEN
+        UPDATE player SET trophy_count_npwr = trophy_count_npwr + 1 WHERE account_id = NEW.account_id;
     END IF;
 END
 $$

--- a/database/psn100.sql
+++ b/database/psn100.sql
@@ -239,25 +239,33 @@ PARTITIONS 256;
 --
 DELIMITER $$
 CREATE TRIGGER `after_delete_trophy_earned` AFTER DELETE ON `trophy_earned` FOR EACH ROW BEGIN
-    IF OLD.earned = 1 AND OLD.np_communication_id LIKE 'NPWR%' THEN
-    UPDATE player SET trophy_count_npwr = trophy_count_npwr - 1 WHERE account_id = OLD.account_id;
-END IF;
+    IF IFNULL(@psn100_skip_trophy_count, 0) = 0
+        AND OLD.earned = 1
+        AND OLD.np_communication_id LIKE 'NPWR%' THEN
+        UPDATE player SET trophy_count_npwr = trophy_count_npwr - 1 WHERE account_id = OLD.account_id;
+    END IF;
 END
 $$
 DELIMITER ;
 DELIMITER $$
 CREATE TRIGGER `after_insert_trophy_earned` AFTER INSERT ON `trophy_earned` FOR EACH ROW BEGIN
-    IF NEW.earned = 1 AND NEW.np_communication_id LIKE 'NPWR%' THEN
-    UPDATE player SET trophy_count_npwr = trophy_count_npwr + 1 WHERE account_id = NEW.account_id;
-END IF;
+    IF IFNULL(@psn100_skip_trophy_count, 0) = 0
+        AND NEW.earned = 1
+        AND NEW.np_communication_id LIKE 'NPWR%' THEN
+        UPDATE player SET trophy_count_npwr = trophy_count_npwr + 1 WHERE account_id = NEW.account_id;
+    END IF;
 END
 $$
 DELIMITER ;
 DELIMITER $$
 CREATE TRIGGER `after_update_trophy_earned` AFTER UPDATE ON `trophy_earned` FOR EACH ROW BEGIN
-    IF OLD.earned = 0 AND NEW.earned = 1 AND NEW.np_communication_id LIKE 'NPWR%' THEN
-    UPDATE player SET trophy_count_npwr = trophy_count_npwr + 1 WHERE account_id = NEW.account_id;
-END IF;
+    IF IFNULL(@psn100_skip_trophy_count, 0) = 0 THEN
+        IF OLD.earned = 0 AND NEW.earned = 1 AND NEW.np_communication_id LIKE 'NPWR%' THEN
+            UPDATE player SET trophy_count_npwr = trophy_count_npwr + 1 WHERE account_id = NEW.account_id;
+        ELSEIF OLD.earned = 1 AND NEW.earned = 0 AND OLD.np_communication_id LIKE 'NPWR%' THEN
+            UPDATE player SET trophy_count_npwr = trophy_count_npwr - 1 WHERE account_id = OLD.account_id;
+        END IF;
+    END IF;
 END
 $$
 DELIMITER ;
@@ -573,7 +581,7 @@ ALTER TABLE `trophy_group_history`
 --
 ALTER TABLE `trophy_group_player`
   ADD PRIMARY KEY (`np_communication_id`,`group_id`,`account_id`) USING BTREE,
-  ADD KEY `idx_account_id` (`account_id`);
+  ADD KEY `idx_tgp_account_np` (`account_id`,`np_communication_id`);
 
 --
 -- Indexes for table `trophy_history`

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -41,6 +41,17 @@ final class DailyCronJobTest extends TestCase
         $this->assertFalse(str_contains($source, 'player_ranking'));
     }
 
+    public function testZeroOwnersFastPathUsesLiveRankedOwnerCheckNotCachedMeta(): void
+    {
+        $source = $this->readClassSource();
+
+        $this->assertStringContainsString('SELECT EXISTS (', $source);
+        $this->assertStringContainsString('FROM trophy_title_player ttp', $source);
+        $this->assertStringContainsString('INNER JOIN player_ranking pr', $source);
+        $this->assertStringContainsString('pr.ranking <= 10000', $source);
+        $this->assertFalse(str_contains($source, 'SELECT owners FROM trophy_title_meta'));
+    }
+
     public function testUpdateTrophyRarityQueryAssignsRarityNamesFromThresholds(): void
     {
         $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_QUERY');
@@ -179,11 +190,11 @@ final class DailyCronJobPerGameRetryTestDatabase extends PDO
             }, isSelect: true);
         }
 
-        if (str_contains($query, 'SELECT owners FROM trophy_title_meta')) {
-            // Non-zero owners force the full ranked trophy_earned rarity path.
+        if (str_contains($query, 'SELECT EXISTS (') && str_contains($query, 'trophy_title_player ttp')) {
+            // Ranked owners present => full ranked trophy_earned rarity path.
             return new DailyCronJobTestStatement(static function (): int {
-                return 10;
-            }, isSelect: true, fetchColumnValue: 10);
+                return 1;
+            }, isSelect: true, fetchColumnValue: 1);
         }
 
         if (str_contains($query, 'UPDATE trophy_meta tm')) {
@@ -234,7 +245,7 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
             }, isSelect: true);
         }
 
-        if (str_contains($query, 'SELECT owners FROM trophy_title_meta')) {
+        if (str_contains($query, 'SELECT EXISTS (') && str_contains($query, 'trophy_title_player ttp')) {
             return new DailyCronJobTestStatement(static function (): int {
                 return 0;
             }, isSelect: true, fetchColumnValue: 0);

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -33,7 +33,10 @@ final class DailyCronJobTest extends TestCase
         $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY');
 
         $this->assertStringContainsString('UPDATE trophy_meta tm', $source);
-        $this->assertStringContainsString("tm.rarity_name = 'NONE'", $source);
+        $this->assertStringContainsString('JOIN trophy_title_meta ttm', $source);
+        $this->assertStringContainsString('IF(tm.status = 0 AND ttm.status = 0, 10000, 0)', $source);
+        $this->assertStringContainsString("IF(tm.status = 0 AND ttm.status = 0, 'LEGENDARY', 'NONE')", $source);
+        $this->assertStringContainsString('tm.in_game_rarity_point = 0', $source);
         $this->assertFalse(str_contains($source, 'trophy_earned'));
         $this->assertFalse(str_contains($source, 'player_ranking'));
     }

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -28,6 +28,16 @@ final class DailyCronJobTest extends TestCase
         $this->assertFalse(str_contains($source, 'LEFT JOIN trophy_earned te'));
     }
 
+    public function testZeroOwnersRarityQuerySkipsTrophyEarned(): void
+    {
+        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY');
+
+        $this->assertStringContainsString('UPDATE trophy_meta tm', $source);
+        $this->assertStringContainsString("tm.rarity_name = 'NONE'", $source);
+        $this->assertFalse(str_contains($source, 'trophy_earned'));
+        $this->assertFalse(str_contains($source, 'player_ranking'));
+    }
+
     public function testUpdateTrophyRarityQueryAssignsRarityNamesFromThresholds(): void
     {
         $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_QUERY');
@@ -166,6 +176,13 @@ final class DailyCronJobPerGameRetryTestDatabase extends PDO
             }, isSelect: true);
         }
 
+        if (str_contains($query, 'SELECT owners FROM trophy_title_meta')) {
+            // Non-zero owners force the full ranked trophy_earned rarity path.
+            return new DailyCronJobTestStatement(static function (): int {
+                return 10;
+            }, isSelect: true, fetchColumnValue: 10);
+        }
+
         if (str_contains($query, 'UPDATE trophy_meta tm')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->perGameUpdateCount++;
@@ -214,6 +231,12 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
             }, isSelect: true);
         }
 
+        if (str_contains($query, 'SELECT owners FROM trophy_title_meta')) {
+            return new DailyCronJobTestStatement(static function (): int {
+                return 0;
+            }, isSelect: true, fetchColumnValue: 0);
+        }
+
         if (str_contains($query, 'UPDATE trophy_meta tm')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->perGameUpdateCount++;
@@ -241,13 +264,16 @@ final class DailyCronJobTestStatement extends PDOStatement
 
     private bool $isSelect;
 
+    private mixed $fetchColumnValue;
+
     /**
      * @param callable(): mixed $callback
      */
-    public function __construct(callable $callback, bool $isSelect = false)
+    public function __construct(callable $callback, bool $isSelect = false, mixed $fetchColumnValue = null)
     {
         $this->callback = $callback;
         $this->isSelect = $isSelect;
+        $this->fetchColumnValue = $fetchColumnValue;
     }
 
     public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
@@ -273,5 +299,10 @@ final class DailyCronJobTestStatement extends PDOStatement
         $result = ($this->callback)();
 
         return is_array($result) ? $result : [];
+    }
+
+    public function fetchColumn(int $column = 0): mixed
+    {
+        return $this->fetchColumnValue;
     }
 }

--- a/tests/GameResetServiceTest.php
+++ b/tests/GameResetServiceTest.php
@@ -26,9 +26,9 @@ final class GameResetServiceTest extends TestCase
         $this->database->exec("INSERT INTO trophy_title_meta (np_communication_id, owners, owners_completed, parent_np_communication_id) VALUES ('NPWR-OTHER', 5, 2, 'MERGE-123')");
 
         $this->database->exec("INSERT INTO trophy_merge (parent_np_communication_id) VALUES ('MERGE-123')");
-        $this->database->exec("INSERT INTO trophy_earned (np_communication_id) VALUES ('MERGE-123')");
+        $this->database->exec("INSERT INTO trophy_title_player (np_communication_id, account_id) VALUES ('MERGE-123', 1001)");
+        $this->database->exec("INSERT INTO trophy_earned (np_communication_id, account_id) VALUES ('MERGE-123', 1001)");
         $this->database->exec("INSERT INTO trophy_group_player (np_communication_id) VALUES ('MERGE-123')");
-        $this->database->exec("INSERT INTO trophy_title_player (np_communication_id) VALUES ('MERGE-123')");
 
         $message = $this->service->process(1, 0);
 
@@ -76,28 +76,27 @@ final class GameResetServiceTest extends TestCase
         $this->database->exec("INSERT INTO trophy_title (id, np_communication_id, name) VALUES (2, 'NPWR-OTHER', 'Child Game')");
         $this->database->exec("INSERT INTO trophy_title_meta (np_communication_id, owners, owners_completed, parent_np_communication_id) VALUES ('NPWR-OTHER', 5, 2, 'MERGE-456')");
 
-        $tables = [
-            'trophy_merge' => 'parent_np_communication_id',
-            'trophy' => 'np_communication_id',
-            'trophy_earned' => 'np_communication_id',
-            'trophy_group_player' => 'np_communication_id',
-            'trophy_title_player' => 'np_communication_id',
-            'trophy_group' => 'np_communication_id',
-        ];
+        $this->database->exec("INSERT INTO trophy_merge (parent_np_communication_id) VALUES ('MERGE-456')");
+        $this->database->exec("INSERT INTO trophy (np_communication_id) VALUES ('MERGE-456')");
+        $this->database->exec("INSERT INTO trophy_title_player (np_communication_id, account_id) VALUES ('MERGE-456', 1002)");
+        $this->database->exec("INSERT INTO trophy_earned (np_communication_id, account_id) VALUES ('MERGE-456', 1002)");
+        $this->database->exec("INSERT INTO trophy_group_player (np_communication_id) VALUES ('MERGE-456')");
+        $this->database->exec("INSERT INTO trophy_group (np_communication_id) VALUES ('MERGE-456')");
 
-        foreach ($tables as $table => $column) {
-            $this->database->exec(sprintf(
-                "INSERT INTO %s (%s) VALUES ('MERGE-456')",
-                $table,
-                $column
-            ));
-        }
+        $tables = [
+            'trophy_merge',
+            'trophy',
+            'trophy_earned',
+            'trophy_group_player',
+            'trophy_title_player',
+            'trophy_group',
+        ];
 
         $message = $this->service->process(1, 1);
 
         $this->assertSame('Game 1 was deleted.', $message);
 
-        foreach (array_keys($tables) as $table) {
+        foreach ($tables as $table) {
             $this->assertSame(0, (int) $this->database->query(sprintf('SELECT COUNT(*) FROM %s', $table))->fetchColumn());
         }
 
@@ -165,6 +164,22 @@ final class GameResetServiceTest extends TestCase
         }
     }
 
+    public function testProcessDeletesAllTrophyEarnedRowsForTitleIncludingOrphans(): void
+    {
+        $this->insertMergedGame('MERGE-ACC', 11, 'Merged Game', 3, 1);
+        $this->database->exec("INSERT INTO trophy_title_player (np_communication_id, account_id) VALUES ('MERGE-ACC', 2001)");
+        $this->database->exec("INSERT INTO trophy_earned (np_communication_id, account_id) VALUES ('MERGE-ACC', 2001)");
+        // Orphan row without trophy_title_player must still be removed on reset/delete.
+        $this->database->exec("INSERT INTO trophy_earned (np_communication_id, account_id) VALUES ('MERGE-ACC', 2002)");
+
+        $this->service->process(11, 0);
+
+        $this->assertSame(
+            0,
+            (int) $this->database->query("SELECT COUNT(*) FROM trophy_earned WHERE np_communication_id = 'MERGE-ACC'")->fetchColumn()
+        );
+    }
+
     public function testProcessRollsBackWhenStatementFails(): void
     {
         $this->insertMergedGame('MERGE-999', 9, 'Merge Failure Game', 33, 12);
@@ -207,7 +222,10 @@ final class GameResetServiceTest extends TestCase
             psnprofiles_id TEXT NULL
         )');
         $this->database->exec('CREATE TABLE trophy_merge (parent_np_communication_id TEXT)');
-        $this->database->exec('CREATE TABLE trophy_earned (np_communication_id TEXT)');
+        $this->database->exec('CREATE TABLE trophy_earned (
+            np_communication_id TEXT,
+            account_id INTEGER
+        )');
         $this->database->exec('CREATE TABLE trophy_group_player (np_communication_id TEXT)');
         $this->database->exec('CREATE TABLE trophy_title_player (
             np_communication_id TEXT,

--- a/tests/PlayerAdvisorServiceTest.php
+++ b/tests/PlayerAdvisorServiceTest.php
@@ -263,12 +263,15 @@ final class PlayerAdvisorServiceTest extends TestCase
         $this->assertSame(25.0, $trophies[0]->getInGameRarityPercent());
     }
 
-    public function testAdvisorQueriesUseNotExistsAntiJoinForUnearnedTrophies(): void
+    public function testAdvisorQueriesUseSingleTrophyEarnedLeftJoinForUnearnedTrophies(): void
     {
         $source = (string) file_get_contents(__DIR__ . '/../wwwroot/classes/PlayerAdvisorService.php');
 
-        $this->assertStringContainsString('AND NOT EXISTS (', $source);
+        $this->assertStringContainsString('LEFT JOIN trophy_earned te ON', $source);
+        $this->assertStringContainsString('AND (te.account_id IS NULL OR te.earned = 0)', $source);
         $this->assertStringContainsString('FROM trophy_title_player ttp', $source);
-        $this->assertFalse(str_contains($source, 'LEFT JOIN trophy_earned te_completed'));
+        $this->assertFalse(str_contains($source, 'AND NOT EXISTS ('));
+        $this->assertFalse(str_contains($source, 'te_completed'));
+        $this->assertFalse(str_contains($source, 'te_progress'));
     }
 }

--- a/tests/PlayerEarnedTrophyPersisterTest.php
+++ b/tests/PlayerEarnedTrophyPersisterTest.php
@@ -29,6 +29,14 @@ final class PlayerEarnedTrophyPersisterTest extends TestCase
             str_contains($pdo->upsertSql[0], 'IF(trophy_earned.earned = 0, new.earned_date, trophy_earned.earned_date)'),
             'Child upsert should use child-specific earned_date merge rule.'
         );
+        $this->assertTrue(
+            str_contains($pdo->upsertSql[0], 'IF(trophy_earned.earned = 1, trophy_earned.earned, new.earned)'),
+            'Child upsert must never allow earned to go from 1 to 0.'
+        );
+        $this->assertFalse(
+            str_contains($pdo->upsertSql[0], 'earned = new.earned'),
+            'Child upsert must not overwrite earned unconditionally.'
+        );
 
         $this->assertSame([
             ':np_communication_id' => 'NPWR12345_00',

--- a/tests/PossibleCheaterServiceTest.php
+++ b/tests/PossibleCheaterServiceTest.php
@@ -90,6 +90,13 @@ final class PossibleCheaterServiceTest extends TestCase
         $this->service = new PossibleCheaterService($this->database, $rulesCatalog);
     }
 
+    public function testGeneralCheaterQueryRequiresEarnedTrophies(): void
+    {
+        $source = (string) file_get_contents(__DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterService.php');
+
+        $this->assertStringContainsString('AND te.earned = 1', $source);
+    }
+
     public function testCreateReportFindsMatchingGeneralCheaters(): void
     {
         $this->database->exec(

--- a/tests/TrophyStatusProgressRecalculatorTest.php
+++ b/tests/TrophyStatusProgressRecalculatorTest.php
@@ -27,7 +27,7 @@ final class TrophyStatusProgressRecalculatorTest extends TestCase
         $this->assertTrue(str_contains($query, 'AND tm.status = 0'));
         $this->assertTrue(str_contains($query, 'AND aggregate.account_id IS NOT NULL'));
 
-        $this->assertNotNull($database->impactedAccountsQuery);
+        $this->assertTrue($database->impactedAccountsQuery !== null);
         $this->assertTrue(str_contains((string) $database->impactedAccountsQuery, 'te.order_id IN ('));
         $this->assertTrue(str_contains((string) $database->impactedAccountsQuery, 'AND te.earned = 1'));
         $this->assertFalse(str_contains((string) $database->impactedAccountsQuery, 'INNER JOIN trophy t ON'));

--- a/tests/TrophyStatusProgressRecalculatorTest.php
+++ b/tests/TrophyStatusProgressRecalculatorTest.php
@@ -26,6 +26,12 @@ final class TrophyStatusProgressRecalculatorTest extends TestCase
         $this->assertTrue(str_contains($query, 'AND te.earned = 1'));
         $this->assertTrue(str_contains($query, 'AND tm.status = 0'));
         $this->assertTrue(str_contains($query, 'AND aggregate.account_id IS NOT NULL'));
+
+        $this->assertNotNull($database->impactedAccountsQuery);
+        $this->assertTrue(str_contains((string) $database->impactedAccountsQuery, 'te.order_id IN ('));
+        $this->assertTrue(str_contains((string) $database->impactedAccountsQuery, 'AND te.earned = 1'));
+        $this->assertFalse(str_contains((string) $database->impactedAccountsQuery, 'INNER JOIN trophy t ON'));
+        $this->assertSame('SELECT DISTINCT order_id FROM trophy WHERE id IN (?)', $database->orderIdsQuery);
     }
 
     public function testRecalculateTitleAggregatesFromTrophyGroupPlayer(): void
@@ -73,6 +79,10 @@ final class RecordingTrophyStatusProgressPDO extends PDO
 
     public ?string $titlePlayerCountQuery = null;
 
+    public ?string $impactedAccountsQuery = null;
+
+    public ?string $orderIdsQuery = null;
+
     public string|int|false|null $gameId = false;
 
     public ?string $insertedChangeType = null;
@@ -86,6 +96,18 @@ final class RecordingTrophyStatusProgressPDO extends PDO
     public function prepare(string $query, array $options = []): PDOStatement
     {
         $trimmedQuery = trim($query);
+
+        if (str_starts_with($trimmedQuery, 'SELECT DISTINCT order_id FROM trophy WHERE id IN')) {
+            $this->orderIdsQuery = $trimmedQuery;
+
+            return new RecordingTrophyStatusProgressFetchAllStatement([7]);
+        }
+
+        if (str_starts_with($trimmedQuery, 'INSERT IGNORE INTO temp_impacted_accounts')) {
+            $this->impactedAccountsQuery = $trimmedQuery;
+
+            return new RecordingTrophyStatusProgressExecuteOnlyStatement();
+        }
 
         if (str_starts_with($trimmedQuery, 'UPDATE') && str_contains($trimmedQuery, 'LEFT JOIN (') && str_contains($trimmedQuery, 'trophy_earned te')) {
             $this->playerTrophyCountQueries[] = $trimmedQuery;
@@ -192,5 +214,28 @@ final class RecordingTrophyStatusProgressFetchColumnStatement extends PDOStateme
     public function fetchColumn(int $column = 0): string|int|false|null
     {
         return $this->value;
+    }
+}
+
+final class RecordingTrophyStatusProgressFetchAllStatement extends PDOStatement
+{
+    /** @param list<int|string> $values */
+    public function __construct(private readonly array $values)
+    {
+    }
+
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args): array
+    {
+        return $this->values;
     }
 }

--- a/wwwroot/classes/Admin/DeletePlayerService.php
+++ b/wwwroot/classes/Admin/DeletePlayerService.php
@@ -61,9 +61,16 @@ final class DeletePlayerService
             throw new RuntimeException('Failed to start database transaction.');
         }
 
+        $skipTrophyCountEnabled = false;
+
         try {
             $player = $this->findPlayerByAccountId($accountId);
             $onlineId = $player['online_id'] ?? null;
+
+            // Avoid one player.trophy_count_npwr UPDATE per deleted NPWR row; the player
+            // row is deleted in this same transaction. Session var is honored by the
+            // trophy_earned triggers (see database/mysql84_trophy_earned_triggers.sql).
+            $skipTrophyCountEnabled = $this->setSkipTrophyCountTriggers(true);
 
             $counts = [];
             $counts['trophy_earned'] = $this->deleteByAccountId(
@@ -104,7 +111,22 @@ final class DeletePlayerService
             }
 
             throw new RuntimeException('Failed to delete player data.', 0, $exception);
+        } finally {
+            if ($skipTrophyCountEnabled) {
+                $this->setSkipTrophyCountTriggers(false);
+            }
         }
+    }
+
+    private function setSkipTrophyCountTriggers(bool $enabled): bool
+    {
+        if ($this->database->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'mysql') {
+            return false;
+        }
+
+        $this->database->exec('SET @psn100_skip_trophy_count = ' . ($enabled ? '1' : '0'));
+
+        return true;
     }
 
     private function deleteLogMessagesForAccountId(string $accountId): int

--- a/wwwroot/classes/Admin/PossibleCheaterService.php
+++ b/wwwroot/classes/Admin/PossibleCheaterService.php
@@ -108,6 +108,7 @@ class PossibleCheaterService
             ) cheat_rules ON
                 te.np_communication_id = cheat_rules.np_communication_id
                 AND te.order_id = cheat_rules.order_id
+                AND te.earned = 1
                 AND (
                     cheat_rules.date_operator IS NULL
                     OR (cheat_rules.date_operator = '>=' AND te.earned_date >= cheat_rules.date_value)

--- a/wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php
+++ b/wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php
@@ -285,32 +285,60 @@ SQL;
             return;
         }
 
-        $placeholders = implode(',', array_fill(0, count($affectedTrophyIds), '?'));
+        $orderIds = $this->resolveOrderIds($affectedTrophyIds);
+        if ($orderIds === []) {
+            return;
+        }
+
+        // Resolve order_ids from the small trophy table first, then probe
+        // trophy_earned via (np_communication_id, order_id, earned) — the leading
+        // columns of idx_te_npcomm_order_earned_date — instead of joining trophy
+        // into the multi-billion-row scan.
+        $placeholders = implode(',', array_fill(0, count($orderIds), '?'));
         $sql = 'INSERT IGNORE INTO temp_impacted_accounts (account_id)
             SELECT DISTINCT te.account_id
             FROM trophy_earned te
-            INNER JOIN trophy t ON t.np_communication_id = te.np_communication_id
-                AND t.group_id = te.group_id
-                AND t.order_id = te.order_id
             WHERE te.np_communication_id = ?
+              AND te.order_id IN (' . $placeholders . ')
               AND te.earned = 1';
 
         if ($groupId !== null) {
             $sql .= ' AND te.group_id = ?';
         }
 
-        $sql .= ' AND t.id IN (' . $placeholders . ')';
-
         $statement = $this->database->prepare($sql);
         $parameterIndex = 1;
         $statement->bindValue($parameterIndex++, $npCommunicationId, PDO::PARAM_STR);
+        foreach ($orderIds as $orderId) {
+            $statement->bindValue($parameterIndex++, $orderId, PDO::PARAM_INT);
+        }
         if ($groupId !== null) {
             $statement->bindValue($parameterIndex++, $groupId, PDO::PARAM_STR);
         }
-        foreach ($affectedTrophyIds as $trophyId) {
-            $statement->bindValue($parameterIndex++, (int) $trophyId, PDO::PARAM_INT);
+        $statement->execute();
+    }
+
+    /**
+     * @param int[] $affectedTrophyIds
+     * @return list<int>
+     */
+    private function resolveOrderIds(array $affectedTrophyIds): array
+    {
+        $placeholders = implode(',', array_fill(0, count($affectedTrophyIds), '?'));
+        $statement = $this->database->prepare(
+            'SELECT DISTINCT order_id FROM trophy WHERE id IN (' . $placeholders . ')'
+        );
+        foreach (array_values($affectedTrophyIds) as $index => $trophyId) {
+            $statement->bindValue($index + 1, (int) $trophyId, PDO::PARAM_INT);
         }
         $statement->execute();
+
+        $orderIds = [];
+        foreach ($statement->fetchAll(PDO::FETCH_COLUMN) as $orderId) {
+            $orderIds[] = (int) $orderId;
+        }
+
+        return $orderIds;
     }
 
     private function findGameId(string $npCommunicationId): ?int

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -87,20 +87,23 @@ final readonly class DailyCronJob implements CronJobInterface
         SQL;
 
     /**
-     * Titles with zero owners cannot produce non-zero rarity. Skip probing
-     * trophy_earned via the top-10k ranking join for that long tail.
+     * Titles with zero owners have zero trophy_owners in the top-10k join, so
+     * rarity_percent is always 0. Skip probing trophy_earned, but keep the same
+     * zero-percent scoring as UPDATE_TROPHY_RARITY_QUERY (10000 / LEGENDARY for
+     * obtainable trophies; in-game points stay 0 when title owners are 0).
      */
     private const string UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY = <<<'SQL'
         UPDATE trophy_meta tm
         JOIN trophy t ON t.id = tm.trophy_id
+        JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
         SET
             tm.owners = 0,
             tm.rarity_percent = 0,
-            tm.rarity_point = 0,
-            tm.rarity_name = 'NONE',
+            tm.rarity_point = IF(tm.status = 0 AND ttm.status = 0, 10000, 0),
+            tm.rarity_name = IF(tm.status = 0 AND ttm.status = 0, 'LEGENDARY', 'NONE'),
             tm.in_game_rarity_percent = 0,
             tm.in_game_rarity_point = 0,
-            tm.in_game_rarity_name = 'NONE'
+            tm.in_game_rarity_name = IF(tm.status = 0 AND ttm.status = 0, 'LEGENDARY', 'NONE')
         WHERE t.np_communication_id = :np_communication_id
         SQL;
 

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -86,6 +86,24 @@ final readonly class DailyCronJob implements CronJobInterface
             END
         SQL;
 
+    /**
+     * Titles with zero owners cannot produce non-zero rarity. Skip probing
+     * trophy_earned via the top-10k ranking join for that long tail.
+     */
+    private const string UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY = <<<'SQL'
+        UPDATE trophy_meta tm
+        JOIN trophy t ON t.id = tm.trophy_id
+        SET
+            tm.owners = 0,
+            tm.rarity_percent = 0,
+            tm.rarity_point = 0,
+            tm.rarity_name = 'NONE',
+            tm.in_game_rarity_percent = 0,
+            tm.in_game_rarity_point = 0,
+            tm.in_game_rarity_name = 'NONE'
+        WHERE t.np_communication_id = :np_communication_id
+        SQL;
+
     private const string UPDATE_TITLE_RARITY_POINTS_QUERY = <<<'SQL'
         WITH rarity AS (
             SELECT
@@ -136,7 +154,18 @@ final readonly class DailyCronJob implements CronJobInterface
 
     private function updateTrophyRarityForGame(string $npCommunicationId): void
     {
-        $query = $this->database->prepare(self::UPDATE_TROPHY_RARITY_QUERY);
+        $ownersQuery = $this->database->prepare(
+            'SELECT owners FROM trophy_title_meta WHERE np_communication_id = :np_communication_id'
+        );
+        $ownersQuery->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $ownersQuery->execute();
+        $owners = $ownersQuery->fetchColumn();
+
+        $sql = ((int) $owners) === 0
+            ? self::UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY
+            : self::UPDATE_TROPHY_RARITY_QUERY;
+
+        $query = $this->database->prepare($sql);
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->execute();
     }

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -157,14 +157,26 @@ final readonly class DailyCronJob implements CronJobInterface
 
     private function updateTrophyRarityForGame(string $npCommunicationId): void
     {
-        $ownersQuery = $this->database->prepare(
-            'SELECT owners FROM trophy_title_meta WHERE np_communication_id = :np_communication_id'
+        // Do not trust trophy_title_meta.owners alone: hourly cache can lag behind
+        // freshly scanned trophy_title_player / trophy_earned rows. Match the rarity
+        // query's top-10k definition before taking the zero-owners fast path.
+        $hasRankedOwnersQuery = $this->database->prepare(
+            <<<'SQL'
+            SELECT EXISTS (
+                SELECT 1
+                FROM trophy_title_player ttp
+                INNER JOIN player_ranking pr
+                    ON pr.account_id = ttp.account_id
+                   AND pr.ranking <= 10000
+                WHERE ttp.np_communication_id = :np_communication_id
+            )
+            SQL
         );
-        $ownersQuery->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $ownersQuery->execute();
-        $owners = $ownersQuery->fetchColumn();
+        $hasRankedOwnersQuery->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $hasRankedOwnersQuery->execute();
+        $hasRankedOwners = (int) $hasRankedOwnersQuery->fetchColumn();
 
-        $sql = ((int) $owners) === 0
+        $sql = $hasRankedOwners === 0
             ? self::UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY
             : self::UPDATE_TROPHY_RARITY_QUERY;
 

--- a/wwwroot/classes/Cron/PlayerEarnedTrophyPersister.php
+++ b/wwwroot/classes/Cron/PlayerEarnedTrophyPersister.php
@@ -92,7 +92,8 @@ final class PlayerEarnedTrophyPersister
             UPDATE
                 earned_date = IF(trophy_earned.earned = 0, new.earned_date, trophy_earned.earned_date),
                 progress = new.progress,
-                earned = new.earned");
+                -- earned never goes 1→0; only insert as 0/1 or promote 0→1.
+                earned = IF(trophy_earned.earned = 1, trophy_earned.earned, new.earned)");
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
         $query->bindValue(':order_id', $orderId, PDO::PARAM_INT);

--- a/wwwroot/classes/GameResetService.php
+++ b/wwwroot/classes/GameResetService.php
@@ -48,8 +48,7 @@ class GameResetService
                 'DELETE FROM trophy_merge WHERE parent_np_communication_id = :np_communication_id',
                 [':np_communication_id' => $npCommunicationId]
             );
-            // Drive trophy_earned deletes from trophy_title_player.account_id so
-            // HASH(account_id) partition pruning applies on the multi-billion-row table.
+            // Per-partition deletes on trophy_earned (see deleteTrophyEarnedForTitle).
             $this->deleteTrophyEarnedForTitle($npCommunicationId);
             $this->executeStatement(
                 'DELETE FROM trophy_group_player WHERE np_communication_id = :np_communication_id',
@@ -87,8 +86,7 @@ class GameResetService
                 'DELETE FROM trophy WHERE np_communication_id = :np_communication_id',
                 [':np_communication_id' => $npCommunicationId]
             );
-            // Drive trophy_earned deletes from trophy_title_player.account_id so
-            // HASH(account_id) partition pruning applies on the multi-billion-row table.
+            // Per-partition deletes on trophy_earned (see deleteTrophyEarnedForTitle).
             $this->deleteTrophyEarnedForTitle($npCommunicationId);
             $this->executeStatement(
                 'DELETE FROM trophy_group_player WHERE np_communication_id = :np_communication_id',

--- a/wwwroot/classes/GameResetService.php
+++ b/wwwroot/classes/GameResetService.php
@@ -44,18 +44,29 @@ class GameResetService
     private function resetGame(int $gameId, string $npCommunicationId): string
     {
         $this->executeWithinTransaction(function () use ($npCommunicationId): void {
-            $statements = [
+            $this->executeStatement(
                 'DELETE FROM trophy_merge WHERE parent_np_communication_id = :np_communication_id',
-                'DELETE FROM trophy_earned WHERE np_communication_id = :np_communication_id',
+                [':np_communication_id' => $npCommunicationId]
+            );
+            // Drive trophy_earned deletes from trophy_title_player.account_id so
+            // HASH(account_id) partition pruning applies on the multi-billion-row table.
+            $this->deleteTrophyEarnedForTitle($npCommunicationId);
+            $this->executeStatement(
                 'DELETE FROM trophy_group_player WHERE np_communication_id = :np_communication_id',
+                [':np_communication_id' => $npCommunicationId]
+            );
+            $this->executeStatement(
                 'DELETE FROM trophy_title_player WHERE np_communication_id = :np_communication_id',
+                [':np_communication_id' => $npCommunicationId]
+            );
+            $this->executeStatement(
                 'UPDATE trophy_title_meta SET owners = 0, owners_completed = 0 WHERE np_communication_id = :np_communication_id',
+                [':np_communication_id' => $npCommunicationId]
+            );
+            $this->executeStatement(
                 'UPDATE trophy_title_meta SET parent_np_communication_id = NULL WHERE parent_np_communication_id = :np_communication_id',
-            ];
-
-            foreach ($statements as $sql) {
-                $this->executeStatement($sql, [':np_communication_id' => $npCommunicationId]);
-            }
+                [':np_communication_id' => $npCommunicationId]
+            );
         });
 
         $this->logChange('GAME_RESET', $gameId);
@@ -68,25 +79,74 @@ class GameResetService
         $gameName = $this->getGameName($gameId) ?? '';
 
         $this->executeWithinTransaction(function () use ($npCommunicationId): void {
-            $statements = [
+            $this->executeStatement(
                 'DELETE FROM trophy_merge WHERE parent_np_communication_id = :np_communication_id',
+                [':np_communication_id' => $npCommunicationId]
+            );
+            $this->executeStatement(
                 'DELETE FROM trophy WHERE np_communication_id = :np_communication_id',
-                'DELETE FROM trophy_earned WHERE np_communication_id = :np_communication_id',
+                [':np_communication_id' => $npCommunicationId]
+            );
+            // Drive trophy_earned deletes from trophy_title_player.account_id so
+            // HASH(account_id) partition pruning applies on the multi-billion-row table.
+            $this->deleteTrophyEarnedForTitle($npCommunicationId);
+            $this->executeStatement(
                 'DELETE FROM trophy_group_player WHERE np_communication_id = :np_communication_id',
+                [':np_communication_id' => $npCommunicationId]
+            );
+            $this->executeStatement(
                 'DELETE FROM trophy_title_player WHERE np_communication_id = :np_communication_id',
+                [':np_communication_id' => $npCommunicationId]
+            );
+            $this->executeStatement(
                 'DELETE FROM trophy_group WHERE np_communication_id = :np_communication_id',
+                [':np_communication_id' => $npCommunicationId]
+            );
+            $this->executeStatement(
                 'DELETE FROM trophy_title WHERE np_communication_id = :np_communication_id',
+                [':np_communication_id' => $npCommunicationId]
+            );
+            $this->executeStatement(
                 'UPDATE trophy_title_meta SET parent_np_communication_id = NULL WHERE parent_np_communication_id = :np_communication_id',
-            ];
-
-            foreach ($statements as $sql) {
-                $this->executeStatement($sql, [':np_communication_id' => $npCommunicationId]);
-            }
+                [':np_communication_id' => $npCommunicationId]
+            );
         });
 
         $this->logChange('GAME_DELETE', $gameId, $gameName);
 
         return sprintf('Game %d was deleted.', $gameId);
+    }
+
+    /**
+     * Delete all trophy_earned rows for a title without one statement spanning every partition.
+     *
+     * trophy_earned is PARTITION BY HASH(account_id) with 256 partitions (~billions of rows).
+     * A bare DELETE ... WHERE np_communication_id = ? opens all partitions at once. Issuing
+     * one DELETE per partition keeps each statement partition-local while still removing
+     * every matching row (including orphans not present in trophy_title_player).
+     */
+    private function deleteTrophyEarnedForTitle(string $npCommunicationId): void
+    {
+        $driver = $this->database->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'mysql') {
+            for ($partition = 0; $partition < 256; $partition++) {
+                $this->executeStatement(
+                    sprintf(
+                        'DELETE FROM trophy_earned PARTITION (p%d) WHERE np_communication_id = :np_communication_id',
+                        $partition
+                    ),
+                    [':np_communication_id' => $npCommunicationId]
+                );
+            }
+
+            return;
+        }
+
+        // Non-MySQL drivers (SQLite tests) have no HASH partitions.
+        $this->executeStatement(
+            'DELETE FROM trophy_earned WHERE np_communication_id = :np_communication_id',
+            [':np_communication_id' => $npCommunicationId]
+        );
     }
 
     private function getGameName(int $gameId): ?string

--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -29,17 +29,14 @@ class PlayerAdvisorService
             JOIN trophy_meta tm ON tm.trophy_id = t.id
             JOIN trophy_title tt ON tt.np_communication_id = t.np_communication_id
             JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
+            LEFT JOIN trophy_earned te ON
+                te.account_id = :account_id
+                AND te.np_communication_id = t.np_communication_id
+                AND te.order_id = t.order_id
             WHERE ttp.account_id = :account_id
                 AND ttm.status = 0
                 AND tm.status = 0
-                AND NOT EXISTS (
-                    SELECT 1
-                    FROM trophy_earned te_completed
-                    WHERE te_completed.account_id = :account_id
-                        AND te_completed.np_communication_id = t.np_communication_id
-                        AND te_completed.order_id = t.order_id
-                        AND te_completed.earned = 1
-                )
+                AND (te.account_id IS NULL OR te.earned = 0)
         SQL;
 
         $sql .= $this->buildPlatformClause($filter);
@@ -72,28 +69,20 @@ class PlayerAdvisorService
                 tt.name AS game_name,
                 tt.icon_url AS game_icon,
                 tt.platform,
-                te_progress.progress
+                te.progress
             FROM trophy_title_player ttp
             JOIN trophy t ON t.np_communication_id = ttp.np_communication_id
             JOIN trophy_meta tm ON tm.trophy_id = t.id
             JOIN trophy_title tt ON tt.np_communication_id = t.np_communication_id
             JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
-            LEFT JOIN trophy_earned te_progress ON
-                te_progress.account_id = :account_id
-                AND te_progress.np_communication_id = t.np_communication_id
-                AND te_progress.order_id = t.order_id
-                AND te_progress.earned = 0
+            LEFT JOIN trophy_earned te ON
+                te.account_id = :account_id
+                AND te.np_communication_id = t.np_communication_id
+                AND te.order_id = t.order_id
             WHERE ttp.account_id = :account_id
                 AND ttm.status = 0
                 AND tm.status = 0
-                AND NOT EXISTS (
-                    SELECT 1
-                    FROM trophy_earned te_completed
-                    WHERE te_completed.account_id = :account_id
-                        AND te_completed.np_communication_id = t.np_communication_id
-                        AND te_completed.order_id = t.order_id
-                        AND te_completed.earned = 1
-                )
+                AND (te.account_id IS NULL OR te.earned = 0)
         SQL;
 
         $sql .= $this->buildPlatformClause($filter);

--- a/wwwroot/classes/PlayerTimelineService.php
+++ b/wwwroot/classes/PlayerTimelineService.php
@@ -27,6 +27,7 @@ class PlayerTimelineService
                 JOIN trophy_earned te
                     ON te.np_communication_id = ttp.np_communication_id
                     AND te.account_id = ttp.account_id
+                    AND te.earned = 1
                 JOIN trophy_title tt ON tt.np_communication_id = ttp.np_communication_id
                 JOIN trophy_title_meta ttm ON ttm.np_communication_id = ttp.np_communication_id
                 WHERE ttp.account_id = :account_id

--- a/wwwroot/config/possible-cheater-sections.php
+++ b/wwwroot/config/possible-cheater-sections.php
@@ -16,12 +16,14 @@ return [
                     fuel_end.account_id = fuel_start.account_id
                     AND fuel_end.np_communication_id = 'NPWR00481_00'
                     AND fuel_end.order_id = 34
+                    AND fuel_end.earned = 1
                 JOIN player p ON
                     p.account_id = fuel_start.account_id
                     AND p.status != 1
                 WHERE
                     fuel_start.np_communication_id = 'NPWR00481_00'
                     AND fuel_start.order_id = 33
+                    AND fuel_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -42,12 +44,14 @@ return [
                     socom_end.account_id = socom_start.account_id
                     AND socom_end.np_communication_id = 'NPWR00302_00'
                     AND socom_end.order_id = 33
+                    AND socom_end.earned = 1
                 JOIN player p ON
                     p.account_id = socom_start.account_id
                     AND p.status != 1
                 WHERE
                     socom_start.np_communication_id = 'NPWR00302_00'
                     AND socom_start.order_id = 32
+                    AND socom_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -68,12 +72,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR01103_00'
                     AND trophy_end.order_id = 48
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR01103_00'
                     AND trophy_start.order_id = 38
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -94,12 +100,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR00987_00'
                     AND trophy_end.order_id = 48
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR00987_00'
                     AND trophy_start.order_id = 38
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -120,12 +128,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR17582_00'
                     AND trophy_end.order_id = 51
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR17582_00'
                     AND trophy_start.order_id = 50
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -146,12 +156,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR17415_00'
                     AND trophy_end.order_id = 51
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR17415_00'
                     AND trophy_start.order_id = 50
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -172,12 +184,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR14836_00'
                     AND trophy_end.order_id = 51
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR14836_00'
                     AND trophy_start.order_id = 50
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -198,12 +212,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR00928_00'
                     AND trophy_end.order_id = 11
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR00928_00'
                     AND trophy_start.order_id = 10
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -224,12 +240,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR00928_00'
                     AND trophy_end.order_id = 20
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR00928_00'
                     AND trophy_start.order_id = 19
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -250,12 +268,14 @@ return [
                     rer_end.account_id = rer_start.account_id
                     AND rer_end.np_communication_id = 'NPWR11777_00'
                     AND rer_end.order_id = 55
+                    AND rer_end.earned = 1
                 JOIN player p ON
                     p.account_id = rer_start.account_id
                     AND p.status != 1
                 WHERE
                     rer_start.np_communication_id = 'NPWR11777_00'
                     AND rer_start.order_id = 54
+                    AND rer_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -276,12 +296,14 @@ return [
                     rer_end.account_id = rer_start.account_id
                     AND rer_end.np_communication_id = 'NPWR11777_00'
                     AND rer_end.order_id = 38
+                    AND rer_end.earned = 1
                 JOIN player p ON
                     p.account_id = rer_start.account_id
                     AND p.status != 1
                 WHERE
                     rer_start.np_communication_id = 'NPWR11777_00'
                     AND rer_start.order_id = 37
+                    AND rer_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -302,12 +324,14 @@ return [
                     rer_end.account_id = rer_start.account_id
                     AND rer_end.np_communication_id = 'NPWR03903_00'
                     AND rer_end.order_id = 50
+                    AND rer_end.earned = 1
                 JOIN player p ON
                     p.account_id = rer_start.account_id
                     AND p.status != 1
                 WHERE
                     rer_start.np_communication_id = 'NPWR03903_00'
                     AND rer_start.order_id = 49
+                    AND rer_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -328,12 +352,14 @@ return [
                     rer_end.account_id = rer_start.account_id
                     AND rer_end.np_communication_id = 'NPWR03903_00'
                     AND rer_end.order_id = 37
+                    AND rer_end.earned = 1
                 JOIN player p ON
                     p.account_id = rer_start.account_id
                     AND p.status != 1
                 WHERE
                     rer_start.np_communication_id = 'NPWR03903_00'
                     AND rer_start.order_id = 36
+                    AND rer_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -354,12 +380,14 @@ return [
                     abt_end.account_id = abt_start.account_id
                     AND abt_end.np_communication_id = 'NPWR03771_00'
                     AND abt_end.order_id = 31
+                    AND abt_end.earned = 1
                 JOIN player p ON
                     p.account_id = abt_start.account_id
                     AND p.status != 1
                 WHERE
                     abt_start.np_communication_id = 'NPWR03771_00'
                     AND abt_start.order_id = 30
+                    AND abt_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -384,9 +412,11 @@ return [
                         marker.account_id = te.account_id
                         AND marker.np_communication_id = 'NPWR00623_00'
                         AND marker.order_id = 9
+                        AND marker.earned = 1
                     WHERE
                         te.np_communication_id = 'NPWR00623_00'
                         AND te.order_id != 9
+                        AND te.earned = 1
                         AND te.earned_date >= marker.earned_date
                     GROUP BY
                         te.account_id
@@ -414,12 +444,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR03734_00'
                     AND trophy_end.order_id = 4
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR03734_00'
                     AND trophy_start.order_id = 3
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -440,12 +472,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR09098_00'
                     AND trophy_end.order_id = 7
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR09098_00'
                     AND trophy_start.order_id = 6
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -466,12 +500,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR00626_00'
                     AND trophy_end.order_id = 32
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR00626_00'
                     AND trophy_start.order_id = 31
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -492,12 +528,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR01012_00'
                     AND trophy_end.order_id = 32
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR01012_00'
                     AND trophy_start.order_id = 31
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -518,12 +556,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR00464_00'
                     AND trophy_end.order_id = 20
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR00464_00'
                     AND trophy_start.order_id = 19
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -544,12 +584,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR03139_00'
                     AND trophy_end.order_id = 37
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR03139_00'
                     AND trophy_start.order_id = 36
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 600
                 ORDER BY
@@ -570,12 +612,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR01781_00'
                     AND trophy_end.order_id = 39
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR01781_00'
                     AND trophy_start.order_id = 38
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 600
                 ORDER BY
@@ -596,12 +640,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR00737_00'
                     AND trophy_end.order_id = 26
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR00737_00'
                     AND trophy_start.order_id = 0
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 300
                 ORDER BY
@@ -622,12 +668,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR14318_00'
                     AND trophy_end.order_id = 39
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR14318_00'
                     AND trophy_start.order_id = 2
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference >= 10
                 ORDER BY
@@ -648,12 +696,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR14318_00'
                     AND trophy_end.order_id = 40
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR14318_00'
                     AND trophy_start.order_id = 2
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference >= 10
                 ORDER BY
@@ -674,12 +724,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR14318_00'
                     AND trophy_end.order_id = 41
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR14318_00'
                     AND trophy_start.order_id = 2
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference >= 10
                 ORDER BY
@@ -700,12 +752,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR05019_00'
                     AND trophy_end.order_id = 32
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR05019_00'
                     AND trophy_start.order_id = 34
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference >= 10
                 ORDER BY
@@ -726,12 +780,14 @@ return [
                     trophy_end.account_id = trophy_start.account_id
                     AND trophy_end.np_communication_id = 'NPWR18592_00'
                     AND trophy_end.order_id = 4
+                    AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = trophy_start.account_id
                     AND p.status != 1
                 WHERE
                     trophy_start.np_communication_id = 'NPWR18592_00'
                     AND trophy_start.order_id = 1
+                    AND trophy_start.earned = 1
                 HAVING
                     time_difference <= 10
                 ORDER BY


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Further MySQL 8.4 SQL improvements focused on `trophy_earned` (~2.6B rows / ~448 GiB, `HASH(account_id)` × 256 partitions). No new secondary indexes on that table.

### Changes
- **Triggers**: honor `@psn100_skip_trophy_count` for bulk deletes (`database/mysql84_trophy_earned_triggers.sql`). `earned` only transitions `0→1` (never `1→0`), so `after_update` only increments on that path.
- **DeletePlayerService**: sets the skip variable around `trophy_earned` deletes so whale deletes do not fire one counter `UPDATE` per row
- **PlayerEarnedTrophyPersister**: child upserts keep `earned` monotonic (`IF(earned = 1, earned, new.earned)`), matching the parent merge rule
- **GameResetService**: per-partition `DELETE ... PARTITION (pN)` instead of one title-scoped delete that opens all 256 partitions
- **DailyCronJob**: zero-owners titles take a fast path that never touches `trophy_earned`
- **TrophyStatusProgressRecalculator**: resolve `order_id`s from `trophy` first, then probe `trophy_earned` via `(np_communication_id, order_id, earned)`
- **Possible Cheaters**: require `earned = 1` (uses existing secondary index prefix)
- **PlayerAdvisorService**: one account-scoped `LEFT JOIN trophy_earned` instead of `NOT EXISTS` + progress join
- **PlayerTimelineService**: filter `earned = 1`
- **Schema**: `trophy_group_player.idx_tgp_account_np` in `psn100.sql` for fresh installs; upgrade ALTER is optional/scheduled (`mysql84_trophy_group_player_index.sql`) because that table is ~227M rows / ~24 GiB

### Deploy notes
```bash
mysql "$DB_NAME" < database/mysql84_trophy_earned_triggers.sql
mysql "$DB_NAME" < database/mysql84_covering_indexes.sql
# optional, maintenance window — ~24 GiB online index build:
# mysql "$DB_NAME" < database/mysql84_trophy_group_player_index.sql
```

### Intentionally not changed
- No new indexes / histograms / `ANALYZE` on `trophy_earned`
- No driving popular-title admin queries from `trophy_title_player` (~123M rows / ~33 GiB) — can be worse than the title/order secondary index on `trophy_earned`
- `trophy_group_player` index swap is not part of the routine covering-index deploy script

### Tests
All 948 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2543df87-d8b8-4668-8567-7cdcaa187908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2543df87-d8b8-4668-8567-7cdcaa187908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

