### PR TITLE
Batch trophy rarity updates for ranked-owner titles

### DIFF
--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -180,6 +180,27 @@ final class DailyCronJobTest extends TestCase
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
     }
 
+    public function testRunFlushesPendingRankedOwnerBatchBeforeZeroOwnerUpdate(): void
+    {
+        $database = new DailyCronJobFlushBeforeZeroOwnerTestDatabase();
+
+        $job = new DailyCronJob(
+            $database,
+            retryDelaySeconds: 1,
+            sleeper: static function (int $seconds): void {
+            },
+        );
+
+        $job->run();
+
+        $this->assertSame([
+            'ranked:NPWR00001_00,NPWR00002_00',
+            'zero:NPWR00003_00',
+            'zero:NPWR00003_00',
+            'title-points',
+        ], $database->getOperations());
+    }
+
     private function readClassSource(): string
     {
         $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/DailyCronJob.php');
@@ -453,6 +474,71 @@ final class DailyCronJobRankedOwnerLookupTestDatabase extends PDO
         if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->titlePointsUpdateCount++;
+            });
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
+
+final class DailyCronJobFlushBeforeZeroOwnerTestDatabase extends PDO
+{
+    /** @var list<string> */
+    private array $operations = [];
+
+    private int $zeroOwnerUpdateCount = 0;
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getOperations(): array
+    {
+        return $this->operations;
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
+            return new DailyCronJobTestStatement(static function (): array {
+                return ['NPWR00001_00', 'NPWR00002_00', 'NPWR00003_00'];
+            }, isSelect: true);
+        }
+
+        if (str_contains($query, 'SELECT DISTINCT ttp.np_communication_id')) {
+            return new DailyCronJobTestStatement(static function (): array {
+                return ['NPWR00001_00', 'NPWR00002_00'];
+            }, isSelect: true);
+        }
+
+        if (str_contains($query, 'ranked_owners AS')) {
+            return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
+                $json = $boundValues[':np_communication_ids'] ?? '[]';
+                $decoded = json_decode((string) $json, true, flags: JSON_THROW_ON_ERROR);
+                $titles = is_array($decoded) ? array_values(array_filter($decoded, 'is_string')) : [];
+                $this->operations[] = 'ranked:' . implode(',', $titles);
+            });
+        }
+
+        if (str_contains($query, 'UPDATE trophy_meta tm')) {
+            return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
+                $npCommunicationId = (string) ($boundValues[':np_communication_id'] ?? '');
+                $this->operations[] = 'zero:' . $npCommunicationId;
+                $this->zeroOwnerUpdateCount++;
+
+                if ($this->zeroOwnerUpdateCount === 1) {
+                    throw new RuntimeException('Simulated zero-owner rarity update failure.');
+                }
+            });
+        }
+
+        if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'title-points';
             });
         }
 

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -9,22 +9,23 @@ final class DailyCronJobTest extends TestCase
 {
     public function testUpdateTrophyRarityQueryUsesTopTenThousandRankingFilter(): void
     {
-        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_QUERY');
+        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_BATCH_QUERY');
 
         $this->assertStringContainsString('JOIN player_ranking pr ON pr.ranking <= 10000', $source);
         $this->assertStringContainsString('te.account_id = pr.account_id', $source);
         $this->assertStringContainsString('/ 10000.0) * 100 AS rarity_percent', $source);
-        $this->assertStringContainsString('CAST(:np_communication_id AS CHAR(12))', $source);
+        $this->assertStringContainsString('JSON_TABLE(', $source);
+        $this->assertStringContainsString(':np_communication_ids', $source);
         $this->assertStringContainsString('JOIN trophy t ON t.np_communication_id = title.np_communication_id', $source);
     }
 
     public function testUpdateTrophyRarityQueryDrivesTrophyEarnedByAccountIdForPartitionPruning(): void
     {
-        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_QUERY');
+        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_BATCH_QUERY');
 
         $this->assertStringContainsString('ranked_owners AS', $source);
         $this->assertStringContainsString('INNER JOIN trophy_earned te', $source);
-        $this->assertStringContainsString('GROUP BY te.order_id', $source);
+        $this->assertStringContainsString('GROUP BY te.np_communication_id, te.order_id', $source);
         $this->assertFalse(str_contains($source, 'LEFT JOIN trophy_earned te'));
     }
 
@@ -55,7 +56,7 @@ final class DailyCronJobTest extends TestCase
 
     public function testUpdateTrophyRarityQueryAssignsRarityNamesFromThresholds(): void
     {
-        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_QUERY');
+        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_BATCH_QUERY');
 
         $this->assertStringContainsString("WHEN r.rarity_percent > 10 THEN 'COMMON'", $source);
         $this->assertStringContainsString("WHEN r.rarity_percent > 2 THEN 'UNCOMMON'", $source);
@@ -72,6 +73,8 @@ final class DailyCronJobTest extends TestCase
         $this->assertStringContainsString('SELECT np_communication_id FROM trophy_title', $source);
         $this->assertStringContainsString('fetchTopTenThousandOwnerTitleLookup', $source);
         $this->assertStringContainsString('isset($rankedOwnerTitles[$npCommunicationId])', $source);
+        $this->assertStringContainsString('RANKED_OWNER_TITLE_BATCH_SIZE = 100', $source);
+        $this->assertStringContainsString('updateTrophyRarityForGames', $source);
     }
 
     public function testUpdateTrophyTitleRarityPointsAggregatesPerGame(): void
@@ -91,7 +94,7 @@ final class DailyCronJobTest extends TestCase
 
         $this->assertStringContainsString('while (true)', $source);
         $this->assertFalse(str_contains($source, 'maxAttempt'));
-        $this->assertStringContainsString('updateTrophyRarityForGame', $source);
+        $this->assertStringContainsString('updateTrophyRarityForGames', $source);
         $this->assertStringContainsString('updateTrophyTitleRarityPoints', $source);
     }
 
@@ -156,7 +159,7 @@ final class DailyCronJobTest extends TestCase
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
     }
 
-    public function testRunFetchesRankedOwnerLookupOnceAndChoosesRarityQueryPerTitle(): void
+    public function testRunProcessesRankedOwnerTitlesInBatchesAndZeroOwnerTitlesIndividually(): void
     {
         $database = new DailyCronJobRankedOwnerLookupTestDatabase();
 
@@ -171,8 +174,9 @@ final class DailyCronJobTest extends TestCase
         $job->run();
 
         $this->assertSame(1, $database->getRankedOwnerLookupCount());
-        $this->assertSame(['NPWR00001_00'], $database->getFullRarityUpdates());
-        $this->assertSame(['NPWR00002_00'], $database->getZeroOwnerRarityUpdates());
+        $expectedFirstBatch = array_map(static fn (int $index): string => sprintf('NPWR%05d_00', $index), range(1, 100));
+        $this->assertSame([$expectedFirstBatch, ['NPWR00101_00']], $database->getFullRarityUpdateBatches());
+        $this->assertSame(['NPWR00102_00'], $database->getZeroOwnerRarityUpdates());
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
     }
 
@@ -358,7 +362,9 @@ final class DailyCronJobRankedOwnerLookupRetryTestDatabase extends PDO
 
         if (str_contains($query, 'ranked_owners AS')) {
             return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
-                $this->fullRarityUpdates[] = $boundValues[':np_communication_id'] ?? '';
+                $json = $boundValues[':np_communication_ids'] ?? '[]';
+                $decoded = json_decode((string) $json, true, flags: JSON_THROW_ON_ERROR);
+                $this->fullRarityUpdates = array_merge($this->fullRarityUpdates, is_array($decoded) ? $decoded : []);
             });
         }
 
@@ -376,8 +382,8 @@ final class DailyCronJobRankedOwnerLookupTestDatabase extends PDO
 {
     private int $rankedOwnerLookupCount = 0;
 
-    /** @var list<string> */
-    private array $fullRarityUpdates = [];
+    /** @var list<list<string>> */
+    private array $fullRarityUpdateBatches = [];
 
     /** @var list<string> */
     private array $zeroOwnerRarityUpdates = [];
@@ -394,11 +400,11 @@ final class DailyCronJobRankedOwnerLookupTestDatabase extends PDO
     }
 
     /**
-     * @return list<string>
+     * @return list<list<string>>
      */
-    public function getFullRarityUpdates(): array
+    public function getFullRarityUpdateBatches(): array
     {
-        return $this->fullRarityUpdates;
+        return $this->fullRarityUpdateBatches;
     }
 
     /**
@@ -418,7 +424,7 @@ final class DailyCronJobRankedOwnerLookupTestDatabase extends PDO
     {
         if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
             return new DailyCronJobTestStatement(static function (): array {
-                return ['NPWR00001_00', 'NPWR00002_00'];
+                return array_map(static fn (int $index): string => sprintf('NPWR%05d_00', $index), range(1, 102));
             }, isSelect: true);
         }
 
@@ -426,13 +432,15 @@ final class DailyCronJobRankedOwnerLookupTestDatabase extends PDO
             return new DailyCronJobTestStatement(function (): array {
                 $this->rankedOwnerLookupCount++;
 
-                return ['NPWR00001_00'];
+                return array_map(static fn (int $index): string => sprintf('NPWR%05d_00', $index), range(1, 101));
             }, isSelect: true);
         }
 
         if (str_contains($query, 'ranked_owners AS')) {
             return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
-                $this->fullRarityUpdates[] = $boundValues[':np_communication_id'] ?? '';
+                $json = $boundValues[':np_communication_ids'] ?? '[]';
+                $decoded = json_decode((string) $json, true, flags: JSON_THROW_ON_ERROR);
+                $this->fullRarityUpdateBatches[] = is_array($decoded) ? $decoded : [];
             });
         }
 

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -240,6 +240,11 @@ final readonly class DailyCronJob implements CronJobInterface
             }
 
             if (!isset($rankedOwnerTitles[$npCommunicationId])) {
+                if ($rankedOwnerBatch !== []) {
+                    $this->executeWithRetry([$this, 'updateTrophyRarityForGames'], $rankedOwnerBatch);
+                    $rankedOwnerBatch = [];
+                }
+
                 $this->executeWithRetry([$this, 'updateZeroOwnerTrophyRarityForGame'], $npCommunicationId);
                 continue;
             }

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -6,6 +6,8 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final readonly class DailyCronJob implements CronJobInterface
 {
+    private const int RANKED_OWNER_TITLE_BATCH_SIZE = 100;
+
     private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
         sleep($seconds);
     };
@@ -51,6 +53,89 @@ final readonly class DailyCronJob implements CronJobInterface
             JOIN trophy_meta tm ON tm.trophy_id = t.id
             JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
             LEFT JOIN ranked_owners owners ON owners.order_id = t.order_id
+        )
+        UPDATE trophy_meta tm
+        JOIN rarity r ON tm.trophy_id = r.trophy_id
+        SET
+            tm.rarity_percent = r.rarity_percent,
+            tm.owners = r.trophy_owners,
+            tm.rarity_point = IF(
+                r.meta_status = 0 AND r.title_status = 0,
+                IF(r.rarity_percent = 0, 10000, FLOOR(1 / (r.rarity_percent / 100) - 1)),
+                0
+            ),
+            tm.rarity_name = CASE
+                WHEN r.meta_status != 0 OR r.title_status != 0 THEN 'NONE'
+                WHEN r.rarity_percent > 10 THEN 'COMMON'
+                WHEN r.rarity_percent > 2 THEN 'UNCOMMON'
+                WHEN r.rarity_percent > 0.2 THEN 'RARE'
+                WHEN r.rarity_percent > 0.02 THEN 'EPIC'
+                ELSE 'LEGENDARY'
+            END,
+            tm.in_game_rarity_percent = r.in_game_rarity_percent,
+            tm.in_game_rarity_point = IF(
+                r.meta_status = 0 AND r.title_status = 0 AND r.title_owners > 0,
+                IF(r.in_game_rarity_percent = 0, 0, FLOOR(1 / (r.in_game_rarity_percent / 100) - 1)),
+                0
+            ),
+            tm.in_game_rarity_name = CASE
+                WHEN r.meta_status != 0 OR r.title_status != 0 THEN 'NONE'
+                WHEN r.in_game_rarity_percent <= 1 THEN 'LEGENDARY'
+                WHEN r.in_game_rarity_percent <= 5 THEN 'EPIC'
+                WHEN r.in_game_rarity_percent <= 20 THEN 'RARE'
+                WHEN r.in_game_rarity_percent <= 60 THEN 'UNCOMMON'
+                ELSE 'COMMON'
+            END
+        SQL;
+
+
+    /**
+     * Recalculate rarity for a bounded batch of titles with ranked owners.
+     *
+     * The JSON_TABLE CTE materializes the selected np_communication_id values
+     * once, then the owner aggregation stays scoped to those titles while still
+     * driving from player_ranking into trophy_earned by account_id.
+     */
+    private const string UPDATE_TROPHY_RARITY_BATCH_QUERY = <<<'SQL'
+        WITH selected_titles AS (
+            SELECT np_communication_id
+            FROM JSON_TABLE(
+                :np_communication_ids,
+                '$[*]' COLUMNS (np_communication_id CHAR(12) PATH '$')
+            ) AS selected
+        ),
+        ranked_owners AS (
+            SELECT
+                te.np_communication_id,
+                te.order_id,
+                COUNT(*) AS trophy_owners
+            FROM selected_titles title
+            JOIN player_ranking pr ON pr.ranking <= 10000
+            INNER JOIN trophy_earned te
+                ON te.account_id = pr.account_id
+                AND te.np_communication_id = title.np_communication_id
+                AND te.earned = 1
+            GROUP BY te.np_communication_id, te.order_id
+        ),
+        rarity AS (
+            SELECT
+                t.id AS trophy_id,
+                tm.status AS meta_status,
+                ttm.status AS title_status,
+                ttm.owners AS title_owners,
+                IFNULL(owners.trophy_owners, 0) AS trophy_owners,
+                (IFNULL(owners.trophy_owners, 0) / 10000.0) * 100 AS rarity_percent,
+                CASE
+                    WHEN ttm.owners = 0 THEN 0
+                    ELSE LEAST((IFNULL(owners.trophy_owners, 0) / ttm.owners) * 100, 100.0)
+                END AS in_game_rarity_percent
+            FROM selected_titles title
+            JOIN trophy t ON t.np_communication_id = title.np_communication_id
+            JOIN trophy_meta tm ON tm.trophy_id = t.id
+            JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
+            LEFT JOIN ranked_owners owners
+                ON owners.np_communication_id = t.np_communication_id
+                AND owners.order_id = t.order_id
         )
         UPDATE trophy_meta tm
         JOIN rarity r ON tm.trophy_id = r.trophy_id
@@ -147,16 +232,28 @@ final readonly class DailyCronJob implements CronJobInterface
         $games = $query->fetchAll(PDO::FETCH_COLUMN);
         $rankedOwnerTitles = $this->executeWithRetry([$this, 'fetchTopTenThousandOwnerTitleLookup']);
 
+        $rankedOwnerBatch = [];
+
         foreach ($games as $npCommunicationId) {
             if (!is_string($npCommunicationId)) {
                 continue;
             }
 
-            $this->executeWithRetry(
-                [$this, 'updateTrophyRarityForGame'],
-                $npCommunicationId,
-                isset($rankedOwnerTitles[$npCommunicationId]),
-            );
+            if (!isset($rankedOwnerTitles[$npCommunicationId])) {
+                $this->executeWithRetry([$this, 'updateZeroOwnerTrophyRarityForGame'], $npCommunicationId);
+                continue;
+            }
+
+            $rankedOwnerBatch[] = $npCommunicationId;
+
+            if (count($rankedOwnerBatch) >= self::RANKED_OWNER_TITLE_BATCH_SIZE) {
+                $this->executeWithRetry([$this, 'updateTrophyRarityForGames'], $rankedOwnerBatch);
+                $rankedOwnerBatch = [];
+            }
+        }
+
+        if ($rankedOwnerBatch !== []) {
+            $this->executeWithRetry([$this, 'updateTrophyRarityForGames'], $rankedOwnerBatch);
         }
     }
 
@@ -188,13 +285,21 @@ final readonly class DailyCronJob implements CronJobInterface
         return $rankedOwnerTitles;
     }
 
-    private function updateTrophyRarityForGame(string $npCommunicationId, bool $hasRankedOwners): void
+    /**
+     * @param non-empty-list<string> $npCommunicationIds
+     */
+    private function updateTrophyRarityForGames(array $npCommunicationIds): void
     {
-        $sql = !$hasRankedOwners
-            ? self::UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY
-            : self::UPDATE_TROPHY_RARITY_QUERY;
+        $encodedIds = json_encode(array_values($npCommunicationIds), JSON_THROW_ON_ERROR);
 
-        $query = $this->database->prepare($sql);
+        $query = $this->database->prepare(self::UPDATE_TROPHY_RARITY_BATCH_QUERY);
+        $query->bindValue(':np_communication_ids', $encodedIds, PDO::PARAM_STR);
+        $query->execute();
+    }
+
+    private function updateZeroOwnerTrophyRarityForGame(string $npCommunicationId): void
+    {
+        $query = $this->database->prepare(self::UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY);
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->execute();
     }


### PR DESCRIPTION
### Motivation
- Reduce per-title full rarity queries for titles that have ranked owners by grouping those titles into bounded batches while retaining the fast zero-owner path for titles without ranked owners.

### Description
- Add a new batch size constant `RANKED_OWNER_TITLE_BATCH_SIZE` (100) and a new SQL constant `UPDATE_TROPHY_RARITY_BATCH_QUERY` which materializes a JSON array of `np_communication_id` values via `JSON_TABLE`, aggregates owners by both `np_communication_id` and `order_id`, and updates `trophy_meta` using the same rarity/owner/rarity-point and in-game rarity formulas as the per-title query.
- Change `recalculateTrophyRarityForGames()` to collect ranked-owner titles into batches and call a new private method `updateTrophyRarityForGames(array $npCommunicationIds)` that binds the JSON list and executes the batched query, while titles not returned by `fetchTopTenThousandOwnerTitleLookup()` still use the zero-owner fast path via `updateZeroOwnerTrophyRarityForGame()`.
- Preserve the existing retry semantics by continuing to call database operations via `executeWithRetry()` so infinite retry loops remain unchanged.
- Update `tests/DailyCronJobTest.php` to assert the batched query shape (JSON_TABLE usage and parameter), grouping by `np_communication_id` and `order_id`, batch-size behavior, and that zero-owner titles still use the zero-owner update query.

### Testing
- Ran `php -l wwwroot/classes/Cron/DailyCronJob.php` and `php -l tests/DailyCronJobTest.php` with no syntax errors.
- Ran the test suite with `php tests/run.php`; `DailyCronJob` tests (and the updated batch-related assertions) passed, while the full suite reported one unrelated/flaky existing failure: `PlayerScanTrophyTitleLoopTest::testProcessAccessibleTrophyTitlesRetriesTransientFetchExceptions` (expected `cURL error 18`).
- All modified tests in `tests/DailyCronJobTest.php` pass locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59fa38b140832f8c2674e93086d73b)