### PR TITLE
Keep site online during daily ranked-owner rarity populate

### DIFF
--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -35,8 +35,9 @@ final class DailyCronJobTest extends TestCase
         $populate = $this->readPrivateConstant('POPULATE_RANKED_PLAYER_SNAPSHOT_QUERY');
 
         $this->assertStringContainsString('CREATE TEMPORARY TABLE tmp_daily_ranked_players', $create);
-        $this->assertStringContainsString('PRIMARY KEY (ranking)', $create);
-        $this->assertStringContainsString('KEY idx_tmp_daily_ranked_players_account (account_id)', $create);
+        $this->assertStringContainsString('PRIMARY KEY (account_id)', $create);
+        $this->assertStringContainsString('KEY idx_tmp_daily_ranked_players_ranking (ranking)', $create);
+        // RANK() ties are allowed in player_ranking; ranking must not be unique here.
         $this->assertStringContainsString('INSERT INTO tmp_daily_ranked_players (ranking, account_id)', $populate);
         $this->assertStringContainsString('FROM player_ranking pr FORCE INDEX (idx_pr_ranking_account)', $populate);
         $this->assertStringContainsString('WHERE pr.ranking <= 10000', $populate);

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -16,8 +16,14 @@ final class DailyCronJobTest extends TestCase
         $this->assertStringContainsString('STRAIGHT_JOIN trophy_earned te FORCE INDEX (idx_te_acc_comm_order_earned_date)', $source);
         $this->assertStringContainsString('te.account_id = pr.account_id', $source);
         $this->assertStringContainsString('te.earned = 1', $source);
-        $this->assertStringContainsString('WHERE pr.ranking <= 10000', $source);
+        $this->assertStringContainsString('WHERE pr.ranking BETWEEN :min_ranking AND :max_ranking', $source);
         $this->assertStringContainsString('GROUP BY te.np_communication_id, te.order_id', $source);
+        $this->assertStringContainsString('ON DUPLICATE KEY UPDATE', $source);
+        $this->assertStringContainsString(
+            'trophy_owners = trophy_owners + VALUES(trophy_owners)',
+            $source,
+        );
+        $this->assertFalse(str_contains($source, 'WHERE pr.ranking <= 10000'));
         $this->assertFalse(str_contains($source, 'LEFT JOIN trophy_earned te'));
         $this->assertFalse(str_contains($source, 'JSON_TABLE('));
         $this->assertFalse(str_contains($source, 'np_communication_id = title.np_communication_id'));
@@ -63,6 +69,8 @@ final class DailyCronJobTest extends TestCase
         $this->assertStringContainsString('prepareAndPopulateRankedOwnerCounts', $source);
         $this->assertStringContainsString('populateRankedOwnerCounts', $source);
         $this->assertStringContainsString('applyTrophyRarityFromTemporaryTable', $source);
+        $this->assertStringContainsString('RANKED_OWNER_RANKING_BATCH_SIZE', $source);
+        $this->assertStringContainsString('RANKED_OWNER_BATCH_DELAY_SECONDS', $source);
         $this->assertFalse(str_contains($source, 'SELECT np_communication_id FROM trophy_title'));
         $this->assertFalse(str_contains($source, 'JSON_TABLE('));
         $this->assertFalse(str_contains($source, 'RANKED_OWNER_TITLE_BATCH_SIZE'));
@@ -106,6 +114,8 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds): void {
                 throw new RuntimeException('Sleeper should not be called.');
             },
+            rankedOwnerRankingBatchSize: 10000,
+            batchDelaySeconds: 0,
         );
 
         $job->run();
@@ -113,6 +123,43 @@ final class DailyCronJobTest extends TestCase
         $this->assertSame([
             'drop-temp',
             'create-temp',
+            'populate-owners',
+            'apply-rarity',
+            'drop-temp',
+            'title-points',
+        ], $database->getOperations());
+    }
+
+    public function testPopulateRankedOwnerCountsUsesRankingBatchesAndYieldsBetweenThem(): void
+    {
+        $database = new DailyCronJobRankingBatchTestDatabase();
+        $sleepCalls = [];
+
+        $job = new DailyCronJob(
+            $database,
+            retryDelaySeconds: 1,
+            sleeper: static function (int $seconds) use (&$sleepCalls): void {
+                $sleepCalls[] = $seconds;
+            },
+            rankedOwnerRankingBatchSize: 2500,
+            batchDelaySeconds: 1,
+        );
+
+        $job->run();
+
+        $this->assertSame([
+            [1, 2500],
+            [2501, 5000],
+            [5001, 7500],
+            [7501, 10000],
+        ], $database->getRankingBatches());
+        $this->assertSame([1, 1, 1], $sleepCalls);
+        $this->assertSame([
+            'drop-temp',
+            'create-temp',
+            'populate-owners',
+            'populate-owners',
+            'populate-owners',
             'populate-owners',
             'apply-rarity',
             'drop-temp',
@@ -131,6 +178,8 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
+            rankedOwnerRankingBatchSize: 10000,
+            batchDelaySeconds: 0,
         );
 
         $job->run();
@@ -152,6 +201,8 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
+            rankedOwnerRankingBatchSize: 10000,
+            batchDelaySeconds: 0,
         );
 
         $job->run();
@@ -173,6 +224,8 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
+            rankedOwnerRankingBatchSize: 10000,
+            batchDelaySeconds: 0,
         );
 
         $job->run();
@@ -206,6 +259,8 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
+            rankedOwnerRankingBatchSize: 10000,
+            batchDelaySeconds: 0,
         );
 
         $job->run();
@@ -227,6 +282,8 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
+            rankedOwnerRankingBatchSize: 10000,
+            batchDelaySeconds: 0,
         );
 
         $job->run();
@@ -257,6 +314,8 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
+            rankedOwnerRankingBatchSize: 10000,
+            batchDelaySeconds: 0,
         );
 
         $job->run();
@@ -294,6 +353,8 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
+            rankedOwnerRankingBatchSize: 10000,
+            batchDelaySeconds: 0,
         );
 
         $job->run();
@@ -331,6 +392,8 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds): void {
                 throw new RuntimeException('Sleeper should not be called.');
             },
+            rankedOwnerRankingBatchSize: 10000,
+            batchDelaySeconds: 0,
         );
 
         $job->run();
@@ -405,6 +468,79 @@ final class DailyCronJobHappyPathTestDatabase extends PDO
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->operations[] = 'populate-owners';
+            });
+        }
+
+        if (str_contains($query, 'LEFT JOIN tmp_daily_ranked_trophy_owners owners')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'apply-rarity';
+            });
+        }
+
+        if (str_contains($query, 'ttm.rarity_points = r.rarity_sum')) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'title-points';
+            });
+        }
+
+        throw new RuntimeException('Unexpected prepare call: ' . $query);
+    }
+}
+
+final class DailyCronJobRankingBatchTestDatabase extends PDO
+{
+    /** @var list<string> */
+    private array $operations = [];
+
+    /** @var list<array{0: int, 1: int}> */
+    private array $rankingBatches = [];
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getOperations(): array
+    {
+        return $this->operations;
+    }
+
+    /**
+     * @return list<array{0: int, 1: int}>
+     */
+    public function getRankingBatches(): array
+    {
+        return $this->rankingBatches;
+    }
+
+    public function exec(string $statement): int|false
+    {
+        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
+            $this->operations[] = 'drop-temp';
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
+            $this->operations[] = 'create-temp';
+
+            return 0;
+        }
+
+        throw new RuntimeException('Unexpected exec call: ' . $statement);
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
+            return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
+                $this->operations[] = 'populate-owners';
+                $this->rankingBatches[] = [
+                    (int) $boundValues[':min_ranking'],
+                    (int) $boundValues[':max_ranking'],
+                ];
             });
         }
 

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -7,26 +7,39 @@ require_once __DIR__ . '/../wwwroot/classes/Cron/DailyCronJob.php';
 
 final class DailyCronJobTest extends TestCase
 {
-    public function testPopulateQueryDrivesTrophyEarnedByAccountIdForPartitionPruning(): void
+    public function testPopulateQueryDrivesTrophyEarnedFromFrozenRankingSnapshot(): void
     {
         $source = $this->readPrivateConstant('POPULATE_RANKED_OWNER_COUNTS_QUERY');
 
-        $this->assertStringContainsString('SELECT /*+ JOIN_ORDER(pr, te) */', $source);
-        $this->assertStringContainsString('FROM player_ranking pr FORCE INDEX (idx_pr_ranking_account)', $source);
+        $this->assertStringContainsString('SELECT /*+ JOIN_ORDER(rp, te) */', $source);
+        $this->assertStringContainsString('FROM tmp_daily_ranked_players rp', $source);
         $this->assertStringContainsString('STRAIGHT_JOIN trophy_earned te FORCE INDEX (idx_te_acc_comm_order_earned_date)', $source);
-        $this->assertStringContainsString('te.account_id = pr.account_id', $source);
+        $this->assertStringContainsString('te.account_id = rp.account_id', $source);
         $this->assertStringContainsString('te.earned = 1', $source);
-        $this->assertStringContainsString('WHERE pr.ranking BETWEEN :min_ranking AND :max_ranking', $source);
+        $this->assertStringContainsString('WHERE rp.ranking BETWEEN :min_ranking AND :max_ranking', $source);
         $this->assertStringContainsString('GROUP BY te.np_communication_id, te.order_id', $source);
         $this->assertStringContainsString('ON DUPLICATE KEY UPDATE', $source);
         $this->assertStringContainsString(
             'trophy_owners = trophy_owners + VALUES(trophy_owners)',
             $source,
         );
-        $this->assertFalse(str_contains($source, 'WHERE pr.ranking <= 10000'));
+        $this->assertFalse(str_contains($source, 'player_ranking'));
         $this->assertFalse(str_contains($source, 'LEFT JOIN trophy_earned te'));
         $this->assertFalse(str_contains($source, 'JSON_TABLE('));
         $this->assertFalse(str_contains($source, 'np_communication_id = title.np_communication_id'));
+    }
+
+    public function testRankedPlayerSnapshotFreezesTopTenThousandFromPlayerRanking(): void
+    {
+        $create = $this->readPrivateConstant('CREATE_RANKED_PLAYER_SNAPSHOT_QUERY');
+        $populate = $this->readPrivateConstant('POPULATE_RANKED_PLAYER_SNAPSHOT_QUERY');
+
+        $this->assertStringContainsString('CREATE TEMPORARY TABLE tmp_daily_ranked_players', $create);
+        $this->assertStringContainsString('PRIMARY KEY (ranking)', $create);
+        $this->assertStringContainsString('KEY idx_tmp_daily_ranked_players_account (account_id)', $create);
+        $this->assertStringContainsString('INSERT INTO tmp_daily_ranked_players (ranking, account_id)', $populate);
+        $this->assertStringContainsString('FROM player_ranking pr FORCE INDEX (idx_pr_ranking_account)', $populate);
+        $this->assertStringContainsString('WHERE pr.ranking <= 10000', $populate);
     }
 
     public function testApplyTrophyRarityQueryUsesTempTableOwnerCountsAndTopTenThousandDenominator(): void
@@ -67,10 +80,12 @@ final class DailyCronJobTest extends TestCase
         $source = $this->readClassSource();
 
         $this->assertStringContainsString('prepareAndPopulateRankedOwnerCounts', $source);
+        $this->assertStringContainsString('prepareRankedOwnerTempTables', $source);
         $this->assertStringContainsString('populateRankedOwnerCounts', $source);
         $this->assertStringContainsString('applyTrophyRarityFromTemporaryTable', $source);
         $this->assertStringContainsString('RANKED_OWNER_RANKING_BATCH_SIZE', $source);
         $this->assertStringContainsString('RANKED_OWNER_BATCH_DELAY_SECONDS', $source);
+        $this->assertStringContainsString('tmp_daily_ranked_players', $source);
         $this->assertFalse(str_contains($source, 'SELECT np_communication_id FROM trophy_title'));
         $this->assertFalse(str_contains($source, 'JSON_TABLE('));
         $this->assertFalse(str_contains($source, 'RANKED_OWNER_TITLE_BATCH_SIZE'));
@@ -121,11 +136,15 @@ final class DailyCronJobTest extends TestCase
         $job->run();
 
         $this->assertSame([
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners',
             'apply-rarity',
-            'drop-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
             'title-points',
         ], $database->getOperations());
     }
@@ -155,14 +174,18 @@ final class DailyCronJobTest extends TestCase
         ], $database->getRankingBatches());
         $this->assertSame([1, 1, 1], $sleepCalls);
         $this->assertSame([
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners',
             'populate-owners',
             'populate-owners',
             'populate-owners',
             'apply-rarity',
-            'drop-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
             'title-points',
         ], $database->getOperations());
     }
@@ -235,15 +258,22 @@ final class DailyCronJobTest extends TestCase
         $this->assertSame(2, $database->getApplyCount());
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
         $this->assertSame([
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners',
             'apply-missing-temp',
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners',
             'apply-rarity',
-            'drop-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
             'title-points',
         ], $database->getOperations());
     }
@@ -290,15 +320,23 @@ final class DailyCronJobTest extends TestCase
 
         $this->assertSame([1], $sleepCalls);
         $this->assertSame([
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners',
-            'drop-temp',
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners',
             'apply-rarity',
-            'drop-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
             'title-points',
         ], $database->getOperations());
     }
@@ -325,19 +363,30 @@ final class DailyCronJobTest extends TestCase
         $this->assertSame(2, $database->getApplyCount());
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
         $this->assertSame([
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners',
             'apply-missing-temp',
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners-failed',
-            'drop-temp',
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners',
             'apply-rarity',
-            'drop-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
             'title-points',
         ], $database->getOperations());
     }
@@ -365,19 +414,29 @@ final class DailyCronJobTest extends TestCase
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
         $this->assertFalse($database->didApplyWhileCountsUnready());
         $this->assertSame([
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners',
             'apply-missing-temp',
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners-failed',
-            'drop-temp-failed',
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp-failed',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners',
             'apply-rarity',
-            'drop-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
             'title-points',
         ], $database->getOperations());
     }
@@ -399,11 +458,14 @@ final class DailyCronJobTest extends TestCase
         $job->run();
 
         $this->assertSame([
-            'drop-temp',
-            'create-temp',
+            'drop-owners-temp',
+            'drop-players-temp',
+            'create-players-temp',
+            'create-owners-temp',
+            'snapshot-players',
             'populate-owners',
             'apply-rarity',
-            'drop-temp-failed',
+            'drop-owners-temp-failed',
             'title-points',
         ], $database->getOperations());
         $this->assertSame(1, $database->getTitlePointsUpdateCount());
@@ -429,6 +491,46 @@ final class DailyCronJobTest extends TestCase
     }
 }
 
+final class DailyCronJobTempTableTestSupport
+{
+    /**
+     * @param list<string> $operations
+     */
+    public static function recordExec(array &$operations, string $statement): ?int
+    {
+        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
+            $operations[] = 'drop-owners-temp';
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_players')) {
+            $operations[] = 'drop-players-temp';
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_players')) {
+            $operations[] = 'create-players-temp';
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
+            $operations[] = 'create-owners-temp';
+
+            return 0;
+        }
+
+        return null;
+    }
+
+    public static function isSnapshotPopulateQuery(string $query): bool
+    {
+        return str_contains($query, 'INSERT INTO tmp_daily_ranked_players');
+    }
+}
+
 final class DailyCronJobHappyPathTestDatabase extends PDO
 {
     /** @var list<string> */
@@ -448,16 +550,9 @@ final class DailyCronJobHappyPathTestDatabase extends PDO
 
     public function exec(string $statement): int|false
     {
-        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
-            $this->operations[] = 'drop-temp';
-
-            return 0;
-        }
-
-        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
-            $this->operations[] = 'create-temp';
-
-            return 0;
+        $result = DailyCronJobTempTableTestSupport::recordExec($this->operations, $statement);
+        if ($result !== null) {
+            return $result;
         }
 
         throw new RuntimeException('Unexpected exec call: ' . $statement);
@@ -465,6 +560,12 @@ final class DailyCronJobHappyPathTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (DailyCronJobTempTableTestSupport::isSnapshotPopulateQuery($query)) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'snapshot-players';
+            });
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->operations[] = 'populate-owners';
@@ -517,16 +618,9 @@ final class DailyCronJobRankingBatchTestDatabase extends PDO
 
     public function exec(string $statement): int|false
     {
-        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
-            $this->operations[] = 'drop-temp';
-
-            return 0;
-        }
-
-        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
-            $this->operations[] = 'create-temp';
-
-            return 0;
+        $result = DailyCronJobTempTableTestSupport::recordExec($this->operations, $statement);
+        if ($result !== null) {
+            return $result;
         }
 
         throw new RuntimeException('Unexpected exec call: ' . $statement);
@@ -534,6 +628,12 @@ final class DailyCronJobRankingBatchTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (DailyCronJobTempTableTestSupport::isSnapshotPopulateQuery($query)) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'snapshot-players';
+            });
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
                 $this->operations[] = 'populate-owners';
@@ -594,6 +694,11 @@ final class DailyCronJobRarityRetryTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (DailyCronJobTempTableTestSupport::isSnapshotPopulateQuery($query)) {
+            return new DailyCronJobTestStatement(static function (): void {
+            });
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->populateCount++;
@@ -653,6 +758,11 @@ final class DailyCronJobApplyRetryTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (DailyCronJobTempTableTestSupport::isSnapshotPopulateQuery($query)) {
+            return new DailyCronJobTestStatement(static function (): void {
+            });
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->populateCount++;
@@ -712,6 +822,11 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (DailyCronJobTempTableTestSupport::isSnapshotPopulateQuery($query)) {
+            return new DailyCronJobTestStatement(static function (): void {
+            });
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->populateCount++;
@@ -758,16 +873,9 @@ final class DailyCronJobTempCleanupRetryTestDatabase extends PDO
 
     public function exec(string $statement): int|false
     {
-        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
-            $this->operations[] = 'drop-temp';
-
-            return 0;
-        }
-
-        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
-            $this->operations[] = 'create-temp';
-
-            return 0;
+        $result = DailyCronJobTempTableTestSupport::recordExec($this->operations, $statement);
+        if ($result !== null) {
+            return $result;
         }
 
         throw new RuntimeException('Unexpected exec call: ' . $statement);
@@ -775,6 +883,12 @@ final class DailyCronJobTempCleanupRetryTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (DailyCronJobTempTableTestSupport::isSnapshotPopulateQuery($query)) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'snapshot-players';
+            });
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->populateCount++;
@@ -856,18 +970,31 @@ final class DailyCronJobFailedRecoveryCleanupDropTestDatabase extends PDO
             $this->dropCount++;
             // First recovery cleanup DROP after failed populate leaves the empty table.
             if ($this->populateCount === 2 && $this->dropCount === 3) {
-                $this->operations[] = 'drop-temp-failed';
+                $this->operations[] = 'drop-owners-temp-failed';
                 throw new RuntimeException('Simulated recovery cleanup drop failure.');
             }
 
-            $this->operations[] = 'drop-temp';
+            $this->operations[] = 'drop-owners-temp';
+            $this->countsReady = false;
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_players')) {
+            $this->operations[] = 'drop-players-temp';
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_players')) {
+            $this->operations[] = 'create-players-temp';
             $this->countsReady = false;
 
             return 0;
         }
 
         if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
-            $this->operations[] = 'create-temp';
+            $this->operations[] = 'create-owners-temp';
             $this->countsReady = false;
 
             return 0;
@@ -878,6 +1005,12 @@ final class DailyCronJobFailedRecoveryCleanupDropTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (DailyCronJobTempTableTestSupport::isSnapshotPopulateQuery($query)) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'snapshot-players';
+            });
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->populateCount++;
@@ -961,16 +1094,9 @@ final class DailyCronJobFailedRecoveryPopulateTestDatabase extends PDO
 
     public function exec(string $statement): int|false
     {
-        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
-            $this->operations[] = 'drop-temp';
-
-            return 0;
-        }
-
-        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
-            $this->operations[] = 'create-temp';
-
-            return 0;
+        $result = DailyCronJobTempTableTestSupport::recordExec($this->operations, $statement);
+        if ($result !== null) {
+            return $result;
         }
 
         throw new RuntimeException('Unexpected exec call: ' . $statement);
@@ -978,6 +1104,12 @@ final class DailyCronJobFailedRecoveryPopulateTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (DailyCronJobTempTableTestSupport::isSnapshotPopulateQuery($query)) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'snapshot-players';
+            });
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->populateCount++;
@@ -1056,16 +1188,9 @@ final class DailyCronJobMissingTempTableRecoveryTestDatabase extends PDO
 
     public function exec(string $statement): int|false
     {
-        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
-            $this->operations[] = 'drop-temp';
-
-            return 0;
-        }
-
-        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
-            $this->operations[] = 'create-temp';
-
-            return 0;
+        $result = DailyCronJobTempTableTestSupport::recordExec($this->operations, $statement);
+        if ($result !== null) {
+            return $result;
         }
 
         throw new RuntimeException('Unexpected exec call: ' . $statement);
@@ -1073,6 +1198,12 @@ final class DailyCronJobMissingTempTableRecoveryTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (DailyCronJobTempTableTestSupport::isSnapshotPopulateQuery($query)) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'snapshot-players';
+            });
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->populateCount++;
@@ -1110,7 +1241,7 @@ final class DailyCronJobFinalDropFailureTestDatabase extends PDO
     /** @var list<string> */
     private array $operations = [];
 
-    private int $dropCount = 0;
+    private int $ownersDropCount = 0;
 
     private int $titlePointsUpdateCount = 0;
 
@@ -1134,20 +1265,32 @@ final class DailyCronJobFinalDropFailureTestDatabase extends PDO
     public function exec(string $statement): int|false
     {
         if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners')) {
-            $this->dropCount++;
-            if ($this->dropCount === 1) {
+            $this->ownersDropCount++;
+            if ($this->ownersDropCount === 1) {
                 // Initial prepare cleanup before create.
-                $this->operations[] = 'drop-temp';
+                $this->operations[] = 'drop-owners-temp';
 
                 return 0;
             }
 
-            $this->operations[] = 'drop-temp-failed';
+            $this->operations[] = 'drop-owners-temp-failed';
             throw new RuntimeException('Simulated final temp table drop failure.');
         }
 
+        if (str_contains($statement, 'DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_players')) {
+            $this->operations[] = 'drop-players-temp';
+
+            return 0;
+        }
+
+        if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_players')) {
+            $this->operations[] = 'create-players-temp';
+
+            return 0;
+        }
+
         if (str_contains($statement, 'CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners')) {
-            $this->operations[] = 'create-temp';
+            $this->operations[] = 'create-owners-temp';
 
             return 0;
         }
@@ -1157,6 +1300,12 @@ final class DailyCronJobFinalDropFailureTestDatabase extends PDO
 
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (DailyCronJobTempTableTestSupport::isSnapshotPopulateQuery($query)) {
+            return new DailyCronJobTestStatement(function (): void {
+                $this->operations[] = 'snapshot-players';
+            });
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->operations[] = 'populate-owners';

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -16,7 +16,7 @@ final class DailyCronJobTest extends TestCase
         $this->assertStringContainsString('STRAIGHT_JOIN trophy_earned te FORCE INDEX (idx_te_acc_comm_order_earned_date)', $source);
         $this->assertStringContainsString('te.account_id = rp.account_id', $source);
         $this->assertStringContainsString('te.earned = 1', $source);
-        $this->assertStringContainsString('WHERE rp.ranking BETWEEN :min_ranking AND :max_ranking', $source);
+        $this->assertStringContainsString('WHERE rp.batch_position BETWEEN :min_position AND :max_position', $source);
         $this->assertStringContainsString('GROUP BY te.np_communication_id, te.order_id', $source);
         $this->assertStringContainsString('ON DUPLICATE KEY UPDATE', $source);
         $this->assertStringContainsString(
@@ -24,6 +24,7 @@ final class DailyCronJobTest extends TestCase
             $source,
         );
         $this->assertFalse(str_contains($source, 'player_ranking'));
+        $this->assertFalse(str_contains($source, 'rp.ranking BETWEEN'));
         $this->assertFalse(str_contains($source, 'LEFT JOIN trophy_earned te'));
         $this->assertFalse(str_contains($source, 'JSON_TABLE('));
         $this->assertFalse(str_contains($source, 'np_communication_id = title.np_communication_id'));
@@ -35,10 +36,17 @@ final class DailyCronJobTest extends TestCase
         $populate = $this->readPrivateConstant('POPULATE_RANKED_PLAYER_SNAPSHOT_QUERY');
 
         $this->assertStringContainsString('CREATE TEMPORARY TABLE tmp_daily_ranked_players', $create);
-        $this->assertStringContainsString('PRIMARY KEY (account_id)', $create);
-        $this->assertStringContainsString('KEY idx_tmp_daily_ranked_players_ranking (ranking)', $create);
-        // RANK() ties are allowed in player_ranking; ranking must not be unique here.
-        $this->assertStringContainsString('INSERT INTO tmp_daily_ranked_players (ranking, account_id)', $populate);
+        $this->assertStringContainsString('PRIMARY KEY (batch_position)', $create);
+        $this->assertStringContainsString('UNIQUE KEY u_tmp_daily_ranked_players_account (account_id)', $create);
+        // RANK() ties are allowed in player_ranking; batch by dense row numbers instead.
+        $this->assertStringContainsString(
+            'INSERT INTO tmp_daily_ranked_players (batch_position, ranking, account_id)',
+            $populate,
+        );
+        $this->assertStringContainsString(
+            'ROW_NUMBER() OVER (ORDER BY pr.ranking, pr.account_id) AS batch_position',
+            $populate,
+        );
         $this->assertStringContainsString('FROM player_ranking pr FORCE INDEX (idx_pr_ranking_account)', $populate);
         $this->assertStringContainsString('WHERE pr.ranking <= 10000', $populate);
     }
@@ -84,12 +92,14 @@ final class DailyCronJobTest extends TestCase
         $this->assertStringContainsString('prepareRankedOwnerTempTables', $source);
         $this->assertStringContainsString('populateRankedOwnerCounts', $source);
         $this->assertStringContainsString('applyTrophyRarityFromTemporaryTable', $source);
-        $this->assertStringContainsString('RANKED_OWNER_RANKING_BATCH_SIZE', $source);
+        $this->assertStringContainsString('RANKED_OWNER_SNAPSHOT_BATCH_SIZE', $source);
         $this->assertStringContainsString('RANKED_OWNER_BATCH_DELAY_SECONDS', $source);
         $this->assertStringContainsString('tmp_daily_ranked_players', $source);
+        $this->assertStringContainsString('countRankedPlayerSnapshot', $source);
         $this->assertFalse(str_contains($source, 'SELECT np_communication_id FROM trophy_title'));
         $this->assertFalse(str_contains($source, 'JSON_TABLE('));
         $this->assertFalse(str_contains($source, 'RANKED_OWNER_TITLE_BATCH_SIZE'));
+        $this->assertFalse(str_contains($source, 'RANKED_OWNER_RANKING_BATCH_SIZE'));
         $this->assertFalse(str_contains($source, 'RANKED_OWNER_ACCOUNT_BATCH_SIZE'));
         $this->assertFalse(str_contains($source, 'fetchTopTenThousandOwnerTitleLookup'));
         $this->assertFalse(str_contains($source, 'UPDATE_TROPHY_RARITY_BATCH_QUERY'));
@@ -130,7 +140,7 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds): void {
                 throw new RuntimeException('Sleeper should not be called.');
             },
-            rankedOwnerRankingBatchSize: 10000,
+            rankedOwnerSnapshotBatchSize: 10000,
             batchDelaySeconds: 0,
         );
 
@@ -142,6 +152,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners',
             'apply-rarity',
             'drop-owners-temp',
@@ -150,7 +161,7 @@ final class DailyCronJobTest extends TestCase
         ], $database->getOperations());
     }
 
-    public function testPopulateRankedOwnerCountsUsesRankingBatchesAndYieldsBetweenThem(): void
+    public function testPopulateRankedOwnerCountsUsesSnapshotRowBatchesAndYieldsBetweenThem(): void
     {
         $database = new DailyCronJobRankingBatchTestDatabase();
         $sleepCalls = [];
@@ -161,7 +172,7 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
-            rankedOwnerRankingBatchSize: 2500,
+            rankedOwnerSnapshotBatchSize: 2500,
             batchDelaySeconds: 1,
         );
 
@@ -172,7 +183,7 @@ final class DailyCronJobTest extends TestCase
             [2501, 5000],
             [5001, 7500],
             [7501, 10000],
-        ], $database->getRankingBatches());
+        ], $database->getSnapshotBatches());
         $this->assertSame([1, 1, 1], $sleepCalls);
         $this->assertSame([
             'drop-owners-temp',
@@ -180,6 +191,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners',
             'populate-owners',
             'populate-owners',
@@ -202,7 +214,7 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
-            rankedOwnerRankingBatchSize: 10000,
+            rankedOwnerSnapshotBatchSize: 10000,
             batchDelaySeconds: 0,
         );
 
@@ -225,7 +237,7 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
-            rankedOwnerRankingBatchSize: 10000,
+            rankedOwnerSnapshotBatchSize: 10000,
             batchDelaySeconds: 0,
         );
 
@@ -248,7 +260,7 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
-            rankedOwnerRankingBatchSize: 10000,
+            rankedOwnerSnapshotBatchSize: 10000,
             batchDelaySeconds: 0,
         );
 
@@ -264,6 +276,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners',
             'apply-missing-temp',
             'drop-owners-temp',
@@ -271,6 +284,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners',
             'apply-rarity',
             'drop-owners-temp',
@@ -290,7 +304,7 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
-            rankedOwnerRankingBatchSize: 10000,
+            rankedOwnerSnapshotBatchSize: 10000,
             batchDelaySeconds: 0,
         );
 
@@ -313,7 +327,7 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
-            rankedOwnerRankingBatchSize: 10000,
+            rankedOwnerSnapshotBatchSize: 10000,
             batchDelaySeconds: 0,
         );
 
@@ -326,6 +340,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners',
             'drop-owners-temp',
             'drop-players-temp',
@@ -334,6 +349,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners',
             'apply-rarity',
             'drop-owners-temp',
@@ -353,7 +369,7 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
-            rankedOwnerRankingBatchSize: 10000,
+            rankedOwnerSnapshotBatchSize: 10000,
             batchDelaySeconds: 0,
         );
 
@@ -369,6 +385,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners',
             'apply-missing-temp',
             'drop-owners-temp',
@@ -376,6 +393,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners-failed',
             'drop-owners-temp',
             'drop-players-temp',
@@ -384,6 +402,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners',
             'apply-rarity',
             'drop-owners-temp',
@@ -403,7 +422,7 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds) use (&$sleepCalls): void {
                 $sleepCalls[] = $seconds;
             },
-            rankedOwnerRankingBatchSize: 10000,
+            rankedOwnerSnapshotBatchSize: 10000,
             batchDelaySeconds: 0,
         );
 
@@ -420,6 +439,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners',
             'apply-missing-temp',
             'drop-owners-temp',
@@ -427,6 +447,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners-failed',
             'drop-owners-temp-failed',
             'drop-owners-temp',
@@ -434,6 +455,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners',
             'apply-rarity',
             'drop-owners-temp',
@@ -452,7 +474,7 @@ final class DailyCronJobTest extends TestCase
             sleeper: static function (int $seconds): void {
                 throw new RuntimeException('Sleeper should not be called.');
             },
-            rankedOwnerRankingBatchSize: 10000,
+            rankedOwnerSnapshotBatchSize: 10000,
             batchDelaySeconds: 0,
         );
 
@@ -464,6 +486,7 @@ final class DailyCronJobTest extends TestCase
             'create-players-temp',
             'create-owners-temp',
             'snapshot-players',
+            'count-snapshot',
             'populate-owners',
             'apply-rarity',
             'drop-owners-temp-failed',
@@ -530,6 +553,33 @@ final class DailyCronJobTempTableTestSupport
     {
         return str_contains($query, 'INSERT INTO tmp_daily_ranked_players');
     }
+
+    public static function isSnapshotCountQuery(string $query): bool
+    {
+        return str_contains($query, 'SELECT COUNT(*) FROM tmp_daily_ranked_players');
+    }
+
+    /**
+     * @param list<string> $operations
+     */
+    public static function createSnapshotCountStatement(array &$operations, int $count = 10000): DailyCronJobTestStatement
+    {
+        return new DailyCronJobTestStatement(
+            static function () use (&$operations): void {
+                $operations[] = 'count-snapshot';
+            },
+            fetchColumnValue: $count,
+        );
+    }
+
+    public static function createSilentSnapshotCountStatement(int $count = 10000): DailyCronJobTestStatement
+    {
+        return new DailyCronJobTestStatement(
+            static function (): void {
+            },
+            fetchColumnValue: $count,
+        );
+    }
 }
 
 final class DailyCronJobHappyPathTestDatabase extends PDO
@@ -567,6 +617,10 @@ final class DailyCronJobHappyPathTestDatabase extends PDO
             });
         }
 
+        if (DailyCronJobTempTableTestSupport::isSnapshotCountQuery($query)) {
+            return DailyCronJobTempTableTestSupport::createSnapshotCountStatement($this->operations);
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->operations[] = 'populate-owners';
@@ -595,7 +649,7 @@ final class DailyCronJobRankingBatchTestDatabase extends PDO
     private array $operations = [];
 
     /** @var list<array{0: int, 1: int}> */
-    private array $rankingBatches = [];
+    private array $snapshotBatches = [];
 
     public function __construct()
     {
@@ -612,9 +666,9 @@ final class DailyCronJobRankingBatchTestDatabase extends PDO
     /**
      * @return list<array{0: int, 1: int}>
      */
-    public function getRankingBatches(): array
+    public function getSnapshotBatches(): array
     {
-        return $this->rankingBatches;
+        return $this->snapshotBatches;
     }
 
     public function exec(string $statement): int|false
@@ -635,12 +689,16 @@ final class DailyCronJobRankingBatchTestDatabase extends PDO
             });
         }
 
+        if (DailyCronJobTempTableTestSupport::isSnapshotCountQuery($query)) {
+            return DailyCronJobTempTableTestSupport::createSnapshotCountStatement($this->operations);
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (?array $params, array $boundValues): void {
                 $this->operations[] = 'populate-owners';
-                $this->rankingBatches[] = [
-                    (int) $boundValues[':min_ranking'],
-                    (int) $boundValues[':max_ranking'],
+                $this->snapshotBatches[] = [
+                    (int) $boundValues[':min_position'],
+                    (int) $boundValues[':max_position'],
                 ];
             });
         }
@@ -698,6 +756,10 @@ final class DailyCronJobRarityRetryTestDatabase extends PDO
         if (DailyCronJobTempTableTestSupport::isSnapshotPopulateQuery($query)) {
             return new DailyCronJobTestStatement(static function (): void {
             });
+        }
+
+        if (DailyCronJobTempTableTestSupport::isSnapshotCountQuery($query)) {
+            return DailyCronJobTempTableTestSupport::createSilentSnapshotCountStatement();
         }
 
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
@@ -764,6 +826,10 @@ final class DailyCronJobApplyRetryTestDatabase extends PDO
             });
         }
 
+        if (DailyCronJobTempTableTestSupport::isSnapshotCountQuery($query)) {
+            return DailyCronJobTempTableTestSupport::createSilentSnapshotCountStatement();
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->populateCount++;
@@ -828,6 +894,10 @@ final class DailyCronJobTitleRetryTestDatabase extends PDO
             });
         }
 
+        if (DailyCronJobTempTableTestSupport::isSnapshotCountQuery($query)) {
+            return DailyCronJobTempTableTestSupport::createSilentSnapshotCountStatement();
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->populateCount++;
@@ -888,6 +958,10 @@ final class DailyCronJobTempCleanupRetryTestDatabase extends PDO
             return new DailyCronJobTestStatement(function (): void {
                 $this->operations[] = 'snapshot-players';
             });
+        }
+
+        if (DailyCronJobTempTableTestSupport::isSnapshotCountQuery($query)) {
+            return DailyCronJobTempTableTestSupport::createSnapshotCountStatement($this->operations);
         }
 
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
@@ -1012,6 +1086,10 @@ final class DailyCronJobFailedRecoveryCleanupDropTestDatabase extends PDO
             });
         }
 
+        if (DailyCronJobTempTableTestSupport::isSnapshotCountQuery($query)) {
+            return DailyCronJobTempTableTestSupport::createSnapshotCountStatement($this->operations);
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->populateCount++;
@@ -1111,6 +1189,10 @@ final class DailyCronJobFailedRecoveryPopulateTestDatabase extends PDO
             });
         }
 
+        if (DailyCronJobTempTableTestSupport::isSnapshotCountQuery($query)) {
+            return DailyCronJobTempTableTestSupport::createSnapshotCountStatement($this->operations);
+        }
+
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
             return new DailyCronJobTestStatement(function (): void {
                 $this->populateCount++;
@@ -1203,6 +1285,10 @@ final class DailyCronJobMissingTempTableRecoveryTestDatabase extends PDO
             return new DailyCronJobTestStatement(function (): void {
                 $this->operations[] = 'snapshot-players';
             });
+        }
+
+        if (DailyCronJobTempTableTestSupport::isSnapshotCountQuery($query)) {
+            return DailyCronJobTempTableTestSupport::createSnapshotCountStatement($this->operations);
         }
 
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {
@@ -1305,6 +1391,10 @@ final class DailyCronJobFinalDropFailureTestDatabase extends PDO
             return new DailyCronJobTestStatement(function (): void {
                 $this->operations[] = 'snapshot-players';
             });
+        }
+
+        if (DailyCronJobTempTableTestSupport::isSnapshotCountQuery($query)) {
+            return DailyCronJobTempTableTestSupport::createSnapshotCountStatement($this->operations);
         }
 
         if (str_contains($query, 'INSERT INTO tmp_daily_ranked_trophy_owners')) {

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -32,14 +32,17 @@ final readonly class DailyCronJob implements CronJobInterface
         CREATE TEMPORARY TABLE tmp_daily_ranked_players (
             ranking MEDIUMINT UNSIGNED NOT NULL,
             account_id BIGINT UNSIGNED NOT NULL,
-            PRIMARY KEY (ranking),
-            KEY idx_tmp_daily_ranked_players_account (account_id)
+            PRIMARY KEY (account_id),
+            KEY idx_tmp_daily_ranked_players_ranking (ranking)
         )
         SQL;
 
     /**
      * Freeze the top-10k account set once so later player_ranking swaps cannot
      * move an account into another batch window and double-count owners.
+     *
+     * account_id is the primary key because PlayerRankingUpdater uses RANK(),
+     * so tied leaderboard scores share the same ranking value.
      */
     private const string POPULATE_RANKED_PLAYER_SNAPSHOT_QUERY = <<<'SQL'
         INSERT INTO tmp_daily_ranked_players (ranking, account_id)

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -7,19 +7,20 @@ require_once __DIR__ . '/CronJobInterface.php';
 final readonly class DailyCronJob implements CronJobInterface
 {
     /**
-     * Ranking-window size for scanning trophy_earned for top-10k accounts.
+     * Account-window size for scanning trophy_earned from the frozen snapshot.
      *
-     * Each batch drives from a frozen ranking snapshot into trophy_earned by
-     * account_id so HASH(account_id) partition pruning applies. Small windows
-     * keep each aggregation bounded so daily cron cannot saturate MySQL/IO and
-     * take the public site offline (Cloudflare 525).
+     * Each batch drives a fixed number of snapshot rows into trophy_earned by
+     * account_id so HASH(account_id) partition pruning applies. Batching by
+     * synthetic batch_position (not RANK() values) keeps each statement bounded
+     * even when many players share the same ranking, so daily cron cannot
+     * saturate MySQL/IO and take the public site offline (Cloudflare 525).
      */
-    private const int RANKED_OWNER_RANKING_BATCH_SIZE = 100;
+    private const int RANKED_OWNER_SNAPSHOT_BATCH_SIZE = 100;
 
     private const int TOP_RANKED_PLAYERS = 10000;
 
     /**
-     * Pause between ranking batches so web traffic can use MySQL while daily
+     * Pause between snapshot batches so web traffic can use MySQL while daily
      * rarity recalculation is in progress.
      */
     private const int RANKED_OWNER_BATCH_DELAY_SECONDS = 1;
@@ -30,10 +31,11 @@ final readonly class DailyCronJob implements CronJobInterface
 
     private const string CREATE_RANKED_PLAYER_SNAPSHOT_QUERY = <<<'SQL'
         CREATE TEMPORARY TABLE tmp_daily_ranked_players (
+            batch_position INT UNSIGNED NOT NULL,
             ranking MEDIUMINT UNSIGNED NOT NULL,
             account_id BIGINT UNSIGNED NOT NULL,
-            PRIMARY KEY (account_id),
-            KEY idx_tmp_daily_ranked_players_ranking (ranking)
+            PRIMARY KEY (batch_position),
+            UNIQUE KEY u_tmp_daily_ranked_players_account (account_id)
         )
         SQL;
 
@@ -41,14 +43,22 @@ final readonly class DailyCronJob implements CronJobInterface
      * Freeze the top-10k account set once so later player_ranking swaps cannot
      * move an account into another batch window and double-count owners.
      *
-     * account_id is the primary key because PlayerRankingUpdater uses RANK(),
-     * so tied leaderboard scores share the same ranking value.
+     * batch_position is a dense ROW_NUMBER() so later trophy_earned scans can
+     * batch by account count. account_id stays unique because PlayerRankingUpdater
+     * uses RANK(), so tied leaderboard scores share the same ranking value.
      */
     private const string POPULATE_RANKED_PLAYER_SNAPSHOT_QUERY = <<<'SQL'
-        INSERT INTO tmp_daily_ranked_players (ranking, account_id)
-        SELECT pr.ranking, pr.account_id
+        INSERT INTO tmp_daily_ranked_players (batch_position, ranking, account_id)
+        SELECT
+            ROW_NUMBER() OVER (ORDER BY pr.ranking, pr.account_id) AS batch_position,
+            pr.ranking,
+            pr.account_id
         FROM player_ranking pr FORCE INDEX (idx_pr_ranking_account)
         WHERE pr.ranking <= 10000
+        SQL;
+
+    private const string COUNT_RANKED_PLAYER_SNAPSHOT_QUERY = <<<'SQL'
+        SELECT COUNT(*) FROM tmp_daily_ranked_players
         SQL;
 
     private const string CREATE_RANKED_OWNER_TEMP_TABLE_QUERY = <<<'SQL'
@@ -61,7 +71,7 @@ final readonly class DailyCronJob implements CronJobInterface
         SQL;
 
     /**
-     * Count earned trophies for one ranking window of the frozen top players.
+     * Count earned trophies for one account window of the frozen top players.
      *
      * Driving from tmp_daily_ranked_players into trophy_earned on account_id
      * applies HASH(account_id) partition pruning and uses
@@ -85,7 +95,7 @@ final readonly class DailyCronJob implements CronJobInterface
         STRAIGHT_JOIN trophy_earned te FORCE INDEX (idx_te_acc_comm_order_earned_date)
             ON te.account_id = rp.account_id
             AND te.earned = 1
-        WHERE rp.ranking BETWEEN :min_ranking AND :max_ranking
+        WHERE rp.batch_position BETWEEN :min_position AND :max_position
         GROUP BY te.np_communication_id, te.order_id
         ON DUPLICATE KEY UPDATE
             trophy_owners = trophy_owners + VALUES(trophy_owners)
@@ -173,7 +183,7 @@ final readonly class DailyCronJob implements CronJobInterface
         private PDO $database,
         private int $retryDelaySeconds = 3,
         private \Closure $sleeper = self::DEFAULT_SLEEPER,
-        private int $rankedOwnerRankingBatchSize = self::RANKED_OWNER_RANKING_BATCH_SIZE,
+        private int $rankedOwnerSnapshotBatchSize = self::RANKED_OWNER_SNAPSHOT_BATCH_SIZE,
         private int $batchDelaySeconds = self::RANKED_OWNER_BATCH_DELAY_SECONDS,
     ) {
     }
@@ -231,19 +241,32 @@ final readonly class DailyCronJob implements CronJobInterface
 
     private function populateRankedOwnerCounts(): void
     {
-        $batchSize = max(1, $this->rankedOwnerRankingBatchSize);
+        $totalPlayers = $this->countRankedPlayerSnapshot();
+        if ($totalPlayers === 0) {
+            return;
+        }
+
+        $batchSize = max(1, $this->rankedOwnerSnapshotBatchSize);
         $query = $this->database->prepare(self::POPULATE_RANKED_OWNER_COUNTS_QUERY);
 
-        for ($minRanking = 1; $minRanking <= self::TOP_RANKED_PLAYERS; $minRanking += $batchSize) {
-            if ($minRanking > 1 && $this->batchDelaySeconds > 0) {
+        for ($minPosition = 1; $minPosition <= $totalPlayers; $minPosition += $batchSize) {
+            if ($minPosition > 1 && $this->batchDelaySeconds > 0) {
                 ($this->sleeper)($this->batchDelaySeconds);
             }
 
-            $maxRanking = min($minRanking + $batchSize - 1, self::TOP_RANKED_PLAYERS);
-            $query->bindValue(':min_ranking', $minRanking, PDO::PARAM_INT);
-            $query->bindValue(':max_ranking', $maxRanking, PDO::PARAM_INT);
+            $maxPosition = min($minPosition + $batchSize - 1, $totalPlayers);
+            $query->bindValue(':min_position', $minPosition, PDO::PARAM_INT);
+            $query->bindValue(':max_position', $maxPosition, PDO::PARAM_INT);
             $query->execute();
         }
+    }
+
+    private function countRankedPlayerSnapshot(): int
+    {
+        $query = $this->database->prepare(self::COUNT_RANKED_PLAYER_SNAPSHOT_QUERY);
+        $query->execute();
+
+        return max(0, (int) $query->fetchColumn());
     }
 
     /**

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -9,10 +9,10 @@ final readonly class DailyCronJob implements CronJobInterface
     /**
      * Ranking-window size for scanning trophy_earned for top-10k accounts.
      *
-     * Each batch drives from player_ranking into trophy_earned by account_id so
-     * HASH(account_id) partition pruning applies. Small windows keep each
-     * aggregation bounded so daily cron cannot saturate MySQL/IO and take the
-     * public site offline (Cloudflare 525).
+     * Each batch drives from a frozen ranking snapshot into trophy_earned by
+     * account_id so HASH(account_id) partition pruning applies. Small windows
+     * keep each aggregation bounded so daily cron cannot saturate MySQL/IO and
+     * take the public site offline (Cloudflare 525).
      */
     private const int RANKED_OWNER_RANKING_BATCH_SIZE = 100;
 
@@ -28,6 +28,26 @@ final readonly class DailyCronJob implements CronJobInterface
         sleep($seconds);
     };
 
+    private const string CREATE_RANKED_PLAYER_SNAPSHOT_QUERY = <<<'SQL'
+        CREATE TEMPORARY TABLE tmp_daily_ranked_players (
+            ranking MEDIUMINT UNSIGNED NOT NULL,
+            account_id BIGINT UNSIGNED NOT NULL,
+            PRIMARY KEY (ranking),
+            KEY idx_tmp_daily_ranked_players_account (account_id)
+        )
+        SQL;
+
+    /**
+     * Freeze the top-10k account set once so later player_ranking swaps cannot
+     * move an account into another batch window and double-count owners.
+     */
+    private const string POPULATE_RANKED_PLAYER_SNAPSHOT_QUERY = <<<'SQL'
+        INSERT INTO tmp_daily_ranked_players (ranking, account_id)
+        SELECT pr.ranking, pr.account_id
+        FROM player_ranking pr FORCE INDEX (idx_pr_ranking_account)
+        WHERE pr.ranking <= 10000
+        SQL;
+
     private const string CREATE_RANKED_OWNER_TEMP_TABLE_QUERY = <<<'SQL'
         CREATE TEMPORARY TABLE tmp_daily_ranked_trophy_owners (
             np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
@@ -38,14 +58,15 @@ final readonly class DailyCronJob implements CronJobInterface
         SQL;
 
     /**
-     * Count earned trophies for one ranking window of top players.
+     * Count earned trophies for one ranking window of the frozen top players.
      *
-     * Driving from player_ranking into trophy_earned on account_id applies
-     * HASH(account_id) partition pruning and uses idx_te_acc_comm_order_earned_date.
-     * Batches accumulate into the temp table via ON DUPLICATE KEY UPDATE so the
-     * full top-10k pass never runs as one long, site-blocking statement.
-     * This replaces the previous per-title (or title-batch × 10k) probes that
-     * re-scanned the same accounts for every game and made daily cron take 10+ hours.
+     * Driving from tmp_daily_ranked_players into trophy_earned on account_id
+     * applies HASH(account_id) partition pruning and uses
+     * idx_te_acc_comm_order_earned_date. Batches accumulate into the temp table
+     * via ON DUPLICATE KEY UPDATE so the full top-10k pass never runs as one
+     * long, site-blocking statement. This replaces the previous per-title (or
+     * title-batch × 10k) probes that re-scanned the same accounts for every
+     * game and made daily cron take 10+ hours.
      */
     private const string POPULATE_RANKED_OWNER_COUNTS_QUERY = <<<'SQL'
         INSERT INTO tmp_daily_ranked_trophy_owners (
@@ -53,15 +74,15 @@ final readonly class DailyCronJob implements CronJobInterface
             order_id,
             trophy_owners
         )
-        SELECT /*+ JOIN_ORDER(pr, te) */
+        SELECT /*+ JOIN_ORDER(rp, te) */
             te.np_communication_id,
             te.order_id,
             COUNT(*)
-        FROM player_ranking pr FORCE INDEX (idx_pr_ranking_account)
+        FROM tmp_daily_ranked_players rp
         STRAIGHT_JOIN trophy_earned te FORCE INDEX (idx_te_acc_comm_order_earned_date)
-            ON te.account_id = pr.account_id
+            ON te.account_id = rp.account_id
             AND te.earned = 1
-        WHERE pr.ranking BETWEEN :min_ranking AND :max_ranking
+        WHERE rp.ranking BETWEEN :min_ranking AND :max_ranking
         GROUP BY te.np_communication_id, te.order_id
         ON DUPLICATE KEY UPDATE
             trophy_owners = trophy_owners + VALUES(trophy_owners)
@@ -170,9 +191,9 @@ final readonly class DailyCronJob implements CronJobInterface
             $this->executeWithRetry([$this, 'applyTrophyRarityFromTemporaryTableWithRecovery']);
         } finally {
             // Best-effort: a transient DROP failure must not abort run() before
-            // title rarity points. The table is TEMPORARY/session-scoped anyway.
+            // title rarity points. The tables are TEMPORARY/session-scoped anyway.
             try {
-                $this->dropRankedOwnerTempTable();
+                $this->dropRankedOwnerTempTables();
             } catch (Throwable) {
             }
         }
@@ -181,13 +202,13 @@ final readonly class DailyCronJob implements CronJobInterface
     private function prepareAndPopulateRankedOwnerCounts(): void
     {
         try {
-            $this->prepareRankedOwnerTempTable();
+            $this->prepareRankedOwnerTempTables();
             $this->populateRankedOwnerCounts();
         } catch (Throwable $exception) {
             // Do not leave an empty/partial temp table behind. A later apply retry
             // would otherwise see the table exist and write zero/stale rarities.
             try {
-                $this->dropRankedOwnerTempTable();
+                $this->dropRankedOwnerTempTables();
             } catch (Throwable) {
             }
 
@@ -195,10 +216,14 @@ final readonly class DailyCronJob implements CronJobInterface
         }
     }
 
-    private function prepareRankedOwnerTempTable(): void
+    private function prepareRankedOwnerTempTables(): void
     {
-        $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners');
+        $this->dropRankedOwnerTempTables();
+        $this->database->exec(self::CREATE_RANKED_PLAYER_SNAPSHOT_QUERY);
         $this->database->exec(self::CREATE_RANKED_OWNER_TEMP_TABLE_QUERY);
+
+        $snapshot = $this->database->prepare(self::POPULATE_RANKED_PLAYER_SNAPSHOT_QUERY);
+        $snapshot->execute();
     }
 
     private function populateRankedOwnerCounts(): void
@@ -254,8 +279,10 @@ final readonly class DailyCronJob implements CronJobInterface
     private function isMissingRankedOwnerTempTableError(Throwable $exception): bool
     {
         $message = $exception->getMessage();
+        $mentionsTempTable = str_contains($message, 'tmp_daily_ranked_trophy_owners')
+            || str_contains($message, 'tmp_daily_ranked_players');
 
-        return str_contains($message, 'tmp_daily_ranked_trophy_owners')
+        return $mentionsTempTable
             && (
                 str_contains($message, "doesn't exist")
                 || str_contains($message, 'does not exist')
@@ -263,9 +290,10 @@ final readonly class DailyCronJob implements CronJobInterface
             );
     }
 
-    private function dropRankedOwnerTempTable(): void
+    private function dropRankedOwnerTempTables(): void
     {
         $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_trophy_owners');
+        $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_daily_ranked_players');
     }
 
     private function recalculateTitleRarityPoints(): void

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -6,6 +6,24 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final readonly class DailyCronJob implements CronJobInterface
 {
+    /**
+     * Ranking-window size for scanning trophy_earned for top-10k accounts.
+     *
+     * Each batch drives from player_ranking into trophy_earned by account_id so
+     * HASH(account_id) partition pruning applies. Small windows keep each
+     * aggregation bounded so daily cron cannot saturate MySQL/IO and take the
+     * public site offline (Cloudflare 525).
+     */
+    private const int RANKED_OWNER_RANKING_BATCH_SIZE = 100;
+
+    private const int TOP_RANKED_PLAYERS = 10000;
+
+    /**
+     * Pause between ranking batches so web traffic can use MySQL while daily
+     * rarity recalculation is in progress.
+     */
+    private const int RANKED_OWNER_BATCH_DELAY_SECONDS = 1;
+
     private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
         sleep($seconds);
     };
@@ -20,15 +38,21 @@ final readonly class DailyCronJob implements CronJobInterface
         SQL;
 
     /**
-     * Count earned trophies for the top 10k ranked players once.
+     * Count earned trophies for one ranking window of top players.
      *
      * Driving from player_ranking into trophy_earned on account_id applies
      * HASH(account_id) partition pruning and uses idx_te_acc_comm_order_earned_date.
+     * Batches accumulate into the temp table via ON DUPLICATE KEY UPDATE so the
+     * full top-10k pass never runs as one long, site-blocking statement.
      * This replaces the previous per-title (or title-batch × 10k) probes that
      * re-scanned the same accounts for every game and made daily cron take 10+ hours.
      */
     private const string POPULATE_RANKED_OWNER_COUNTS_QUERY = <<<'SQL'
-        INSERT INTO tmp_daily_ranked_trophy_owners (np_communication_id, order_id, trophy_owners)
+        INSERT INTO tmp_daily_ranked_trophy_owners (
+            np_communication_id,
+            order_id,
+            trophy_owners
+        )
         SELECT /*+ JOIN_ORDER(pr, te) */
             te.np_communication_id,
             te.order_id,
@@ -37,8 +61,10 @@ final readonly class DailyCronJob implements CronJobInterface
         STRAIGHT_JOIN trophy_earned te FORCE INDEX (idx_te_acc_comm_order_earned_date)
             ON te.account_id = pr.account_id
             AND te.earned = 1
-        WHERE pr.ranking <= 10000
+        WHERE pr.ranking BETWEEN :min_ranking AND :max_ranking
         GROUP BY te.np_communication_id, te.order_id
+        ON DUPLICATE KEY UPDATE
+            trophy_owners = trophy_owners + VALUES(trophy_owners)
         SQL;
 
     /**
@@ -123,6 +149,8 @@ final readonly class DailyCronJob implements CronJobInterface
         private PDO $database,
         private int $retryDelaySeconds = 3,
         private \Closure $sleeper = self::DEFAULT_SLEEPER,
+        private int $rankedOwnerRankingBatchSize = self::RANKED_OWNER_RANKING_BATCH_SIZE,
+        private int $batchDelaySeconds = self::RANKED_OWNER_BATCH_DELAY_SECONDS,
     ) {
     }
 
@@ -175,8 +203,19 @@ final readonly class DailyCronJob implements CronJobInterface
 
     private function populateRankedOwnerCounts(): void
     {
+        $batchSize = max(1, $this->rankedOwnerRankingBatchSize);
         $query = $this->database->prepare(self::POPULATE_RANKED_OWNER_COUNTS_QUERY);
-        $query->execute();
+
+        for ($minRanking = 1; $minRanking <= self::TOP_RANKED_PLAYERS; $minRanking += $batchSize) {
+            if ($minRanking > 1 && $this->batchDelaySeconds > 0) {
+                ($this->sleeper)($this->batchDelaySeconds);
+            }
+
+            $maxRanking = min($minRanking + $batchSize - 1, self::TOP_RANKED_PLAYERS);
+            $query->bindValue(':min_ranking', $minRanking, PDO::PARAM_INT);
+            $query->bindValue(':max_ranking', $maxRanking, PDO::PARAM_INT);
+            $query->execute();
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The one-pass `POPULATE_RANKED_OWNER_COUNTS_QUERY` joined all top-10k `player_ranking` accounts into `trophy_earned` in a single statement. That saturated MySQL/IO hard enough for the origin to become unreachable (Cloudflare **525 SSL handshake failed**), which is unacceptable while daily cron runs.

## Fix
- Snapshot the top-10k into session-scoped `tmp_daily_ranked_players` once at prepare time
- Assign dense `batch_position` with `ROW_NUMBER()`; unique key on `account_id` (ties from `RANK()` are allowed)
- Populate owner counts in **fixed account windows of 100** via `batch_position BETWEEN`, not ranking-value windows
- Keep the account-driven plan (`JOIN_ORDER` / `STRAIGHT_JOIN` / `FORCE INDEX`) so `HASH(account_id)` partition pruning still applies
- Accumulate batch counts with `ON DUPLICATE KEY UPDATE trophy_owners = trophy_owners + VALUES(trophy_owners)`
- **Sleep 1s between batches** so web requests can use MySQL while daily rarity recalculation runs
- On failure, existing retry still drops/recreates the temp tables and restarts the full populate

## Review fixes
- Snapshot freezes the top-10k set so mid-run `player_ranking` swaps cannot double-count owners across batches
- Snapshot allows tied rankings (`account_id` uniqueness, not `ranking`)
- Batch by snapshot row position so a large `RANK()` tie cannot collapse into one site-blocking statement

## Tests
- Updated `DailyCronJobTest` for snapshot + row-position batches + ODKU
- Added coverage for batch yields and snapshot freeze
- Existing retry/recovery tests kept single-batch via constructor overrides
- Full suite: all `DailyCronJobTest` cases pass; one unrelated pre-existing failure remains (`PlayerScanTrophyTitleLoopTest`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d606777-f734-4663-835a-4d75c3cbb93d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d606777-f734-4663-835a-4d75c3cbb93d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

