### PR TITLE
Batch daily trophy rarity ranked-owner lookup

### DIFF
--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -41,14 +41,15 @@ final class DailyCronJobTest extends TestCase
         $this->assertFalse(str_contains($source, 'player_ranking'));
     }
 
-    public function testZeroOwnersFastPathUsesLiveRankedOwnerCheckNotCachedMeta(): void
+    public function testZeroOwnersFastPathUsesBatchedLiveRankedOwnerLookupNotCachedMeta(): void
     {
         $source = $this->readClassSource();
 
-        $this->assertStringContainsString('SELECT EXISTS (', $source);
-        $this->assertStringContainsString('FROM trophy_title_player ttp', $source);
-        $this->assertStringContainsString('INNER JOIN player_ranking pr', $source);
-        $this->assertStringContainsString('pr.ranking <= 10000', $source);
+        $this->assertStringContainsString('SELECT DISTINCT ttp.np_communication_id', $source);
+        $this->assertStringContainsString('FROM player_ranking pr', $source);
+        $this->assertStringContainsString('JOIN trophy_title_player ttp ON ttp.account_id = pr.account_id', $source);
+        $this->assertStringContainsString('WHERE pr.ranking <= 10000', $source);
+        $this->assertFalse(str_contains($source, 'SELECT EXISTS ('));
         $this->assertFalse(str_contains($source, 'SELECT owners FROM trophy_title_meta'));
     }
 
@@ -69,10 +70,8 @@ final class DailyCronJobTest extends TestCase
         $source = $this->readClassSource();
 
         $this->assertStringContainsString('SELECT np_communication_id FROM trophy_title', $source);
-        $this->assertStringContainsString(
-            '$this->executeWithRetry([$this, \'updateTrophyRarityForGame\'], $npCommunicationId);',
-            $source
-        );
+        $this->assertStringContainsString('fetchTopTenThousandOwnerTitleLookup', $source);
+        $this->assertStringContainsString('isset($rankedOwnerTitles[$npCommunicationId])', $source);
     }
 
     public function testUpdateTrophyTitleRarityPointsAggregatesPerGame(): void
@@ -92,14 +91,8 @@ final class DailyCronJobTest extends TestCase
 
         $this->assertStringContainsString('while (true)', $source);
         $this->assertFalse(str_contains($source, 'maxAttempt'));
-        $this->assertStringContainsString(
-            '$this->executeWithRetry([$this, \'updateTrophyRarityForGame\'], $npCommunicationId);',
-            $source
-        );
-        $this->assertStringContainsString(
-            '$this->executeWithRetry([$this, \'updateTrophyTitleRarityPoints\']);',
-            $source
-        );
+        $this->assertStringContainsString('updateTrophyRarityForGame', $source);
+        $this->assertStringContainsString('updateTrophyTitleRarityPoints', $source);
     }
 
     public function testRunRetriesPerGameRarityUpdateUntilItSucceeds(): void
@@ -140,6 +133,27 @@ final class DailyCronJobTest extends TestCase
         $this->assertSame([1, 1], $sleepCalls);
         $this->assertSame(0, $database->getPerGameUpdateCount());
         $this->assertSame(3, $database->getTitlePointsUpdateCount());
+    }
+
+
+    public function testRunFetchesRankedOwnerLookupOnceAndChoosesRarityQueryPerTitle(): void
+    {
+        $database = new DailyCronJobRankedOwnerLookupTestDatabase();
+
+        $job = new DailyCronJob(
+            $database,
+            retryDelaySeconds: 1,
+            sleeper: static function (int $seconds): void {
+                throw new RuntimeException('Sleeper should not be called.');
+            },
+        );
+
+        $job->run();
+
+        $this->assertSame(1, $database->getRankedOwnerLookupCount());
+        $this->assertSame(['NPWR00001_00'], $database->getFullRarityUpdates());
+        $this->assertSame(['NPWR00002_00'], $database->getZeroOwnerRarityUpdates());
+        $this->assertSame(1, $database->getTitlePointsUpdateCount());
     }
 
     private function readClassSource(): string
@@ -190,11 +204,11 @@ final class DailyCronJobPerGameRetryTestDatabase extends PDO
             }, isSelect: true);
         }
 
-        if (str_contains($query, 'SELECT EXISTS (') && str_contains($query, 'trophy_title_player ttp')) {
+        if (str_contains($query, 'SELECT DISTINCT ttp.np_communication_id')) {
             // Ranked owners present => full ranked trophy_earned rarity path.
-            return new DailyCronJobTestStatement(static function (): int {
-                return 1;
-            }, isSelect: true, fetchColumnValue: 1);
+            return new DailyCronJobTestStatement(static function (): array {
+                return ['NPWR00001_00'];
+            }, isSelect: true);
         }
 
         if (str_contains($query, 'UPDATE trophy_meta tm')) {
@@ -245,10 +259,10 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
             }, isSelect: true);
         }
 
-        if (str_contains($query, 'SELECT EXISTS (') && str_contains($query, 'trophy_title_player ttp')) {
-            return new DailyCronJobTestStatement(static function (): int {
-                return 0;
-            }, isSelect: true, fetchColumnValue: 0);
+        if (str_contains($query, 'SELECT DISTINCT ttp.np_communication_id')) {
+            return new DailyCronJobTestStatement(static function (): array {
+                return [];
+            }, isSelect: true);
         }
 
         if (str_contains($query, 'UPDATE trophy_meta tm')) {
@@ -271,17 +285,101 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
     }
 }
 
+
+final class DailyCronJobRankedOwnerLookupTestDatabase extends PDO
+{
+    private int $rankedOwnerLookupCount = 0;
+
+    /** @var list<string> */
+    private array $fullRarityUpdates = [];
+
+    /** @var list<string> */
+    private array $zeroOwnerRarityUpdates = [];
+
+    private int $titlePointsUpdateCount = 0;
+
+    public function __construct()
+    {
+    }
+
+    public function getRankedOwnerLookupCount(): int
+    {
+        return $this->rankedOwnerLookupCount;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getFullRarityUpdates(): array
+    {
+        return $this->fullRarityUpdates;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getZeroOwnerRarityUpdates(): array
+    {
+        return $this->zeroOwnerRarityUpdates;
+    }
+
+    public function getTitlePointsUpdateCount(): int
+    {
+        return $this->titlePointsUpdateCount;
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
+            return new DailyCronJobTestStatement(static function (): array {
+                return ['NPWR00001_00', 'NPWR00002_00'];
+            }, isSelect: true);
+        }
+
+        if (str_contains($query, 'SELECT DISTINCT ttp.np_communication_id')) {
+            return new DailyCronJobTestStatement(function (): array {
+                $this->rankedOwnerLookupCount++;
+
+                return ['NPWR00001_00'];
+            }, isSelect: true);
+        }
+
+        if (str_contains($query, 'ranked_owners AS')) {
+            return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
+                $this->fullRarityUpdates[] = $boundValues[':np_communication_id'] ?? '';
+            });
+        }
+
+        if (str_contains($query, 'UPDATE trophy_meta tm')) {
+            return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
+                $this->zeroOwnerRarityUpdates[] = $boundValues[':np_communication_id'] ?? '';
+            });
+        }
+
+        if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->titlePointsUpdateCount++;
+            });
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
 final class DailyCronJobTestStatement extends PDOStatement
 {
-    /** @var callable(): mixed */
+    /** @var callable */
     private $callback;
 
     private bool $isSelect;
 
     private mixed $fetchColumnValue;
 
+    /** @var array<string|int, mixed> */
+    private array $boundValues = [];
+
     /**
-     * @param callable(): mixed $callback
+     * @param callable $callback
      */
     public function __construct(callable $callback, bool $isSelect = false, mixed $fetchColumnValue = null)
     {
@@ -292,13 +390,15 @@ final class DailyCronJobTestStatement extends PDOStatement
 
     public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
     {
+        $this->boundValues[$param] = $value;
+
         return true;
     }
 
     public function execute(?array $params = null): bool
     {
         if (!$this->isSelect) {
-            ($this->callback)();
+            ($this->callback)($params, $this->boundValues);
         }
 
         return true;

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -135,6 +135,26 @@ final class DailyCronJobTest extends TestCase
         $this->assertSame(3, $database->getTitlePointsUpdateCount());
     }
 
+    public function testRunRetriesRankedOwnerLookupUntilItSucceeds(): void
+    {
+        $database = new DailyCronJobRankedOwnerLookupRetryTestDatabase();
+        $sleepCalls = [];
+
+        $job = new DailyCronJob(
+            $database,
+            retryDelaySeconds: 1,
+            sleeper: static function (int $seconds) use (&$sleepCalls): void {
+                $sleepCalls[] = $seconds;
+            },
+        );
+
+        $job->run();
+
+        $this->assertSame([1, 1], $sleepCalls);
+        $this->assertSame(3, $database->getRankedOwnerLookupCount());
+        $this->assertSame(['NPWR00001_00'], $database->getFullRarityUpdates());
+        $this->assertSame(1, $database->getTitlePointsUpdateCount());
+    }
 
     public function testRunFetchesRankedOwnerLookupOnceAndChoosesRarityQueryPerTitle(): void
     {
@@ -285,6 +305,72 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
     }
 }
 
+final class DailyCronJobRankedOwnerLookupRetryTestDatabase extends PDO
+{
+    private int $rankedOwnerLookupCount = 0;
+
+    /** @var list<string> */
+    private array $fullRarityUpdates = [];
+
+    private int $titlePointsUpdateCount = 0;
+
+    public function __construct()
+    {
+    }
+
+    public function getRankedOwnerLookupCount(): int
+    {
+        return $this->rankedOwnerLookupCount;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getFullRarityUpdates(): array
+    {
+        return $this->fullRarityUpdates;
+    }
+
+    public function getTitlePointsUpdateCount(): int
+    {
+        return $this->titlePointsUpdateCount;
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
+            return new DailyCronJobTestStatement(static function (): array {
+                return ['NPWR00001_00'];
+            }, isSelect: true);
+        }
+
+        if (str_contains($query, 'SELECT DISTINCT ttp.np_communication_id')) {
+            return new DailyCronJobTestStatement(function (): array {
+                $this->rankedOwnerLookupCount++;
+
+                if ($this->rankedOwnerLookupCount < 3) {
+                    throw new RuntimeException('Simulated ranked-owner lookup failure.');
+                }
+
+                return ['NPWR00001_00'];
+            }, isSelect: true);
+        }
+
+        if (str_contains($query, 'ranked_owners AS')) {
+            return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
+                $this->fullRarityUpdates[] = $boundValues[':np_communication_id'] ?? '';
+            });
+        }
+
+        if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->titlePointsUpdateCount++;
+            });
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
 
 final class DailyCronJobRankedOwnerLookupTestDatabase extends PDO
 {

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -145,7 +145,7 @@ final readonly class DailyCronJob implements CronJobInterface
         );
         $query->execute();
         $games = $query->fetchAll(PDO::FETCH_COLUMN);
-        $rankedOwnerTitles = $this->fetchTopTenThousandOwnerTitleLookup();
+        $rankedOwnerTitles = $this->executeWithRetry([$this, 'fetchTopTenThousandOwnerTitleLookup']);
 
         foreach ($games as $npCommunicationId) {
             if (!is_string($npCommunicationId)) {
@@ -210,12 +210,11 @@ final readonly class DailyCronJob implements CronJobInterface
         $query->execute();
     }
 
-    private function executeWithRetry(callable $operation, mixed ...$arguments): void
+    private function executeWithRetry(callable $operation, mixed ...$arguments): mixed
     {
         while (true) {
             try {
-                $operation(...$arguments);
-                return;
+                return $operation(...$arguments);
             } catch (Throwable $exception) {
                 ($this->sleeper)($this->retryDelaySeconds);
             }

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -145,38 +145,52 @@ final readonly class DailyCronJob implements CronJobInterface
         );
         $query->execute();
         $games = $query->fetchAll(PDO::FETCH_COLUMN);
+        $rankedOwnerTitles = $this->fetchTopTenThousandOwnerTitleLookup();
 
         foreach ($games as $npCommunicationId) {
             if (!is_string($npCommunicationId)) {
                 continue;
             }
 
-            $this->executeWithRetry([$this, 'updateTrophyRarityForGame'], $npCommunicationId);
+            $this->executeWithRetry(
+                [$this, 'updateTrophyRarityForGame'],
+                $npCommunicationId,
+                isset($rankedOwnerTitles[$npCommunicationId]),
+            );
         }
     }
 
-    private function updateTrophyRarityForGame(string $npCommunicationId): void
+    /**
+     * @return array<string, true>
+     */
+    private function fetchTopTenThousandOwnerTitleLookup(): array
     {
         // Do not trust trophy_title_meta.owners alone: hourly cache can lag behind
         // freshly scanned trophy_title_player / trophy_earned rows. Match the rarity
         // query's top-10k definition before taking the zero-owners fast path.
-        $hasRankedOwnersQuery = $this->database->prepare(
+        $query = $this->database->prepare(
             <<<'SQL'
-            SELECT EXISTS (
-                SELECT 1
-                FROM trophy_title_player ttp
-                INNER JOIN player_ranking pr
-                    ON pr.account_id = ttp.account_id
-                   AND pr.ranking <= 10000
-                WHERE ttp.np_communication_id = :np_communication_id
-            )
+            SELECT DISTINCT ttp.np_communication_id
+            FROM player_ranking pr
+            JOIN trophy_title_player ttp ON ttp.account_id = pr.account_id
+            WHERE pr.ranking <= 10000
             SQL
         );
-        $hasRankedOwnersQuery->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $hasRankedOwnersQuery->execute();
-        $hasRankedOwners = (int) $hasRankedOwnersQuery->fetchColumn();
+        $query->execute();
 
-        $sql = $hasRankedOwners === 0
+        $rankedOwnerTitles = [];
+        foreach ($query->fetchAll(PDO::FETCH_COLUMN) as $npCommunicationId) {
+            if (is_string($npCommunicationId)) {
+                $rankedOwnerTitles[$npCommunicationId] = true;
+            }
+        }
+
+        return $rankedOwnerTitles;
+    }
+
+    private function updateTrophyRarityForGame(string $npCommunicationId, bool $hasRankedOwners): void
+    {
+        $sql = !$hasRankedOwners
             ? self::UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY
             : self::UPDATE_TROPHY_RARITY_QUERY;
 


### PR DESCRIPTION
### Motivation

- Reduce per-title database probing by computing which titles have top-10k owners once per daily run instead of running a `SELECT EXISTS(...)` for every title.

### Description

- Add `fetchTopTenThousandOwnerTitleLookup()` to `DailyCronJob` which runs a single query `SELECT DISTINCT ttp.np_communication_id FROM player_ranking pr JOIN trophy_title_player ttp ON ttp.account_id = pr.account_id WHERE pr.ranking <= 10000` and returns an associative lookup array of titles with at least one top-10k owner.
- Change `recalculateTrophyRarityForGames()` to call the new lookup once, then pass `isset($rankedOwnerTitles[$npCommunicationId])` into `updateTrophyRarityForGame()` for each title.
- Replace the per-title `SELECT EXISTS(...)` probe by accepting a `bool $hasRankedOwners` parameter in `updateTrophyRarityForGame()` and selecting between `UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY` and `UPDATE_TROPHY_RARITY_QUERY` accordingly, preserving the existing zero-owner fast path and full update behavior.
- Update `tests/DailyCronJobTest.php` to assert the batched lookup SQL exists, the old per-title `SELECT EXISTS` is absent, and add `DailyCronJobRankedOwnerLookupTestDatabase` plus `testRunFetchesRankedOwnerLookupOnceAndChoosesRarityQueryPerTitle()` to validate the lookup runs once and that titles chosen for zero-owner vs full rarity updates use the expected SQL paths.

### Testing

- Ran syntax checks: `php -l wwwroot/classes/Cron/DailyCronJob.php` and `php -l tests/DailyCronJobTest.php`, both succeeded.
- Ran the full test runner `php tests/run.php`; the modified `DailyCronJob` test coverage passed and the new ranked-owner lookup test passed, but the full suite reported 1 unrelated failure: `PlayerScanTrophyTitleLoopTest::testProcessAccessibleTrophyTitlesRetriesTransientFetchExceptions` (suite result: 970 tests, 1 failure, 0 errors).
- The change does not alter existing SQL update behavior for zero-owner and full-ranked-owner paths and preserves retry loops used by cron jobs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59efb08758832f978061527dffdac5)