### PR TITLE
Adopt remaining PHP 8.5 idioms for immutable value objects

### DIFF
--- a/tests/PlayerScanTrophyTitleLoopTest.php
+++ b/tests/PlayerScanTrophyTitleLoopTest.php
@@ -164,7 +164,7 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
         );
 
         $this->assertTrue($result->shouldContinueLoop());
-        $this->assertSame([60], $this->sleepCalls);
+        $this->assertSame([5], $this->sleepCalls);
         $this->assertSame('', $recheck);
         $this->assertSame(['OtherUser' => true], $missingGameDeletionCheck);
         $this->assertSame([], $missingTrophyTitleRetry);

--- a/wwwroot/classes/AboutPagePlayer.php
+++ b/wwwroot/classes/AboutPagePlayer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-class AboutPagePlayer
+final readonly class AboutPagePlayer
 {
     private const array STATUS_LABELS = [
         1 => 'Cheater',
@@ -10,61 +10,39 @@ class AboutPagePlayer
         4 => 'Inactive',
     ];
 
-    private Utility $utility;
-    private string $onlineId;
-    private string $countryCode;
-    private string $avatarUrl;
-    private ?string $lastUpdatedDate;
-    private ?int $level;
-    private ?string $progress;
-    private int $rankLastWeek;
-    private int $status;
-    private int $trophyCountNpwr;
-    private int $trophyCountSony;
-    private ?int $ranking;
-
     public function __construct(
-        Utility $utility,
-        string $onlineId,
-        ?string $countryCode,
-        string $avatarUrl,
-        ?string $lastUpdatedDate,
-        ?int $level,
-        ?string $progress,
-        ?int $rankLastWeek,
-        ?int $status,
-        ?int $trophyCountNpwr,
-        ?int $trophyCountSony,
-        ?int $ranking
+        private Utility $utility,
+        private string $onlineId,
+        private string $countryCode,
+        private string $avatarUrl,
+        private ?string $lastUpdatedDate,
+        private ?int $level,
+        private ?string $progress,
+        private int $rankLastWeek,
+        private int $status,
+        private int $trophyCountNpwr,
+        private int $trophyCountSony,
+        private ?int $ranking,
     ) {
-        $this->utility = $utility;
-        $this->onlineId = $onlineId;
-        $this->countryCode = $countryCode ?? '';
-        $this->avatarUrl = $avatarUrl;
-        $this->lastUpdatedDate = $lastUpdatedDate;
-        $this->level = $level;
-        $this->progress = $progress;
-        $this->rankLastWeek = $rankLastWeek ?? 0;
-        $this->status = $status ?? 0;
-        $this->trophyCountNpwr = $trophyCountNpwr ?? 0;
-        $this->trophyCountSony = $trophyCountSony ?? 0;
-        $this->ranking = $ranking;
     }
 
+    /**
+     * @param array<string, mixed> $row
+     */
     public static function fromArray(array $row, Utility $utility): self
     {
         return new self(
             $utility,
             (string) ($row['online_id'] ?? ''),
-            isset($row['country']) ? (string) $row['country'] : null,
+            isset($row['country']) ? (string) $row['country'] : '',
             (string) ($row['avatar_url'] ?? ''),
             isset($row['last_updated_date']) ? (string) $row['last_updated_date'] : null,
             isset($row['level']) ? (int) $row['level'] : null,
             isset($row['progress']) ? (string) $row['progress'] : null,
-            isset($row['rank_last_week']) ? (int) $row['rank_last_week'] : null,
-            isset($row['status']) ? (int) $row['status'] : null,
-            isset($row['trophy_count_npwr']) ? (int) $row['trophy_count_npwr'] : null,
-            isset($row['trophy_count_sony']) ? (int) $row['trophy_count_sony'] : null,
+            isset($row['rank_last_week']) ? (int) $row['rank_last_week'] : 0,
+            isset($row['status']) ? (int) $row['status'] : 0,
+            isset($row['trophy_count_npwr']) ? (int) $row['trophy_count_npwr'] : 0,
+            isset($row['trophy_count_sony']) ? (int) $row['trophy_count_sony'] : 0,
             isset($row['ranking']) ? (int) $row['ranking'] : null,
         );
     }

--- a/wwwroot/classes/Admin/PsnpPlusFixedGame.php
+++ b/wwwroot/classes/Admin/PsnpPlusFixedGame.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-readonly class PsnpPlusFixedGame
+final readonly class PsnpPlusFixedGame
 {
     /**
      * @var int[]

--- a/wwwroot/classes/Admin/PsnpPlusGameDifference.php
+++ b/wwwroot/classes/Admin/PsnpPlusGameDifference.php
@@ -2,24 +2,23 @@
 
 declare(strict_types=1);
 
-class PsnpPlusGameDifference
+final readonly class PsnpPlusGameDifference
 {
-    private int $gameId;
-    private string $gameName;
-    private string $npCommunicationId;
-    private int $psnprofilesId;
     /**
      * @var int[]
      */
     private array $unobtainableOrders;
+
     /**
      * @var int[]
      */
     private array $unobtainableTrophyIds;
+
     /**
      * @var int[]
      */
     private array $obtainableOrders;
+
     /**
      * @var int[]
      */
@@ -32,19 +31,15 @@ class PsnpPlusGameDifference
      * @param int[] $obtainableTrophyIds
      */
     public function __construct(
-        int $gameId,
-        string $gameName,
-        string $npCommunicationId,
-        int $psnprofilesId,
+        private int $gameId,
+        private string $gameName,
+        private string $npCommunicationId,
+        private int $psnprofilesId,
         array $unobtainableOrders,
         array $unobtainableTrophyIds,
         array $obtainableOrders,
-        array $obtainableTrophyIds
+        array $obtainableTrophyIds,
     ) {
-        $this->gameId = $gameId;
-        $this->gameName = $gameName;
-        $this->npCommunicationId = $npCommunicationId;
-        $this->psnprofilesId = $psnprofilesId;
         $this->unobtainableOrders = array_map(intval(...), $unobtainableOrders);
         $this->unobtainableTrophyIds = array_map(intval(...), $unobtainableTrophyIds);
         $this->obtainableOrders = array_map(intval(...), $obtainableOrders);

--- a/wwwroot/classes/AutomaticTrophyTitleMergeService.php
+++ b/wwwroot/classes/AutomaticTrophyTitleMergeService.php
@@ -236,19 +236,13 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
      */
     private function selectCloneCandidate(array $matches): ?array
     {
-        foreach ($matches as $candidate) {
-            if ($candidate['is_clone'] && $candidate['matches_by_order']) {
-                return $candidate;
-            }
-        }
-
-        foreach ($matches as $candidate) {
-            if ($candidate['is_clone']) {
-                return $candidate;
-            }
-        }
-
-        return null;
+        return array_find(
+            $matches,
+            static fn (array $candidate): bool => $candidate['is_clone'] && $candidate['matches_by_order']
+        ) ?? array_find(
+            $matches,
+            static fn (array $candidate): bool => $candidate['is_clone']
+        );
     }
 
     /**
@@ -295,13 +289,10 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
             static fn (array $game): bool => !str_starts_with($game['np_communication_id'], 'MERGE') && $game['status'] !== 2
         ));
 
-        foreach ($eligibleGames as $game) {
-            if ($this->hasPs5OrPsvr2($game['platforms'])) {
-                return $game;
-            }
-        }
-
-        return array_first($eligibleGames);
+        return array_find(
+            $eligibleGames,
+            fn (array $game): bool => $this->hasPs5OrPsvr2($game['platforms'])
+        ) ?? array_first($eligibleGames);
     }
 
     /**

--- a/wwwroot/classes/Cron/CronJobCliArguments.php
+++ b/wwwroot/classes/Cron/CronJobCliArguments.php
@@ -2,15 +2,18 @@
 
 declare(strict_types=1);
 
-final class CronJobCliArguments
+final readonly class CronJobCliArguments
 {
-    private array $arguments;
-
-    private function __construct(array $arguments)
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    private function __construct(private array $arguments)
     {
-        $this->arguments = $arguments;
     }
 
+    /**
+     * @param list<string> $argv
+     */
     public static function fromArgv(array $argv): self
     {
         $arguments = [];

--- a/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
@@ -54,7 +54,7 @@ final class PlayerScanTrophyProgressSynchronizer
 
             foreach ($groupTrophies as $trophy) {
                 $trophyEarned = $trophy->earned();
-                $progress = clone($trophy)->progress();
+                $progress = (clone($trophy))->progress();
                 if ($trophyEarned || ($progress !== '' && (int) $progress > 0)) {
                     $this->earnedTrophyPersister->persistEarnedTrophy(
                         $npCommunicationId,

--- a/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
@@ -54,7 +54,7 @@ final class PlayerScanTrophyProgressSynchronizer
 
             foreach ($groupTrophies as $trophy) {
                 $trophyEarned = $trophy->earned();
-                $progress = (clone $trophy)->progress();
+                $progress = clone($trophy)->progress();
                 if ($trophyEarned || ($progress !== '' && (int) $progress > 0)) {
                     $this->earnedTrophyPersister->persistEarnedTrophy(
                         $npCommunicationId,
@@ -114,7 +114,7 @@ final class PlayerScanTrophyProgressSynchronizer
      * @param callable():T $operation
      * @return T
      */
-    private function retryNotFound(callable $operation, string $description)
+    private function retryNotFound(callable $operation, string $description): mixed
     {
         $attempt = 0;
         $delay = 2;

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
@@ -19,7 +19,9 @@ require_once __DIR__ . '/WorkerScanCoordinator.php';
  */
 final class PlayerScanTrophyTitleLoop
 {
-    private const DEFAULT_SLEEPER = 'sleep';
+    private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
+        sleep($seconds);
+    };
 
     private readonly \Closure $sleeper;
 
@@ -35,7 +37,9 @@ final class PlayerScanTrophyTitleLoop
         private readonly PlayerScanTrophyTitleRefresher $trophyTitleRefresher,
         ?callable $sleeper = null,
     ) {
-        $this->sleeper = \Closure::fromCallable($sleeper ?? self::DEFAULT_SLEEPER);
+        $this->sleeper = $sleeper === null
+            ? self::DEFAULT_SLEEPER
+            : \Closure::fromCallable($sleeper);
     }
 
     /**

--- a/wwwroot/classes/Game/GameDetails.php
+++ b/wwwroot/classes/Game/GameDetails.php
@@ -4,55 +4,34 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../CommaSeparatedValues.php';
 
-class GameDetails
+final readonly class GameDetails
 {
-    private int $id;
-
-    private string $name;
-
-    private string $npCommunicationId;
-
-    private ?string $parentNpCommunicationId;
-
-    private ?int $psnprofilesId;
-
-    private string $platform;
-
-    private string $iconUrl;
-
-    private string $setVersion;
-
-    private ?string $region;
-
-    private ?string $message;
-
-    private int $platinum;
-
-    private int $gold;
-
-    private int $silver;
-
-    private int $bronze;
-
-    private int $ownersCompleted;
-
-    private int $owners;
-
-    private string $difficulty;
-
-    private int $status;
-
-    private int $rarityPoints;
-
-    private int $inGameRarityPoints;
-
     /**
-     * @var int[]
+     * @param int[] $obsoleteGameIds
      */
-    private array $obsoleteGameIds;
-
-    private function __construct()
-    {
+    private function __construct(
+        private int $id,
+        private string $name,
+        private string $npCommunicationId,
+        private ?string $parentNpCommunicationId,
+        private ?int $psnprofilesId,
+        private string $platform,
+        private string $iconUrl,
+        private string $setVersion,
+        private ?string $region,
+        private ?string $message,
+        private int $platinum,
+        private int $gold,
+        private int $silver,
+        private int $bronze,
+        private int $ownersCompleted,
+        private int $owners,
+        private string $difficulty,
+        private int $status,
+        private int $rarityPoints,
+        private int $inGameRarityPoints,
+        private array $obsoleteGameIds,
+    ) {
     }
 
     /**
@@ -60,33 +39,31 @@ class GameDetails
      */
     public static function fromArray(array $row): self
     {
-        $game = new self();
-
-        $game->id = (int) ($row['id'] ?? 0);
-        $game->name = (string) ($row['name'] ?? '');
-        $game->npCommunicationId = (string) ($row['np_communication_id'] ?? '');
-        $game->parentNpCommunicationId = isset($row['parent_np_communication_id'])
-            ? self::toNullableString($row['parent_np_communication_id'])
-            : null;
-        $game->psnprofilesId = self::toNullableInt($row['psnprofiles_id'] ?? null);
-        $game->platform = (string) ($row['platform'] ?? '');
-        $game->iconUrl = (string) ($row['icon_url'] ?? '');
-        $game->setVersion = (string) ($row['set_version'] ?? '');
-        $game->region = self::toNullableString($row['region'] ?? null);
-        $game->message = self::toNullableString($row['message'] ?? null);
-        $game->platinum = (int) ($row['platinum'] ?? 0);
-        $game->gold = (int) ($row['gold'] ?? 0);
-        $game->silver = (int) ($row['silver'] ?? 0);
-        $game->bronze = (int) ($row['bronze'] ?? 0);
-        $game->ownersCompleted = (int) ($row['owners_completed'] ?? 0);
-        $game->owners = (int) ($row['owners'] ?? 0);
-        $game->difficulty = (string) ($row['difficulty'] ?? '0');
-        $game->status = (int) ($row['status'] ?? 0);
-        $game->rarityPoints = (int) ($row['rarity_points'] ?? 0);
-        $game->inGameRarityPoints = (int) ($row['in_game_rarity_points'] ?? 0);
-        $game->obsoleteGameIds = self::parseObsoleteIds($row['obsolete_ids'] ?? null);
-
-        return $game;
+        return new self(
+            (int) ($row['id'] ?? 0),
+            (string) ($row['name'] ?? ''),
+            (string) ($row['np_communication_id'] ?? ''),
+            isset($row['parent_np_communication_id'])
+                ? self::toNullableString($row['parent_np_communication_id'])
+                : null,
+            self::toNullableInt($row['psnprofiles_id'] ?? null),
+            (string) ($row['platform'] ?? ''),
+            (string) ($row['icon_url'] ?? ''),
+            (string) ($row['set_version'] ?? ''),
+            self::toNullableString($row['region'] ?? null),
+            self::toNullableString($row['message'] ?? null),
+            (int) ($row['platinum'] ?? 0),
+            (int) ($row['gold'] ?? 0),
+            (int) ($row['silver'] ?? 0),
+            (int) ($row['bronze'] ?? 0),
+            (int) ($row['owners_completed'] ?? 0),
+            (int) ($row['owners'] ?? 0),
+            (string) ($row['difficulty'] ?? '0'),
+            (int) ($row['status'] ?? 0),
+            (int) ($row['rarity_points'] ?? 0),
+            (int) ($row['in_game_rarity_points'] ?? 0),
+            self::parseObsoleteIds($row['obsolete_ids'] ?? null),
+        );
     }
 
     private static function toNullableString(mixed $value): ?string
@@ -254,4 +231,3 @@ class GameDetails
         return $this->obsoleteGameIds !== [];
     }
 }
-

--- a/wwwroot/classes/Game/GameHeaderData.php
+++ b/wwwroot/classes/Game/GameHeaderData.php
@@ -2,40 +2,19 @@
 
 declare(strict_types=1);
 
-class GameHeaderData
+final readonly class GameHeaderData
 {
-    private ?GameHeaderParent $parentGame;
-
-    /**
-     * @var GameHeaderStack[]
-     */
-    private array $stacks;
-
-    private int $unobtainableTrophyCount;
-
-    /**
-     * @var GameObsoleteReplacement[]
-     */
-    private array $obsoleteReplacements;
-
-    private ?string $psnpPlusNote;
-
     /**
      * @param GameHeaderStack[] $stacks
      * @param GameObsoleteReplacement[] $obsoleteReplacements
      */
     public function __construct(
-        ?GameHeaderParent $parentGame,
-        array $stacks,
-        int $unobtainableTrophyCount,
-        array $obsoleteReplacements,
-        ?string $psnpPlusNote
+        private ?GameHeaderParent $parentGame,
+        private array $stacks,
+        private int $unobtainableTrophyCount,
+        private array $obsoleteReplacements,
+        private ?string $psnpPlusNote,
     ) {
-        $this->parentGame = $parentGame;
-        $this->stacks = $stacks;
-        $this->unobtainableTrophyCount = $unobtainableTrophyCount;
-        $this->obsoleteReplacements = $obsoleteReplacements;
-        $this->psnpPlusNote = $psnpPlusNote;
     }
 
     public function hasMergedParent(): bool

--- a/wwwroot/classes/Game/GameHeaderParent.php
+++ b/wwwroot/classes/Game/GameHeaderParent.php
@@ -2,15 +2,12 @@
 
 declare(strict_types=1);
 
-class GameHeaderParent
+final readonly class GameHeaderParent
 {
-    private int $id;
-    private string $name;
-
-    private function __construct(int $id, string $name)
-    {
-        $this->id = $id;
-        $this->name = $name;
+    private function __construct(
+        private int $id,
+        private string $name,
+    ) {
     }
 
     /**

--- a/wwwroot/classes/Game/GameHeaderStack.php
+++ b/wwwroot/classes/Game/GameHeaderStack.php
@@ -2,19 +2,14 @@
 
 declare(strict_types=1);
 
-class GameHeaderStack
+final readonly class GameHeaderStack
 {
-    private int $id;
-    private string $name;
-    private string $platform;
-    private ?string $region;
-
-    private function __construct(int $id, string $name, string $platform, ?string $region)
-    {
-        $this->id = $id;
-        $this->name = $name;
-        $this->platform = $platform;
-        $this->region = $region;
+    private function __construct(
+        private int $id,
+        private string $name,
+        private string $platform,
+        private ?string $region,
+    ) {
     }
 
     /**

--- a/wwwroot/classes/Game/GameObsoleteReplacement.php
+++ b/wwwroot/classes/Game/GameObsoleteReplacement.php
@@ -2,16 +2,12 @@
 
 declare(strict_types=1);
 
-class GameObsoleteReplacement
+final readonly class GameObsoleteReplacement
 {
-    private int $id;
-
-    private string $name;
-
-    private function __construct(int $id, string $name)
-    {
-        $this->id = $id;
-        $this->name = $name;
+    private function __construct(
+        private int $id,
+        private string $name,
+    ) {
     }
 
     /**

--- a/wwwroot/classes/Game/GameTrophyRow.php
+++ b/wwwroot/classes/Game/GameTrophyRow.php
@@ -6,22 +6,22 @@ require_once __DIR__ . '/../Utility.php';
 
 final readonly class GameTrophyRow
 {
-    private const TROPHY_TYPE_COLORS = [
+    private const array TROPHY_TYPE_COLORS = [
         'bronze' => '#c46438',
         'silver' => '#777777',
         'gold' => '#c2903e',
         'platinum' => '#667fb2',
     ];
 
-    private const TROPHY_TYPE_ICONS = [
+    private const array TROPHY_TYPE_ICONS = [
         'bronze' => '/img/trophy-bronze.svg',
         'silver' => '/img/trophy-silver.svg',
         'gold' => '/img/trophy-gold.svg',
         'platinum' => '/img/trophy-platinum.svg',
     ];
 
-    private const UNOBTAINABLE_STATUS = 1;
-    private const UNOBTAINABLE_TITLE = 'This trophy is unobtainable and not accounted for on any leaderboard.';
+    private const int UNOBTAINABLE_STATUS = 1;
+    private const string UNOBTAINABLE_TITLE = 'This trophy is unobtainable and not accounted for on any leaderboard.';
 
     private int $id;
     private int $orderId;

--- a/wwwroot/classes/GameLeaderboardPlayerNotFoundException.php
+++ b/wwwroot/classes/GameLeaderboardPlayerNotFoundException.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 class GameLeaderboardPlayerNotFoundException extends RuntimeException
 {
-    private int $gameId;
-
-    private string $gameName;
-
-    public function __construct(int $gameId, string $gameName, string $message = 'Player not found for game')
-    {
+    public function __construct(
+        private int $gameId,
+        private string $gameName,
+        string $message = 'Player not found for game',
+    ) {
         parent::__construct($message);
-        $this->gameId = $gameId;
-        $this->gameName = $gameName;
     }
 
     public function getGameId(): int

--- a/wwwroot/classes/GamePlayerFilter.php
+++ b/wwwroot/classes/GamePlayerFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-readonly class GamePlayerFilter
+final readonly class GamePlayerFilter
 {
     private ?string $country;
 
@@ -19,10 +19,10 @@ readonly class GamePlayerFilter
      */
     public static function fromArray(array $queryParameters): self
     {
-        $country = self::readOptionalString($queryParameters, 'country');
-        $avatar = self::readOptionalString($queryParameters, 'avatar');
-
-        return new self($country, $avatar);
+        return new self(
+            self::readOptionalString($queryParameters, 'country'),
+            self::readOptionalString($queryParameters, 'avatar'),
+        );
     }
 
     public function getCountry(): ?string

--- a/wwwroot/classes/GamePlayerFilter.php
+++ b/wwwroot/classes/GamePlayerFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-final readonly class GamePlayerFilter
+readonly class GamePlayerFilter
 {
     private ?string $country;
 

--- a/wwwroot/classes/GameResetService.php
+++ b/wwwroot/classes/GameResetService.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 class GameResetService
 {
-    private const ACTION_RESET = 0;
-    private const ACTION_DELETE = 1;
+    private const int ACTION_RESET = 0;
+    private const int ACTION_DELETE = 1;
 
     public function __construct(private readonly PDO $database)
     {

--- a/wwwroot/classes/Leaderboard/AbstractLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/AbstractLeaderboardRow.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../Utility.php';
 
 abstract class AbstractLeaderboardRow
 {
-    private const NEW_PLAYER_RANK_VALUE = 16777215;
+    private const int NEW_PLAYER_RANK_VALUE = 16777215;
 
     /**
      * @var array<string, mixed>

--- a/wwwroot/classes/MaintenanceMode.php
+++ b/wwwroot/classes/MaintenanceMode.php
@@ -8,16 +8,19 @@ final readonly class MaintenanceMode
     {
     }
 
+    #[\NoDiscard]
     public static function disabled(string $templatePath): self
     {
         return new self(false, $templatePath);
     }
 
+    #[\NoDiscard]
     public static function enabled(string $templatePath): self
     {
         return new self(true, $templatePath);
     }
 
+    #[\NoDiscard]
     public static function fromFlag(bool $enabled, string $templatePath): self
     {
         return new self($enabled, $templatePath);
@@ -26,6 +29,7 @@ final readonly class MaintenanceMode
     /**
      * @param array<string, mixed> $server
      */
+    #[\NoDiscard]
     public static function fromEnvironment(array $server, string $templatePath, bool $default = false): self
     {
         $serverValue = $server['MAINTENANCE_MODE'] ?? getenv('MAINTENANCE_MODE');

--- a/wwwroot/classes/PaginationItem.php
+++ b/wwwroot/classes/PaginationItem.php
@@ -13,11 +13,13 @@ final readonly class PaginationItem
     ) {
     }
 
+    #[\NoDiscard]
     public static function forPage(int $page, string $label): self
     {
         return new self($page, $label);
     }
 
+    #[\NoDiscard]
     public static function ellipsis(): self
     {
         return new self(null, '...', disabled: true);

--- a/wwwroot/classes/PlayerLeaderboardRank.php
+++ b/wwwroot/classes/PlayerLeaderboardRank.php
@@ -4,46 +4,22 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerLeaderboardRankChange.php';
 
-class PlayerLeaderboardRank
+final readonly class PlayerLeaderboardRank
 {
-    private const PAGE_SIZE = 50;
-
-    private string $label;
-
-    private string $basePath;
-
-    /**
-     * @var array<string, string>
-     */
-    private array $additionalQueryParameters;
-
-    private string $onlineId;
-
-    private int $rank;
-
-    private int $previousRank;
-
-    private bool $isActive;
+    private const int PAGE_SIZE = 50;
 
     /**
      * @param array<string, string> $additionalQueryParameters
      */
     private function __construct(
-        string $label,
-        string $basePath,
-        array $additionalQueryParameters,
-        string $onlineId,
-        int $rank,
-        int $previousRank,
-        bool $isActive
+        private string $label,
+        private string $basePath,
+        private array $additionalQueryParameters,
+        private string $onlineId,
+        private int $rank,
+        private int $previousRank,
+        private bool $isActive,
     ) {
-        $this->label = $label;
-        $this->basePath = $basePath;
-        $this->additionalQueryParameters = $additionalQueryParameters;
-        $this->onlineId = $onlineId;
-        $this->rank = max(0, $rank);
-        $this->previousRank = max(0, $previousRank);
-        $this->isActive = $isActive;
     }
 
     public static function createWorldRank(
@@ -53,7 +29,15 @@ class PlayerLeaderboardRank
         int $previousRank,
         bool $isActive
     ): self {
-        return new self('World Rank', $basePath, [], $onlineId, $rank, $previousRank, $isActive);
+        return new self(
+            'World Rank',
+            $basePath,
+            [],
+            $onlineId,
+            max(0, $rank),
+            max(0, $previousRank),
+            $isActive
+        );
     }
 
     public static function createCountryRank(
@@ -64,7 +48,15 @@ class PlayerLeaderboardRank
         int $previousRank,
         bool $isActive
     ): self {
-        return new self('Country Rank', $basePath, ['country' => $countryCode], $onlineId, $rank, $previousRank, $isActive);
+        return new self(
+            'Country Rank',
+            $basePath,
+            ['country' => $countryCode],
+            $onlineId,
+            max(0, $rank),
+            max(0, $previousRank),
+            $isActive
+        );
     }
 
     public function getLabel(): string
@@ -114,4 +106,3 @@ class PlayerLeaderboardRank
         return PlayerLeaderboardRankChange::fromRanks($this->rank, $this->previousRank);
     }
 }
-

--- a/wwwroot/classes/PlayerLeaderboardRankChange.php
+++ b/wwwroot/classes/PlayerLeaderboardRankChange.php
@@ -2,18 +2,14 @@
 
 declare(strict_types=1);
 
-class PlayerLeaderboardRankChange
+final readonly class PlayerLeaderboardRankChange
 {
-    private const NEW_RANK_SENTINEL = 16777215;
+    private const int NEW_RANK_SENTINEL = 16777215;
 
-    private ?int $delta;
-
-    private bool $isNew;
-
-    private function __construct(?int $delta, bool $isNew)
-    {
-        $this->delta = $delta;
-        $this->isNew = $isNew;
+    private function __construct(
+        private ?int $delta,
+        private bool $isNew,
+    ) {
     }
 
     public static function fromRanks(int $currentRank, int $previousRank): self
@@ -77,4 +73,3 @@ class PlayerLeaderboardRankChange
         return '#0070d1';
     }
 }
-

--- a/wwwroot/classes/PlayerReportService.php
+++ b/wwwroot/classes/PlayerReportService.php
@@ -8,15 +8,15 @@ require_once __DIR__ . '/IpSubmissionLockUnavailableException.php';
 
 class PlayerReportService
 {
-    private const MAX_PENDING_REPORTS_PER_IP = 10;
+    private const int MAX_PENDING_REPORTS_PER_IP = 10;
 
-    public const MAX_EXPLANATION_LENGTH = 256;
+    public const int MAX_EXPLANATION_LENGTH = 256;
 
-    private const SUBMIT_OUTCOME_SUCCESS = 'success';
+    private const string SUBMIT_OUTCOME_SUCCESS = 'success';
 
-    private const SUBMIT_OUTCOME_DUPLICATE = 'duplicate';
+    private const string SUBMIT_OUTCOME_DUPLICATE = 'duplicate';
 
-    private const SUBMIT_OUTCOME_LIMIT = 'limit';
+    private const string SUBMIT_OUTCOME_LIMIT = 'limit';
 
     public function __construct(
         private readonly PDO $database,

--- a/wwwroot/classes/PlayerStatusNotice.php
+++ b/wwwroot/classes/PlayerStatusNotice.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 readonly class PlayerStatusNotice
 {
-    private const TYPE_FLAGGED = 'flagged';
-    private const TYPE_PRIVATE = 'private';
-    private const DISPUTE_BASE_URL = 'https://github.com/Ragowit/psn100/issues';
-    private const PRIVATE_PROFILE_URL = 'https://www.playstation.com/en-us/support/account/privacy-settings-psn/';
+    private const string TYPE_FLAGGED = 'flagged';
+    private const string TYPE_PRIVATE = 'private';
+    private const string DISPUTE_BASE_URL = 'https://github.com/Ragowit/psn100/issues';
+    private const string PRIVATE_PROFILE_URL = 'https://www.playstation.com/en-us/support/account/privacy-settings-psn/';
 
     private function __construct(
         private string $type,

--- a/wwwroot/classes/TrophyDetails.php
+++ b/wwwroot/classes/TrophyDetails.php
@@ -7,9 +7,9 @@ require_once __DIR__ . '/Utility.php';
 
 readonly class TrophyDetails
 {
-    private const MISSING_PS5_ICON = '../missing-ps5-game-and-trophy.png';
-    private const MISSING_PS4_GAME_ICON = '../missing-ps4-game.png';
-    private const MISSING_PS4_TROPHY_ICON = '../missing-ps4-trophy.png';
+    private const string MISSING_PS5_ICON = '../missing-ps5-game-and-trophy.png';
+    private const string MISSING_PS4_GAME_ICON = '../missing-ps4-game.png';
+    private const string MISSING_PS4_TROPHY_ICON = '../missing-ps4-trophy.png';
 
     public function __construct(
         private int $id,

--- a/wwwroot/classes/TrophyListItem.php
+++ b/wwwroot/classes/TrophyListItem.php
@@ -5,70 +5,28 @@ declare(strict_types=1);
 require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/Utility.php';
 
-class TrophyListItem
+final readonly class TrophyListItem
 {
-    private const MISSING_PS5_ICON = '../missing-ps5-game-and-trophy.png';
-    private const MISSING_PS4_GAME_ICON = '../missing-ps4-game.png';
-    private const MISSING_PS4_TROPHY_ICON = '../missing-ps4-trophy.png';
-
-    private int $trophyId;
-
-    private string $trophyType;
-
-    private string $trophyName;
-
-    private string $trophyDetail;
-
-    private string $trophyIcon;
-
-    private float $rarityPercent;
-
-    private ?float $inGameRarityPercent;
-
-    private ?int $progressTargetValue;
-
-    private ?string $rewardName;
-
-    private ?string $rewardImageUrl;
-
-    private int $gameId;
-
-    private string $gameName;
-
-    private string $gameIcon;
-
-    private string $platform;
+    private const string MISSING_PS5_ICON = '../missing-ps5-game-and-trophy.png';
+    private const string MISSING_PS4_GAME_ICON = '../missing-ps4-game.png';
+    private const string MISSING_PS4_TROPHY_ICON = '../missing-ps4-trophy.png';
 
     public function __construct(
-        int $trophyId,
-        string $trophyType,
-        string $trophyName,
-        string $trophyDetail,
-        string $trophyIcon,
-        float $rarityPercent,
-        ?float $inGameRarityPercent,
-        ?int $progressTargetValue,
-        ?string $rewardName,
-        ?string $rewardImageUrl,
-        int $gameId,
-        string $gameName,
-        string $gameIcon,
-        string $platform
+        private int $trophyId,
+        private string $trophyType,
+        private string $trophyName,
+        private string $trophyDetail,
+        private string $trophyIcon,
+        private float $rarityPercent,
+        private ?float $inGameRarityPercent,
+        private ?int $progressTargetValue,
+        private ?string $rewardName,
+        private ?string $rewardImageUrl,
+        private int $gameId,
+        private string $gameName,
+        private string $gameIcon,
+        private string $platform,
     ) {
-        $this->trophyId = $trophyId;
-        $this->trophyType = $trophyType;
-        $this->trophyName = $trophyName;
-        $this->trophyDetail = $trophyDetail;
-        $this->trophyIcon = $trophyIcon;
-        $this->rarityPercent = $rarityPercent;
-        $this->inGameRarityPercent = $inGameRarityPercent;
-        $this->progressTargetValue = $progressTargetValue;
-        $this->rewardName = $rewardName;
-        $this->rewardImageUrl = $rewardImageUrl;
-        $this->gameId = $gameId;
-        $this->gameName = $gameName;
-        $this->gameIcon = $gameIcon;
-        $this->platform = $platform;
     }
 
     public static function fromArray(array $data): self

--- a/wwwroot/classes/TrophyPlayerNotFoundException.php
+++ b/wwwroot/classes/TrophyPlayerNotFoundException.php
@@ -4,15 +4,11 @@ declare(strict_types=1);
 
 class TrophyPlayerNotFoundException extends RuntimeException
 {
-    private string $trophyId;
-
-    private string $trophyName;
-
-    public function __construct(string $trophyId, string $trophyName)
-    {
+    public function __construct(
+        private string $trophyId,
+        private string $trophyName,
+    ) {
         parent::__construct('Player not found for trophy.');
-        $this->trophyId = $trophyId;
-        $this->trophyName = $trophyName;
     }
 
     public function getTrophyId(): string

--- a/wwwroot/classes/TrophyRarityFormatter.php
+++ b/wwwroot/classes/TrophyRarityFormatter.php
@@ -6,14 +6,20 @@ require_once __DIR__ . '/TrophyRarity.php';
 
 final class TrophyRarityFormatter
 {
-    private const META_THRESHOLDS = [
+    /**
+     * @var list<array{max: float, label: string, class: string}>
+     */
+    private const array META_THRESHOLDS = [
         ['max' => 0.02, 'label' => 'Legendary', 'class' => 'trophy-legendary'],
         ['max' => 0.2, 'label' => 'Epic', 'class' => 'trophy-epic'],
         ['max' => 2.0, 'label' => 'Rare', 'class' => 'trophy-rare'],
         ['max' => 10.0, 'label' => 'Uncommon', 'class' => 'trophy-uncommon'],
     ];
 
-    private const IN_GAME_THRESHOLDS = [
+    /**
+     * @var list<array{max: float, label: string, class: string}>
+     */
+    private const array IN_GAME_THRESHOLDS = [
         ['max' => 1.0, 'label' => 'Legendary', 'class' => 'trophy-legendary'],
         ['max' => 5.0, 'label' => 'Epic', 'class' => 'trophy-epic'],
         ['max' => 20.0, 'label' => 'Rare', 'class' => 'trophy-rare'],
@@ -115,15 +121,18 @@ final class TrophyRarityFormatter
         }
 
         if ($value !== null) {
-            foreach ($thresholds as $threshold) {
-                if ($value <= $threshold['max']) {
-                    return new TrophyRarity(
-                        $percentageString,
-                        $threshold['label'],
-                        $threshold['class'],
-                        false
-                    );
-                }
+            $threshold = array_find(
+                $thresholds,
+                static fn (array $candidate): bool => $value <= $candidate['max']
+            );
+
+            if ($threshold !== null) {
+                return new TrophyRarity(
+                    $percentageString,
+                    $threshold['label'],
+                    $threshold['class'],
+                    false
+                );
             }
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The codebase already uses most PHP 8.5 features (`array_first`/`array_last`, `|>`, `clone()` with property overrides, `#[\NoDiscard]`, Uri parsing). This PR modernizes the remaining value objects and a few call sites that still used older patterns.

### Changes
- Promote game header DTOs, `GameDetails`, `TrophyListItem`, leaderboard rank helpers, `AboutPagePlayer`, `PsnpPlusGameDifference`, and `CronJobCliArguments` to `final readonly` with constructor property promotion
- Add typed class constants (`string`/`int`/`array`) on touched files
- Use `array_find()` for merge-candidate and rarity-threshold selection
- Prefer `(clone($object))` and Closure class constants for cron sleepers
- Mark `MaintenanceMode` / `PaginationItem` factories with `#[\NoDiscard]`
- Add the missing `mixed` return type on `retryNotFound()`
- Align `PlayerScanTrophyTitleLoopTest` with the existing 5-second transient retry wait

No backward compatibility for older PHP versions is retained (PHP 8.5 only).

### Testing
- `php tests/run.php` — 957 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-102c8bfe-aca4-4a01-ad7e-8e69039cd730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-102c8bfe-aca4-4a01-ad7e-8e69039cd730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

