### PR TITLE
Suppress libpng iCCP warnings in perceptual image hashing

### DIFF
--- a/tests/ImageHashCalculatorTest.php
+++ b/tests/ImageHashCalculatorTest.php
@@ -77,6 +77,66 @@ final class ImageHashCalculatorTest extends TestCase
 
         $this->assertSame(md5($buffer), $calculator->calculate('image-data'));
     }
+
+    public function testCalculatePHashReturnsNullWhenContentsEmpty(): void
+    {
+        $calculator = new ImageHashCalculator(new FakeImageProcessor());
+
+        $this->assertSame(null, $calculator->calculatePHash(''));
+    }
+
+    public function testCalculatePHashReturnsNullWhenProcessorUnsupported(): void
+    {
+        $calculator = new ImageHashCalculator(new FakeImageProcessor(supported: false));
+
+        $this->assertSame(null, $calculator->calculatePHash('image-data'));
+    }
+
+    public function testCalculatePHashReturnsNullWhenImageCreationFails(): void
+    {
+        $calculator = new ImageHashCalculator(new FakeImageProcessor(createSucceeds: false));
+
+        $this->assertSame(null, $calculator->calculatePHash('image-data'));
+    }
+
+    public function testCalculatePHashUsesImageProcessorForDecoding(): void
+    {
+        // Regression: calculatePHash previously called imagecreatefromstring()
+        // directly, which logged libpng iCCP/sRGB profile warnings. Decoding
+        // must go through ImageProcessor (which uses @imagecreatefromstring).
+        $source = (string) file_get_contents(__DIR__ . '/../wwwroot/classes/ImageHashCalculator.php');
+
+        $pHashMethodStart = strpos($source, 'function calculatePHash');
+        $this->assertTrue($pHashMethodStart !== false);
+
+        $nextMethodStart = strpos($source, "\n    public function ", $pHashMethodStart + 1);
+        if ($nextMethodStart === false) {
+            $nextMethodStart = strpos($source, "\n    private function ", $pHashMethodStart + 1);
+        }
+        $this->assertTrue($nextMethodStart !== false);
+
+        $pHashMethod = substr($source, $pHashMethodStart, $nextMethodStart - $pHashMethodStart);
+        $this->assertTrue(!str_contains($pHashMethod, 'imagecreatefromstring('));
+        $this->assertStringContainsString('createImageFromString($contents)', $pHashMethod);
+    }
+
+    public function testCalculatePHashReturnsThirtyEightCharacterHexHash(): void
+    {
+        $image = imagecreatetruecolor(16, 16);
+        $this->assertTrue($image instanceof \GdImage);
+        imagefilledrectangle($image, 0, 0, 7, 15, imagecolorallocate($image, 255, 0, 0));
+        imagefilledrectangle($image, 8, 0, 15, 15, imagecolorallocate($image, 0, 0, 255));
+
+        ob_start();
+        imagepng($image);
+        $contents = (string) ob_get_clean();
+
+        $hash = (new ImageHashCalculator())->calculatePHash($contents);
+
+        $this->assertTrue(is_string($hash));
+        $this->assertSame(38, strlen((string) $hash));
+        $this->assertTrue((bool) preg_match('/^[0-9a-f]{38}$/', (string) $hash));
+    }
 }
 
 final class FakeImageProcessor implements ImageProcessorInterface

--- a/wwwroot/classes/ImageHashCalculator.php
+++ b/wwwroot/classes/ImageHashCalculator.php
@@ -61,89 +61,115 @@ final class ImageHashCalculator
     }
 
     /**
-     * * * Generates a high-precision perceptual hash (dHash) for images.
+     * Generates a high-precision perceptual hash (dHash) for images.
      * Architecture: 152 bits total (38 hex characters)
      * - 64 bits: Luminance Structure (8x8)
      * - 64 bits: Alpha/Transparency Structure (8x8)
      * - 24 bits: Average RGB Color
-     * Calculates the perceptual hash of an image from a binary string.
-     * * @param string $contents The raw image data.
+     *
+     * @param string $contents The raw image data.
      * @return string|null The 38-character hex hash, or null on failure.
      */
-    public function calculatePHash(string $contents): ?string 
+    public function calculatePHash(string $contents): ?string
     {
         if ($contents === '') {
             return null;
         }
 
-        // Create image resource from binary string
-        $image = imagecreatefromstring($contents);
-        if (!$image) {
+        if (!$this->imageProcessor->isSupported()) {
             return null;
         }
 
-        // Sampling size: 9x8 pixels to allow for 8 horizontal comparisons per row
-        $width = 9;
-        $height = 8;
-        $sample = imagecreatetruecolor($width, $height);
-
-        // Prepare the sample to handle transparency correctly
-        imagealphablending($sample, false);
-        imagesavealpha($sample, true);
-
-        // Resize original image to the sampling grid
-        imagecopyresampled(
-            $sample, $image,
-            0, 0, 0, 0,
-            $width, $height,
-            imagesx($image), imagesy($image)
-        );
-
-        $lBits = ''; // Luminance gradient bits
-        $aBits = ''; // Alpha gradient bits
-        $rTotal = 0; $gTotal = 0; $bTotal = 0;
-
-        for ($y = 0; $y < $height; $y++) {
-            for ($x = 0; $x < 8; $x++) {
-                // Get RGBA values for current pixel and the pixel to its right
-                $rgbL = imagecolorat($sample, $x, $y);
-                $rgbR = imagecolorat($sample, $x + 1, $y);
-
-                // Extract Alpha and calculate Luminance (Y) for both pixels
-                // GD Alpha is 0 (opaque) to 127 (transparent)
-                $aL = ($rgbL >> 24) & 0x7F;
-                $rL = ($rgbL >> 16) & 0xFF;
-                $gL = ($rgbL >> 8) & 0xFF;
-                $bL = $rgbL & 0xFF;
-                $yL = ($rL * 0.299 + $gL * 0.587 + $bL * 0.114);
-
-                $aR = ($rgbR >> 24) & 0x7F;
-                $rR = ($rgbR >> 16) & 0xFF;
-                $gR = ($rgbR >> 8) & 0xFF;
-                $bR = $rgbR & 0xFF;
-                $yR = ($rR * 0.299 + $gR * 0.587 + $bR * 0.114);
-
-                // Difference Hash Logic: 1 if left is greater than right, else 0
-                $lBits .= ($yL > $yR) ? '1' : '0'; // Structural change in brightness
-                $aBits .= ($aL > $aR) ? '1' : '0'; // Structural change in transparency
-
-                // Accumulate RGB values for the global color signature
-                $rTotal += $rL;
-                $gTotal += $gL;
-                $bTotal += $bL;
-            }
+        // Route through ImageProcessor so libpng iCCP/sRGB profile warnings
+        // (and other benign decode notices) are suppressed, matching calculate().
+        $image = $this->imageProcessor->createImageFromString($contents);
+        if ($image === null) {
+            return null;
         }
 
-        // Construct final hash: 16 chars (Luminance) + 16 chars (Alpha) + 6 chars (Color)
-        $hash = $this->binToHex($lBits);
-        $hash .= $this->binToHex($aBits);
+        try {
+            $sourceWidth = $this->imageProcessor->getWidth($image);
+            $sourceHeight = $this->imageProcessor->getHeight($image);
+            if ($sourceWidth <= 0 || $sourceHeight <= 0) {
+                return null;
+            }
 
-        // Calculate average color across all 72 sampled pixels
-        $hash .= str_pad(dechex((int)($rTotal / 72)), 2, '0', STR_PAD_LEFT);
-        $hash .= str_pad(dechex((int)($gTotal / 72)), 2, '0', STR_PAD_LEFT);
-        $hash .= str_pad(dechex((int)($bTotal / 72)), 2, '0', STR_PAD_LEFT);
+            // Sampling size: 9x8 pixels to allow for 8 horizontal comparisons per row
+            $width = 9;
+            $height = 8;
+            $sample = imagecreatetruecolor($width, $height);
+            if ($sample === false) {
+                return null;
+            }
 
-        return $hash;
+            // Prepare the sample to handle transparency correctly
+            imagealphablending($sample, false);
+            imagesavealpha($sample, true);
+
+            // Resize original image to the sampling grid
+            imagecopyresampled(
+                $sample,
+                $image,
+                0,
+                0,
+                0,
+                0,
+                $width,
+                $height,
+                $sourceWidth,
+                $sourceHeight
+            );
+
+            $lBits = ''; // Luminance gradient bits
+            $aBits = ''; // Alpha gradient bits
+            $rTotal = 0;
+            $gTotal = 0;
+            $bTotal = 0;
+
+            for ($y = 0; $y < $height; $y++) {
+                for ($x = 0; $x < 8; $x++) {
+                    // Get RGBA values for current pixel and the pixel to its right
+                    $rgbL = imagecolorat($sample, $x, $y);
+                    $rgbR = imagecolorat($sample, $x + 1, $y);
+
+                    // Extract Alpha and calculate Luminance (Y) for both pixels
+                    // GD Alpha is 0 (opaque) to 127 (transparent)
+                    $aL = ($rgbL >> 24) & 0x7F;
+                    $rL = ($rgbL >> 16) & 0xFF;
+                    $gL = ($rgbL >> 8) & 0xFF;
+                    $bL = $rgbL & 0xFF;
+                    $yL = ($rL * 0.299 + $gL * 0.587 + $bL * 0.114);
+
+                    $aR = ($rgbR >> 24) & 0x7F;
+                    $rR = ($rgbR >> 16) & 0xFF;
+                    $gR = ($rgbR >> 8) & 0xFF;
+                    $bR = $rgbR & 0xFF;
+                    $yR = ($rR * 0.299 + $gR * 0.587 + $bR * 0.114);
+
+                    // Difference Hash Logic: 1 if left is greater than right, else 0
+                    $lBits .= ($yL > $yR) ? '1' : '0'; // Structural change in brightness
+                    $aBits .= ($aL > $aR) ? '1' : '0'; // Structural change in transparency
+
+                    // Accumulate RGB values for the global color signature
+                    $rTotal += $rL;
+                    $gTotal += $gL;
+                    $bTotal += $bL;
+                }
+            }
+
+            // Construct final hash: 16 chars (Luminance) + 16 chars (Alpha) + 6 chars (Color)
+            $hash = $this->binToHex($lBits);
+            $hash .= $this->binToHex($aBits);
+
+            // Calculate average color across all 72 sampled pixels
+            $hash .= str_pad(dechex((int) ($rTotal / 72)), 2, '0', STR_PAD_LEFT);
+            $hash .= str_pad(dechex((int) ($gTotal / 72)), 2, '0', STR_PAD_LEFT);
+            $hash .= str_pad(dechex((int) ($bTotal / 72)), 2, '0', STR_PAD_LEFT);
+
+            return $hash;
+        } finally {
+            $this->imageProcessor->destroyImage($image);
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
PNGs with a broken embedded sRGB ICC profile were logging:

`PHP Warning: imagecreatefromstring(): gd-png: libpng warning: iCCP: known incorrect sRGB profile`

from `ImageHashCalculator::calculatePHash()`.

`calculate()` already decoded images through `ImageProcessor` (`@imagecreatefromstring`), but `calculatePHash()` called GD directly.

## Changes
- Route `calculatePHash()` through `ImageProcessor::createImageFromString()` / support checks / cleanup, matching `calculate()`
- Keep the existing dHash algorithm; only the decode path changes
- Add regression coverage so `calculatePHash` stays on the processor path and still returns a 38-char hex hash

## Test plan
- [x] `php tests/run.php` (957 tests passed)
- [ ] Confirm avatar/pHash cron path no longer emits iCCP warnings for affected PNGs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a93ab38-e3af-4a69-833d-d1d85eed3618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a93ab38-e3af-4a69-833d-d1d85eed3618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

