### PR TITLE
Speed up daily cron with one-pass top-10k rarity scan

### DIFF
--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -7,56 +7,36 @@ require_once __DIR__ . '/../wwwroot/classes/Cron/DailyCronJob.php';
 
 final class DailyCronJobTest extends TestCase
 {
-    public function testUpdateTrophyRarityQueryUsesTopTenThousandRankingFilter(): void
+    public function testPopulateQueryDrivesTrophyEarnedByAccountIdForPartitionPruning(): void
     {
-        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_BATCH_QUERY');
+        $source = $this->readPrivateConstant('POPULATE_RANKED_OWNER_COUNTS_QUERY');
 
-        $this->assertStringContainsString('JOIN player_ranking pr ON pr.ranking <= 10000', $source);
-        $this->assertStringContainsString('te.account_id = pr.account_id', $source);
-        $this->assertStringContainsString('/ 10000.0) * 100 AS rarity_percent', $source);
-        $this->assertStringContainsString('JSON_TABLE(', $source);
-        $this->assertStringContainsString(':np_communication_ids', $source);
-        $this->assertStringContainsString('JOIN trophy t ON t.np_communication_id = title.np_communication_id', $source);
-    }
-
-    public function testUpdateTrophyRarityQueryDrivesTrophyEarnedByAccountIdForPartitionPruning(): void
-    {
-        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_BATCH_QUERY');
-
-        $this->assertStringContainsString('ranked_owners AS', $source);
+        $this->assertStringContainsString('FROM player_ranking pr', $source);
         $this->assertStringContainsString('INNER JOIN trophy_earned te', $source);
+        $this->assertStringContainsString('te.account_id = pr.account_id', $source);
+        $this->assertStringContainsString('te.earned = 1', $source);
+        $this->assertStringContainsString('WHERE pr.ranking <= 10000', $source);
         $this->assertStringContainsString('GROUP BY te.np_communication_id, te.order_id', $source);
         $this->assertFalse(str_contains($source, 'LEFT JOIN trophy_earned te'));
+        $this->assertFalse(str_contains($source, 'JSON_TABLE('));
+        $this->assertFalse(str_contains($source, 'np_communication_id = title.np_communication_id'));
     }
 
-    public function testZeroOwnersRarityQuerySkipsTrophyEarned(): void
+    public function testApplyTrophyRarityQueryUsesTempTableOwnerCountsAndTopTenThousandDenominator(): void
     {
-        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY');
+        $source = $this->readPrivateConstant('APPLY_TROPHY_RARITY_QUERY');
 
-        $this->assertStringContainsString('UPDATE trophy_meta tm', $source);
-        $this->assertStringContainsString('JOIN trophy_title_meta ttm', $source);
-        $this->assertStringContainsString('IF(tm.status = 0 AND ttm.status = 0, 10000, 0)', $source);
-        $this->assertStringContainsString("IF(tm.status = 0 AND ttm.status = 0, 'LEGENDARY', 'NONE')", $source);
-        $this->assertStringContainsString('tm.in_game_rarity_point = 0', $source);
+        $this->assertStringContainsString('LEFT JOIN tmp_daily_ranked_trophy_owners owners', $source);
+        $this->assertStringContainsString('/ 10000.0) * 100 AS rarity_percent', $source);
+        $this->assertStringContainsString('IFNULL(owners.trophy_owners, 0) AS trophy_owners', $source);
+        $this->assertStringContainsString('IF(r.rarity_percent = 0, 10000, FLOOR(1 / (r.rarity_percent / 100) - 1))', $source);
         $this->assertFalse(str_contains($source, 'trophy_earned'));
         $this->assertFalse(str_contains($source, 'player_ranking'));
     }
 
-    public function testZeroOwnersFastPathUsesBatchedLiveRankedOwnerLookupNotCachedMeta(): void
+    public function testApplyTrophyRarityQueryAssignsRarityNamesFromThresholds(): void
     {
-        $source = $this->readClassSource();
-
-        $this->assertStringContainsString('SELECT DISTINCT ttp.np_communication_id', $source);
-        $this->assertStringContainsString('FROM player_ranking pr', $source);
-        $this->assertStringContainsString('JOIN trophy_title_player ttp ON ttp.account_id = pr.account_id', $source);
-        $this->assertStringContainsString('WHERE pr.ranking <= 10000', $source);
-        $this->assertFalse(str_contains($source, 'SELECT EXISTS ('));
-        $this->assertFalse(str_contains($source, 'SELECT owners FROM trophy_title_meta'));
-    }
-
-    public function testUpdateTrophyRarityQueryAssignsRarityNamesFromThresholds(): void
-    {
-        $source = $this->readPrivateConstant('UPDATE_TROPHY_RARITY_BATCH_QUERY');
+        $source = $this->readPrivateConstant('APPLY_TROPHY_RARITY_QUERY');
 
         $this->assertStringContainsString("WHEN r.rarity_percent > 10 THEN 'COMMON'", $source);
         $this->assertStringContainsString("WHEN r.rarity_percent > 2 THEN 'UNCOMMON'", $source);
@@ -66,15 +46,29 @@ final class DailyCronJobTest extends TestCase
         $this->assertStringContainsString("WHEN r.in_game_rarity_percent <= 1 THEN 'LEGENDARY'", $source);
     }
 
-    public function testUpdateTrophyRarityQueryScopesTrophyEarnedByTitle(): void
+    public function testRankedOwnerTempTableUsesPrimaryKeyForLookup(): void
+    {
+        $source = $this->readPrivateConstant('CREATE_RANKED_OWNER_TEMP_TABLE_QUERY');
+
+        $this->assertStringContainsString('CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners', $source);
+        $this->assertStringContainsString('PRIMARY KEY (np_communication_id, order_id)', $source);
+        $this->assertStringContainsString('order_id SMALLINT UNSIGNED NOT NULL', $source);
+    }
+
+    public function testDailyCronAvoidsPerTitleTrophyEarnedProbes(): void
     {
         $source = $this->readClassSource();
 
-        $this->assertStringContainsString('SELECT np_communication_id FROM trophy_title', $source);
-        $this->assertStringContainsString('fetchTopTenThousandOwnerTitleLookup', $source);
-        $this->assertStringContainsString('isset($rankedOwnerTitles[$npCommunicationId])', $source);
-        $this->assertStringContainsString('RANKED_OWNER_TITLE_BATCH_SIZE = 100', $source);
-        $this->assertStringContainsString('updateTrophyRarityForGames', $source);
+        $this->assertStringContainsString('rebuildRankedOwnerCountsAndApplyRarity', $source);
+        $this->assertStringContainsString('populateRankedOwnerCounts', $source);
+        $this->assertStringContainsString('applyTrophyRarityFromTemporaryTable', $source);
+        $this->assertFalse(str_contains($source, 'SELECT np_communication_id FROM trophy_title'));
+        $this->assertFalse(str_contains($source, 'JSON_TABLE('));
+        $this->assertFalse(str_contains($source, 'RANKED_OWNER_TITLE_BATCH_SIZE'));
+        $this->assertFalse(str_contains($source, 'RANKED_OWNER_ACCOUNT_BATCH_SIZE'));
+        $this->assertFalse(str_contains($source, 'fetchTopTenThousandOwnerTitleLookup'));
+        $this->assertFalse(str_contains($source, 'UPDATE_TROPHY_RARITY_BATCH_QUERY'));
+        $this->assertFalse(str_contains($source, 'UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY'));
     }
 
     public function testUpdateTrophyTitleRarityPointsAggregatesPerGame(): void
@@ -94,13 +88,37 @@ final class DailyCronJobTest extends TestCase
 
         $this->assertStringContainsString('while (true)', $source);
         $this->assertFalse(str_contains($source, 'maxAttempt'));
-        $this->assertStringContainsString('updateTrophyRarityForGames', $source);
+        $this->assertStringContainsString('rebuildRankedOwnerCountsAndApplyRarity', $source);
         $this->assertStringContainsString('updateTrophyTitleRarityPoints', $source);
     }
 
-    public function testRunRetriesPerGameRarityUpdateUntilItSucceeds(): void
+    public function testRunBuildsTempOwnerCountsAppliesRarityThenTitlePoints(): void
     {
-        $database = new DailyCronJobPerGameRetryTestDatabase();
+        $database = new DailyCronJobHappyPathTestDatabase();
+
+        $job = new DailyCronJob(
+            $database,
+            retryDelaySeconds: 1,
+            sleeper: static function (int $seconds): void {
+                throw new RuntimeException('Sleeper should not be called.');
+            },
+        );
+
+        $job->run();
+
+        $this->assertSame([
+            'drop-temp',
+            'create-temp',
+            'populate-owners',
+            'apply-rarity',
+            'drop-temp',
+            'title-points',
+        ], $database->getOperations());
+    }
+
+    public function testRunRetriesRarityRebuildUntilItSucceeds(): void
+    {
+        $database = new DailyCronJobRarityRetryTestDatabase();
         $sleepCalls = [];
 
         $job = new DailyCronJob(
@@ -114,7 +132,8 @@ final class DailyCronJobTest extends TestCase
         $job->run();
 
         $this->assertSame([1, 1], $sleepCalls);
-        $this->assertSame(3, $database->getPerGameUpdateCount());
+        $this->assertSame(3, $database->getPopulateCount());
+        $this->assertSame(1, $database->getApplyCount());
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
     }
 
@@ -134,13 +153,14 @@ final class DailyCronJobTest extends TestCase
         $job->run();
 
         $this->assertSame([1, 1], $sleepCalls);
-        $this->assertSame(0, $database->getPerGameUpdateCount());
+        $this->assertSame(1, $database->getPopulateCount());
+        $this->assertSame(1, $database->getApplyCount());
         $this->assertSame(3, $database->getTitlePointsUpdateCount());
     }
 
-    public function testRunRetriesRankedOwnerLookupUntilItSucceeds(): void
+    public function testRunDropsTempTableAfterRarityRebuildFailureBeforeRetry(): void
     {
-        $database = new DailyCronJobRankedOwnerLookupRetryTestDatabase();
+        $database = new DailyCronJobTempCleanupRetryTestDatabase();
         $sleepCalls = [];
 
         $job = new DailyCronJob(
@@ -153,50 +173,16 @@ final class DailyCronJobTest extends TestCase
 
         $job->run();
 
-        $this->assertSame([1, 1], $sleepCalls);
-        $this->assertSame(3, $database->getRankedOwnerLookupCount());
-        $this->assertSame(['NPWR00001_00'], $database->getFullRarityUpdates());
-        $this->assertSame(1, $database->getTitlePointsUpdateCount());
-    }
-
-    public function testRunProcessesRankedOwnerTitlesInBatchesAndZeroOwnerTitlesIndividually(): void
-    {
-        $database = new DailyCronJobRankedOwnerLookupTestDatabase();
-
-        $job = new DailyCronJob(
-            $database,
-            retryDelaySeconds: 1,
-            sleeper: static function (int $seconds): void {
-                throw new RuntimeException('Sleeper should not be called.');
-            },
-        );
-
-        $job->run();
-
-        $this->assertSame(1, $database->getRankedOwnerLookupCount());
-        $expectedFirstBatch = array_map(static fn (int $index): string => sprintf('NPWR%05d_00', $index), range(1, 100));
-        $this->assertSame([$expectedFirstBatch, ['NPWR00101_00']], $database->getFullRarityUpdateBatches());
-        $this->assertSame(['NPWR00102_00'], $database->getZeroOwnerRarityUpdates());
-        $this->assertSame(1, $database->getTitlePointsUpdateCount());
-    }
-
-    public function testRunFlushesPendingRankedOwnerBatchBeforeZeroOwnerUpdate(): void
-    {
-        $database = new DailyCronJobFlushBeforeZeroOwnerTestDatabase();
-
-        $job = new DailyCronJob(
-            $database,
-            retryDelaySeconds: 1,
-            sleeper: static function (int $seconds): void {
-            },
-        );
-
-        $job->run();
-
+        $this->assertSame([1], $sleepCalls);
         $this->assertSame([
-            'ranked:NPWR00001_00,NPWR00002_00',
-            'zero:NPWR00003_00',
-            'zero:NPWR00003_00',
+            'drop-temp',
+            'create-temp',
+            'populate-owners',
+            'drop-temp',
+            'create-temp',
+            'populate-owners',
+            'apply-rarity',
+            'drop-temp',
             'title-points',
         ], $database->getOperations());
     }
@@ -221,9 +207,69 @@ final class DailyCronJobTest extends TestCase
     }
 }
 
-final class DailyCronJobPerGameRetryTestDatabase extends PDO
+final class DailyCronJobHappyPathTestDatabase extends PDO
 {
-    private int $perGameUpdateCount = 0;
+    /** @var list<string> */
+    private array $operations = [];
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getOperations(): array
+    {
+        return $this->operations;
+    }
+
+    public function exec(string $statement): int|false
+    {
+        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
+            $this->operations[] = 'drop-temp';
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
+            $this->operations[] = 'create-temp';
+
+            return 0;
+        }
+
+        throw new RuntimeException('Unexpected exec call: ' . $statement);
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'populate-owners';
+            });
+        }
+
+        if (str_contains($query, 'LEFT JOIN tmp_daily_ranked_trophy_owners owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'apply-rarity';
+            });
+        }
+
+        if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'title-points';
+            });
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
+final class DailyCronJobRarityRetryTestDatabase extends PDO
+{
+    private int $populateCount = 0;
+
+    private int $applyCount = 0;
 
     private int $titlePointsUpdateCount = 0;
 
@@ -231,9 +277,14 @@ final class DailyCronJobPerGameRetryTestDatabase extends PDO
     {
     }
 
-    public function getPerGameUpdateCount(): int
+    public function getPopulateCount(): int
     {
-        return $this->perGameUpdateCount;
+        return $this->populateCount;
+    }
+
+    public function getApplyCount(): int
+    {
+        return $this->applyCount;
     }
 
     public function getTitlePointsUpdateCount(): int
@@ -241,28 +292,25 @@ final class DailyCronJobPerGameRetryTestDatabase extends PDO
         return $this->titlePointsUpdateCount;
     }
 
+    public function exec(string $statement): int|false
+    {
+        return 0;
+    }
+
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
-        if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
-            return new DailyCronJobTestStatement(static function (): array {
-                return ['NPWR00001_00'];
-            }, isSelect: true);
-        }
-
-        if (str_contains($query, 'SELECT DISTINCT ttp.np_communication_id')) {
-            // Ranked owners present => full ranked trophy_earned rarity path.
-            return new DailyCronJobTestStatement(static function (): array {
-                return ['NPWR00001_00'];
-            }, isSelect: true);
-        }
-
-        if (str_contains($query, 'UPDATE trophy_meta tm')) {
+        if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
-                $this->perGameUpdateCount++;
-
-                if ($this->perGameUpdateCount < 3) {
-                    throw new RuntimeException('Simulated per-game rarity update failure.');
+                $this->populateCount++;
+                if ($this->populateCount < 3) {
+                    throw new RuntimeException('Simulated populate failure.');
                 }
+            });
+        }
+
+        if (str_contains($query, 'LEFT JOIN tmp_daily_ranked_trophy_owners owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->applyCount++;
             });
         }
 
@@ -278,7 +326,9 @@ final class DailyCronJobPerGameRetryTestDatabase extends PDO
 
 final class DailyCronJobTitleRetryTestDatabase extends PDO
 {
-    private int $perGameUpdateCount = 0;
+    private int $populateCount = 0;
+
+    private int $applyCount = 0;
 
     private int $titlePointsUpdateCount = 0;
 
@@ -286,9 +336,14 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
     {
     }
 
-    public function getPerGameUpdateCount(): int
+    public function getPopulateCount(): int
     {
-        return $this->perGameUpdateCount;
+        return $this->populateCount;
+    }
+
+    public function getApplyCount(): int
+    {
+        return $this->applyCount;
     }
 
     public function getTitlePointsUpdateCount(): int
@@ -296,30 +351,28 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
         return $this->titlePointsUpdateCount;
     }
 
+    public function exec(string $statement): int|false
+    {
+        return 0;
+    }
+
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
-        if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
-            return new DailyCronJobTestStatement(static function (): array {
-                return [];
-            }, isSelect: true);
-        }
-
-        if (str_contains($query, 'SELECT DISTINCT ttp.np_communication_id')) {
-            return new DailyCronJobTestStatement(static function (): array {
-                return [];
-            }, isSelect: true);
-        }
-
-        if (str_contains($query, 'UPDATE trophy_meta tm')) {
+        if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
-                $this->perGameUpdateCount++;
+                $this->populateCount++;
+            });
+        }
+
+        if (str_contains($query, 'LEFT JOIN tmp_daily_ranked_trophy_owners owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->applyCount++;
             });
         }
 
         if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->titlePointsUpdateCount++;
-
                 if ($this->titlePointsUpdateCount < 3) {
                     throw new RuntimeException('Simulated title rarity point aggregation failure.');
                 }
@@ -330,164 +383,12 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
     }
 }
 
-final class DailyCronJobRankedOwnerLookupRetryTestDatabase extends PDO
-{
-    private int $rankedOwnerLookupCount = 0;
-
-    /** @var list<string> */
-    private array $fullRarityUpdates = [];
-
-    private int $titlePointsUpdateCount = 0;
-
-    public function __construct()
-    {
-    }
-
-    public function getRankedOwnerLookupCount(): int
-    {
-        return $this->rankedOwnerLookupCount;
-    }
-
-    /**
-     * @return list<string>
-     */
-    public function getFullRarityUpdates(): array
-    {
-        return $this->fullRarityUpdates;
-    }
-
-    public function getTitlePointsUpdateCount(): int
-    {
-        return $this->titlePointsUpdateCount;
-    }
-
-    public function prepare(string $query, array $options = []): PDOStatement|false
-    {
-        if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
-            return new DailyCronJobTestStatement(static function (): array {
-                return ['NPWR00001_00'];
-            }, isSelect: true);
-        }
-
-        if (str_contains($query, 'SELECT DISTINCT ttp.np_communication_id')) {
-            return new DailyCronJobTestStatement(function (): array {
-                $this->rankedOwnerLookupCount++;
-
-                if ($this->rankedOwnerLookupCount < 3) {
-                    throw new RuntimeException('Simulated ranked-owner lookup failure.');
-                }
-
-                return ['NPWR00001_00'];
-            }, isSelect: true);
-        }
-
-        if (str_contains($query, 'ranked_owners AS')) {
-            return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
-                $json = $boundValues[':np_communication_ids'] ?? '[]';
-                $decoded = json_decode((string) $json, true, flags: JSON_THROW_ON_ERROR);
-                $this->fullRarityUpdates = array_merge($this->fullRarityUpdates, is_array($decoded) ? $decoded : []);
-            });
-        }
-
-        if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
-            return new DailyCronJobTestStatement(function (): void {
-                $this->titlePointsUpdateCount++;
-            });
-        }
-
-        throw new RuntimeException('Unexpected prepare call: ' . $query);
-    }
-}
-
-final class DailyCronJobRankedOwnerLookupTestDatabase extends PDO
-{
-    private int $rankedOwnerLookupCount = 0;
-
-    /** @var list<list<string>> */
-    private array $fullRarityUpdateBatches = [];
-
-    /** @var list<string> */
-    private array $zeroOwnerRarityUpdates = [];
-
-    private int $titlePointsUpdateCount = 0;
-
-    public function __construct()
-    {
-    }
-
-    public function getRankedOwnerLookupCount(): int
-    {
-        return $this->rankedOwnerLookupCount;
-    }
-
-    /**
-     * @return list<list<string>>
-     */
-    public function getFullRarityUpdateBatches(): array
-    {
-        return $this->fullRarityUpdateBatches;
-    }
-
-    /**
-     * @return list<string>
-     */
-    public function getZeroOwnerRarityUpdates(): array
-    {
-        return $this->zeroOwnerRarityUpdates;
-    }
-
-    public function getTitlePointsUpdateCount(): int
-    {
-        return $this->titlePointsUpdateCount;
-    }
-
-    public function prepare(string $query, array $options = []): PDOStatement|false
-    {
-        if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
-            return new DailyCronJobTestStatement(static function (): array {
-                return array_map(static fn (int $index): string => sprintf('NPWR%05d_00', $index), range(1, 102));
-            }, isSelect: true);
-        }
-
-        if (str_contains($query, 'SELECT DISTINCT ttp.np_communication_id')) {
-            return new DailyCronJobTestStatement(function (): array {
-                $this->rankedOwnerLookupCount++;
-
-                return array_map(static fn (int $index): string => sprintf('NPWR%05d_00', $index), range(1, 101));
-            }, isSelect: true);
-        }
-
-        if (str_contains($query, 'ranked_owners AS')) {
-            return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
-                $json = $boundValues[':np_communication_ids'] ?? '[]';
-                $decoded = json_decode((string) $json, true, flags: JSON_THROW_ON_ERROR);
-                $this->fullRarityUpdateBatches[] = is_array($decoded) ? $decoded : [];
-            });
-        }
-
-        if (str_contains($query, 'UPDATE trophy_meta tm')) {
-            return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
-                $this->zeroOwnerRarityUpdates[] = $boundValues[':np_communication_id'] ?? '';
-            });
-        }
-
-        if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
-            return new DailyCronJobTestStatement(function (): void {
-                $this->titlePointsUpdateCount++;
-            });
-        }
-
-        throw new RuntimeException('Unexpected prepare call: ' . $query);
-    }
-}
-
-
-final class DailyCronJobFlushBeforeZeroOwnerTestDatabase extends PDO
+final class DailyCronJobTempCleanupRetryTestDatabase extends PDO
 {
     /** @var list<string> */
     private array $operations = [];
 
-    private int $zeroOwnerUpdateCount = 0;
+    private int $populateCount = 0;
 
     public function __construct()
     {
@@ -501,38 +402,38 @@ final class DailyCronJobFlushBeforeZeroOwnerTestDatabase extends PDO
         return $this->operations;
     }
 
+    public function exec(string $statement): int|false
+    {
+        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
+            $this->operations[] = 'drop-temp';
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
+            $this->operations[] = 'create-temp';
+
+            return 0;
+        }
+
+        throw new RuntimeException('Unexpected exec call: ' . $statement);
+    }
+
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
-        if (str_contains($query, 'SELECT np_communication_id FROM trophy_title')) {
-            return new DailyCronJobTestStatement(static function (): array {
-                return ['NPWR00001_00', 'NPWR00002_00', 'NPWR00003_00'];
-            }, isSelect: true);
-        }
-
-        if (str_contains($query, 'SELECT DISTINCT ttp.np_communication_id')) {
-            return new DailyCronJobTestStatement(static function (): array {
-                return ['NPWR00001_00', 'NPWR00002_00'];
-            }, isSelect: true);
-        }
-
-        if (str_contains($query, 'ranked_owners AS')) {
-            return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
-                $json = $boundValues[':np_communication_ids'] ?? '[]';
-                $decoded = json_decode((string) $json, true, flags: JSON_THROW_ON_ERROR);
-                $titles = is_array($decoded) ? array_values(array_filter($decoded, 'is_string')) : [];
-                $this->operations[] = 'ranked:' . implode(',', $titles);
+        if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->populateCount++;
+                $this->operations[] = 'populate-owners';
+                if ($this->populateCount === 1) {
+                    throw new RuntimeException('Simulated populate failure.');
+                }
             });
         }
 
-        if (str_contains($query, 'UPDATE trophy_meta tm')) {
-            return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
-                $npCommunicationId = (string) ($boundValues[':np_communication_id'] ?? '');
-                $this->operations[] = 'zero:' . $npCommunicationId;
-                $this->zeroOwnerUpdateCount++;
-
-                if ($this->zeroOwnerUpdateCount === 1) {
-                    throw new RuntimeException('Simulated zero-owner rarity update failure.');
-                }
+        if (str_contains($query, 'LEFT JOIN tmp_daily_ranked_trophy_owners owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'apply-rarity';
             });
         }
 

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -11,8 +11,9 @@ final class DailyCronJobTest extends TestCase
     {
         $source = $this->readPrivateConstant('POPULATE_RANKED_OWNER_COUNTS_QUERY');
 
-        $this->assertStringContainsString('FROM player_ranking pr', $source);
-        $this->assertStringContainsString('INNER JOIN trophy_earned te', $source);
+        $this->assertStringContainsString('SELECT /*+ JOIN_ORDER(pr, te) */', $source);
+        $this->assertStringContainsString('FROM player_ranking pr FORCE INDEX (idx_pr_ranking_account)', $source);
+        $this->assertStringContainsString('STRAIGHT_JOIN trophy_earned te FORCE INDEX (idx_te_acc_comm_order_earned_date)', $source);
         $this->assertStringContainsString('te.account_id = pr.account_id', $source);
         $this->assertStringContainsString('te.earned = 1', $source);
         $this->assertStringContainsString('WHERE pr.ranking <= 10000', $source);

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -59,7 +59,7 @@ final class DailyCronJobTest extends TestCase
     {
         $source = $this->readClassSource();
 
-        $this->assertStringContainsString('rebuildRankedOwnerCountsAndApplyRarity', $source);
+        $this->assertStringContainsString('prepareAndPopulateRankedOwnerCounts', $source);
         $this->assertStringContainsString('populateRankedOwnerCounts', $source);
         $this->assertStringContainsString('applyTrophyRarityFromTemporaryTable', $source);
         $this->assertFalse(str_contains($source, 'SELECT np_communication_id FROM trophy_title'));
@@ -88,7 +88,8 @@ final class DailyCronJobTest extends TestCase
 
         $this->assertStringContainsString('while (true)', $source);
         $this->assertFalse(str_contains($source, 'maxAttempt'));
-        $this->assertStringContainsString('rebuildRankedOwnerCountsAndApplyRarity', $source);
+        $this->assertStringContainsString('prepareAndPopulateRankedOwnerCounts', $source);
+        $this->assertStringContainsString('applyTrophyRarityFromTemporaryTable', $source);
         $this->assertStringContainsString('updateTrophyTitleRarityPoints', $source);
     }
 
@@ -134,6 +135,27 @@ final class DailyCronJobTest extends TestCase
         $this->assertSame([1, 1], $sleepCalls);
         $this->assertSame(3, $database->getPopulateCount());
         $this->assertSame(1, $database->getApplyCount());
+        $this->assertSame(1, $database->getTitlePointsUpdateCount());
+    }
+
+    public function testRunRetriesApplyWithoutRepopulatingRankedOwnerCounts(): void
+    {
+        $database = new DailyCronJobApplyRetryTestDatabase();
+        $sleepCalls = [];
+
+        $job = new DailyCronJob(
+            $database,
+            retryDelaySeconds: 1,
+            sleeper: static function (int $seconds) use (&$sleepCalls): void {
+                $sleepCalls[] = $seconds;
+            },
+        );
+
+        $job->run();
+
+        $this->assertSame([1, 1], $sleepCalls);
+        $this->assertSame(1, $database->getPopulateCount());
+        $this->assertSame(3, $database->getApplyCount());
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
     }
 
@@ -311,6 +333,65 @@ final class DailyCronJobRarityRetryTestDatabase extends PDO
         if (str_contains($query, 'LEFT JOIN tmp_daily_ranked_trophy_owners owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->applyCount++;
+            });
+        }
+
+        if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->titlePointsUpdateCount++;
+            });
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
+final class DailyCronJobApplyRetryTestDatabase extends PDO
+{
+    private int $populateCount = 0;
+
+    private int $applyCount = 0;
+
+    private int $titlePointsUpdateCount = 0;
+
+    public function __construct()
+    {
+    }
+
+    public function getPopulateCount(): int
+    {
+        return $this->populateCount;
+    }
+
+    public function getApplyCount(): int
+    {
+        return $this->applyCount;
+    }
+
+    public function getTitlePointsUpdateCount(): int
+    {
+        return $this->titlePointsUpdateCount;
+    }
+
+    public function exec(string $statement): int|false
+    {
+        return 0;
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->populateCount++;
+            });
+        }
+
+        if (str_contains($query, 'LEFT JOIN tmp_daily_ranked_trophy_owners owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->applyCount++;
+                if ($this->applyCount < 3) {
+                    throw new RuntimeException('Simulated apply rarity failure.');
+                }
             });
         }
 

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -90,7 +90,8 @@ final class DailyCronJobTest extends TestCase
         $this->assertStringContainsString('while (true)', $source);
         $this->assertFalse(str_contains($source, 'maxAttempt'));
         $this->assertStringContainsString('prepareAndPopulateRankedOwnerCounts', $source);
-        $this->assertStringContainsString('applyTrophyRarityFromTemporaryTable', $source);
+        $this->assertStringContainsString('applyTrophyRarityFromTemporaryTableWithRecovery', $source);
+        $this->assertStringContainsString('isMissingRankedOwnerTempTableError', $source);
         $this->assertStringContainsString('updateTrophyTitleRarityPoints', $source);
     }
 
@@ -158,6 +159,39 @@ final class DailyCronJobTest extends TestCase
         $this->assertSame(1, $database->getPopulateCount());
         $this->assertSame(3, $database->getApplyCount());
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
+    }
+
+    public function testRunRebuildsRankedOwnerCountsWhenApplyLosesTempTable(): void
+    {
+        $database = new DailyCronJobMissingTempTableRecoveryTestDatabase();
+        $sleepCalls = [];
+
+        $job = new DailyCronJob(
+            $database,
+            retryDelaySeconds: 1,
+            sleeper: static function (int $seconds) use (&$sleepCalls): void {
+                $sleepCalls[] = $seconds;
+            },
+        );
+
+        $job->run();
+
+        $this->assertSame([], $sleepCalls);
+        $this->assertSame(2, $database->getPopulateCount());
+        $this->assertSame(2, $database->getApplyCount());
+        $this->assertSame(1, $database->getTitlePointsUpdateCount());
+        $this->assertSame([
+            'drop-temp',
+            'create-temp',
+            'populate-owners',
+            'apply-missing-temp',
+            'drop-temp',
+            'create-temp',
+            'populate-owners',
+            'apply-rarity',
+            'drop-temp',
+            'title-points',
+        ], $database->getOperations());
     }
 
     public function testRunRetriesTitleRarityPointAggregationUntilItSucceeds(): void
@@ -547,6 +581,95 @@ final class DailyCronJobTempCleanupRetryTestDatabase extends PDO
         if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->operations[] = 'title-points';
+            });
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
+final class DailyCronJobMissingTempTableRecoveryTestDatabase extends PDO
+{
+    /** @var list<string> */
+    private array $operations = [];
+
+    private int $populateCount = 0;
+
+    private int $applyCount = 0;
+
+    private int $titlePointsUpdateCount = 0;
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getOperations(): array
+    {
+        return $this->operations;
+    }
+
+    public function getPopulateCount(): int
+    {
+        return $this->populateCount;
+    }
+
+    public function getApplyCount(): int
+    {
+        return $this->applyCount;
+    }
+
+    public function getTitlePointsUpdateCount(): int
+    {
+        return $this->titlePointsUpdateCount;
+    }
+
+    public function exec(string $statement): int|false
+    {
+        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
+            $this->operations[] = 'drop-temp';
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
+            $this->operations[] = 'create-temp';
+
+            return 0;
+        }
+
+        throw new RuntimeException('Unexpected exec call: ' . $statement);
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->populateCount++;
+                $this->operations[] = 'populate-owners';
+            });
+        }
+
+        if (str_contains($query, 'LEFT JOIN tmp_daily_ranked_trophy_owners owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->applyCount++;
+                if ($this->applyCount === 1) {
+                    $this->operations[] = 'apply-missing-temp';
+                    throw new RuntimeException(
+                        "SQLSTATE[42S02]: Base table or view not found: 1146 Table 'psn100.tmp_daily_ranked_trophy_owners' doesn't exist"
+                    );
+                }
+
+                $this->operations[] = 'apply-rarity';
+            });
+        }
+
+        if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'title-points';
+                $this->titlePointsUpdateCount++;
             });
         }
 

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -236,6 +236,45 @@ final class DailyCronJobTest extends TestCase
             'create-temp',
             'populate-owners',
             'drop-temp',
+            'drop-temp',
+            'create-temp',
+            'populate-owners',
+            'apply-rarity',
+            'drop-temp',
+            'title-points',
+        ], $database->getOperations());
+    }
+
+    public function testRunDoesNotApplyEmptyTempTableAfterFailedRecoveryPopulate(): void
+    {
+        $database = new DailyCronJobFailedRecoveryPopulateTestDatabase();
+        $sleepCalls = [];
+
+        $job = new DailyCronJob(
+            $database,
+            retryDelaySeconds: 1,
+            sleeper: static function (int $seconds) use (&$sleepCalls): void {
+                $sleepCalls[] = $seconds;
+            },
+        );
+
+        $job->run();
+
+        $this->assertSame([1], $sleepCalls);
+        $this->assertSame(3, $database->getPopulateCount());
+        $this->assertSame(3, $database->getApplyCount());
+        $this->assertSame(1, $database->getTitlePointsUpdateCount());
+        $this->assertSame([
+            'drop-temp',
+            'create-temp',
+            'populate-owners',
+            'apply-missing-temp',
+            'drop-temp',
+            'create-temp',
+            'populate-owners-failed',
+            'drop-temp',
+            'apply-missing-temp',
+            'drop-temp',
             'create-temp',
             'populate-owners',
             'apply-rarity',
@@ -581,6 +620,101 @@ final class DailyCronJobTempCleanupRetryTestDatabase extends PDO
         if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->operations[] = 'title-points';
+            });
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
+final class DailyCronJobFailedRecoveryPopulateTestDatabase extends PDO
+{
+    /** @var list<string> */
+    private array $operations = [];
+
+    private int $populateCount = 0;
+
+    private int $applyCount = 0;
+
+    private int $titlePointsUpdateCount = 0;
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getOperations(): array
+    {
+        return $this->operations;
+    }
+
+    public function getPopulateCount(): int
+    {
+        return $this->populateCount;
+    }
+
+    public function getApplyCount(): int
+    {
+        return $this->applyCount;
+    }
+
+    public function getTitlePointsUpdateCount(): int
+    {
+        return $this->titlePointsUpdateCount;
+    }
+
+    public function exec(string $statement): int|false
+    {
+        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
+            $this->operations[] = 'drop-temp';
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
+            $this->operations[] = 'create-temp';
+
+            return 0;
+        }
+
+        throw new RuntimeException('Unexpected exec call: ' . $statement);
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->populateCount++;
+                if ($this->populateCount === 2) {
+                    $this->operations[] = 'populate-owners-failed';
+                    throw new RuntimeException('Simulated recovery populate failure.');
+                }
+
+                $this->operations[] = 'populate-owners';
+            });
+        }
+
+        if (str_contains($query, 'LEFT JOIN tmp_daily_ranked_trophy_owners owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->applyCount++;
+                // Fail until a successful recovery populate has completed (populateCount === 3).
+                if ($this->populateCount < 3) {
+                    $this->operations[] = 'apply-missing-temp';
+                    throw new RuntimeException(
+                        "SQLSTATE[42S02]: Base table or view not found: 1146 Table 'psn100.tmp_daily_ranked_trophy_owners' doesn't exist"
+                    );
+                }
+
+                $this->operations[] = 'apply-rarity';
+            });
+        }
+
+        if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'title-points';
+                $this->titlePointsUpdateCount++;
             });
         }
 

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -91,6 +91,7 @@ final class DailyCronJobTest extends TestCase
         $this->assertFalse(str_contains($source, 'maxAttempt'));
         $this->assertStringContainsString('prepareAndPopulateRankedOwnerCounts', $source);
         $this->assertStringContainsString('applyTrophyRarityFromTemporaryTableWithRecovery', $source);
+        $this->assertStringContainsString('preparePopulateAndApplyRankedOwnerRarity', $source);
         $this->assertStringContainsString('isMissingRankedOwnerTempTableError', $source);
         $this->assertStringContainsString('updateTrophyTitleRarityPoints', $source);
     }
@@ -262,7 +263,7 @@ final class DailyCronJobTest extends TestCase
 
         $this->assertSame([1], $sleepCalls);
         $this->assertSame(3, $database->getPopulateCount());
-        $this->assertSame(3, $database->getApplyCount());
+        $this->assertSame(2, $database->getApplyCount());
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
         $this->assertSame([
             'drop-temp',
@@ -273,7 +274,44 @@ final class DailyCronJobTest extends TestCase
             'create-temp',
             'populate-owners-failed',
             'drop-temp',
+            'drop-temp',
+            'create-temp',
+            'populate-owners',
+            'apply-rarity',
+            'drop-temp',
+            'title-points',
+        ], $database->getOperations());
+    }
+
+    public function testRunDoesNotApplyEmptyTempTableWhenRecoveryCleanupDropFails(): void
+    {
+        $database = new DailyCronJobFailedRecoveryCleanupDropTestDatabase();
+        $sleepCalls = [];
+
+        $job = new DailyCronJob(
+            $database,
+            retryDelaySeconds: 1,
+            sleeper: static function (int $seconds) use (&$sleepCalls): void {
+                $sleepCalls[] = $seconds;
+            },
+        );
+
+        $job->run();
+
+        $this->assertSame([1], $sleepCalls);
+        $this->assertSame(3, $database->getPopulateCount());
+        $this->assertSame(2, $database->getApplyCount());
+        $this->assertSame(1, $database->getTitlePointsUpdateCount());
+        $this->assertFalse($database->didApplyWhileCountsUnready());
+        $this->assertSame([
+            'drop-temp',
+            'create-temp',
+            'populate-owners',
             'apply-missing-temp',
+            'drop-temp',
+            'create-temp',
+            'populate-owners-failed',
+            'drop-temp-failed',
             'drop-temp',
             'create-temp',
             'populate-owners',
@@ -620,6 +658,126 @@ final class DailyCronJobTempCleanupRetryTestDatabase extends PDO
         if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->operations[] = 'title-points';
+            });
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
+final class DailyCronJobFailedRecoveryCleanupDropTestDatabase extends PDO
+{
+    /** @var list<string> */
+    private array $operations = [];
+
+    private int $populateCount = 0;
+
+    private int $applyCount = 0;
+
+    private int $titlePointsUpdateCount = 0;
+
+    private int $dropCount = 0;
+
+    private bool $countsReady = false;
+
+    private bool $appliedWhileCountsUnready = false;
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getOperations(): array
+    {
+        return $this->operations;
+    }
+
+    public function getPopulateCount(): int
+    {
+        return $this->populateCount;
+    }
+
+    public function getApplyCount(): int
+    {
+        return $this->applyCount;
+    }
+
+    public function getTitlePointsUpdateCount(): int
+    {
+        return $this->titlePointsUpdateCount;
+    }
+
+    public function didApplyWhileCountsUnready(): bool
+    {
+        return $this->appliedWhileCountsUnready;
+    }
+
+    public function exec(string $statement): int|false
+    {
+        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
+            $this->dropCount++;
+            // First recovery cleanup DROP after failed populate leaves the empty table.
+            if ($this->populateCount === 2 && $this->dropCount === 3) {
+                $this->operations[] = 'drop-temp-failed';
+                throw new RuntimeException('Simulated recovery cleanup drop failure.');
+            }
+
+            $this->operations[] = 'drop-temp';
+            $this->countsReady = false;
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
+            $this->operations[] = 'create-temp';
+            $this->countsReady = false;
+
+            return 0;
+        }
+
+        throw new RuntimeException('Unexpected exec call: ' . $statement);
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->populateCount++;
+                if ($this->populateCount === 2) {
+                    $this->operations[] = 'populate-owners-failed';
+                    $this->countsReady = false;
+                    throw new RuntimeException('Simulated recovery populate failure.');
+                }
+
+                $this->operations[] = 'populate-owners';
+                $this->countsReady = true;
+            });
+        }
+
+        if (str_contains($query, 'LEFT JOIN tmp_daily_ranked_trophy_owners owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->applyCount++;
+                if (!$this->countsReady) {
+                    $this->appliedWhileCountsUnready = true;
+                }
+
+                if ($this->applyCount === 1) {
+                    $this->operations[] = 'apply-missing-temp';
+                    throw new RuntimeException(
+                        "SQLSTATE[42S02]: Base table or view not found: 1146 Table 'psn100.tmp_daily_ranked_trophy_owners' doesn't exist"
+                    );
+                }
+
+                $this->operations[] = 'apply-rarity';
+            });
+        }
+
+        if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'title-points';
+                $this->titlePointsUpdateCount++;
             });
         }
 

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -210,6 +210,31 @@ final class DailyCronJobTest extends TestCase
         ], $database->getOperations());
     }
 
+    public function testRunContinuesToTitlePointsWhenFinalTempTableDropFails(): void
+    {
+        $database = new DailyCronJobFinalDropFailureTestDatabase();
+
+        $job = new DailyCronJob(
+            $database,
+            retryDelaySeconds: 1,
+            sleeper: static function (int $seconds): void {
+                throw new RuntimeException('Sleeper should not be called.');
+            },
+        );
+
+        $job->run();
+
+        $this->assertSame([
+            'drop-temp',
+            'create-temp',
+            'populate-owners',
+            'apply-rarity',
+            'drop-temp-failed',
+            'title-points',
+        ], $database->getOperations());
+        $this->assertSame(1, $database->getTitlePointsUpdateCount());
+    }
+
     private function readClassSource(): string
     {
         $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/DailyCronJob.php');
@@ -522,6 +547,81 @@ final class DailyCronJobTempCleanupRetryTestDatabase extends PDO
         if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->operations[] = 'title-points';
+            });
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
+final class DailyCronJobFinalDropFailureTestDatabase extends PDO
+{
+    /** @var list<string> */
+    private array $operations = [];
+
+    private int $dropCount = 0;
+
+    private int $titlePointsUpdateCount = 0;
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getOperations(): array
+    {
+        return $this->operations;
+    }
+
+    public function getTitlePointsUpdateCount(): int
+    {
+        return $this->titlePointsUpdateCount;
+    }
+
+    public function exec(string $statement): int|false
+    {
+        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
+            $this->dropCount++;
+            if ($this->dropCount === 1) {
+                // Initial prepare cleanup before create.
+                $this->operations[] = 'drop-temp';
+
+                return 0;
+            }
+
+            $this->operations[] = 'drop-temp-failed';
+            throw new RuntimeException('Simulated final temp table drop failure.');
+        }
+
+        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
+            $this->operations[] = 'create-temp';
+
+            return 0;
+        }
+
+        throw new RuntimeException('Unexpected exec call: ' . $statement);
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'populate-owners';
+            });
+        }
+
+        if (str_contains($query, 'LEFT JOIN tmp_daily_ranked_trophy_owners owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'apply-rarity';
+            });
+        }
+
+        if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'title-points';
+                $this->titlePointsUpdateCount++;
             });
         }
 

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -141,7 +141,12 @@ final readonly class DailyCronJob implements CronJobInterface
             $this->executeWithRetry([$this, 'prepareAndPopulateRankedOwnerCounts']);
             $this->executeWithRetry([$this, 'applyTrophyRarityFromTemporaryTable']);
         } finally {
-            $this->dropRankedOwnerTempTable();
+            // Best-effort: a transient DROP failure must not abort run() before
+            // title rarity points. The table is TEMPORARY/session-scoped anyway.
+            try {
+                $this->dropRankedOwnerTempTable();
+            } catch (Throwable) {
+            }
         }
     }
 

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -136,17 +136,19 @@ final readonly class DailyCronJob implements CronJobInterface
     private function recalculateTrophyRarity(): void
     {
         try {
-            $this->executeWithRetry([$this, 'rebuildRankedOwnerCountsAndApplyRarity']);
+            // Populate and apply retry independently so a trophy_meta lock/timeout
+            // does not force another full scan of top-10k trophy_earned rows.
+            $this->executeWithRetry([$this, 'prepareAndPopulateRankedOwnerCounts']);
+            $this->executeWithRetry([$this, 'applyTrophyRarityFromTemporaryTable']);
         } finally {
             $this->dropRankedOwnerTempTable();
         }
     }
 
-    private function rebuildRankedOwnerCountsAndApplyRarity(): void
+    private function prepareAndPopulateRankedOwnerCounts(): void
     {
         $this->prepareRankedOwnerTempTable();
         $this->populateRankedOwnerCounts();
-        $this->applyTrophyRarityFromTemporaryTable();
     }
 
     private function prepareRankedOwnerTempTable(): void

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -192,9 +192,18 @@ final readonly class DailyCronJob implements CronJobInterface
                 throw $exception;
             }
 
-            $this->prepareAndPopulateRankedOwnerCounts();
-            $this->applyTrophyRarityFromTemporaryTable();
+            // Missing-table recovery must populate+apply as one retry unit.
+            // Otherwise a failed rebuild can leave an empty temp table (if DROP
+            // cleanup also fails) and the next apply-first attempt would write
+            // zero owners / LEGENDARY-style rarities for every trophy.
+            $this->executeWithRetry([$this, 'preparePopulateAndApplyRankedOwnerRarity']);
         }
+    }
+
+    private function preparePopulateAndApplyRankedOwnerRarity(): void
+    {
+        $this->prepareAndPopulateRankedOwnerCounts();
+        $this->applyTrophyRarityFromTemporaryTable();
     }
 
     private function applyTrophyRarityFromTemporaryTable(): void

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -139,7 +139,7 @@ final readonly class DailyCronJob implements CronJobInterface
             // Populate and apply retry independently so a trophy_meta lock/timeout
             // does not force another full scan of top-10k trophy_earned rows.
             $this->executeWithRetry([$this, 'prepareAndPopulateRankedOwnerCounts']);
-            $this->executeWithRetry([$this, 'applyTrophyRarityFromTemporaryTable']);
+            $this->executeWithRetry([$this, 'applyTrophyRarityFromTemporaryTableWithRecovery']);
         } finally {
             // Best-effort: a transient DROP failure must not abort run() before
             // title rarity points. The table is TEMPORARY/session-scoped anyway.
@@ -168,10 +168,40 @@ final readonly class DailyCronJob implements CronJobInterface
         $query->execute();
     }
 
+    /**
+     * Apply rarity from the temp table, rebuilding counts if the session-scoped
+     * table disappeared (e.g. MySQL session reset after populate succeeded).
+     */
+    private function applyTrophyRarityFromTemporaryTableWithRecovery(): void
+    {
+        try {
+            $this->applyTrophyRarityFromTemporaryTable();
+        } catch (Throwable $exception) {
+            if (!$this->isMissingRankedOwnerTempTableError($exception)) {
+                throw $exception;
+            }
+
+            $this->prepareAndPopulateRankedOwnerCounts();
+            $this->applyTrophyRarityFromTemporaryTable();
+        }
+    }
+
     private function applyTrophyRarityFromTemporaryTable(): void
     {
         $query = $this->database->prepare(self::APPLY_TROPHY_RARITY_QUERY);
         $query->execute();
+    }
+
+    private function isMissingRankedOwnerTempTableError(Throwable $exception): bool
+    {
+        $message = $exception->getMessage();
+
+        return str_contains($message, 'tmp_daily_ranked_trophy_owners')
+            && (
+                str_contains($message, "doesn't exist")
+                || str_contains($message, 'does not exist')
+                || str_contains($message, 'Base table or view not found')
+            );
     }
 
     private function dropRankedOwnerTempTable(): void

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -29,12 +29,12 @@ final readonly class DailyCronJob implements CronJobInterface
      */
     private const string POPULATE_RANKED_OWNER_COUNTS_QUERY = <<<'SQL'
         INSERT INTO tmp_daily_ranked_trophy_owners (np_communication_id, order_id, trophy_owners)
-        SELECT
+        SELECT /*+ JOIN_ORDER(pr, te) */
             te.np_communication_id,
             te.order_id,
             COUNT(*)
-        FROM player_ranking pr
-        INNER JOIN trophy_earned te
+        FROM player_ranking pr FORCE INDEX (idx_pr_ranking_account)
+        STRAIGHT_JOIN trophy_earned te FORCE INDEX (idx_te_acc_comm_order_earned_date)
             ON te.account_id = pr.account_id
             AND te.earned = 1
         WHERE pr.ranking <= 10000

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -152,8 +152,19 @@ final readonly class DailyCronJob implements CronJobInterface
 
     private function prepareAndPopulateRankedOwnerCounts(): void
     {
-        $this->prepareRankedOwnerTempTable();
-        $this->populateRankedOwnerCounts();
+        try {
+            $this->prepareRankedOwnerTempTable();
+            $this->populateRankedOwnerCounts();
+        } catch (Throwable $exception) {
+            // Do not leave an empty/partial temp table behind. A later apply retry
+            // would otherwise see the table exist and write zero/stale rarities.
+            try {
+                $this->dropRankedOwnerTempTable();
+            } catch (Throwable) {
+            }
+
+            throw $exception;
+        }
     }
 
     private function prepareRankedOwnerTempTable(): void

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -6,118 +6,50 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final readonly class DailyCronJob implements CronJobInterface
 {
-    private const int RANKED_OWNER_TITLE_BATCH_SIZE = 100;
-
     private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
         sleep($seconds);
     };
 
-    /**
-     * Recalculate rarity for one title.
-     *
-     * Owners are counted by driving from player_ranking (top 10k) into
-     * trophy_earned on account_id so HASH(account_id) partition pruning applies.
-     * The aggregated derived table is materialized once per title instead of
-     * scanning trophy_earned by np_communication_id across all 256 partitions.
-     */
-    private const string UPDATE_TROPHY_RARITY_QUERY = <<<'SQL'
-        WITH title AS (
-            SELECT CAST(:np_communication_id AS CHAR(12)) AS np_communication_id
-        ),
-        ranked_owners AS (
-            SELECT
-                te.order_id,
-                COUNT(*) AS trophy_owners
-            FROM title
-            JOIN player_ranking pr ON pr.ranking <= 10000
-            INNER JOIN trophy_earned te
-                ON te.account_id = pr.account_id
-                AND te.np_communication_id = title.np_communication_id
-                AND te.earned = 1
-            GROUP BY te.order_id
-        ),
-        rarity AS (
-            SELECT
-                t.id AS trophy_id,
-                tm.status AS meta_status,
-                ttm.status AS title_status,
-                ttm.owners AS title_owners,
-                IFNULL(owners.trophy_owners, 0) AS trophy_owners,
-                (IFNULL(owners.trophy_owners, 0) / 10000.0) * 100 AS rarity_percent,
-                CASE
-                    WHEN ttm.owners = 0 THEN 0
-                    ELSE LEAST((IFNULL(owners.trophy_owners, 0) / ttm.owners) * 100, 100.0)
-                END AS in_game_rarity_percent
-            FROM title
-            JOIN trophy t ON t.np_communication_id = title.np_communication_id
-            JOIN trophy_meta tm ON tm.trophy_id = t.id
-            JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
-            LEFT JOIN ranked_owners owners ON owners.order_id = t.order_id
+    private const string CREATE_RANKED_OWNER_TEMP_TABLE_QUERY = <<<'SQL'
+        CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners (
+            np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+            order_id SMALLINT UNSIGNED NOT NULL,
+            trophy_owners INT UNSIGNED NOT NULL,
+            PRIMARY KEY (np_communication_id, order_id)
         )
-        UPDATE trophy_meta tm
-        JOIN rarity r ON tm.trophy_id = r.trophy_id
-        SET
-            tm.rarity_percent = r.rarity_percent,
-            tm.owners = r.trophy_owners,
-            tm.rarity_point = IF(
-                r.meta_status = 0 AND r.title_status = 0,
-                IF(r.rarity_percent = 0, 10000, FLOOR(1 / (r.rarity_percent / 100) - 1)),
-                0
-            ),
-            tm.rarity_name = CASE
-                WHEN r.meta_status != 0 OR r.title_status != 0 THEN 'NONE'
-                WHEN r.rarity_percent > 10 THEN 'COMMON'
-                WHEN r.rarity_percent > 2 THEN 'UNCOMMON'
-                WHEN r.rarity_percent > 0.2 THEN 'RARE'
-                WHEN r.rarity_percent > 0.02 THEN 'EPIC'
-                ELSE 'LEGENDARY'
-            END,
-            tm.in_game_rarity_percent = r.in_game_rarity_percent,
-            tm.in_game_rarity_point = IF(
-                r.meta_status = 0 AND r.title_status = 0 AND r.title_owners > 0,
-                IF(r.in_game_rarity_percent = 0, 0, FLOOR(1 / (r.in_game_rarity_percent / 100) - 1)),
-                0
-            ),
-            tm.in_game_rarity_name = CASE
-                WHEN r.meta_status != 0 OR r.title_status != 0 THEN 'NONE'
-                WHEN r.in_game_rarity_percent <= 1 THEN 'LEGENDARY'
-                WHEN r.in_game_rarity_percent <= 5 THEN 'EPIC'
-                WHEN r.in_game_rarity_percent <= 20 THEN 'RARE'
-                WHEN r.in_game_rarity_percent <= 60 THEN 'UNCOMMON'
-                ELSE 'COMMON'
-            END
         SQL;
 
+    /**
+     * Count earned trophies for the top 10k ranked players once.
+     *
+     * Driving from player_ranking into trophy_earned on account_id applies
+     * HASH(account_id) partition pruning and uses idx_te_acc_comm_order_earned_date.
+     * This replaces the previous per-title (or title-batch × 10k) probes that
+     * re-scanned the same accounts for every game and made daily cron take 10+ hours.
+     */
+    private const string POPULATE_RANKED_OWNER_COUNTS_QUERY = <<<'SQL'
+        INSERT INTO tmp_daily_ranked_trophy_owners (np_communication_id, order_id, trophy_owners)
+        SELECT
+            te.np_communication_id,
+            te.order_id,
+            COUNT(*)
+        FROM player_ranking pr
+        INNER JOIN trophy_earned te
+            ON te.account_id = pr.account_id
+            AND te.earned = 1
+        WHERE pr.ranking <= 10000
+        GROUP BY te.np_communication_id, te.order_id
+        SQL;
 
     /**
-     * Recalculate rarity for a bounded batch of titles with ranked owners.
+     * Apply rarity for every trophy from the once-built top-10k owner counts.
      *
-     * The JSON_TABLE CTE materializes the selected np_communication_id values
-     * once, then the owner aggregation stays scoped to those titles while still
-     * driving from player_ranking into trophy_earned by account_id.
+     * trophy / trophy_meta are small enough for a single UPDATE. Titles never
+     * earned by a top-10k player get zero owners via LEFT JOIN + IFNULL, matching
+     * the previous zero-owner fast path (10000 / LEGENDARY when obtainable).
      */
-    private const string UPDATE_TROPHY_RARITY_BATCH_QUERY = <<<'SQL'
-        WITH selected_titles AS (
-            SELECT np_communication_id
-            FROM JSON_TABLE(
-                :np_communication_ids,
-                '$[*]' COLUMNS (np_communication_id CHAR(12) PATH '$')
-            ) AS selected
-        ),
-        ranked_owners AS (
-            SELECT
-                te.np_communication_id,
-                te.order_id,
-                COUNT(*) AS trophy_owners
-            FROM selected_titles title
-            JOIN player_ranking pr ON pr.ranking <= 10000
-            INNER JOIN trophy_earned te
-                ON te.account_id = pr.account_id
-                AND te.np_communication_id = title.np_communication_id
-                AND te.earned = 1
-            GROUP BY te.np_communication_id, te.order_id
-        ),
-        rarity AS (
+    private const string APPLY_TROPHY_RARITY_QUERY = <<<'SQL'
+        WITH rarity AS (
             SELECT
                 t.id AS trophy_id,
                 tm.status AS meta_status,
@@ -129,11 +61,10 @@ final readonly class DailyCronJob implements CronJobInterface
                     WHEN ttm.owners = 0 THEN 0
                     ELSE LEAST((IFNULL(owners.trophy_owners, 0) / ttm.owners) * 100, 100.0)
                 END AS in_game_rarity_percent
-            FROM selected_titles title
-            JOIN trophy t ON t.np_communication_id = title.np_communication_id
+            FROM trophy t
             JOIN trophy_meta tm ON tm.trophy_id = t.id
             JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
-            LEFT JOIN ranked_owners owners
+            LEFT JOIN tmp_daily_ranked_trophy_owners owners
                 ON owners.np_communication_id = t.np_communication_id
                 AND owners.order_id = t.order_id
         )
@@ -171,27 +102,6 @@ final readonly class DailyCronJob implements CronJobInterface
             END
         SQL;
 
-    /**
-     * Titles with zero owners have zero trophy_owners in the top-10k join, so
-     * rarity_percent is always 0. Skip probing trophy_earned, but keep the same
-     * zero-percent scoring as UPDATE_TROPHY_RARITY_QUERY (10000 / LEGENDARY for
-     * obtainable trophies; in-game points stay 0 when title owners are 0).
-     */
-    private const string UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY = <<<'SQL'
-        UPDATE trophy_meta tm
-        JOIN trophy t ON t.id = tm.trophy_id
-        JOIN trophy_title_meta ttm ON ttm.np_communication_id = t.np_communication_id
-        SET
-            tm.owners = 0,
-            tm.rarity_percent = 0,
-            tm.rarity_point = IF(tm.status = 0 AND ttm.status = 0, 10000, 0),
-            tm.rarity_name = IF(tm.status = 0 AND ttm.status = 0, 'LEGENDARY', 'NONE'),
-            tm.in_game_rarity_percent = 0,
-            tm.in_game_rarity_point = 0,
-            tm.in_game_rarity_name = IF(tm.status = 0 AND ttm.status = 0, 'LEGENDARY', 'NONE')
-        WHERE t.np_communication_id = :np_communication_id
-        SQL;
-
     private const string UPDATE_TITLE_RARITY_POINTS_QUERY = <<<'SQL'
         WITH rarity AS (
             SELECT
@@ -219,94 +129,47 @@ final readonly class DailyCronJob implements CronJobInterface
     #[\Override]
     public function run(): void
     {
-        $this->recalculateTrophyRarityForGames();
+        $this->recalculateTrophyRarity();
         $this->recalculateTitleRarityPoints();
     }
 
-    private function recalculateTrophyRarityForGames(): void
+    private function recalculateTrophyRarity(): void
     {
-        $query = $this->database->prepare(
-            'SELECT np_communication_id FROM trophy_title ORDER BY id DESC'
-        );
-        $query->execute();
-        $games = $query->fetchAll(PDO::FETCH_COLUMN);
-        $rankedOwnerTitles = $this->executeWithRetry([$this, 'fetchTopTenThousandOwnerTitleLookup']);
-
-        $rankedOwnerBatch = [];
-
-        foreach ($games as $npCommunicationId) {
-            if (!is_string($npCommunicationId)) {
-                continue;
-            }
-
-            if (!isset($rankedOwnerTitles[$npCommunicationId])) {
-                if ($rankedOwnerBatch !== []) {
-                    $this->executeWithRetry([$this, 'updateTrophyRarityForGames'], $rankedOwnerBatch);
-                    $rankedOwnerBatch = [];
-                }
-
-                $this->executeWithRetry([$this, 'updateZeroOwnerTrophyRarityForGame'], $npCommunicationId);
-                continue;
-            }
-
-            $rankedOwnerBatch[] = $npCommunicationId;
-
-            if (count($rankedOwnerBatch) >= self::RANKED_OWNER_TITLE_BATCH_SIZE) {
-                $this->executeWithRetry([$this, 'updateTrophyRarityForGames'], $rankedOwnerBatch);
-                $rankedOwnerBatch = [];
-            }
-        }
-
-        if ($rankedOwnerBatch !== []) {
-            $this->executeWithRetry([$this, 'updateTrophyRarityForGames'], $rankedOwnerBatch);
+        try {
+            $this->executeWithRetry([$this, 'rebuildRankedOwnerCountsAndApplyRarity']);
+        } finally {
+            $this->dropRankedOwnerTempTable();
         }
     }
 
-    /**
-     * @return array<string, true>
-     */
-    private function fetchTopTenThousandOwnerTitleLookup(): array
+    private function rebuildRankedOwnerCountsAndApplyRarity(): void
     {
-        // Do not trust trophy_title_meta.owners alone: hourly cache can lag behind
-        // freshly scanned trophy_title_player / trophy_earned rows. Match the rarity
-        // query's top-10k definition before taking the zero-owners fast path.
-        $query = $this->database->prepare(
-            <<<'SQL'
-            SELECT DISTINCT ttp.np_communication_id
-            FROM player_ranking pr
-            JOIN trophy_title_player ttp ON ttp.account_id = pr.account_id
-            WHERE pr.ranking <= 10000
-            SQL
-        );
-        $query->execute();
-
-        $rankedOwnerTitles = [];
-        foreach ($query->fetchAll(PDO::FETCH_COLUMN) as $npCommunicationId) {
-            if (is_string($npCommunicationId)) {
-                $rankedOwnerTitles[$npCommunicationId] = true;
-            }
-        }
-
-        return $rankedOwnerTitles;
+        $this->prepareRankedOwnerTempTable();
+        $this->populateRankedOwnerCounts();
+        $this->applyTrophyRarityFromTemporaryTable();
     }
 
-    /**
-     * @param non-empty-list<string> $npCommunicationIds
-     */
-    private function updateTrophyRarityForGames(array $npCommunicationIds): void
+    private function prepareRankedOwnerTempTable(): void
     {
-        $encodedIds = json_encode(array_values($npCommunicationIds), JSON_THROW_ON_ERROR);
+        $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners');
+        $this->database->exec(self::CREATE_RANKED_OWNER_TEMP_TABLE_QUERY);
+    }
 
-        $query = $this->database->prepare(self::UPDATE_TROPHY_RARITY_BATCH_QUERY);
-        $query->bindValue(':np_communication_ids', $encodedIds, PDO::PARAM_STR);
+    private function populateRankedOwnerCounts(): void
+    {
+        $query = $this->database->prepare(self::POPULATE_RANKED_OWNER_COUNTS_QUERY);
         $query->execute();
     }
 
-    private function updateZeroOwnerTrophyRarityForGame(string $npCommunicationId): void
+    private function applyTrophyRarityFromTemporaryTable(): void
     {
-        $query = $this->database->prepare(self::UPDATE_TROPHY_RARITY_ZERO_OWNERS_QUERY);
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query = $this->database->prepare(self::APPLY_TROPHY_RARITY_QUERY);
         $query->execute();
+    }
+
+    private function dropRankedOwnerTempTable(): void
+    {
+        $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners');
     }
 
     private function recalculateTitleRarityPoints(): void


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Daily cron rarity recalculation slowed to 10+ hours after recent per-title / title-batch `trophy_earned` probes. Those paths re-scanned the same top-10k accounts once per game (or via a title×player cross join), which does not scale at ~2.7B `trophy_earned` rows.

### Fix

Rebuild rarity in two steps:

1. **One account-driven pass** over top-10k `player_ranking` → `trophy_earned` (`account_id` + `earned = 1`), aggregated into `tmp_daily_ranked_trophy_owners`
2. **One `trophy_meta` UPDATE** from that temp table (LEFT JOIN so titles with no top-10k owners still get 0% / 10000 LEGENDARY when obtainable)

Populate and apply retry independently, so a `trophy_meta` lock/timeout does not force another full top-10k scan. If apply fails because the session-scoped temp table is gone, recovery rebuilds via a nested `populate+apply` retry unit so a failed rebuild (even when cleanup DROP also fails) cannot leave an empty table for an apply-first retry.

Join order is pinned (`JOIN_ORDER` + `STRAIGHT_JOIN` + `FORCE INDEX`) because `trophy_earned` has no histograms/ANALYZE at production scale and a reversed plan would scan ~2.7B rows.

Final temp-table DROP is best-effort so a transient cleanup error cannot abort `run()` before title rarity points.

This keeps `HASH(account_id)` partition pruning and `idx_te_acc_comm_order_earned_date`, but drops complexity from **O(titles × 10k lookups)** to **one scan of top-10k players’ earned rows**.

### Intentionally removed

- Per-title rarity loop
- `JSON_TABLE` title batching (`RANKED_OWNER_TITLE_BATCH_SIZE`)
- Live `trophy_title_player` ranked-owner title lookup
- Separate zero-owner update query (covered by LEFT JOIN + IFNULL)

### Not the same as the earlier “full table” batch revert

Prior reverts blocked a single statement that joined **all** of `trophy_earned` (~2.7B rows). This change only reads rows for the 10k ranked accounts via the partition key.

### Tests

- Updated `tests/DailyCronJobTest.php` for SQL shape, retries, cleanup, missing-temp recovery, failed recovery populate, and failed cleanup DROP
- `php tests/run.php`: all 16 `DailyCronJob` tests pass; suite still has the existing unrelated failure in `PlayerScanTrophyTitleLoopTest`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aef5025c-71d0-4c0c-bba1-581643f5df88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aef5025c-71d0-4c0c-bba1-581643f5df88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

