### PR TITLE
Extract PsnTrophyGroupAssembler from PsnGameLookupService

### DIFF
--- a/tests/PsnTrophyGroupAssemblerTest.php
+++ b/tests/PsnTrophyGroupAssemblerTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PsnTrophyGroupAssembler.php';
+
+final class PsnTrophyGroupAssemblerTest extends TestCase
+{
+    private PsnTrophyGroupAssembler $assembler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->assembler = new PsnTrophyGroupAssembler();
+    }
+
+    public function testGroupTrophiesByGroupIdGroupsFlatTrophies(): void
+    {
+        $groups = $this->assembler->groupTrophiesByGroupId([
+            [
+                'trophyGroupId' => 'default',
+                'trophyGroupName' => 'Base',
+                'trophyId' => 1,
+                'trophyName' => 'Bronze',
+            ],
+            [
+                'trophyGroupId' => 'default',
+                'trophyId' => 2,
+                'trophyName' => 'Silver',
+            ],
+            [
+                'trophyGroupId' => '001',
+                'trophyGroupName' => 'DLC',
+                'trophyGroupDetail' => 'Extra',
+                'trophyGroupIconUrl' => 'https://example.com/dlc.png',
+                'trophyId' => 3,
+            ],
+            [
+                'trophyId' => 4,
+            ],
+            'not-an-array',
+        ]);
+
+        $this->assertCount(2, $groups);
+        $this->assertSame('default', $groups[0]['trophyGroupId']);
+        $this->assertSame('Base', $groups[0]['trophyGroupName']);
+        $this->assertSame([1, 2], array_column($groups[0]['trophies'], 'trophyId'));
+        $this->assertSame('001', $groups[1]['trophyGroupId']);
+        $this->assertSame('DLC', $groups[1]['trophyGroupName']);
+        $this->assertSame('Extra', $groups[1]['trophyGroupDetail']);
+        $this->assertSame('https://example.com/dlc.png', $groups[1]['trophyGroupIconUrl']);
+        $this->assertSame([3], array_column($groups[1]['trophies'], 'trophyId'));
+    }
+
+    public function testGroupTrophiesByGroupIdReturnsEmptyForNonArray(): void
+    {
+        $this->assertSame([], $this->assembler->groupTrophiesByGroupId(null));
+        $this->assertSame([], $this->assembler->groupTrophiesByGroupId('oops'));
+    }
+
+    public function testGroupNestedTrophiesFromGroupsPreservesNestedPayload(): void
+    {
+        $groups = $this->assembler->groupNestedTrophiesFromGroups([
+            [
+                'trophyGroupId' => 'all',
+                'trophyGroupName' => 'All',
+                'trophyGroupDetail' => 'Detail',
+                'trophyGroupIconUrl' => 'https://example.com/all.png',
+                'trophies' => [
+                    ['trophyId' => 10, 'trophyName' => 'Nested'],
+                ],
+            ],
+            [
+                'trophyGroupId' => 'empty',
+                'trophies' => null,
+            ],
+            [
+                'trophyGroupName' => 'Missing id',
+            ],
+            'not-an-array',
+        ]);
+
+        $this->assertCount(2, $groups);
+        $this->assertSame('all', $groups[0]['trophyGroupId']);
+        $this->assertSame('All', $groups[0]['trophyGroupName']);
+        $this->assertSame('Detail', $groups[0]['trophyGroupDetail']);
+        $this->assertSame('https://example.com/all.png', $groups[0]['trophyGroupIconUrl']);
+        $this->assertSame('Nested', $groups[0]['trophies'][0]['trophyName']);
+        $this->assertSame('empty', $groups[1]['trophyGroupId']);
+        $this->assertSame([], $groups[1]['trophies']);
+    }
+
+    public function testBuildTrophyGroupsPrefersEndpointMetadata(): void
+    {
+        $groupedTrophies = [
+            [
+                'trophyGroupId' => 'default',
+                'trophyGroupName' => 'From trophies',
+                'trophyGroupDetail' => '',
+                'trophyGroupIconUrl' => '',
+                'trophies' => [
+                    ['trophyId' => 1, 'trophyName' => 'Bronze Trophy'],
+                ],
+            ],
+        ];
+
+        $groups = $this->assembler->buildTrophyGroups(
+            [
+                [
+                    'trophyGroupId' => 'default',
+                    'trophyGroupName' => 'Base Group Name',
+                    'trophyGroupDetail' => 'Base Group Detail',
+                    'trophyGroupIconUrl' => 'https://example.com/group-icon.png',
+                ],
+            ],
+            $groupedTrophies,
+        );
+
+        $this->assertCount(1, $groups);
+        $this->assertSame('Base Group Name', $groups[0]['trophyGroupName']);
+        $this->assertSame('Base Group Detail', $groups[0]['trophyGroupDetail']);
+        $this->assertSame('https://example.com/group-icon.png', $groups[0]['trophyGroupIconUrl']);
+        $this->assertSame('Bronze Trophy', $groups[0]['trophies'][0]['trophyName']);
+    }
+
+    public function testBuildTrophyGroupsFallsBackWhenEndpointGroupsMissing(): void
+    {
+        $groupedTrophies = [
+            [
+                'trophyGroupId' => 'default',
+                'trophyGroupName' => 'Fallback',
+                'trophyGroupDetail' => '',
+                'trophyGroupIconUrl' => '',
+                'trophies' => [['trophyId' => 7]],
+            ],
+        ];
+
+        $this->assertSame($groupedTrophies, $this->assembler->buildTrophyGroups(null, $groupedTrophies));
+        $this->assertSame($groupedTrophies, $this->assembler->buildTrophyGroups([], $groupedTrophies));
+    }
+
+    public function testAssemblePrefersFlatTrophiesOverNestedGroups(): void
+    {
+        $assembled = $this->assembler->assemble(
+            [
+                [
+                    'trophyGroupId' => 'default',
+                    'trophyId' => 1,
+                    'trophyName' => 'Flat',
+                ],
+            ],
+            [
+                [
+                    'trophyGroupId' => 'default',
+                    'trophies' => [
+                        ['trophyId' => 99, 'trophyName' => 'Nested'],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'trophyGroupId' => 'default',
+                    'trophyGroupName' => 'Endpoint Name',
+                    'trophyGroupDetail' => '',
+                    'trophyGroupIconUrl' => '',
+                ],
+            ],
+        );
+
+        $this->assertSame('Endpoint Name', $assembled[0]['trophyGroupName']);
+        $this->assertSame('Flat', $assembled[0]['trophies'][0]['trophyName']);
+        $this->assertCount(1, $assembled[0]['trophies']);
+    }
+
+    public function testAssembleUsesNestedGroupsWhenFlatTrophiesMissing(): void
+    {
+        $assembled = $this->assembler->assemble(
+            null,
+            [
+                [
+                    'trophyGroupId' => 'all',
+                    'trophyGroupName' => 'All',
+                    'trophies' => [
+                        ['trophyId' => 5, 'trophyName' => 'Nested Only'],
+                    ],
+                ],
+            ],
+            null,
+        );
+
+        $this->assertSame('all', $assembled[0]['trophyGroupId']);
+        $this->assertSame('Nested Only', $assembled[0]['trophies'][0]['trophyName']);
+    }
+
+    public function testAssembleReturnsEmptyWhenNoTrophyDataPresent(): void
+    {
+        $this->assertSame([], $this->assembler->assemble(null, null, null));
+    }
+}

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/Worker.php';
 require_once __DIR__ . '/PlayStationWorkerAuthenticator.php';
 require_once __DIR__ . '/PsnGameLookupException.php';
 require_once __DIR__ . '/PsnTrophyApiPayloadInspector.php';
+require_once __DIR__ . '/PsnTrophyGroupAssembler.php';
 require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
 require_once __DIR__ . '/../CommaSeparatedValues.php';
 
@@ -16,6 +17,7 @@ final class PsnGameLookupService
 {
     private readonly PlayStationWorkerAuthenticator $workerAuthenticator;
     private readonly PsnTrophyApiPayloadInspector $payloadInspector;
+    private readonly PsnTrophyGroupAssembler $trophyGroupAssembler;
 
     public function __construct(
         private readonly PDO $database,
@@ -24,6 +26,7 @@ final class PsnGameLookupService
         ?callable $refreshTokenSaver = null,
         ?PlayStationWorkerAuthenticator $workerAuthenticator = null,
         ?PsnTrophyApiPayloadInspector $payloadInspector = null,
+        ?PsnTrophyGroupAssembler $trophyGroupAssembler = null,
     ) {
         $this->workerAuthenticator = $workerAuthenticator ?? new PlayStationWorkerAuthenticator(
             $workerFetcher,
@@ -31,6 +34,7 @@ final class PsnGameLookupService
             $refreshTokenSaver,
         );
         $this->payloadInspector = $payloadInspector ?? new PsnTrophyApiPayloadInspector();
+        $this->trophyGroupAssembler = $trophyGroupAssembler ?? new PsnTrophyGroupAssembler();
     }
 
     public static function fromDatabase(PDO $database): self
@@ -177,140 +181,13 @@ final class PsnGameLookupService
             );
         }
 
-        $groupedTrophies = $this->groupTrophiesByGroupId($normalizedResponse['trophies'] ?? null);
-        if ($groupedTrophies === []) {
-            $groupedTrophies = $this->groupNestedTrophiesFromGroups($normalizedResponse['trophyGroups'] ?? null);
-        }
-        $normalizedResponse['trophyGroups'] = $this->buildTrophyGroups(
+        $normalizedResponse['trophyGroups'] = $this->trophyGroupAssembler->assemble(
+            $normalizedResponse['trophies'] ?? null,
+            $normalizedResponse['trophyGroups'] ?? null,
             $normalizedGroupResponse['trophyGroups'] ?? null,
-            $groupedTrophies
         );
 
         return $normalizedResponse;
-    }
-
-    /**
-     * @param mixed $rawGroups
-     * @param array<int, array{trophyGroupId: string, trophyGroupName: string, trophyGroupDetail: string, trophyGroupIconUrl: string, trophies: array<int, array<string, mixed>>}> $groupedTrophies
-     * @return array<int, array{trophyGroupId: string, trophyGroupName: string, trophyGroupDetail: string, trophyGroupIconUrl: string, trophies: array<int, array<string, mixed>>}>
-     */
-    private function buildTrophyGroups(mixed $rawGroups, array $groupedTrophies): array
-    {
-        $trophiesByGroupId = [];
-        foreach ($groupedTrophies as $groupedTrophy) {
-            $groupId = $groupedTrophy['trophyGroupId'] ?? '';
-            if (!is_string($groupId) || $groupId === '') {
-                continue;
-            }
-
-            $trophiesByGroupId[$groupId] = $groupedTrophy['trophies'] ?? [];
-        }
-
-        if (!is_array($rawGroups)) {
-            return $groupedTrophies;
-        }
-
-        $groups = [];
-
-        foreach ($rawGroups as $rawGroup) {
-            if (!is_array($rawGroup)) {
-                continue;
-            }
-
-            $groupId = (string) ($rawGroup['trophyGroupId'] ?? '');
-            if ($groupId === '') {
-                continue;
-            }
-
-            $groups[] = [
-                'trophyGroupId' => $groupId,
-                'trophyGroupName' => (string) ($rawGroup['trophyGroupName'] ?? ''),
-                'trophyGroupDetail' => (string) ($rawGroup['trophyGroupDetail'] ?? ''),
-                'trophyGroupIconUrl' => (string) ($rawGroup['trophyGroupIconUrl'] ?? ''),
-                'trophies' => is_array($trophiesByGroupId[$groupId] ?? null) ? $trophiesByGroupId[$groupId] : [],
-            ];
-        }
-
-        if ($groups === []) {
-            return $groupedTrophies;
-        }
-
-        return $groups;
-    }
-
-    /**
-     * @return array<int, array{trophyGroupId: string, trophyGroupName: string, trophyGroupDetail: string, trophyGroupIconUrl: string, trophies: array<int, array<string, mixed>>}>
-     */
-    private function groupTrophiesByGroupId(mixed $rawTrophies): array
-    {
-        if (!is_array($rawTrophies)) {
-            return [];
-        }
-
-        $groups = [];
-
-        foreach ($rawTrophies as $rawTrophy) {
-            if (!is_array($rawTrophy)) {
-                continue;
-            }
-
-            $groupId = (string) ($rawTrophy['trophyGroupId'] ?? '');
-            if ($groupId === '') {
-                continue;
-            }
-
-            if (!isset($groups[$groupId])) {
-                $groups[$groupId] = [
-                    'trophyGroupId' => $groupId,
-                    'trophyGroupName' => (string) ($rawTrophy['trophyGroupName'] ?? ''),
-                    'trophyGroupDetail' => (string) ($rawTrophy['trophyGroupDetail'] ?? ''),
-                    'trophyGroupIconUrl' => (string) ($rawTrophy['trophyGroupIconUrl'] ?? ''),
-                    'trophies' => [],
-                ];
-            }
-
-            $groups[$groupId]['trophies'][] = $rawTrophy;
-        }
-
-        return array_values($groups);
-    }
-
-    /**
-     * @return array<int, array{trophyGroupId: string, trophyGroupName: string, trophyGroupDetail: string, trophyGroupIconUrl: string, trophies: array<int, array<string, mixed>>}>
-     */
-    private function groupNestedTrophiesFromGroups(mixed $rawGroups): array
-    {
-        if (!is_array($rawGroups)) {
-            return [];
-        }
-
-        $groups = [];
-
-        foreach ($rawGroups as $rawGroup) {
-            if (!is_array($rawGroup)) {
-                continue;
-            }
-
-            $groupId = (string) ($rawGroup['trophyGroupId'] ?? '');
-            if ($groupId === '') {
-                continue;
-            }
-
-            $trophies = $rawGroup['trophies'] ?? null;
-            if (!is_array($trophies)) {
-                $trophies = [];
-            }
-
-            $groups[] = [
-                'trophyGroupId' => $groupId,
-                'trophyGroupName' => (string) ($rawGroup['trophyGroupName'] ?? ''),
-                'trophyGroupDetail' => (string) ($rawGroup['trophyGroupDetail'] ?? ''),
-                'trophyGroupIconUrl' => (string) ($rawGroup['trophyGroupIconUrl'] ?? ''),
-                'trophies' => $trophies,
-            ];
-        }
-
-        return $groups;
     }
 
     private function resolvePreferredNpServiceName(string $npCommunicationId): ?string

--- a/wwwroot/classes/Admin/PsnTrophyGroupAssembler.php
+++ b/wwwroot/classes/Admin/PsnTrophyGroupAssembler.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Assembles PSN trophy payloads into a consistent trophyGroups structure.
+ *
+ * Flat trophies (from all/trophies) are preferred; when absent, nested trophies
+ * under trophyGroups are used. Group metadata from the trophyGroups endpoint
+ * wins when present.
+ */
+final class PsnTrophyGroupAssembler
+{
+    /**
+     * @return array<int, array{trophyGroupId: string, trophyGroupName: string, trophyGroupDetail: string, trophyGroupIconUrl: string, trophies: array<int, array<string, mixed>>}>
+     */
+    public function assemble(
+        mixed $flatTrophies,
+        mixed $nestedGroupsFromTrophiesPayload,
+        mixed $rawGroupsFromGroupsEndpoint,
+    ): array {
+        $groupedTrophies = $this->groupTrophiesByGroupId($flatTrophies);
+        if ($groupedTrophies === []) {
+            $groupedTrophies = $this->groupNestedTrophiesFromGroups($nestedGroupsFromTrophiesPayload);
+        }
+
+        return $this->buildTrophyGroups($rawGroupsFromGroupsEndpoint, $groupedTrophies);
+    }
+
+    /**
+     * @param mixed $rawGroups
+     * @param array<int, array{trophyGroupId: string, trophyGroupName: string, trophyGroupDetail: string, trophyGroupIconUrl: string, trophies: array<int, array<string, mixed>>}> $groupedTrophies
+     * @return array<int, array{trophyGroupId: string, trophyGroupName: string, trophyGroupDetail: string, trophyGroupIconUrl: string, trophies: array<int, array<string, mixed>>}>
+     */
+    public function buildTrophyGroups(mixed $rawGroups, array $groupedTrophies): array
+    {
+        $trophiesByGroupId = [];
+        foreach ($groupedTrophies as $groupedTrophy) {
+            $groupId = $groupedTrophy['trophyGroupId'] ?? '';
+            if (!is_string($groupId) || $groupId === '') {
+                continue;
+            }
+
+            $trophiesByGroupId[$groupId] = $groupedTrophy['trophies'] ?? [];
+        }
+
+        if (!is_array($rawGroups)) {
+            return $groupedTrophies;
+        }
+
+        $groups = [];
+
+        foreach ($rawGroups as $rawGroup) {
+            if (!is_array($rawGroup)) {
+                continue;
+            }
+
+            $groupId = (string) ($rawGroup['trophyGroupId'] ?? '');
+            if ($groupId === '') {
+                continue;
+            }
+
+            $groups[] = [
+                'trophyGroupId' => $groupId,
+                'trophyGroupName' => (string) ($rawGroup['trophyGroupName'] ?? ''),
+                'trophyGroupDetail' => (string) ($rawGroup['trophyGroupDetail'] ?? ''),
+                'trophyGroupIconUrl' => (string) ($rawGroup['trophyGroupIconUrl'] ?? ''),
+                'trophies' => is_array($trophiesByGroupId[$groupId] ?? null) ? $trophiesByGroupId[$groupId] : [],
+            ];
+        }
+
+        if ($groups === []) {
+            return $groupedTrophies;
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @return array<int, array{trophyGroupId: string, trophyGroupName: string, trophyGroupDetail: string, trophyGroupIconUrl: string, trophies: array<int, array<string, mixed>>}>
+     */
+    public function groupTrophiesByGroupId(mixed $rawTrophies): array
+    {
+        if (!is_array($rawTrophies)) {
+            return [];
+        }
+
+        $groups = [];
+
+        foreach ($rawTrophies as $rawTrophy) {
+            if (!is_array($rawTrophy)) {
+                continue;
+            }
+
+            $groupId = (string) ($rawTrophy['trophyGroupId'] ?? '');
+            if ($groupId === '') {
+                continue;
+            }
+
+            if (!isset($groups[$groupId])) {
+                $groups[$groupId] = [
+                    'trophyGroupId' => $groupId,
+                    'trophyGroupName' => (string) ($rawTrophy['trophyGroupName'] ?? ''),
+                    'trophyGroupDetail' => (string) ($rawTrophy['trophyGroupDetail'] ?? ''),
+                    'trophyGroupIconUrl' => (string) ($rawTrophy['trophyGroupIconUrl'] ?? ''),
+                    'trophies' => [],
+                ];
+            }
+
+            $groups[$groupId]['trophies'][] = $rawTrophy;
+        }
+
+        return array_values($groups);
+    }
+
+    /**
+     * @return array<int, array{trophyGroupId: string, trophyGroupName: string, trophyGroupDetail: string, trophyGroupIconUrl: string, trophies: array<int, array<string, mixed>>}>
+     */
+    public function groupNestedTrophiesFromGroups(mixed $rawGroups): array
+    {
+        if (!is_array($rawGroups)) {
+            return [];
+        }
+
+        $groups = [];
+
+        foreach ($rawGroups as $rawGroup) {
+            if (!is_array($rawGroup)) {
+                continue;
+            }
+
+            $groupId = (string) ($rawGroup['trophyGroupId'] ?? '');
+            if ($groupId === '') {
+                continue;
+            }
+
+            $trophies = $rawGroup['trophies'] ?? null;
+            if (!is_array($trophies)) {
+                $trophies = [];
+            }
+
+            $groups[] = [
+                'trophyGroupId' => $groupId,
+                'trophyGroupName' => (string) ($rawGroup['trophyGroupName'] ?? ''),
+                'trophyGroupDetail' => (string) ($rawGroup['trophyGroupDetail'] ?? ''),
+                'trophyGroupIconUrl' => (string) ($rawGroup['trophyGroupIconUrl'] ?? ''),
+                'trophies' => $trophies,
+            ];
+        }
+
+        return $groups;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Peels one concern out of the oversized `PsnGameLookupService` God-class mix: **PSN trophy payload → `trophyGroups` assembly**.

`PsnGameLookupService` still owns DB metadata, worker auth, HTTP lookup/retry, and payload integrity checks. Flat/nested group reshaping now lives in `PsnTrophyGroupAssembler`.

## Changes

- Add `wwwroot/classes/Admin/PsnTrophyGroupAssembler.php` with:
  - `assemble()` — prefers flat trophies, falls back to nested groups, then applies trophyGroups-endpoint metadata
  - `groupTrophiesByGroupId()`, `groupNestedTrophiesFromGroups()`, `buildTrophyGroups()`
- Inject optional assembler into `PsnGameLookupService` (default constructed) and delegate after successful PSN fetches
- Add focused unit tests in `tests/PsnTrophyGroupAssemblerTest.php`

## Why this slice

`PsnGameLookupService` mixed HTTP/auth/DB with pure payload transforms. Group assembly is private, network-free, and already covered by lookup service tests — a low-risk first peel that leaves the public lookup API unchanged.

`PsnGameLookupService` drops from ~458 to ~335 lines.

## Test plan

- [x] `php tests/run.php` — 968/969 pass; all `PsnTrophyGroupAssemblerTest` (8) and `PsnGameLookupServiceTest` (18) pass
- [x] Unrelated pre-existing failure: `PlayerScanTrophyTitleLoopTest::testProcessAccessibleTrophyTitlesRetriesTransientFetchExceptions` (log message assertion, not touched by this PR)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff59840f-c379-4d45-ad37-4c643dccf963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff59840f-c379-4d45-ad37-4c643dccf963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

