### PR TITLE
Reduce deadlock scan retry delay to 5 seconds

### DIFF
--- a/tests/ThirtyMinuteCronJobWorkerValidationTest.php
+++ b/tests/ThirtyMinuteCronJobWorkerValidationTest.php
@@ -108,8 +108,10 @@ final class ThirtyMinuteCronJobWorkerValidationTest extends TestCase
             $source
         );
         $this->assertStringContainsString('isLockWaitTimeoutException', $source);
-        $this->assertStringContainsString('$waitSeconds = $isLockWaitTimeout ? 5 : 60', $source);
+        $this->assertStringContainsString('isDeadlockException', $source);
+        $this->assertStringContainsString('$waitSeconds = $isQuickDbRetry ? 5 : 60', $source);
         $this->assertStringContainsString("=== 1205", $source);
+        $this->assertStringContainsString("=== 1213", $source);
     }
 
     public function testIsLockWaitTimeoutExceptionDetectsMysqlError1205(): void
@@ -135,6 +137,35 @@ final class ThirtyMinuteCronJobWorkerValidationTest extends TestCase
         $this->assertTrue($method->invoke(
             $cronJob,
             new RuntimeException('SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded; try restarting transaction')
+        ));
+        $this->assertFalse($method->invoke($cronJob, new RuntimeException('cURL error 18')));
+    }
+
+    public function testIsDeadlockExceptionDetectsMysqlError1213(): void
+    {
+        $method = new ReflectionMethod(ThirtyMinuteCronJob::class, 'isDeadlockException');
+        $method->setAccessible(true);
+
+        $database = new PDO('sqlite::memory:');
+        $cronJob = new ThirtyMinuteCronJob(
+            $database,
+            new TrophyCalculator($database),
+            new Psn100Logger($database),
+            new TrophyHistoryRecorder($database, new Psn100Logger($database)),
+            1
+        );
+
+        $deadlock = new PDOException(
+            'SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction'
+        );
+        $deadlock->errorInfo = ['40001', 1213, 'Deadlock found when trying to get lock; try restarting transaction'];
+
+        $this->assertTrue($method->invoke($cronJob, $deadlock));
+        $this->assertTrue($method->invoke(
+            $cronJob,
+            new RuntimeException(
+                'SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction'
+            )
         ));
         $this->assertFalse($method->invoke($cronJob, new RuntimeException('cURL error 18')));
     }

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -281,10 +281,12 @@ final readonly class ThirtyMinuteCronJob implements CronJobInterface
                 // back off and keep the worker alive instead of terminating the cron job.
                 // Guzzle's httpErrors middleware can also TypeError when a null response
                 // reaches a ResponseInterface-typed onFulfilled handler after a network failure.
-                // Lock wait timeouts usually clear quickly, so retry sooner than other errors.
-                $isLockWaitTimeout = $this->isLockWaitTimeoutException($exception);
-                $waitSeconds = $isLockWaitTimeout ? 5 : 60;
-                $waitDescription = $isLockWaitTimeout ? '5 seconds' : '1 minute';
+                // Lock wait timeouts and deadlocks usually clear quickly, so retry sooner
+                // than other errors.
+                $isQuickDbRetry = $this->isLockWaitTimeoutException($exception)
+                    || $this->isDeadlockException($exception);
+                $waitSeconds = $isQuickDbRetry ? 5 : 60;
+                $waitDescription = $isQuickDbRetry ? '5 seconds' : '1 minute';
 
                 $this->logger->log(sprintf(
                     'Encountered a problem while scanning %s: %s. Waiting %s before retrying.',
@@ -320,5 +322,16 @@ final readonly class ThirtyMinuteCronJob implements CronJobInterface
         }
 
         return str_contains($exception->getMessage(), 'Lock wait timeout exceeded');
+    }
+
+    private function isDeadlockException(Throwable $exception): bool
+    {
+        if ($exception instanceof PDOException) {
+            if ($exception->getCode() === '40001' || (($exception->errorInfo[1] ?? null) === 1213)) {
+                return true;
+            }
+        }
+
+        return str_contains($exception->getMessage(), 'Deadlock found when trying to get lock');
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Detect MySQL deadlocks (`SQLSTATE[40001]` / error `1213`) in the 30-minute player scan retry path.
- Use a 5-second backoff for deadlocks (same as lock wait timeouts) instead of waiting a full minute.
- Keep the 1-minute backoff for other transient scan failures.

## Test plan
- [x] `php tests/run.php` — all 981 tests passed
- [x] New `testIsDeadlockExceptionDetectsMysqlError1213` covers PDO error info, message matching, and non-deadlock negatives

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-061c1f51-7e6c-4b2e-ab7a-d813eff722f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-061c1f51-7e6c-4b2e-ab7a-d813eff722f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

