### PR TITLE
Modernize PHP for 8.5 (array helpers, readonly DTOs, match)

### DIFF
--- a/tests/PlayerScanTrophyTitleLoopTest.php
+++ b/tests/PlayerScanTrophyTitleLoopTest.php
@@ -175,9 +175,8 @@ final class PlayerScanTrophyTitleLoopTest extends TestCase
         $this->assertTrue(is_string($scanProgress));
         $this->assertStringContainsString('fetching game list', $scanProgress);
 
-        $logMessage = $this->database->query('SELECT message FROM log ORDER BY rowid DESC LIMIT 1')->fetchColumn();
-        $this->assertStringContainsString('cURL error 18', (string) $logMessage);
-        $this->assertStringContainsString('ExampleUser', (string) $logMessage);
+        $logCount = (int) $this->database->query('SELECT COUNT(*) FROM log')->fetchColumn();
+        $this->assertSame(0, $logCount);
     }
 
     public function testProcessAccessibleTrophyTitlesRetriesTypeErrorsQuickly(): void

--- a/wwwroot/classes/AboutPageContext.php
+++ b/wwwroot/classes/AboutPageContext.php
@@ -5,36 +5,11 @@ declare(strict_types=1);
 require_once __DIR__ . '/AboutPageDataProviderInterface.php';
 require_once __DIR__ . '/AboutPagePlayerArraySerializer.php';
 
-final class AboutPageContext
+final readonly class AboutPageContext
 {
     private const DEFAULT_SCAN_LOG_LIMIT = 30;
     private const DEFAULT_MAX_INITIAL_DISPLAY_COUNT = 10;
     private const DEFAULT_TITLE = 'About ~ PSN 100%';
-
-    private AboutPageScanSummary $scanSummary;
-
-    /**
-     * @var list<AboutPagePlayer>
-     */
-    private array $scanLogPlayers;
-
-    /**
-     * @var list<AboutPagePlayer>
-     */
-    private array $initialScanLogPlayers;
-
-    /**
-     * @var list<array<string, mixed>>
-     */
-    private array $serializedScanLogPlayers;
-
-    private int $scanLogLimit;
-
-    private int $initialDisplayCount;
-
-    private int $maxInitialDisplayCount;
-
-    private string $title;
 
     /**
      * @param list<AboutPagePlayer> $scanLogPlayers
@@ -42,23 +17,15 @@ final class AboutPageContext
      * @param list<array<string, mixed>> $serializedScanLogPlayers
      */
     private function __construct(
-        AboutPageScanSummary $scanSummary,
-        array $scanLogPlayers,
-        array $initialScanLogPlayers,
-        array $serializedScanLogPlayers,
-        int $scanLogLimit,
-        int $initialDisplayCount,
-        int $maxInitialDisplayCount,
-        string $title
+        private AboutPageScanSummary $scanSummary,
+        private array $scanLogPlayers,
+        private array $initialScanLogPlayers,
+        private array $serializedScanLogPlayers,
+        private int $scanLogLimit,
+        private int $initialDisplayCount,
+        private int $maxInitialDisplayCount,
+        private string $title,
     ) {
-        $this->scanSummary = $scanSummary;
-        $this->scanLogPlayers = $scanLogPlayers;
-        $this->initialScanLogPlayers = $initialScanLogPlayers;
-        $this->serializedScanLogPlayers = $serializedScanLogPlayers;
-        $this->scanLogLimit = $scanLogLimit;
-        $this->initialDisplayCount = $initialDisplayCount;
-        $this->maxInitialDisplayCount = $maxInitialDisplayCount;
-        $this->title = $title;
     }
 
     public static function create(

--- a/wwwroot/classes/Admin/DeletePlayerService.php
+++ b/wwwroot/classes/Admin/DeletePlayerService.php
@@ -26,7 +26,7 @@ final class DeletePlayerService
 
         return [
             'account_id' => (string) $player['account_id'],
-            'online_id' => array_key_exists('online_id', $player) ? ($player['online_id'] === null ? null : (string) $player['online_id']) : null,
+            'online_id' => isset($player['online_id']) ? (string) $player['online_id'] : null,
         ];
     }
 
@@ -48,7 +48,7 @@ final class DeletePlayerService
 
         return [
             'account_id' => (string) $player['account_id'],
-            'online_id' => array_key_exists('online_id', $player) ? ($player['online_id'] === null ? null : (string) $player['online_id']) : null,
+            'online_id' => isset($player['online_id']) ? (string) $player['online_id'] : null,
         ];
     }
 

--- a/wwwroot/classes/Admin/GameDetail.php
+++ b/wwwroot/classes/Admin/GameDetail.php
@@ -29,14 +29,10 @@ final readonly class GameDetail
         $platform = (string) ($row['platform'] ?? '');
         $message = (string) ($row['message'] ?? '');
         $setVersion = (string) ($row['set_version'] ?? '');
-        $region = array_key_exists('region', $row) ? ($row['region'] !== null ? (string) $row['region'] : null) : null;
-        $psnprofilesId = array_key_exists('psnprofiles_id', $row)
-            ? ($row['psnprofiles_id'] !== null ? (string) $row['psnprofiles_id'] : null)
-            : null;
+        $region = isset($row['region']) ? (string) $row['region'] : null;
+        $psnprofilesId = isset($row['psnprofiles_id']) ? (string) $row['psnprofiles_id'] : null;
         $status = GameAvailabilityStatus::fromInt((int) ($row['status'] ?? 0));
-        $obsoleteIds = array_key_exists('obsolete_ids', $row)
-            ? ($row['obsolete_ids'] !== null ? (string) $row['obsolete_ids'] : null)
-            : null;
+        $obsoleteIds = isset($row['obsolete_ids']) ? (string) $row['obsolete_ids'] : null;
 
         return new self(
             $id,

--- a/wwwroot/classes/Admin/GameDetailPageResult.php
+++ b/wwwroot/classes/Admin/GameDetailPageResult.php
@@ -4,19 +4,13 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/GameDetail.php';
 
-class GameDetailPageResult
+final readonly class GameDetailPageResult
 {
-    private ?GameDetail $gameDetail;
-
-    private ?string $successMessage;
-
-    private ?string $errorMessage;
-
-    public function __construct(?GameDetail $gameDetail, ?string $successMessage, ?string $errorMessage)
-    {
-        $this->gameDetail = $gameDetail;
-        $this->successMessage = $successMessage;
-        $this->errorMessage = $errorMessage;
+    public function __construct(
+        private ?GameDetail $gameDetail,
+        private ?string $successMessage,
+        private ?string $errorMessage,
+    ) {
     }
 
     public function getGameDetail(): ?GameDetail

--- a/wwwroot/classes/Admin/LogEntryFormatter.php
+++ b/wwwroot/classes/Admin/LogEntryFormatter.php
@@ -83,10 +83,6 @@ final class LogEntryFormatter
         $between = substr($message, $npPosition + strlen($npCommunicationId), $groupPosition - ($npPosition + strlen($npCommunicationId)));
         $suffix = substr($message, $groupPosition + strlen($groupId));
 
-        $prefix = $prefix === false ? '' : $prefix;
-        $between = $between === false ? '' : $between;
-        $suffix = $suffix === false ? '' : $suffix;
-
         $game = $this->fetchGameByNpCommunicationId($npCommunicationId);
 
         if ($game === null) {
@@ -113,10 +109,6 @@ final class LogEntryFormatter
         $prefix = substr($message, 0, $npPosition);
         $between = substr($message, $npPosition + strlen($npCommunicationId), $groupPosition - ($npPosition + strlen($npCommunicationId)));
         $suffix = substr($message, $groupPosition + strlen($groupId));
-
-        $prefix = $prefix === false ? '' : $prefix;
-        $between = $between === false ? '' : $between;
-        $suffix = $suffix === false ? '' : $suffix;
 
         $game = $this->fetchGameByNpCommunicationId($npCommunicationId);
 

--- a/wwwroot/classes/Admin/MergeTrophyCopier.php
+++ b/wwwroot/classes/Admin/MergeTrophyCopier.php
@@ -302,9 +302,9 @@ final class MergeTrophyCopier
             ':name' => (string) $trophy['name'],
             ':detail' => (string) $trophy['detail'],
             ':icon_url' => (string) $trophy['icon_url'],
-            ':progress_target_value' => $trophy['progress_target_value'] === null ? null : (int) $trophy['progress_target_value'],
-            ':reward_name' => $trophy['reward_name'] === null ? null : (string) $trophy['reward_name'],
-            ':reward_image_url' => $trophy['reward_image_url'] === null ? null : (string) $trophy['reward_image_url'],
+            ':progress_target_value' => isset($trophy['progress_target_value']) ? (int) $trophy['progress_target_value'] : null,
+            ':reward_name' => isset($trophy['reward_name']) ? (string) $trophy['reward_name'] : null,
+            ':reward_image_url' => isset($trophy['reward_image_url']) ? (string) $trophy['reward_image_url'] : null,
             ':np_communication_id' => $parentNpCommunicationId,
             ':group_id' => $parentGroupId,
             ':order_id' => $parentOrderId,
@@ -334,9 +334,9 @@ final class MergeTrophyCopier
             ':name' => (string) $trophy['name'],
             ':detail' => (string) $trophy['detail'],
             ':icon_url' => (string) $trophy['icon_url'],
-            ':progress_target_value' => $trophy['progress_target_value'] === null ? null : (int) $trophy['progress_target_value'],
-            ':reward_name' => $trophy['reward_name'] === null ? null : (string) $trophy['reward_name'],
-            ':reward_image_url' => $trophy['reward_image_url'] === null ? null : (string) $trophy['reward_image_url'],
+            ':progress_target_value' => isset($trophy['progress_target_value']) ? (int) $trophy['progress_target_value'] : null,
+            ':reward_name' => isset($trophy['reward_name']) ? (string) $trophy['reward_name'] : null,
+            ':reward_image_url' => isset($trophy['reward_image_url']) ? (string) $trophy['reward_image_url'] : null,
         ]);
 
         $trophyId = (int) $this->database->lastInsertId();

--- a/wwwroot/classes/Admin/PlayerReportAdminPageResult.php
+++ b/wwwroot/classes/Admin/PlayerReportAdminPageResult.php
@@ -4,25 +4,16 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/ReportedPlayer.php';
 
-class PlayerReportAdminPageResult
+final readonly class PlayerReportAdminPageResult
 {
-    /**
-     * @var ReportedPlayer[]
-     */
-    private array $reportedPlayers;
-
-    private ?string $successMessage;
-
-    private ?string $errorMessage;
-
     /**
      * @param ReportedPlayer[] $reportedPlayers
      */
-    public function __construct(array $reportedPlayers, ?string $successMessage = null, ?string $errorMessage = null)
-    {
-        $this->reportedPlayers = $reportedPlayers;
-        $this->successMessage = $successMessage;
-        $this->errorMessage = $errorMessage;
+    public function __construct(
+        private array $reportedPlayers,
+        private ?string $successMessage = null,
+        private ?string $errorMessage = null,
+    ) {
     }
 
     /**

--- a/wwwroot/classes/Admin/PossibleCheaterRuleGroup.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleGroup.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-final class PossibleCheaterRule
+final readonly class PossibleCheaterRule
 {
     public function __construct(private string $condition)
     {
@@ -19,7 +19,7 @@ final class PossibleCheaterRule
     }
 }
 
-final class PossibleCheaterRuleGroup
+final readonly class PossibleCheaterRuleGroup
 {
     /**
      * @param PossibleCheaterRule[] $rules

--- a/wwwroot/classes/Admin/PossibleCheaterRuleTuple.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleTuple.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-final class PossibleCheaterRuleTuple
+final readonly class PossibleCheaterRuleTuple
 {
     public function __construct(
         private string $npCommunicationId,
         private int $orderId,
         private ?string $dateOperator,
-        private ?string $dateValue
+        private ?string $dateValue,
     ) {
     }
 

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -210,13 +210,11 @@ final class PsnGameLookupService
         }
 
         $legacyPlatforms = ['PS3', 'PS4', 'PSVR', 'PSVITA'];
-        foreach ($platforms as $platformValue) {
-            if (in_array($platformValue, $legacyPlatforms, true)) {
-                return 'trophy';
-            }
-        }
 
-        return 'trophy2';
+        return array_any(
+            $platforms,
+            static fn (string $platformValue): bool => in_array($platformValue, $legacyPlatforms, true)
+        ) ? 'trophy' : 'trophy2';
     }
 
     /**

--- a/wwwroot/classes/AutomaticTrophyTitleMergeService.php
+++ b/wwwroot/classes/AutomaticTrophyTitleMergeService.php
@@ -396,13 +396,10 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
      */
     private function hasPs5OrPsvr2(array $platforms): bool
     {
-        foreach ($platforms as $platform) {
-            if ($platform === 'PS5' || $platform === 'PSVR2') {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $platforms,
+            static fn (string $platform): bool => $platform === 'PS5' || $platform === 'PSVR2'
+        );
     }
 
     /**

--- a/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
@@ -50,11 +50,14 @@ final class PlayerAvatarSynchronizer
                 $query->execute();
                 $existingPHashes = $query->fetchAll(PDO::FETCH_COLUMN);
 
-                foreach ($existingPHashes as $existingPHash) {
-                    if ($this->imageHashCalculator->getHammingDistance($newPHash, $existingPHash) <= 10) {
-                        $newPHash = $existingPHash;
-                        break;
-                    }
+                $matchedPHash = array_find(
+                    $existingPHashes,
+                    fn (mixed $existingPHash): bool => is_string($existingPHash)
+                        && $this->imageHashCalculator->getHammingDistance($newPHash, $existingPHash) <= 10
+                );
+
+                if (is_string($matchedPHash)) {
+                    $newPHash = $matchedPHash;
                 }
 
                 $extension = strtolower(pathinfo($avatarUrl, PATHINFO_EXTENSION));

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
@@ -425,19 +425,23 @@ final class PlayerScanTrophyTitleLoop
      */
     public function determineScanStartIndex(array $trophyTitles, array $gameLastUpdatedDate): int
     {
-        foreach ($trophyTitles as $index => $trophyTitle) {
-            $npid = $trophyTitle->npCommunicationId();
+        $index = array_find_key(
+            $trophyTitles,
+            function (object $trophyTitle) use ($gameLastUpdatedDate): bool {
+                $npid = $trophyTitle->npCommunicationId();
 
-            if (!isset($gameLastUpdatedDate[$npid])) {
-                return (int) $index;
+                if (!isset($gameLastUpdatedDate[$npid])) {
+                    return true;
+                }
+
+                return !$this->titleMetadataHelper->gameTimestampsMatch(
+                    $trophyTitle->lastUpdatedDateTime(),
+                    $gameLastUpdatedDate[$npid]
+                );
             }
+        );
 
-            if (!$this->titleMetadataHelper->gameTimestampsMatch($trophyTitle->lastUpdatedDateTime(), $gameLastUpdatedDate[$npid])) {
-                return (int) $index;
-            }
-        }
-
-        return count($trophyTitles);
+        return $index !== null ? (int) $index : count($trophyTitles);
     }
 
     /**

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleRefresher.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleRefresher.php
@@ -115,14 +115,11 @@ final class PlayerScanTrophyTitleRefresher
         string $npCommunicationId,
         object $fallbackTitle
     ): object {
-        $trophyTitleCollection = $user->trophyTitles();
+        $trophyTitles = iterator_to_array($user->trophyTitles(), false);
 
-        foreach ($trophyTitleCollection as $refreshedTitle) {
-            if ((string) $refreshedTitle->npCommunicationId() === $npCommunicationId) {
-                return $refreshedTitle;
-            }
-        }
-
-        return $fallbackTitle;
+        return array_find(
+            $trophyTitles,
+            static fn (object $refreshedTitle): bool => (string) $refreshedTitle->npCommunicationId() === $npCommunicationId
+        ) ?? $fallbackTitle;
     }
 }

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleRefresher.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleRefresher.php
@@ -115,11 +115,14 @@ final class PlayerScanTrophyTitleRefresher
         string $npCommunicationId,
         object $fallbackTitle
     ): object {
-        $trophyTitles = iterator_to_array($user->trophyTitles(), false);
+        // Keep this lazy: trophyTitles() may be a paginated collection, so avoid
+        // iterator_to_array()/array_find() which would fetch every page first.
+        foreach ($user->trophyTitles() as $refreshedTitle) {
+            if ((string) $refreshedTitle->npCommunicationId() === $npCommunicationId) {
+                return $refreshedTitle;
+            }
+        }
 
-        return array_find(
-            $trophyTitles,
-            static fn (object $refreshedTitle): bool => (string) $refreshedTitle->npCommunicationId() === $npCommunicationId
-        ) ?? $fallbackTitle;
+        return $fallbackTitle;
     }
 }

--- a/wwwroot/classes/GameHistoryRenderer.php
+++ b/wwwroot/classes/GameHistoryRenderer.php
@@ -102,17 +102,7 @@ final class GameHistoryRenderer
             return '<div class="text-center"><span class="history-diff__empty">&mdash;</span></div>';
         }
 
-        $objectFit = 'object-fit-scale';
-        $directory = 'trophy';
-        $height = 3.5;
-
-        if ($type === 'group') {
-            $objectFit = 'object-fit-cover';
-            $directory = 'group';
-        } elseif ($type === 'title') {
-            $directory = 'title';
-            $height = 5.5;
-        }
+        ['objectFit' => $objectFit, 'directory' => $directory, 'height' => $height] = $this->resolveIconDisplay($type);
 
         return '<div class="text-center">'
             . '<img class="' . $objectFit . ' rounded" style="height: ' . $height . 'rem;" src="/img/' . $directory . '/'
@@ -363,23 +353,25 @@ final class GameHistoryRenderer
         }
 
         $borderClass = $state === 'previous' ? 'border-danger' : 'border-success';
-        $objectFit = 'object-fit-scale';
-        $directory = 'trophy';
-        $height = 3.5;
-
-        if ($type === 'group') {
-            $objectFit = 'object-fit-cover';
-            $directory = 'group';
-        } elseif ($type === 'title') {
-            $directory = 'title';
-            $height = 5.5;
-        }
+        ['objectFit' => $objectFit, 'directory' => $directory, 'height' => $height] = $this->resolveIconDisplay($type);
 
         return '<div class="text-center">'
             . '<img class="' . $objectFit . ' border border-2 ' . $borderClass . ' rounded" style="height: ' . $height . 'rem;" src="/img/'
             . $directory . '/' . Html::escape($resolvedPath)
             . '" alt="' . Html::escape($name ?? '') . '">'
             . '</div>';
+    }
+
+    /**
+     * @return array{objectFit: string, directory: string, height: float}
+     */
+    private function resolveIconDisplay(string $type): array
+    {
+        return match ($type) {
+            'group' => ['objectFit' => 'object-fit-cover', 'directory' => 'group', 'height' => 3.5],
+            'title' => ['objectFit' => 'object-fit-scale', 'directory' => 'title', 'height' => 5.5],
+            default => ['objectFit' => 'object-fit-scale', 'directory' => 'trophy', 'height' => 3.5],
+        };
     }
 }
 

--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -46,6 +46,7 @@ final readonly class GameLeaderboardFilter extends GamePlayerFilter
     /**
      * @return array<string, int|string>
      */
+    #[\Override]
     public function toQueryParameters(): array
     {
         $parameters = parent::getFilterParameters();

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -160,13 +160,10 @@ readonly class GameListFilter
 
     public function hasPlatformFilters(): bool
     {
-        foreach ($this->platformFilters as $selected) {
-            if ($selected) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $this->platformFilters,
+            static fn (bool $selected): bool => $selected
+        );
     }
 
     public function isPlatformSelected(string $platform): bool

--- a/wwwroot/classes/GameRecentPlayersPageContext.php
+++ b/wwwroot/classes/GameRecentPlayersPageContext.php
@@ -9,30 +9,15 @@ require_once __DIR__ . '/Utility.php';
 require_once __DIR__ . '/GameNotFoundException.php';
 require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
 
-final class GameRecentPlayersPageContext
+final readonly class GameRecentPlayersPageContext
 {
-    private ?GameRecentPlayersPage $page;
-
-    private ?string $title;
-
-    private ?string $gameSlug;
-
-    private ?string $redirectLocation;
-
-    private int $redirectStatusCode;
-
     private function __construct(
-        ?GameRecentPlayersPage $page,
-        ?string $title,
-        ?string $gameSlug,
-        ?string $redirectLocation,
-        int $redirectStatusCode
+        private ?GameRecentPlayersPage $page,
+        private ?string $title,
+        private ?string $gameSlug,
+        private ?string $redirectLocation,
+        private int $redirectStatusCode,
     ) {
-        $this->page = $page;
-        $this->title = $title;
-        $this->gameSlug = $gameSlug;
-        $this->redirectLocation = $redirectLocation;
-        $this->redirectStatusCode = $redirectStatusCode;
     }
 
     /**

--- a/wwwroot/classes/Homepage/HomepageDlc.php
+++ b/wwwroot/classes/Homepage/HomepageDlc.php
@@ -61,6 +61,7 @@ readonly class HomepageDlc extends HomepageTitle
         return $this->bronze;
     }
 
+    #[\Override]
     public function getRelativeUrl(Utility $utility): string
     {
         return parent::getRelativeUrl($utility) . '#' . $this->groupId;

--- a/wwwroot/classes/HomepageViewModel.php
+++ b/wwwroot/classes/HomepageViewModel.php
@@ -7,25 +7,8 @@ require_once __DIR__ . '/Homepage/HomepageDlc.php';
 require_once __DIR__ . '/Homepage/HomepagePopularGame.php';
 require_once __DIR__ . '/HomepagePopularGamesFilter.php';
 
-class HomepageViewModel
+final readonly class HomepageViewModel
 {
-    private string $title;
-
-    /**
-     * @var HomepageNewGame[]
-     */
-    private array $newGames;
-
-    /**
-     * @var HomepageDlc[]
-     */
-    private array $newDlcs;
-
-    /**
-     * @var HomepagePopularGame[]
-     */
-    private array $popularGames;
-
     private HomepagePopularGamesFilter $popularGamesFilter;
 
     /**
@@ -34,16 +17,12 @@ class HomepageViewModel
      * @param HomepagePopularGame[] $popularGames
      */
     public function __construct(
-        string $title,
-        array $newGames,
-        array $newDlcs,
-        array $popularGames,
-        ?HomepagePopularGamesFilter $popularGamesFilter = null
+        private string $title,
+        private array $newGames,
+        private array $newDlcs,
+        private array $popularGames,
+        ?HomepagePopularGamesFilter $popularGamesFilter = null,
     ) {
-        $this->title = $title;
-        $this->newGames = $newGames;
-        $this->newDlcs = $newDlcs;
-        $this->popularGames = $popularGames;
         $this->popularGamesFilter = $popularGamesFilter ?? HomepagePopularGamesFilter::fromArray([]);
     }
 

--- a/wwwroot/classes/MaintenancePageStylesheet.php
+++ b/wwwroot/classes/MaintenancePageStylesheet.php
@@ -4,22 +4,14 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/BootstrapAssets.php';
 
-final class MaintenancePageStylesheet
+final readonly class MaintenancePageStylesheet
 {
-    private string $href;
-
-    private string $rel;
-
-    private ?string $integrity;
-
-    private ?string $crossorigin;
-
-    private function __construct(string $href, string $rel = 'stylesheet', ?string $integrity = null, ?string $crossorigin = null)
-    {
-        $this->href = $href;
-        $this->rel = $rel;
-        $this->integrity = $integrity;
-        $this->crossorigin = $crossorigin;
+    private function __construct(
+        private string $href,
+        private string $rel = 'stylesheet',
+        private ?string $integrity = null,
+        private ?string $crossorigin = null,
+    ) {
     }
 
     public static function create(string $href, string $rel = 'stylesheet', ?string $integrity = null, ?string $crossorigin = null): self
@@ -36,9 +28,7 @@ final class MaintenancePageStylesheet
         return new self(BootstrapAssets::stylesheetUrl());
     }
 
-    /**
-     * @deprecated Use bootstrap() for the self-hosted stylesheet.
-     */
+    #[\Deprecated(message: 'Use bootstrap() for the self-hosted stylesheet.')]
     public static function bootstrapCdn(string $version = BootstrapAssets::VERSION): self
     {
         return self::bootstrap($version);

--- a/wwwroot/classes/NavigationState.php
+++ b/wwwroot/classes/NavigationState.php
@@ -6,17 +6,17 @@ require_once __DIR__ . '/NavigationSection.php';
 require_once __DIR__ . '/NavigationSectionState.php';
 require_once __DIR__ . '/RequestParameter.php';
 
-final class NavigationState
+final readonly class NavigationState
 {
     /**
      * @param array<string, NavigationSectionState> $sectionStates
      */
     private function __construct(
-        private readonly string $sort,
-        private readonly string $player,
-        private readonly string $filter,
-        private readonly string $search,
-        private readonly array $sectionStates,
+        private string $sort,
+        private string $player,
+        private string $filter,
+        private string $search,
+        private array $sectionStates,
     ) {
     }
 

--- a/wwwroot/classes/PlayerAdvisableTrophy.php
+++ b/wwwroot/classes/PlayerAdvisableTrophy.php
@@ -88,13 +88,13 @@ class PlayerAdvisableTrophy
             (float) ($data['rarity_percent'] ?? 0.0),
             (float) ($data['in_game_rarity_percent'] ?? 0.0),
             isset($data['progress_target_value']) ? (int) $data['progress_target_value'] : null,
-            array_key_exists('reward_name', $data) ? ($data['reward_name'] !== null ? (string) $data['reward_name'] : null) : null,
-            array_key_exists('reward_image_url', $data) ? ($data['reward_image_url'] !== null ? (string) $data['reward_image_url'] : null) : null,
+            isset($data['reward_name']) ? (string) $data['reward_name'] : null,
+            isset($data['reward_image_url']) ? (string) $data['reward_image_url'] : null,
             (int) ($data['game_id'] ?? 0),
             (string) ($data['game_name'] ?? ''),
             (string) ($data['game_icon'] ?? ''),
             (string) ($data['platform'] ?? ''),
-            array_key_exists('progress', $data) ? ($data['progress'] !== null ? (float) $data['progress'] : null) : null,
+            isset($data['progress']) ? (float) $data['progress'] : null,
             $utility
         );
     }
@@ -233,12 +233,9 @@ class PlayerAdvisableTrophy
 
     private function usesPlayStation5Assets(): bool
     {
-        foreach ($this->platforms as $platform) {
-            if (str_contains($platform, 'PS5') || str_contains($platform, 'PSVR2')) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $this->platforms,
+            static fn (string $platform): bool => str_contains($platform, 'PS5') || str_contains($platform, 'PSVR2')
+        );
     }
 }

--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -40,6 +40,7 @@ final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
     /**
      * @return array{country?: string, avatar?: string}
      */
+    #[\Override]
     public function getFilterParameters(): array
     {
         return parent::getFilterParameters();
@@ -48,6 +49,7 @@ final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
     /**
      * @return array<string, int|string>
      */
+    #[\Override]
     public function toQueryParameters(): array
     {
         return $this->withPage($this->page);

--- a/wwwroot/classes/PlayerQueueMessageBuilder.php
+++ b/wwwroot/classes/PlayerQueueMessageBuilder.php
@@ -103,13 +103,13 @@ final class PlayerQueueMessageBuilder
         foreach ($this->parts as $part) {
             $type = $part['type'] ?? '';
 
-            if ($type === 'text' || $type === 'emphasis') {
-                $text .= (string) ($part['value'] ?? '');
-            } elseif ($type === 'link') {
-                $text .= (string) ($part['label'] ?? '');
-            } elseif ($type === 'progress') {
+            $text .= match ($type) {
+                'text', 'emphasis' => (string) ($part['value'] ?? ''),
+                'link' => (string) ($part['label'] ?? ''),
                 // Progress bars are rendered separately in the client.
-            }
+                'progress' => '',
+                default => '',
+            };
         }
 
         return trim($text);

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -131,22 +131,20 @@ final class PlayerQueueResponseFactory
         foreach ($messageParts as $part) {
             $type = $part['type'] ?? '';
 
-            if ($type === 'text') {
-                $builder->text((string) ($part['value'] ?? ''));
-            } elseif ($type === 'link') {
-                $builder->link(
+            match ($type) {
+                'text' => $builder->text((string) ($part['value'] ?? '')),
+                'link' => $builder->link(
                     (string) ($part['href'] ?? ''),
                     (string) ($part['label'] ?? '')
-                );
-            } elseif ($type === 'emphasis') {
-                $builder->emphasis((string) ($part['value'] ?? ''));
-            } elseif ($type === 'progress') {
-                $builder->progress(
+                ),
+                'emphasis' => $builder->emphasis((string) ($part['value'] ?? '')),
+                'progress' => $builder->progress(
                     (int) ($part['percentage'] ?? 0),
                     isset($part['title']) ? (string) $part['title'] : null,
                     isset($part['summary']) ? (string) $part['summary'] : null,
-                );
-            }
+                ),
+                default => null,
+            };
         }
 
         return $builder->toPlainText();

--- a/wwwroot/classes/PsnHttpExceptionClassifier.php
+++ b/wwwroot/classes/PsnHttpExceptionClassifier.php
@@ -47,10 +47,11 @@ final class PsnHttpExceptionClassifier
             'Tustin\\Haste\\Exception\\NotFoundHttpException',
         ];
 
-        foreach ($retryableExceptionClasses as $retryableExceptionClass) {
-            if ($exception instanceof $retryableExceptionClass) {
-                return true;
-            }
+        if (array_any(
+            $retryableExceptionClasses,
+            static fn (string $retryableExceptionClass): bool => $exception instanceof $retryableExceptionClass
+        )) {
+            return true;
         }
 
         $previous = $exception->getPrevious();

--- a/wwwroot/classes/Routing/SimpleRouteHandler.php
+++ b/wwwroot/classes/Routing/SimpleRouteHandler.php
@@ -28,12 +28,9 @@ final readonly class SimpleRouteHandler implements RouteHandlerInterface
      */
     private function hasAdditionalSegments(array $segments): bool
     {
-        foreach ($segments as $segment) {
-            if ($segment !== '') {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $segments,
+            static fn (string $segment): bool => $segment !== ''
+        );
     }
 }

--- a/wwwroot/classes/TrophyCatalogSynchronizer.php
+++ b/wwwroot/classes/TrophyCatalogSynchronizer.php
@@ -41,11 +41,11 @@ final class TrophyCatalogSynchronizer
         $platforms = CommaSeparatedValues::parseTrimmed($platform);
 
         return [
-            'detail' => $row['detail'] === null ? null : (string) $row['detail'],
-            'icon' => $row['icon_url'] === null ? null : (string) $row['icon_url'],
+            'detail' => self::toNullableString($row['detail'] ?? null),
+            'icon' => self::toNullableString($row['icon_url'] ?? null),
             'platform' => $platform,
             'platforms' => $platforms,
-            'set_version' => $row['set_version'] === null ? null : (string) $row['set_version'],
+            'set_version' => self::toNullableString($row['set_version'] ?? null),
         ];
     }
 
@@ -82,9 +82,9 @@ final class TrophyCatalogSynchronizer
         while (($row = $query->fetch(PDO::FETCH_ASSOC)) !== false) {
             $groupId = (string) $row['group_id'];
             $groups[$groupId] = [
-                'name' => $row['name'] === null ? null : (string) $row['name'],
-                'detail' => $row['detail'] === null ? null : (string) $row['detail'],
-                'icon' => $row['icon_url'] === null ? null : (string) $row['icon_url'],
+                'name' => self::toNullableString($row['name'] ?? null),
+                'detail' => self::toNullableString($row['detail'] ?? null),
+                'icon' => self::toNullableString($row['icon_url'] ?? null),
             ];
         }
 
@@ -127,14 +127,14 @@ final class TrophyCatalogSynchronizer
             $groupId = (string) $row['group_id'];
             $orderId = (int) $row['order_id'];
             $trophies[$groupId][$orderId] = [
-                'hidden' => $row['hidden'] === null ? null : (string) $row['hidden'],
-                'type' => $row['type'] === null ? null : (string) $row['type'],
-                'name' => $row['name'] === null ? null : (string) $row['name'],
-                'detail' => $row['detail'] === null ? null : (string) $row['detail'],
-                'icon' => $row['icon_url'] === null ? null : (string) $row['icon_url'],
-                'progress_target_value' => $row['progress_target_value'] === null ? null : (string) $row['progress_target_value'],
-                'reward_name' => $row['reward_name'] === null ? null : (string) $row['reward_name'],
-                'reward_image' => $row['reward_image_url'] === null ? null : (string) $row['reward_image_url'],
+                'hidden' => self::toNullableString($row['hidden'] ?? null),
+                'type' => self::toNullableString($row['type'] ?? null),
+                'name' => self::toNullableString($row['name'] ?? null),
+                'detail' => self::toNullableString($row['detail'] ?? null),
+                'icon' => self::toNullableString($row['icon_url'] ?? null),
+                'progress_target_value' => self::toNullableString($row['progress_target_value'] ?? null),
+                'reward_name' => self::toNullableString($row['reward_name'] ?? null),
+                'reward_image' => self::toNullableString($row['reward_image_url'] ?? null),
             ];
         }
 
@@ -339,5 +339,10 @@ final class TrophyCatalogSynchronizer
         }
 
         $query->bindValue($parameter, $value, PDO::PARAM_STR);
+    }
+
+    private static function toNullableString(mixed $value): ?string
+    {
+        return $value === null ? null : (string) $value;
     }
 }

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -242,14 +242,9 @@ final class TrophyTitleNameFormatter
             return false;
         }
 
-        $triggerCharacters = [':', '!', '?', '.'];
-
-        foreach ($triggerCharacters as $character) {
-            if (str_contains($punctuation, $character)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            [':', '!', '?', '.'],
+            static fn (string $character): bool => str_contains($punctuation, $character)
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The codebase was already largely on modern PHP (pipes, `clone(...)`, `array_first`/`array_last`, `#[\NoDiscard]`, URI). This pass cleans up remaining gaps now that we target PHP 8.5 with no backward compatibility.

### Changes
- Prefer `array_any()`, `array_find()`, and `array_find_key()` over manual “any/find” loops (platform checks, routing segments, cron start index, avatar hash match, HTTP exception retry classification).
- Add missing `#[\Override]` on filter/DLC methods that override parents.
- Convert immutable page/result DTOs to `final readonly` with constructor property promotion (`GameDetailPageResult`, report results, `HomepageViewModel`, `AboutPageContext`, `NavigationState`, cheater rule value objects, etc.).
- Use `match` for icon display config and player-queue message part dispatch; mark `MaintenancePageStylesheet::bootstrapCdn()` with `#[\Deprecated]`.
- Remove dead `substr(...) === false` guards (PHP 8+ never returns `false`) and simplify nested null-cast ternaries to `isset(...) ? (cast) : null`.
- Fix `PlayerScanTrophyTitleLoopTest` to match the earlier removal of transient fetch failure logging (pre-existing failure on master).
- Keep trophy title refetch search as a lazy `foreach` (review feedback): `iterator_to_array()`/`array_find()` would eagerly paginate the PSN collection.

## Test plan
- [x] `php tests/run.php` — all 981 tests passed
- [ ] Spot-check homepage, game list platform filters, about page, and admin game detail / report pages still render.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-394173cf-d9f5-42bd-a73f-e2227211e4cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-394173cf-d9f5-42bd-a73f-e2227211e4cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

