### PR TITLE
Improve MySQL 8.4 SQL around large trophy tables

### DIFF
--- a/tests/GameRescanPsnAccessorTest.php
+++ b/tests/GameRescanPsnAccessorTest.php
@@ -89,6 +89,7 @@ final class GameRescanPsnAccessorTest extends TestCase
 
         $this->assertTrue(str_contains($source, 'ACCESSIBLE_PLAYER_PROBE_BATCH_SIZE'));
         $this->assertTrue(str_contains($source, 'LIMIT \' . self::ACCESSIBLE_PLAYER_PROBE_BATCH_SIZE . \' OFFSET \' . $offset'));
+        $this->assertTrue(str_contains($source, 'ORDER BY ttp.last_updated_date DESC, ttp.account_id DESC'));
         $this->assertFalse(str_contains($source, 'ACCESSIBLE_PLAYER_PROBE_LIMIT'));
     }
 

--- a/tests/GameRescanPsnAccessorTest.php
+++ b/tests/GameRescanPsnAccessorTest.php
@@ -83,6 +83,14 @@ final class GameRescanPsnAccessorTest extends TestCase
         $this->assertSame('200', $user->accountId());
     }
 
+    public function testFindAccessibleUserWithGameBoundsPlayerProbe(): void
+    {
+        $source = (string) file_get_contents(__DIR__ . '/../wwwroot/classes/Admin/GameRescanPsnAccessor.php');
+
+        $this->assertTrue(str_contains($source, 'ACCESSIBLE_PLAYER_PROBE_LIMIT'));
+        $this->assertTrue(str_contains($source, 'LIMIT \' . self::ACCESSIBLE_PLAYER_PROBE_LIMIT'));
+    }
+
     public function testLoginToWorkerDelegatesToAuthenticator(): void
     {
         $worker = new Worker(5, 'refresh-token', '', '', new DateTimeImmutable('2024-01-01'), null);

--- a/tests/GameRescanPsnAccessorTest.php
+++ b/tests/GameRescanPsnAccessorTest.php
@@ -83,12 +83,42 @@ final class GameRescanPsnAccessorTest extends TestCase
         $this->assertSame('200', $user->accountId());
     }
 
-    public function testFindAccessibleUserWithGameBoundsPlayerProbe(): void
+    public function testFindAccessibleUserWithGamePagesOwnerProbes(): void
     {
         $source = (string) file_get_contents(__DIR__ . '/../wwwroot/classes/Admin/GameRescanPsnAccessor.php');
 
-        $this->assertTrue(str_contains($source, 'ACCESSIBLE_PLAYER_PROBE_LIMIT'));
-        $this->assertTrue(str_contains($source, 'LIMIT \' . self::ACCESSIBLE_PLAYER_PROBE_LIMIT'));
+        $this->assertTrue(str_contains($source, 'ACCESSIBLE_PLAYER_PROBE_BATCH_SIZE'));
+        $this->assertTrue(str_contains($source, 'LIMIT \' . self::ACCESSIBLE_PLAYER_PROBE_BATCH_SIZE . \' OFFSET \' . $offset'));
+        $this->assertFalse(str_contains($source, 'ACCESSIBLE_PLAYER_PROBE_LIMIT'));
+    }
+
+    public function testFindAccessibleUserWithGameContinuesPastFullPrivateBatch(): void
+    {
+        // Higher account ids are more recent, so the first batch is 101..2 (private)
+        // and the second batch starts at account 1 (public).
+        $rows = [];
+        $users = [];
+        for ($accountId = 1; $accountId <= 101; $accountId++) {
+            $rows[] = [
+                'account_id' => $accountId,
+                'np_communication_id' => 'NPWR00001_00',
+                'last_updated_date' => sprintf(
+                    '2024-02-%02dT%02d:00:00Z',
+                    1 + intdiv($accountId - 1, 24),
+                    ($accountId - 1) % 24
+                ),
+            ];
+            $users[$accountId] = new GameRescanPsnAccessorTestUser([], privateProfile: $accountId !== 1);
+        }
+
+        $database = $this->createDatabaseWithTitlePlayers($rows);
+        $accessor = $this->createAccessor($database);
+        $client = new GameRescanPsnAccessorTestClient($users);
+
+        $user = $accessor->findAccessibleUserWithGame($client, 'NPWR00001_00');
+
+        $this->assertTrue($user !== null);
+        $this->assertSame('1', $user->accountId());
     }
 
     public function testLoginToWorkerDelegatesToAuthenticator(): void
@@ -129,7 +159,7 @@ final class GameRescanPsnAccessorTest extends TestCase
     }
 
     /**
-     * @param list<array{account_id: int, np_communication_id: string}> $rows
+     * @param list<array{account_id: int, np_communication_id: string, last_updated_date?: string}> $rows
      */
     private function createDatabaseWithTitlePlayers(array $rows): PDO
     {
@@ -153,7 +183,7 @@ final class GameRescanPsnAccessorTest extends TestCase
             $statement->execute([
                 'account_id' => $row['account_id'],
                 'np_communication_id' => $row['np_communication_id'],
-                'last_updated_date' => '2024-01-01T00:00:00Z',
+                'last_updated_date' => $row['last_updated_date'] ?? '2024-01-01T00:00:00Z',
             ]);
         }
 

--- a/tests/PossibleCheaterServiceTest.php
+++ b/tests/PossibleCheaterServiceTest.php
@@ -41,6 +41,12 @@ final class PossibleCheaterServiceTest extends TestCase
                 progress INTEGER,
                 earned INTEGER NOT NULL DEFAULT 1
             );
+
+            CREATE TABLE trophy_title_player (
+                np_communication_id TEXT NOT NULL,
+                account_id INTEGER NOT NULL,
+                PRIMARY KEY (np_communication_id, account_id)
+            );
             SQL
         );
 
@@ -95,6 +101,21 @@ final class PossibleCheaterServiceTest extends TestCase
         $source = (string) file_get_contents(__DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterService.php');
 
         $this->assertStringContainsString('AND te.earned = 1', $source);
+        $this->assertStringContainsString('JOIN trophy_title_player ttp ON', $source);
+        $this->assertStringContainsString('te.account_id = ttp.account_id', $source);
+    }
+
+    public function testProductionSectionQueriesDriveFromTrophyTitlePlayer(): void
+    {
+        $sections = require __DIR__ . '/../wwwroot/config/possible-cheater-sections.php';
+
+        $this->assertTrue($sections !== []);
+        foreach ($sections as $section) {
+            $this->assertTrue(
+                str_contains((string) $section['query'], 'trophy_title_player'),
+                'Expected section "' . $section['title'] . '" to drive from trophy_title_player for partition pruning.'
+            );
+        }
     }
 
     public function testCreateReportFindsMatchingGeneralCheaters(): void
@@ -114,6 +135,11 @@ final class PossibleCheaterServiceTest extends TestCase
                 ('NPWR05066_00', 'default', 2, 1, '2020-01-01 00:00:00'),
                 ('NPWR99999_00', 'default', 0, 1, '2019-01-01 00:00:00'),
                 ('NPWR05066_00', 'default', 2, 3, '2020-01-01 00:00:00');
+
+            INSERT INTO trophy_title_player (np_communication_id, account_id) VALUES
+                ('NPWR05066_00', 1),
+                ('NPWR99999_00', 1),
+                ('NPWR05066_00', 3);
             SQL
         );
 
@@ -139,6 +165,10 @@ final class PossibleCheaterServiceTest extends TestCase
             INSERT INTO trophy_earned (np_communication_id, group_id, order_id, account_id, earned_date) VALUES
                 ('NPWR00550_00', 'default', 4, 4, '2014-12-31 23:59:59'),
                 ('NPWR00550_00', 'default', 4, 5, '2015-01-01 00:00:00');
+
+            INSERT INTO trophy_title_player (np_communication_id, account_id) VALUES
+                ('NPWR00550_00', 4),
+                ('NPWR00550_00', 5);
             SQL
         );
 

--- a/tests/TrophyCalculatorTest.php
+++ b/tests/TrophyCalculatorTest.php
@@ -120,6 +120,16 @@ final class TrophyCalculatorTest extends TestCase
         $this->assertTrue($playerProgress !== null);
         $this->assertSame($accountId, $playerProgress['account_id']);
     }
+
+    public function testRecalculateTrophyTitleUsesSetBasedProgressUpdateWhenNewTrophies(): void
+    {
+        $source = (string) file_get_contents(__DIR__ . '/../wwwroot/classes/TrophyCalculator.php');
+
+        $this->assertTrue(str_contains($source, 'SET progress = CASE'));
+        $this->assertTrue(str_contains($source, 'WHEN :max_score = 0 THEN 100'));
+        $this->assertTrue(str_contains($source, 'AND account_id != :account_id'));
+        $this->assertFalse(str_contains($source, 'while ($row = $select->fetch(PDO::FETCH_ASSOC))'));
+    }
 }
 
 final class FakePDO extends PDO

--- a/tests/TrophyStatusProgressRecalculatorTest.php
+++ b/tests/TrophyStatusProgressRecalculatorTest.php
@@ -28,8 +28,11 @@ final class TrophyStatusProgressRecalculatorTest extends TestCase
         $this->assertTrue(str_contains($query, 'AND aggregate.account_id IS NOT NULL'));
 
         $this->assertTrue($database->impactedAccountsQuery !== null);
+        $this->assertTrue(str_contains((string) $database->impactedAccountsQuery, 'FROM trophy_title_player ttp'));
+        $this->assertTrue(str_contains((string) $database->impactedAccountsQuery, 'te.account_id = ttp.account_id'));
         $this->assertTrue(str_contains((string) $database->impactedAccountsQuery, 'te.order_id IN ('));
         $this->assertTrue(str_contains((string) $database->impactedAccountsQuery, 'AND te.earned = 1'));
+        $this->assertTrue(str_contains((string) $database->impactedAccountsQuery, 'WHERE ttp.np_communication_id = ?'));
         $this->assertFalse(str_contains((string) $database->impactedAccountsQuery, 'INNER JOIN trophy t ON'));
         $this->assertSame('SELECT DISTINCT order_id FROM trophy WHERE id IN (?)', $database->orderIdsQuery);
     }

--- a/wwwroot/classes/Admin/GameRescanPsnAccessor.php
+++ b/wwwroot/classes/Admin/GameRescanPsnAccessor.php
@@ -14,7 +14,7 @@ final class GameRescanPsnAccessor
 {
     private const ORIGINAL_GAME_PREFIX = 'NPWR';
     private const LOGIN_RETRY_DELAY_SECONDS = 300;
-    private const int ACCESSIBLE_PLAYER_PROBE_LIMIT = 100;
+    private const int ACCESSIBLE_PLAYER_PROBE_BATCH_SIZE = 100;
 
     public function __construct(
         private PDO $database,
@@ -54,35 +54,45 @@ final class GameRescanPsnAccessor
 
     public function findAccessibleUserWithGame(object $client, string $npCommunicationId): ?object
     {
-        // Bound the probe: idx_npcid_lupdate serves the sort, but popular titles
-        // can have hundreds of thousands of owners. Fresh recent players are enough
-        // to find a public profile for catalog access.
-        $query = $this->database->prepare(
-            'SELECT account_id
-            FROM trophy_title_player ttp
-            JOIN player p USING(account_id)
-            WHERE ttp.np_communication_id = :np_communication_id
-            ORDER BY ttp.last_updated_date DESC
-            LIMIT ' . self::ACCESSIBLE_PLAYER_PROBE_LIMIT
-        );
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->execute();
+        // Page owners in batches (idx_npcid_lupdate serves the sort) so popular
+        // titles do not hold one unbounded result set open, while still scanning
+        // past clusters of recent private profiles until a public owner is found.
+        $offset = 0;
 
-        while (($accountId = $query->fetchColumn()) !== false) {
-            $user = $client->users()->find((string) $accountId);
+        while (true) {
+            $query = $this->database->prepare(
+                'SELECT account_id
+                FROM trophy_title_player ttp
+                JOIN player p USING(account_id)
+                WHERE ttp.np_communication_id = :np_communication_id
+                ORDER BY ttp.last_updated_date DESC
+                LIMIT ' . self::ACCESSIBLE_PLAYER_PROBE_BATCH_SIZE . ' OFFSET ' . $offset
+            );
+            $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+            $query->execute();
 
-            try {
-                $user->trophySummary()->level();
+            $batchCount = 0;
+            while (($accountId = $query->fetchColumn()) !== false) {
+                $batchCount++;
+                $user = $client->users()->find((string) $accountId);
 
-                return $user;
-            } catch (TypeError) {
-                // Something odd, try next player.
-            } catch (Exception) {
-                // Player probably private, try next player.
+                try {
+                    $user->trophySummary()->level();
+
+                    return $user;
+                } catch (TypeError) {
+                    // Something odd, try next player.
+                } catch (Exception) {
+                    // Player probably private, try next player.
+                }
             }
-        }
 
-        return null;
+            if ($batchCount < self::ACCESSIBLE_PLAYER_PROBE_BATCH_SIZE) {
+                return null;
+            }
+
+            $offset += self::ACCESSIBLE_PLAYER_PROBE_BATCH_SIZE;
+        }
     }
 
     public function findTrophyTitleForUser(object $user, string $npCommunicationId): ?object

--- a/wwwroot/classes/Admin/GameRescanPsnAccessor.php
+++ b/wwwroot/classes/Admin/GameRescanPsnAccessor.php
@@ -14,6 +14,7 @@ final class GameRescanPsnAccessor
 {
     private const ORIGINAL_GAME_PREFIX = 'NPWR';
     private const LOGIN_RETRY_DELAY_SECONDS = 300;
+    private const int ACCESSIBLE_PLAYER_PROBE_LIMIT = 100;
 
     public function __construct(
         private PDO $database,
@@ -53,12 +54,16 @@ final class GameRescanPsnAccessor
 
     public function findAccessibleUserWithGame(object $client, string $npCommunicationId): ?object
     {
+        // Bound the probe: idx_npcid_lupdate serves the sort, but popular titles
+        // can have hundreds of thousands of owners. Fresh recent players are enough
+        // to find a public profile for catalog access.
         $query = $this->database->prepare(
             'SELECT account_id
             FROM trophy_title_player ttp
             JOIN player p USING(account_id)
             WHERE ttp.np_communication_id = :np_communication_id
-            ORDER BY ttp.last_updated_date DESC'
+            ORDER BY ttp.last_updated_date DESC
+            LIMIT ' . self::ACCESSIBLE_PLAYER_PROBE_LIMIT
         );
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->execute();

--- a/wwwroot/classes/Admin/GameRescanPsnAccessor.php
+++ b/wwwroot/classes/Admin/GameRescanPsnAccessor.php
@@ -65,7 +65,7 @@ final class GameRescanPsnAccessor
                 FROM trophy_title_player ttp
                 JOIN player p USING(account_id)
                 WHERE ttp.np_communication_id = :np_communication_id
-                ORDER BY ttp.last_updated_date DESC
+                ORDER BY ttp.last_updated_date DESC, ttp.account_id DESC
                 LIMIT ' . self::ACCESSIBLE_PLAYER_PROBE_BATCH_SIZE . ' OFFSET ' . $offset
             );
             $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);

--- a/wwwroot/classes/Admin/PossibleCheaterService.php
+++ b/wwwroot/classes/Admin/PossibleCheaterService.php
@@ -90,6 +90,8 @@ class PossibleCheaterService
             $this->rulesCatalog->getGeneralRuleGroups()
         );
 
+        // Drive from trophy_title_player so trophy_earned is probed by account_id
+        // (HASH partition key) instead of scanning all 256 partitions by title.
         $sql = <<<SQL
         SELECT
             first_games.account_id,
@@ -101,12 +103,14 @@ class PossibleCheaterService
                 p.account_id,
                 p.online_id AS player_name,
                 MIN(tt.np_communication_id) AS first_np_communication_id
-            FROM
-                trophy_earned te
-            INNER JOIN (
+            FROM (
                 {$ruleDerivedTable}
-            ) cheat_rules ON
-                te.np_communication_id = cheat_rules.np_communication_id
+            ) cheat_rules
+            JOIN trophy_title_player ttp ON
+                ttp.np_communication_id = cheat_rules.np_communication_id
+            JOIN trophy_earned te ON
+                te.account_id = ttp.account_id
+                AND te.np_communication_id = cheat_rules.np_communication_id
                 AND te.order_id = cheat_rules.order_id
                 AND te.earned = 1
                 AND (
@@ -115,8 +119,8 @@ class PossibleCheaterService
                     OR (cheat_rules.date_operator = '<=' AND te.earned_date <= cheat_rules.date_value)
                     OR (cheat_rules.date_operator = '<' AND te.earned_date < cheat_rules.date_value)
                 )
-            JOIN player p ON p.account_id = te.account_id
-            JOIN trophy_title tt ON tt.np_communication_id = te.np_communication_id
+            JOIN player p ON p.account_id = ttp.account_id
+            JOIN trophy_title tt ON tt.np_communication_id = cheat_rules.np_communication_id
             WHERE
                 p.status != 1
             GROUP BY

--- a/wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php
+++ b/wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php
@@ -290,17 +290,19 @@ SQL;
             return;
         }
 
-        // Resolve order_ids from the small trophy table first, then probe
-        // trophy_earned via (np_communication_id, order_id, earned) — the leading
-        // columns of idx_te_npcomm_order_earned_date — instead of joining trophy
-        // into the multi-billion-row scan.
+        // Resolve order_ids from the small trophy table first, then drive from
+        // trophy_title_player so trophy_earned is probed by account_id (HASH
+        // partition key) instead of scanning all partitions by title.
         $placeholders = implode(',', array_fill(0, count($orderIds), '?'));
         $sql = 'INSERT IGNORE INTO temp_impacted_accounts (account_id)
-            SELECT DISTINCT te.account_id
-            FROM trophy_earned te
-            WHERE te.np_communication_id = ?
-              AND te.order_id IN (' . $placeholders . ')
-              AND te.earned = 1';
+            SELECT DISTINCT ttp.account_id
+            FROM trophy_title_player ttp
+            JOIN trophy_earned te
+              ON te.account_id = ttp.account_id
+             AND te.np_communication_id = ttp.np_communication_id
+             AND te.order_id IN (' . $placeholders . ')
+             AND te.earned = 1
+            WHERE ttp.np_communication_id = ?';
 
         if ($groupId !== null) {
             $sql .= ' AND te.group_id = ?';
@@ -308,10 +310,10 @@ SQL;
 
         $statement = $this->database->prepare($sql);
         $parameterIndex = 1;
-        $statement->bindValue($parameterIndex++, $npCommunicationId, PDO::PARAM_STR);
         foreach ($orderIds as $orderId) {
             $statement->bindValue($parameterIndex++, $orderId, PDO::PARAM_INT);
         }
+        $statement->bindValue($parameterIndex++, $npCommunicationId, PDO::PARAM_STR);
         if ($groupId !== null) {
             $statement->bindValue($parameterIndex++, $groupId, PDO::PARAM_STR);
         }

--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -97,7 +97,13 @@ class GameRecentPlayersService
         $query = $this->database->prepare(
             <<<'SQL'
             SELECT
-                *
+                np_communication_id,
+                account_id,
+                bronze,
+                silver,
+                gold,
+                platinum,
+                progress
             FROM
                 trophy_title_player
             WHERE

--- a/wwwroot/classes/GameService.php
+++ b/wwwroot/classes/GameService.php
@@ -107,7 +107,13 @@ class GameService
         $query = $this->database->prepare(
             <<<'SQL'
             SELECT
-                *
+                np_communication_id,
+                account_id,
+                bronze,
+                silver,
+                gold,
+                platinum,
+                progress
             FROM
                 trophy_title_player
             WHERE
@@ -159,7 +165,14 @@ class GameService
         $query = $this->database->prepare(
             <<<'SQL'
             SELECT
-                *
+                np_communication_id,
+                group_id,
+                account_id,
+                bronze,
+                silver,
+                gold,
+                platinum,
+                progress
             FROM
                 trophy_group_player
             WHERE

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -19,8 +19,8 @@ class PlayerLogService
             SELECT COUNT(*)
             FROM trophy_earned te
             LEFT JOIN trophy t USING (np_communication_id, group_id, order_id)
-            JOIN trophy_title tt USING (np_communication_id)
             LEFT JOIN trophy_meta tm ON tm.trophy_id = t.id
+            JOIN trophy_title tt USING (np_communication_id)
             JOIN trophy_title_meta ttm USING (np_communication_id)
             WHERE ttm.status != 2
                 AND te.account_id = :account_id
@@ -66,8 +66,8 @@ class PlayerLogService
             FROM trophy_earned te
             LEFT JOIN trophy t USING (np_communication_id, group_id, order_id)
             LEFT JOIN trophy_meta tm ON tm.trophy_id = t.id
-            LEFT JOIN trophy_title tt USING (np_communication_id)
-            LEFT JOIN trophy_title_meta ttm USING (np_communication_id)
+            JOIN trophy_title tt USING (np_communication_id)
+            JOIN trophy_title_meta ttm USING (np_communication_id)
             WHERE ttm.status != 2
                 AND te.account_id = :account_id
                 AND te.earned = 1

--- a/wwwroot/classes/TrophyCalculator.php
+++ b/wwwroot/classes/TrophyCalculator.php
@@ -228,40 +228,37 @@ final class TrophyCalculator
         $maxScore = $this->calculateScore($trophies);
 
         if ($newTrophies) {
-            $select = $this->database->prepare(
-                'SELECT account_id,
-                    bronze,
-                    silver,
-                    gold,
-                    platinum
-                FROM trophy_title_player
+            // Set-based refresh for other owners when the title's max score changes.
+            // Mirrors calculateProgress() / clampProgress() without per-row round-trips.
+            $updateProgress = $this->database->prepare(
+                'UPDATE trophy_title_player
+                SET progress = CASE
+                    WHEN :max_score = 0 THEN 100
+                    ELSE LEAST(
+                        100,
+                        GREATEST(
+                            0,
+                            CASE
+                                WHEN (bronze * 15 + silver * 30 + gold * 90) != 0
+                                    AND FLOOR((bronze * 15 + silver * 30 + gold * 90) / :max_score * 100) = 0
+                                THEN 1
+                                WHEN FLOOR((bronze * 15 + silver * 30 + gold * 90) / :max_score * 100) = 100
+                                    AND :title_have_platinum = 1
+                                    AND platinum = 0
+                                THEN 99
+                                ELSE FLOOR((bronze * 15 + silver * 30 + gold * 90) / :max_score * 100)
+                            END
+                        )
+                    )
+                END
                 WHERE np_communication_id = :np_communication_id
                     AND account_id != :account_id'
             );
-            $select->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-            $select->bindValue(':account_id', $accountId, PDO::PARAM_STR);
-            $select->execute();
-
-            $updateProgress = $this->database->prepare(
-                'UPDATE trophy_title_player
-                SET progress = :progress
-                WHERE np_communication_id = :np_communication_id
-                    AND account_id = :account_id'
-            );
-
-            while ($row = $select->fetch(PDO::FETCH_ASSOC)) {
-                if (!is_array($row)) {
-                    continue;
-                }
-
-                $rowTrophyTypes = $this->normalizeTrophyTypes($row);
-                $progress = $this->calculateProgress($rowTrophyTypes, $maxScore, $titleHavePlatinum);
-
-                $updateProgress->bindValue(':progress', $progress, PDO::PARAM_INT);
-                $updateProgress->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-                $updateProgress->bindValue(':account_id', (string) $row['account_id'], PDO::PARAM_STR);
-                $updateProgress->execute();
-            }
+            $updateProgress->bindValue(':max_score', $maxScore, PDO::PARAM_INT);
+            $updateProgress->bindValue(':title_have_platinum', $titleHavePlatinum ? 1 : 0, PDO::PARAM_INT);
+            $updateProgress->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+            $updateProgress->bindValue(':account_id', $accountId, PDO::PARAM_STR);
+            $updateProgress->execute();
         }
 
         $query = $this->database->prepare(

--- a/wwwroot/config/possible-cheater-sections.php
+++ b/wwwroot/config/possible-cheater-sections.php
@@ -11,19 +11,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, fuel_start.earned_date, fuel_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned fuel_start
+                    trophy_title_player ttp
+                JOIN trophy_earned fuel_start ON
+                    fuel_start.account_id = ttp.account_id
+                    AND fuel_start.np_communication_id = ttp.np_communication_id
+                    AND fuel_start.order_id = 33
+                    AND fuel_start.earned = 1
                 JOIN trophy_earned fuel_end ON
-                    fuel_end.account_id = fuel_start.account_id
+                    fuel_end.account_id = ttp.account_id
                     AND fuel_end.np_communication_id = 'NPWR00481_00'
                     AND fuel_end.order_id = 34
                     AND fuel_end.earned = 1
                 JOIN player p ON
-                    p.account_id = fuel_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    fuel_start.np_communication_id = 'NPWR00481_00'
-                    AND fuel_start.order_id = 33
-                    AND fuel_start.earned = 1
+                    ttp.np_communication_id = 'NPWR00481_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -39,19 +42,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, socom_start.earned_date, socom_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned socom_start
+                    trophy_title_player ttp
+                JOIN trophy_earned socom_start ON
+                    socom_start.account_id = ttp.account_id
+                    AND socom_start.np_communication_id = ttp.np_communication_id
+                    AND socom_start.order_id = 32
+                    AND socom_start.earned = 1
                 JOIN trophy_earned socom_end ON
-                    socom_end.account_id = socom_start.account_id
+                    socom_end.account_id = ttp.account_id
                     AND socom_end.np_communication_id = 'NPWR00302_00'
                     AND socom_end.order_id = 33
                     AND socom_end.earned = 1
                 JOIN player p ON
-                    p.account_id = socom_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    socom_start.np_communication_id = 'NPWR00302_00'
-                    AND socom_start.order_id = 32
-                    AND socom_start.earned = 1
+                    ttp.np_communication_id = 'NPWR00302_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -67,19 +73,22 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 38
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR01103_00'
                     AND trophy_end.order_id = 48
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR01103_00'
-                    AND trophy_start.order_id = 38
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR01103_00'
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -95,19 +104,22 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 38
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR00987_00'
                     AND trophy_end.order_id = 48
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR00987_00'
-                    AND trophy_start.order_id = 38
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR00987_00'
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -123,19 +135,22 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 50
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR17582_00'
                     AND trophy_end.order_id = 51
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR17582_00'
-                    AND trophy_start.order_id = 50
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR17582_00'
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -151,19 +166,22 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 50
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR17415_00'
                     AND trophy_end.order_id = 51
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR17415_00'
-                    AND trophy_start.order_id = 50
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR17415_00'
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -179,19 +197,22 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 50
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR14836_00'
                     AND trophy_end.order_id = 51
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR14836_00'
-                    AND trophy_start.order_id = 50
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR14836_00'
                 HAVING
                     time_difference <= 0
                 ORDER BY
@@ -207,19 +228,22 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 10
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR00928_00'
                     AND trophy_end.order_id = 11
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR00928_00'
-                    AND trophy_start.order_id = 10
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR00928_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -235,19 +259,22 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 19
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR00928_00'
                     AND trophy_end.order_id = 20
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR00928_00'
-                    AND trophy_start.order_id = 19
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR00928_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -263,19 +290,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, rer_start.earned_date, rer_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned rer_start
+                    trophy_title_player ttp
+                JOIN trophy_earned rer_start ON
+                    rer_start.account_id = ttp.account_id
+                    AND rer_start.np_communication_id = ttp.np_communication_id
+                    AND rer_start.order_id = 54
+                    AND rer_start.earned = 1
                 JOIN trophy_earned rer_end ON
-                    rer_end.account_id = rer_start.account_id
+                    rer_end.account_id = ttp.account_id
                     AND rer_end.np_communication_id = 'NPWR11777_00'
                     AND rer_end.order_id = 55
                     AND rer_end.earned = 1
                 JOIN player p ON
-                    p.account_id = rer_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    rer_start.np_communication_id = 'NPWR11777_00'
-                    AND rer_start.order_id = 54
-                    AND rer_start.earned = 1
+                    ttp.np_communication_id = 'NPWR11777_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -291,19 +321,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, rer_start.earned_date, rer_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned rer_start
+                    trophy_title_player ttp
+                JOIN trophy_earned rer_start ON
+                    rer_start.account_id = ttp.account_id
+                    AND rer_start.np_communication_id = ttp.np_communication_id
+                    AND rer_start.order_id = 37
+                    AND rer_start.earned = 1
                 JOIN trophy_earned rer_end ON
-                    rer_end.account_id = rer_start.account_id
+                    rer_end.account_id = ttp.account_id
                     AND rer_end.np_communication_id = 'NPWR11777_00'
                     AND rer_end.order_id = 38
                     AND rer_end.earned = 1
                 JOIN player p ON
-                    p.account_id = rer_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    rer_start.np_communication_id = 'NPWR11777_00'
-                    AND rer_start.order_id = 37
-                    AND rer_start.earned = 1
+                    ttp.np_communication_id = 'NPWR11777_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -319,19 +352,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, rer_start.earned_date, rer_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned rer_start
+                    trophy_title_player ttp
+                JOIN trophy_earned rer_start ON
+                    rer_start.account_id = ttp.account_id
+                    AND rer_start.np_communication_id = ttp.np_communication_id
+                    AND rer_start.order_id = 49
+                    AND rer_start.earned = 1
                 JOIN trophy_earned rer_end ON
-                    rer_end.account_id = rer_start.account_id
+                    rer_end.account_id = ttp.account_id
                     AND rer_end.np_communication_id = 'NPWR03903_00'
                     AND rer_end.order_id = 50
                     AND rer_end.earned = 1
                 JOIN player p ON
-                    p.account_id = rer_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    rer_start.np_communication_id = 'NPWR03903_00'
-                    AND rer_start.order_id = 49
-                    AND rer_start.earned = 1
+                    ttp.np_communication_id = 'NPWR03903_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -347,19 +383,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, rer_start.earned_date, rer_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned rer_start
+                    trophy_title_player ttp
+                JOIN trophy_earned rer_start ON
+                    rer_start.account_id = ttp.account_id
+                    AND rer_start.np_communication_id = ttp.np_communication_id
+                    AND rer_start.order_id = 36
+                    AND rer_start.earned = 1
                 JOIN trophy_earned rer_end ON
-                    rer_end.account_id = rer_start.account_id
+                    rer_end.account_id = ttp.account_id
                     AND rer_end.np_communication_id = 'NPWR03903_00'
                     AND rer_end.order_id = 37
                     AND rer_end.earned = 1
                 JOIN player p ON
-                    p.account_id = rer_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    rer_start.np_communication_id = 'NPWR03903_00'
-                    AND rer_start.order_id = 36
-                    AND rer_start.earned = 1
+                    ttp.np_communication_id = 'NPWR03903_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -375,19 +414,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, abt_start.earned_date, abt_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned abt_start
+                    trophy_title_player ttp
+                JOIN trophy_earned abt_start ON
+                    abt_start.account_id = ttp.account_id
+                    AND abt_start.np_communication_id = ttp.np_communication_id
+                    AND abt_start.order_id = 30
+                    AND abt_start.earned = 1
                 JOIN trophy_earned abt_end ON
-                    abt_end.account_id = abt_start.account_id
+                    abt_end.account_id = ttp.account_id
                     AND abt_end.np_communication_id = 'NPWR03771_00'
                     AND abt_end.order_id = 31
                     AND abt_end.earned = 1
                 JOIN player p ON
-                    p.account_id = abt_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    abt_start.np_communication_id = 'NPWR03771_00'
-                    AND abt_start.order_id = 30
-                    AND abt_start.earned = 1
+                    ttp.np_communication_id = 'NPWR03771_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -404,22 +446,25 @@ return [
                     trophy_counter.trophy_count
                 FROM (
                     SELECT
-                        te.account_id,
+                        ttp.account_id,
                         COUNT(*) AS trophy_count
                     FROM
-                        trophy_earned te
+                        trophy_title_player ttp
                     INNER JOIN trophy_earned marker ON
-                        marker.account_id = te.account_id
-                        AND marker.np_communication_id = 'NPWR00623_00'
+                        marker.account_id = ttp.account_id
+                        AND marker.np_communication_id = ttp.np_communication_id
                         AND marker.order_id = 9
                         AND marker.earned = 1
-                    WHERE
-                        te.np_communication_id = 'NPWR00623_00'
+                    INNER JOIN trophy_earned te ON
+                        te.account_id = ttp.account_id
+                        AND te.np_communication_id = ttp.np_communication_id
                         AND te.order_id != 9
                         AND te.earned = 1
                         AND te.earned_date >= marker.earned_date
+                    WHERE
+                        ttp.np_communication_id = 'NPWR00623_00'
                     GROUP BY
-                        te.account_id
+                        ttp.account_id
                     HAVING
                         trophy_count >= 9
                 ) trophy_counter
@@ -439,19 +484,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 3
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR03734_00'
                     AND trophy_end.order_id = 4
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR03734_00'
-                    AND trophy_start.order_id = 3
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR03734_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -467,19 +515,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 6
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR09098_00'
                     AND trophy_end.order_id = 7
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR09098_00'
-                    AND trophy_start.order_id = 6
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR09098_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -495,19 +546,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 31
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR00626_00'
                     AND trophy_end.order_id = 32
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR00626_00'
-                    AND trophy_start.order_id = 31
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR00626_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -523,19 +577,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 31
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR01012_00'
                     AND trophy_end.order_id = 32
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR01012_00'
-                    AND trophy_start.order_id = 31
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR01012_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -551,19 +608,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 19
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR00464_00'
                     AND trophy_end.order_id = 20
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR00464_00'
-                    AND trophy_start.order_id = 19
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR00464_00'
                 HAVING
                     time_difference <= 60
                 ORDER BY
@@ -579,19 +639,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 36
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR03139_00'
                     AND trophy_end.order_id = 37
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR03139_00'
-                    AND trophy_start.order_id = 36
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR03139_00'
                 HAVING
                     time_difference <= 600
                 ORDER BY
@@ -607,19 +670,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 38
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR01781_00'
                     AND trophy_end.order_id = 39
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR01781_00'
-                    AND trophy_start.order_id = 38
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR01781_00'
                 HAVING
                     time_difference <= 600
                 ORDER BY
@@ -635,19 +701,22 @@ return [
                     p.online_id,
                     ABS(TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date)) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 0
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR00737_00'
                     AND trophy_end.order_id = 26
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR00737_00'
-                    AND trophy_start.order_id = 0
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR00737_00'
                 HAVING
                     time_difference <= 300
                 ORDER BY
@@ -663,19 +732,22 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 2
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR14318_00'
                     AND trophy_end.order_id = 39
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR14318_00'
-                    AND trophy_start.order_id = 2
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR14318_00'
                 HAVING
                     time_difference >= 10
                 ORDER BY
@@ -691,19 +763,22 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 2
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR14318_00'
                     AND trophy_end.order_id = 40
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR14318_00'
-                    AND trophy_start.order_id = 2
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR14318_00'
                 HAVING
                     time_difference >= 10
                 ORDER BY
@@ -719,19 +794,22 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 2
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR14318_00'
                     AND trophy_end.order_id = 41
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR14318_00'
-                    AND trophy_start.order_id = 2
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR14318_00'
                 HAVING
                     time_difference >= 10
                 ORDER BY
@@ -747,19 +825,22 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 34
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR05019_00'
                     AND trophy_end.order_id = 32
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR05019_00'
-                    AND trophy_start.order_id = 34
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR05019_00'
                 HAVING
                     time_difference >= 10
                 ORDER BY
@@ -775,19 +856,22 @@ return [
                     p.online_id,
                     TIMESTAMPDIFF(SECOND, trophy_start.earned_date, trophy_end.earned_date) AS time_difference
                 FROM
-                    trophy_earned trophy_start
+                    trophy_title_player ttp
+                JOIN trophy_earned trophy_start ON
+                    trophy_start.account_id = ttp.account_id
+                    AND trophy_start.np_communication_id = ttp.np_communication_id
+                    AND trophy_start.order_id = 1
+                    AND trophy_start.earned = 1
                 JOIN trophy_earned trophy_end ON
-                    trophy_end.account_id = trophy_start.account_id
+                    trophy_end.account_id = ttp.account_id
                     AND trophy_end.np_communication_id = 'NPWR18592_00'
                     AND trophy_end.order_id = 4
                     AND trophy_end.earned = 1
                 JOIN player p ON
-                    p.account_id = trophy_start.account_id
+                    p.account_id = ttp.account_id
                     AND p.status != 1
                 WHERE
-                    trophy_start.np_communication_id = 'NPWR18592_00'
-                    AND trophy_start.order_id = 1
-                    AND trophy_start.earned = 1
+                    ttp.np_communication_id = 'NPWR18592_00'
                 HAVING
                     time_difference <= 10
                 ORDER BY


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Further MySQL 8.4 SQL improvements focused on the three production-scale tables (`trophy_earned` ~2.6B rows / ~448 GiB, `trophy_group_player` ~227M / ~24 GiB, `trophy_title_player` ~123M / ~33 GiB). No new indexes or ALTERs on those tables — query rewrites only.

### Changes
- **Possible cheaters**: Drive general + section queries from `trophy_title_player`, then probe `trophy_earned` by `account_id` so `HASH(account_id)` partition pruning applies (was scanning all 256 partitions by title/`order_id`).
- **Status recalc**: Same partition-pruning pattern when collecting impacted accounts for trophy status changes.
- **TrophyCalculator**: Replace the per-owner progress refresh loop (N UPDATEs on `trophy_title_player` when new trophies appear) with one set-based `UPDATE` that mirrors `calculateProgress()` / `clampProgress()`.
- **Player log**: Align COUNT and page queries on the same join graph (`JOIN` title/meta required by `ttm.status != 2`).
- **Game rescan**: Page accessible-player probes in batches of 100 (continues until a public owner is found or owners are exhausted), with deterministic `ORDER BY last_updated_date DESC, account_id DESC` so OFFSET paging cannot skip/duplicate tied timestamps.
- **Hot point lookups**: Select only columns needed by `GamePlayerProgress` / `GameTrophyGroupPlayer` instead of `SELECT *` on the large player tables.

### Intentionally not changed
- No new secondary indexes on `trophy_earned` (including player-log date sort) — too expensive at ~448 GiB.
- No `ANALYZE`/histograms on `trophy_earned` (already excluded).
- Advisor anti-join shape left as-is (prior intentional choice).
- Keyset pagination for leaderboard/log deferred (needs UI/API cursor wiring).

### Review follow-ups
- Hard `LIMIT 100` on rescan lookup → batched OFFSET paging that keeps searching.
- Non-unique `ORDER BY last_updated_date` with OFFSET → added `account_id` tie-breaker.

### Tests
- Updated/added coverage in `PossibleCheaterServiceTest`, `TrophyStatusProgressRecalculatorTest`, `TrophyCalculatorTest`, `GameRescanPsnAccessorTest`.
- Full suite: `php tests/run.php` — 961 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a1e72c9-99b9-49dd-bff4-7eee7159ce31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a1e72c9-99b9-49dd-bff4-7eee7159ce31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

