### PR TITLE
Retry transient PSN/cURL failures during trophy title scans

### DIFF
--- a/tests/PlayerScanTrophyTitleLoopTest.php
+++ b/tests/PlayerScanTrophyTitleLoopTest.php
@@ -143,10 +143,10 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
     public function testProcessAccessibleTrophyTitlesRetriesTransientFetchExceptions(): void
     {
         $recheck = '';
-        $missingGameDeletionCheck = [];
-        $missingTrophyTitleRetry = [];
-        $trophyTitleCountRetry = [];
-        $invalidTitleDateRetry = [];
+        $missingGameDeletionCheck = ['ExampleUser' => true, 'OtherUser' => true];
+        $missingTrophyTitleRetry = ['ExampleUser' => true];
+        $trophyTitleCountRetry = ['ExampleUser' => true];
+        $invalidTitleDateRetry = ['ExampleUser:NPWR12345_00' => true, 'OtherUser:NPWR99999_00' => true];
 
         $result = $this->trophyTitleLoop->processAccessibleTrophyTitles(
             new stdClass(),
@@ -165,6 +165,10 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
 
         $this->assertTrue($result->shouldContinueLoop());
         $this->assertSame([60], $this->sleepCalls);
+        $this->assertSame(['OtherUser' => true], $missingGameDeletionCheck);
+        $this->assertSame([], $missingTrophyTitleRetry);
+        $this->assertSame([], $trophyTitleCountRetry);
+        $this->assertSame(['OtherUser:NPWR99999_00' => true], $invalidTitleDateRetry);
 
         $scanProgress = $this->database->query('SELECT scan_progress FROM setting WHERE id = 1')->fetchColumn();
         $this->assertTrue(is_string($scanProgress));
@@ -178,10 +182,10 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
     public function testProcessAccessibleTrophyTitlesRetriesTypeErrorsQuickly(): void
     {
         $recheck = '';
-        $missingGameDeletionCheck = [];
-        $missingTrophyTitleRetry = [];
-        $trophyTitleCountRetry = [];
-        $invalidTitleDateRetry = [];
+        $missingGameDeletionCheck = ['ExampleUser' => true];
+        $missingTrophyTitleRetry = ['ExampleUser' => true];
+        $trophyTitleCountRetry = ['ExampleUser' => true];
+        $invalidTitleDateRetry = ['ExampleUser:NPWR12345_00' => true];
 
         $result = $this->trophyTitleLoop->processAccessibleTrophyTitles(
             new stdClass(),
@@ -200,6 +204,10 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
 
         $this->assertTrue($result->shouldContinueLoop());
         $this->assertSame([5], $this->sleepCalls);
+        $this->assertSame([], $missingGameDeletionCheck);
+        $this->assertSame([], $missingTrophyTitleRetry);
+        $this->assertSame([], $trophyTitleCountRetry);
+        $this->assertSame([], $invalidTitleDateRetry);
     }
 }
 

--- a/tests/PlayerScanTrophyTitleLoopTest.php
+++ b/tests/PlayerScanTrophyTitleLoopTest.php
@@ -142,7 +142,7 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
 
     public function testProcessAccessibleTrophyTitlesRetriesTransientFetchExceptions(): void
     {
-        $recheck = '';
+        $recheck = 'ExampleUser';
         $missingGameDeletionCheck = ['ExampleUser' => true, 'OtherUser' => true];
         $missingTrophyTitleRetry = ['ExampleUser' => true];
         $trophyTitleCountRetry = ['ExampleUser' => true];
@@ -165,6 +165,7 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
 
         $this->assertTrue($result->shouldContinueLoop());
         $this->assertSame([60], $this->sleepCalls);
+        $this->assertSame('', $recheck);
         $this->assertSame(['OtherUser' => true], $missingGameDeletionCheck);
         $this->assertSame([], $missingTrophyTitleRetry);
         $this->assertSame([], $trophyTitleCountRetry);
@@ -181,7 +182,7 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
 
     public function testProcessAccessibleTrophyTitlesRetriesTypeErrorsQuickly(): void
     {
-        $recheck = '';
+        $recheck = 'ExampleUser';
         $missingGameDeletionCheck = ['ExampleUser' => true];
         $missingTrophyTitleRetry = ['ExampleUser' => true];
         $trophyTitleCountRetry = ['ExampleUser' => true];
@@ -204,6 +205,7 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
 
         $this->assertTrue($result->shouldContinueLoop());
         $this->assertSame([5], $this->sleepCalls);
+        $this->assertSame('', $recheck);
         $this->assertSame([], $missingGameDeletionCheck);
         $this->assertSame([], $missingTrophyTitleRetry);
         $this->assertSame([], $trophyTitleCountRetry);

--- a/tests/PlayerScanTrophyTitleLoopTest.php
+++ b/tests/PlayerScanTrophyTitleLoopTest.php
@@ -23,6 +23,8 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
 {
     private PDO $database;
     private PlayerScanTrophyTitleLoop $trophyTitleLoop;
+    /** @var list<int> */
+    private array $sleepCalls = [];
 
     protected function setUp(): void
     {
@@ -33,7 +35,14 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
         $this->database->exec('CREATE TABLE player (account_id INTEGER PRIMARY KEY, online_id TEXT NOT NULL, last_updated_date TEXT)');
         $this->database->exec('CREATE TABLE setting (id INTEGER PRIMARY KEY, scanning TEXT, scan_progress TEXT)');
         $this->database->exec("INSERT INTO setting (id, scanning, scan_progress) VALUES (1, 'ExampleUser', NULL)");
+        $this->database->exec('CREATE TABLE trophy_title_player (
+            account_id TEXT NOT NULL,
+            np_communication_id TEXT NOT NULL,
+            last_updated_date TEXT,
+            PRIMARY KEY (account_id, np_communication_id)
+        )');
 
+        $this->sleepCalls = [];
         $logger = new Psn100Logger($this->database);
         $titleMetadataHelper = new PlayerScanTitleMetadataHelper();
         $workerScanCoordinator = new WorkerScanCoordinator($this->database);
@@ -69,6 +78,9 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
             new PlayerScanStaleGameDeletionService($this->database),
             new PlayerScanCompletionService($this->database),
             new PlayerScanTrophyTitleRefresher($logger, $titleMetadataHelper, $workerScanCoordinator),
+            function (int $seconds): void {
+                $this->sleepCalls[] = $seconds;
+            },
         );
     }
 
@@ -126,6 +138,113 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
 
         $logMessage = $this->database->query('SELECT message FROM log ORDER BY rowid DESC LIMIT 1')->fetchColumn();
         $this->assertStringContainsString('NPWR12345_00', (string) $logMessage);
+    }
+
+    public function testProcessAccessibleTrophyTitlesRetriesTransientFetchExceptions(): void
+    {
+        $recheck = '';
+        $missingGameDeletionCheck = [];
+        $missingTrophyTitleRetry = [];
+        $trophyTitleCountRetry = [];
+        $invalidTitleDateRetry = [];
+
+        $result = $this->trophyTitleLoop->processAccessibleTrophyTitles(
+            new stdClass(),
+            new PlayerScanTrophyTitleLoopTestUserThatThrowsOnTrophyTitles(
+                new RuntimeException('cURL error 18: transfer closed with outstanding read data remaining')
+            ),
+            ['online_id' => 'ExampleUser'],
+            ['id' => 1],
+            'ExampleUser',
+            $recheck,
+            $missingGameDeletionCheck,
+            $missingTrophyTitleRetry,
+            $trophyTitleCountRetry,
+            $invalidTitleDateRetry,
+        );
+
+        $this->assertTrue($result->shouldContinueLoop());
+        $this->assertSame([60], $this->sleepCalls);
+
+        $scanProgress = $this->database->query('SELECT scan_progress FROM setting WHERE id = 1')->fetchColumn();
+        $this->assertTrue(is_string($scanProgress));
+        $this->assertStringContainsString('fetching game list', $scanProgress);
+
+        $logMessage = $this->database->query('SELECT message FROM log ORDER BY rowid DESC LIMIT 1')->fetchColumn();
+        $this->assertStringContainsString('cURL error 18', (string) $logMessage);
+        $this->assertStringContainsString('ExampleUser', (string) $logMessage);
+    }
+
+    public function testProcessAccessibleTrophyTitlesRetriesTypeErrorsQuickly(): void
+    {
+        $recheck = '';
+        $missingGameDeletionCheck = [];
+        $missingTrophyTitleRetry = [];
+        $trophyTitleCountRetry = [];
+        $invalidTitleDateRetry = [];
+
+        $result = $this->trophyTitleLoop->processAccessibleTrophyTitles(
+            new stdClass(),
+            new PlayerScanTrophyTitleLoopTestUserThatThrowsOnTrophyTitles(
+                new TypeError('Unexpected trophyTitles payload')
+            ),
+            ['online_id' => 'ExampleUser'],
+            ['id' => 1],
+            'ExampleUser',
+            $recheck,
+            $missingGameDeletionCheck,
+            $missingTrophyTitleRetry,
+            $trophyTitleCountRetry,
+            $invalidTitleDateRetry,
+        );
+
+        $this->assertTrue($result->shouldContinueLoop());
+        $this->assertSame([5], $this->sleepCalls);
+    }
+}
+
+final class PlayerScanTrophyTitleLoopTestUserThatThrowsOnTrophyTitles
+{
+    public function __construct(private readonly Throwable $exception)
+    {
+    }
+
+    public function accountId(): string
+    {
+        return '2498580493801829235';
+    }
+
+    public function trophySummary(): PlayerScanTrophyTitleLoopTestTrophySummary
+    {
+        return new PlayerScanTrophyTitleLoopTestTrophySummary();
+    }
+
+    public function trophyTitles(): never
+    {
+        throw $this->exception;
+    }
+}
+
+final class PlayerScanTrophyTitleLoopTestTrophySummary
+{
+    public function platinum(): int
+    {
+        return 0;
+    }
+
+    public function gold(): int
+    {
+        return 0;
+    }
+
+    public function silver(): int
+    {
+        return 0;
+    }
+
+    public function bronze(): int
+    {
+        return 0;
     }
 }
 

--- a/tests/ThirtyMinuteCronJobWorkerValidationTest.php
+++ b/tests/ThirtyMinuteCronJobWorkerValidationTest.php
@@ -89,4 +89,19 @@ final class ThirtyMinuteCronJobWorkerValidationTest extends TestCase
             $message !== false ? (string) $message : ''
         );
     }
+
+    public function testRunCatchesTransientScanExceptionsInsteadOfTerminating(): void
+    {
+        $source = (string) file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/ThirtyMinuteCronJob.php');
+
+        $this->assertStringContainsString('} catch (Exception $exception) {', $source);
+        $this->assertStringContainsString(
+            'Transient PSN/network failures (e.g. Guzzle/cURL transfer errors)',
+            $source
+        );
+        $this->assertStringContainsString(
+            'Encountered a problem while scanning %s: %s. Waiting 1 minute before retrying.',
+            $source
+        );
+    }
 }

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
@@ -90,6 +90,8 @@ final class PlayerScanTrophyTitleLoop
                 $trophyTitleCountRetry,
                 $invalidTitleDateRetry,
             );
+            // Keep the outer recheck second-pass guard armed for the next real scan.
+            $recheck = '';
             ($this->sleeper)(5);
 
             return PlayerScanTrophyTitleLoopResult::continueLoop();
@@ -112,6 +114,8 @@ final class PlayerScanTrophyTitleLoop
                 $trophyTitleCountRetry,
                 $invalidTitleDateRetry,
             );
+            // Keep the outer recheck second-pass guard armed for the next real scan.
+            $recheck = '';
             ($this->sleeper)(60);
 
             return PlayerScanTrophyTitleLoopResult::continueLoop();

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
@@ -81,6 +81,15 @@ final class PlayerScanTrophyTitleLoop
             $trophyTitleCollection = $user->trophyTitles();
             $trophyTitles = iterator_to_array($trophyTitleCollection->getIterator());
         } catch (TypeError) {
+            // A failed fetch is not a clean confirmation of missing titles, so reset
+            // deletion/retry guards before asking the worker to try again.
+            $this->clearTitleListRetryState(
+                $onlineId,
+                $missingGameDeletionCheck,
+                $missingTrophyTitleRetry,
+                $trophyTitleCountRetry,
+                $invalidTitleDateRetry,
+            );
             ($this->sleeper)(5);
 
             return PlayerScanTrophyTitleLoopResult::continueLoop();
@@ -95,6 +104,13 @@ final class PlayerScanTrophyTitleLoop
             $this->workerScanCoordinator->setWaitingScanProgress(
                 (int) $worker['id'],
                 'Encountered a problem while fetching game list. Waiting 1 minute before retrying.'
+            );
+            $this->clearTitleListRetryState(
+                $onlineId,
+                $missingGameDeletionCheck,
+                $missingTrophyTitleRetry,
+                $trophyTitleCountRetry,
+                $invalidTitleDateRetry,
             );
             ($this->sleeper)(60);
 
@@ -366,5 +382,24 @@ final class PlayerScanTrophyTitleLoop
         );
 
         $this->workerScanCoordinator->deferPlayerScanAfterFailure($player, $workerId);
+    }
+
+    /**
+     * @param array<string, bool> $missingGameDeletionCheck
+     * @param array<string, bool> $missingTrophyTitleRetry
+     * @param array<string, bool> $trophyTitleCountRetry
+     * @param array<string, bool> $invalidTitleDateRetry
+     */
+    private function clearTitleListRetryState(
+        string $onlineId,
+        array &$missingGameDeletionCheck,
+        array &$missingTrophyTitleRetry,
+        array &$trophyTitleCountRetry,
+        array &$invalidTitleDateRetry,
+    ): void {
+        unset($missingGameDeletionCheck[$onlineId]);
+        unset($missingTrophyTitleRetry[$onlineId]);
+        unset($trophyTitleCountRetry[$onlineId]);
+        $this->titleMetadataHelper->clearInvalidTitleDateRetriesForPlayer($invalidTitleDateRetry, $onlineId);
     }
 }

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
@@ -19,6 +19,10 @@ require_once __DIR__ . '/WorkerScanCoordinator.php';
  */
 final class PlayerScanTrophyTitleLoop
 {
+    private const DEFAULT_SLEEPER = 'sleep';
+
+    private readonly \Closure $sleeper;
+
     public function __construct(
         private readonly PDO $database,
         private readonly Psn100Logger $logger,
@@ -29,7 +33,9 @@ final class PlayerScanTrophyTitleLoop
         private readonly PlayerScanStaleGameDeletionService $staleGameDeletionService,
         private readonly PlayerScanCompletionService $scanCompletionService,
         private readonly PlayerScanTrophyTitleRefresher $trophyTitleRefresher,
+        ?callable $sleeper = null,
     ) {
+        $this->sleeper = \Closure::fromCallable($sleeper ?? self::DEFAULT_SLEEPER);
     }
 
     /**
@@ -75,7 +81,22 @@ final class PlayerScanTrophyTitleLoop
             $trophyTitleCollection = $user->trophyTitles();
             $trophyTitles = iterator_to_array($trophyTitleCollection->getIterator());
         } catch (TypeError) {
-            sleep(5);
+            ($this->sleeper)(5);
+
+            return PlayerScanTrophyTitleLoopResult::continueLoop();
+        } catch (Exception $exception) {
+            // Transient PSN/network failures (e.g. cURL error 18 during paginated
+            // trophyTitles fetches) should retry instead of crashing the worker.
+            $this->logger->log(sprintf(
+                'Failed to fetch trophy titles for %s: %s. Waiting 1 minute before retrying.',
+                $onlineId,
+                $exception->getMessage()
+            ));
+            $this->workerScanCoordinator->setWaitingScanProgress(
+                (int) $worker['id'],
+                'Encountered a problem while fetching game list. Waiting 1 minute before retrying.'
+            );
+            ($this->sleeper)(60);
 
             return PlayerScanTrophyTitleLoopResult::continueLoop();
         }
@@ -94,7 +115,7 @@ final class PlayerScanTrophyTitleLoop
                     'Trophy title count lower than expected. Waiting 1 minute before retrying.'
                 );
 
-                sleep(60 * 1);
+                ($this->sleeper)(60 * 1);
                 $recheck = '';
 
                 return PlayerScanTrophyTitleLoopResult::continueLoop();
@@ -262,7 +283,7 @@ final class PlayerScanTrophyTitleLoop
                     (int) $worker['id'],
                     'Waiting 5 minutes before retrying because of game deletion check.'
                 );
-                sleep(60 * 5);
+                ($this->sleeper)(60 * 5);
                 $recheck = '';
 
                 return PlayerScanTrophyTitleLoopResult::continueLoop();
@@ -281,7 +302,7 @@ final class PlayerScanTrophyTitleLoop
                     'No trophy titles returned. Waiting 1 minute before retrying.'
                 );
 
-                sleep(60 * 1);
+                ($this->sleeper)(60 * 1);
                 $recheck = '';
 
                 return PlayerScanTrophyTitleLoopResult::continueLoop();

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -276,6 +276,26 @@ final readonly class ThirtyMinuteCronJob implements CronJobInterface
                 $this->titleMetadataHelper->clearInvalidTitleDateRetriesForPlayer($invalidTitleDateRetry, $onlineId);
 
                 continue;
+            } catch (Exception $exception) {
+                // Transient PSN/network failures (e.g. Guzzle/cURL transfer errors) should
+                // back off and keep the worker alive instead of terminating the cron job.
+                $this->logger->log(sprintf(
+                    'Encountered a problem while scanning %s: %s. Waiting 1 minute before retrying.',
+                    $onlineId,
+                    $exception->getMessage()
+                ));
+                $this->workerScanCoordinator->setWaitingScanProgress(
+                    (int) $worker['id'],
+                    'Encountered a problem while scanning. Waiting 1 minute before retrying.'
+                );
+                sleep(60 * 1);
+                $recheck = '';
+                unset($missingGameDeletionCheck[$onlineId]);
+                unset($missingTrophyTitleRetry[$onlineId]);
+                unset($trophyTitleCountRetry[$onlineId]);
+                $this->titleMetadataHelper->clearInvalidTitleDateRetriesForPlayer($invalidTitleDateRetry, $onlineId);
+
+                continue;
             } finally {
                 $this->workerScanCoordinator->setWorkerScanProgress((int) $worker['id'], null);
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Yes — this is fixable in our code.

**Root cause of the network error:** Sony (or the path to it) closed the connection mid-transfer while paginating a large `trophyTitles` list (`limit=800&offset=3200`). cURL error 18 is a transient transfer failure, not a bad request we constructed.

**Bug in our handling:** `PlayerScanTrophyTitleLoop` only caught `TypeError` around `iterator_to_array($trophyTitleCollection)`, and `ThirtyMinuteCronJob` only caught `NotFoundHttpException` / `UnauthorizedHttpException` around the scan. A Guzzle `RequestException` therefore escaped and fatally killed the worker.

## Changes

- Catch transient `Exception`s when fetching trophy titles; log, set waiting progress, sleep 1 minute, and continue the scan loop.
- Reset missing-game deletion / title-count retry guards after a failed title-list fetch so an incomplete follow-up response cannot delete local rows without a clean second confirmation.
- Clear `$recheck` on those failed fetches so the next loop remains a first pass and the completion second-pass guard stays armed.
- Add a broader `Exception` safety net in `ThirtyMinuteCronJob` for other mid-scan Guzzle/network failures so the worker stays alive and retries.
- Cover the retry behavior with unit tests (injectable sleeper to avoid real delays).

## Testing

- `php tests/run.php` — all 952 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b23744ce-ef59-44dc-8c0e-d7c40bfd7799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b23744ce-ef59-44dc-8c0e-d7c40bfd7799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

