### PR TITLE
Handle Guzzle null-response TypeError during trophy summary fetch

### DIFF
--- a/tests/PlayerScanTrophyTitleLoopTest.php
+++ b/tests/PlayerScanTrophyTitleLoopTest.php
@@ -211,6 +211,89 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
         $this->assertSame([], $trophyTitleCountRetry);
         $this->assertSame([], $invalidTitleDateRetry);
     }
+
+    public function testProcessAccessibleTrophyTitlesRetriesTrophySummaryTypeErrorAtStart(): void
+    {
+        $recheck = 'ExampleUser';
+        $missingGameDeletionCheck = ['ExampleUser' => true];
+        $missingTrophyTitleRetry = ['ExampleUser' => true];
+        $trophyTitleCountRetry = ['ExampleUser' => true];
+        $invalidTitleDateRetry = ['ExampleUser:NPWR12345_00' => true];
+
+        $result = $this->trophyTitleLoop->processAccessibleTrophyTitles(
+            new stdClass(),
+            new PlayerScanTrophyTitleLoopTestUserThatThrowsOnTrophySummary(
+                new TypeError(
+                    'GuzzleHttp\Middleware::{closure}(): Argument #1 ($response) must be of type'
+                    . ' Psr\Http\Message\ResponseInterface, null given'
+                )
+            ),
+            ['online_id' => 'ExampleUser'],
+            ['id' => 1],
+            'ExampleUser',
+            $recheck,
+            $missingGameDeletionCheck,
+            $missingTrophyTitleRetry,
+            $trophyTitleCountRetry,
+            $invalidTitleDateRetry,
+        );
+
+        $this->assertTrue($result->shouldContinueLoop());
+        $this->assertSame([5], $this->sleepCalls);
+        $this->assertSame('', $recheck);
+        $this->assertSame([], $missingGameDeletionCheck);
+        $this->assertSame([], $missingTrophyTitleRetry);
+        $this->assertSame([], $trophyTitleCountRetry);
+        $this->assertSame([], $invalidTitleDateRetry);
+
+        $scanProgress = $this->database->query('SELECT scan_progress FROM setting WHERE id = 1')->fetchColumn();
+        $this->assertTrue(is_string($scanProgress));
+        $this->assertStringContainsString('trophy summary', $scanProgress);
+
+        $logMessage = $this->database->query('SELECT message FROM log ORDER BY rowid DESC LIMIT 1')->fetchColumn();
+        $this->assertStringContainsString('ResponseInterface', (string) $logMessage);
+        $this->assertStringContainsString('ExampleUser', (string) $logMessage);
+    }
+
+    public function testProcessAccessibleTrophyTitlesRetriesTrophySummaryTypeErrorAtEnd(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_title_player (account_id, np_communication_id, last_updated_date)
+             VALUES ('2498580493801829235', 'NPWR12345_00', '2024-01-01T00:00:00Z')"
+        );
+
+        $recheck = 'ExampleUser';
+        $missingGameDeletionCheck = [];
+        $missingTrophyTitleRetry = [];
+        $trophyTitleCountRetry = [];
+        $invalidTitleDateRetry = [];
+
+        $result = $this->trophyTitleLoop->processAccessibleTrophyTitles(
+            new stdClass(),
+            new PlayerScanTrophyTitleLoopTestUserThatThrowsOnEndTrophySummary(
+                new TypeError(
+                    'GuzzleHttp\Middleware::{closure}(): Argument #1 ($response) must be of type'
+                    . ' Psr\Http\Message\ResponseInterface, null given'
+                )
+            ),
+            ['online_id' => 'ExampleUser'],
+            ['id' => 1],
+            'ExampleUser',
+            $recheck,
+            $missingGameDeletionCheck,
+            $missingTrophyTitleRetry,
+            $trophyTitleCountRetry,
+            $invalidTitleDateRetry,
+        );
+
+        $this->assertTrue($result->shouldContinueLoop());
+        $this->assertSame([5], $this->sleepCalls);
+        $this->assertSame('', $recheck);
+
+        $logMessage = $this->database->query('SELECT message FROM log ORDER BY rowid DESC LIMIT 1')->fetchColumn();
+        $this->assertStringContainsString('Failed to fetch trophy summary', (string) $logMessage);
+        $this->assertStringContainsString('null given', (string) $logMessage);
+    }
 }
 
 final class PlayerScanTrophyTitleLoopTestUserThatThrowsOnTrophyTitles
@@ -232,6 +315,79 @@ final class PlayerScanTrophyTitleLoopTestUserThatThrowsOnTrophyTitles
     public function trophyTitles(): never
     {
         throw $this->exception;
+    }
+}
+
+final class PlayerScanTrophyTitleLoopTestUserThatThrowsOnTrophySummary
+{
+    public function __construct(private readonly Throwable $exception)
+    {
+    }
+
+    public function accountId(): string
+    {
+        return '2498580493801829235';
+    }
+
+    public function trophySummary(): never
+    {
+        throw $this->exception;
+    }
+
+    public function trophyTitles(): never
+    {
+        throw new RuntimeException('trophyTitles should not be called when trophySummary fails first');
+    }
+}
+
+final class PlayerScanTrophyTitleLoopTestUserThatThrowsOnEndTrophySummary
+{
+    private int $trophySummaryCalls = 0;
+
+    public function __construct(private readonly Throwable $exception)
+    {
+    }
+
+    public function accountId(): string
+    {
+        return '2498580493801829235';
+    }
+
+    public function trophySummary(): PlayerScanTrophyTitleLoopTestTrophySummary
+    {
+        $this->trophySummaryCalls++;
+
+        if ($this->trophySummaryCalls > 1) {
+            throw $this->exception;
+        }
+
+        return new PlayerScanTrophyTitleLoopTestTrophySummary();
+    }
+
+    public function trophyTitles(): PlayerScanTrophyTitleLoopTestTrophyTitleCollection
+    {
+        return new PlayerScanTrophyTitleLoopTestTrophyTitleCollection([
+            new PlayerScanTrophyTitleLoopTestTrophyTitle(
+                'NPWR12345_00',
+                '2024-01-01T00:00:00Z',
+                'Example Game'
+            ),
+        ]);
+    }
+}
+
+final class PlayerScanTrophyTitleLoopTestTrophyTitleCollection
+{
+    /**
+     * @param list<object> $titles
+     */
+    public function __construct(private readonly array $titles)
+    {
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->titles);
     }
 }
 
@@ -263,7 +419,8 @@ final class PlayerScanTrophyTitleLoopTestTrophyTitle
     public function __construct(
         private readonly string $npCommunicationId,
         private readonly string $lastUpdatedDateTime,
-        private readonly string $name = ''
+        private readonly string $name = '',
+        private readonly string $iconUrl = 'https://example.test/icon.png',
     ) {
     }
 
@@ -280,5 +437,10 @@ final class PlayerScanTrophyTitleLoopTestTrophyTitle
     public function name(): string
     {
         return $this->name;
+    }
+
+    public function iconUrl(): string
+    {
+        return $this->iconUrl;
     }
 }

--- a/tests/ThirtyMinuteCronJobWorkerValidationTest.php
+++ b/tests/ThirtyMinuteCronJobWorkerValidationTest.php
@@ -94,9 +94,13 @@ final class ThirtyMinuteCronJobWorkerValidationTest extends TestCase
     {
         $source = (string) file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/ThirtyMinuteCronJob.php');
 
-        $this->assertStringContainsString('} catch (Exception $exception) {', $source);
+        $this->assertStringContainsString('} catch (TypeError | Exception $exception) {', $source);
         $this->assertStringContainsString(
             'Transient PSN/network failures (e.g. Guzzle/cURL transfer errors)',
+            $source
+        );
+        $this->assertStringContainsString(
+            'Guzzle\'s httpErrors middleware can also TypeError when a null response',
             $source
         );
         $this->assertStringContainsString(

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
@@ -62,10 +62,22 @@ final class PlayerScanTrophyTitleLoop
         array &$trophyTitleCountRetry,
         array &$invalidTitleDateRetry,
     ): PlayerScanTrophyTitleLoopResult {
-        $totalTrophiesStart = $user->trophySummary()->platinum()
-            + $user->trophySummary()->gold()
-            + $user->trophySummary()->silver()
-            + $user->trophySummary()->bronze();
+        try {
+            $totalTrophiesStart = $this->fetchTotalEarnedTrophies($user);
+        } catch (TypeError | Exception $exception) {
+            // Guzzle can TypeError when httpErrors middleware gets a null response
+            // after a transient network failure; treat like other PSN fetch retries.
+            return $this->retryAfterTransientTrophySummaryFailure(
+                $exception,
+                (int) $worker['id'],
+                $onlineId,
+                $recheck,
+                $missingGameDeletionCheck,
+                $missingTrophyTitleRetry,
+                $trophyTitleCountRetry,
+                $invalidTitleDateRetry,
+            );
+        }
 
         $query = $this->database->prepare("SELECT np_communication_id,
                 last_updated_date
@@ -102,11 +114,11 @@ final class PlayerScanTrophyTitleLoop
         } catch (Exception $exception) {
             // Transient PSN/network failures (e.g. cURL error 18 during paginated
             // trophyTitles fetches) should retry instead of crashing the worker.
-            // $this->logger->log(sprintf(
-            //     'Failed to fetch trophy titles for %s: %s. Waiting 5 seconds before retrying.',
-            //     $onlineId,
-            //     $exception->getMessage()
-            // ));
+            $this->logger->log(sprintf(
+                'Failed to fetch trophy titles for %s: %s. Waiting 5 seconds before retrying.',
+                $onlineId,
+                $exception->getMessage()
+            ));
             $this->workerScanCoordinator->setWaitingScanProgress(
                 (int) $worker['id'],
                 'Encountered a problem while fetching game list. Waiting 5 seconds before retrying.'
@@ -265,10 +277,22 @@ final class PlayerScanTrophyTitleLoop
             return PlayerScanTrophyTitleLoopResult::continueLoop();
         }
 
-        $totalTrophiesEnd = $user->trophySummary()->platinum()
-            + $user->trophySummary()->gold()
-            + $user->trophySummary()->silver()
-            + $user->trophySummary()->bronze();
+        try {
+            $totalTrophiesEnd = $this->fetchTotalEarnedTrophies($user);
+        } catch (TypeError | Exception $exception) {
+            // End-of-scan trophy summary can hit the same Guzzle null-response TypeError
+            // (or transient cURL failures) as earlier PSN fetches.
+            return $this->retryAfterTransientTrophySummaryFailure(
+                $exception,
+                (int) $worker['id'],
+                $onlineId,
+                $recheck,
+                $missingGameDeletionCheck,
+                $missingTrophyTitleRetry,
+                $trophyTitleCountRetry,
+                $invalidTitleDateRetry,
+            );
+        }
 
         if ($totalTrophiesStart !== $totalTrophiesEnd) {
             $recheck = '';
@@ -350,6 +374,54 @@ final class PlayerScanTrophyTitleLoop
         }
 
         return PlayerScanTrophyTitleLoopResult::proceedToFinalize();
+    }
+
+    private function fetchTotalEarnedTrophies(object $user): int
+    {
+        $trophySummary = $user->trophySummary();
+
+        return $trophySummary->platinum()
+            + $trophySummary->gold()
+            + $trophySummary->silver()
+            + $trophySummary->bronze();
+    }
+
+    /**
+     * @param array<string, bool> $missingGameDeletionCheck
+     * @param array<string, bool> $missingTrophyTitleRetry
+     * @param array<string, bool> $trophyTitleCountRetry
+     * @param array<string, bool> $invalidTitleDateRetry
+     */
+    private function retryAfterTransientTrophySummaryFailure(
+        Throwable $exception,
+        int $workerId,
+        string $onlineId,
+        string &$recheck,
+        array &$missingGameDeletionCheck,
+        array &$missingTrophyTitleRetry,
+        array &$trophyTitleCountRetry,
+        array &$invalidTitleDateRetry,
+    ): PlayerScanTrophyTitleLoopResult {
+        $this->logger->log(sprintf(
+            'Failed to fetch trophy summary for %s: %s. Waiting 5 seconds before retrying.',
+            $onlineId,
+            $exception->getMessage()
+        ));
+        $this->workerScanCoordinator->setWaitingScanProgress(
+            $workerId,
+            'Encountered a problem while fetching trophy summary. Waiting 5 seconds before retrying.'
+        );
+        $this->clearTitleListRetryState(
+            $onlineId,
+            $missingGameDeletionCheck,
+            $missingTrophyTitleRetry,
+            $trophyTitleCountRetry,
+            $invalidTitleDateRetry,
+        );
+        $recheck = '';
+        ($this->sleeper)(5);
+
+        return PlayerScanTrophyTitleLoopResult::continueLoop();
     }
 
     /**

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -276,9 +276,11 @@ final readonly class ThirtyMinuteCronJob implements CronJobInterface
                 $this->titleMetadataHelper->clearInvalidTitleDateRetriesForPlayer($invalidTitleDateRetry, $onlineId);
 
                 continue;
-            } catch (Exception $exception) {
+            } catch (TypeError | Exception $exception) {
                 // Transient PSN/network failures (e.g. Guzzle/cURL transfer errors) should
                 // back off and keep the worker alive instead of terminating the cron job.
+                // Guzzle's httpErrors middleware can also TypeError when a null response
+                // reaches a ResponseInterface-typed onFulfilled handler after a network failure.
                 // Lock wait timeouts usually clear quickly, so retry sooner than other errors.
                 $isLockWaitTimeout = $this->isLockWaitTimeoutException($exception);
                 $waitSeconds = $isLockWaitTimeout ? 5 : 60;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Yes — this is handleable, and the same class of failure was already partially covered for `trophyTitles()` fetches.

The fatal came from Guzzle’s `httpErrors` middleware receiving `null` instead of a `ResponseInterface` after a transient network failure while calling `TrophySummary->gold()` at the **end** of a player scan (`PlayerScanTrophyTitleLoop` line 269). `TypeError` extends `Error`, not `Exception`, so the outer `catch (Exception)` in `ThirtyMinuteCronJob` let it crash the worker.

### Changes
- Wrap start/end `trophySummary()` total-earned fetches in try/catch for `TypeError | Exception`, log, wait 5s, and `continueLoop()` (same retry posture as other PSN fetch failures).
- Broaden the outer scan catch in `ThirtyMinuteCronJob` to `TypeError | Exception` as a safety net for any remaining Guzzle null-response TypeErrors during scan work.
- Restore trophy-title fetch failure logging (was commented out; test already expected it).
- Add tests covering trophy-summary TypeError at both start and end of the title loop.

### Testing
- `php tests/run.php` — all 980 tests passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d9875fb-5736-4c5e-8f8d-0fb7e030cb77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d9875fb-5736-4c5e-8f8d-0fb7e030cb77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

