### PR TITLE
Reduce MySQL lock wait timeout scan retry to 5 seconds

### DIFF
--- a/tests/ThirtyMinuteCronJobWorkerValidationTest.php
+++ b/tests/ThirtyMinuteCronJobWorkerValidationTest.php
@@ -100,8 +100,38 @@ final class ThirtyMinuteCronJobWorkerValidationTest extends TestCase
             $source
         );
         $this->assertStringContainsString(
-            'Encountered a problem while scanning %s: %s. Waiting 1 minute before retrying.',
+            'Encountered a problem while scanning %s: %s. Waiting %s before retrying.',
             $source
         );
+        $this->assertStringContainsString('isLockWaitTimeoutException', $source);
+        $this->assertStringContainsString('$waitSeconds = $isLockWaitTimeout ? 5 : 60', $source);
+        $this->assertStringContainsString("=== 1205", $source);
+    }
+
+    public function testIsLockWaitTimeoutExceptionDetectsMysqlError1205(): void
+    {
+        $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'isLockWaitTimeoutException');
+        $method->setAccessible(true);
+
+        $database = new PDO('sqlite::memory:');
+        $cronJob = new ThirtyMinuteCronJob(
+            $database,
+            new TrophyCalculator($database),
+            new Psn100Logger($database),
+            new TrophyHistoryRecorder($database, new Psn100Logger($database)),
+            1
+        );
+
+        $lockWaitTimeout = new PDOException(
+            'SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded; try restarting transaction'
+        );
+        $lockWaitTimeout->errorInfo = ['HY000', 1205, 'Lock wait timeout exceeded; try restarting transaction'];
+
+        $this->assertTrue($method->invoke($cronJob, $lockWaitTimeout));
+        $this->assertTrue($method->invoke(
+            $cronJob,
+            new RuntimeException('SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded; try restarting transaction')
+        ));
+        $this->assertFalse($method->invoke($cronJob, new RuntimeException('cURL error 18')));
     }
 }

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -279,16 +279,25 @@ final readonly class ThirtyMinuteCronJob implements CronJobInterface
             } catch (Exception $exception) {
                 // Transient PSN/network failures (e.g. Guzzle/cURL transfer errors) should
                 // back off and keep the worker alive instead of terminating the cron job.
+                // Lock wait timeouts usually clear quickly, so retry sooner than other errors.
+                $isLockWaitTimeout = $this->isLockWaitTimeoutException($exception);
+                $waitSeconds = $isLockWaitTimeout ? 5 : 60;
+                $waitDescription = $isLockWaitTimeout ? '5 seconds' : '1 minute';
+
                 $this->logger->log(sprintf(
-                    'Encountered a problem while scanning %s: %s. Waiting 1 minute before retrying.',
+                    'Encountered a problem while scanning %s: %s. Waiting %s before retrying.',
                     $onlineId,
-                    $exception->getMessage()
+                    $exception->getMessage(),
+                    $waitDescription
                 ));
                 $this->workerScanCoordinator->setWaitingScanProgress(
                     (int) $worker['id'],
-                    'Encountered a problem while scanning. Waiting 1 minute before retrying.'
+                    sprintf(
+                        'Encountered a problem while scanning. Waiting %s before retrying.',
+                        $waitDescription
+                    )
                 );
-                sleep(60 * 1);
+                sleep($waitSeconds);
                 $recheck = '';
                 unset($missingGameDeletionCheck[$onlineId]);
                 unset($missingTrophyTitleRetry[$onlineId]);
@@ -300,5 +309,14 @@ final readonly class ThirtyMinuteCronJob implements CronJobInterface
                 $this->workerScanCoordinator->setWorkerScanProgress((int) $worker['id'], null);
             }
         }
+    }
+
+    private function isLockWaitTimeoutException(Throwable $exception): bool
+    {
+        if ($exception instanceof PDOException && (($exception->errorInfo[1] ?? null) === 1205)) {
+            return true;
+        }
+
+        return str_contains($exception->getMessage(), 'Lock wait timeout exceeded');
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
When a player scan hits MySQL `SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded`, the 30-minute cron worker currently waits a full minute before retrying. That error usually clears quickly, so this shortens the backoff to **5 seconds** for lock wait timeouts only.

Other transient scan failures still use the existing 1-minute wait.

## Changes
- In `ThirtyMinuteCronJob`, detect lock wait timeouts via PDO error `1205` or the `"Lock wait timeout exceeded"` message.
- Use a 5-second sleep and matching log/progress text for those errors; keep 60 seconds otherwise.
- Extend `ThirtyMinuteCronJobWorkerValidationTest` to cover the detection helper and updated retry messaging.

## Testing
- `php tests/run.php` — new/updated `ThirtyMinuteCronJobWorkerValidationTest` cases pass.
- One pre-existing failure remains on `master`: `PlayerScanTrophyTitleLoopTest::testProcessAccessibleTrophyTitlesRetriesTransientFetchExceptions` (unrelated to this change).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5c0a107-4de1-489b-82cf-6ecd886191a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5c0a107-4de1-489b-82cf-6ecd886191a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

