### PR TITLE
Adopt remaining PHP 8.5 idioms across domain services

### DIFF
--- a/tests/GameResetServiceTest.php
+++ b/tests/GameResetServiceTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../wwwroot/classes/GameResetAction.php';
 require_once __DIR__ . '/../wwwroot/classes/GameResetService.php';
 
 final class GameResetServiceTest extends TestCase
@@ -30,7 +31,7 @@ final class GameResetServiceTest extends TestCase
         $this->database->exec("INSERT INTO trophy_earned (np_communication_id, account_id) VALUES ('MERGE-123', 1001)");
         $this->database->exec("INSERT INTO trophy_group_player (np_communication_id) VALUES ('MERGE-123')");
 
-        $message = $this->service->process(1, 0);
+        $message = $this->service->process(1, GameResetAction::RESET);
 
         $this->assertSame('Game 1 was reset.', $message);
 
@@ -92,7 +93,7 @@ final class GameResetServiceTest extends TestCase
             'trophy_group',
         ];
 
-        $message = $this->service->process(1, 1);
+        $message = $this->service->process(1, GameResetAction::DELETE);
 
         $this->assertSame('Game 1 was deleted.', $message);
 
@@ -132,7 +133,7 @@ final class GameResetServiceTest extends TestCase
     public function testProcessThrowsWhenGameEntryIsMissing(): void
     {
         try {
-            $this->service->process(99, 0);
+            $this->service->process(99, GameResetAction::RESET);
             $this->fail('Expected InvalidArgumentException was not thrown.');
         } catch (InvalidArgumentException $exception) {
             $this->assertSame('Can only reset/delete merged game entries.', $exception->getMessage());
@@ -145,22 +146,10 @@ final class GameResetServiceTest extends TestCase
         $this->database->exec("INSERT INTO trophy_title_meta (np_communication_id, owners, owners_completed, parent_np_communication_id) VALUES ('NPWR-123', 1, 0, NULL)");
 
         try {
-            $this->service->process(5, 0);
+            $this->service->process(5, GameResetAction::RESET);
             $this->fail('Expected InvalidArgumentException was not thrown.');
         } catch (InvalidArgumentException $exception) {
             $this->assertSame('Can only reset/delete merged game entries.', $exception->getMessage());
-        }
-    }
-
-    public function testProcessThrowsForUnknownAction(): void
-    {
-        $this->insertMergedGame('MERGE-789', 7, 'Merged Game', 2, 1);
-
-        try {
-            $this->service->process(7, 42);
-            $this->fail('Expected InvalidArgumentException was not thrown.');
-        } catch (InvalidArgumentException $exception) {
-            $this->assertSame('Unknown method.', $exception->getMessage());
         }
     }
 
@@ -172,7 +161,7 @@ final class GameResetServiceTest extends TestCase
         // Orphan row without trophy_title_player must still be removed on reset/delete.
         $this->database->exec("INSERT INTO trophy_earned (np_communication_id, account_id) VALUES ('MERGE-ACC', 2002)");
 
-        $this->service->process(11, 0);
+        $this->service->process(11, GameResetAction::RESET);
 
         $this->assertSame(
             0,
@@ -187,7 +176,7 @@ final class GameResetServiceTest extends TestCase
         $this->database->exec('CREATE TRIGGER fail_delete BEFORE DELETE ON trophy_merge BEGIN SELECT RAISE(ABORT, "delete failure"); END;');
 
         try {
-            $this->service->process(9, 0);
+            $this->service->process(9, GameResetAction::RESET);
             $this->fail('Expected exception was not thrown.');
         } catch (Throwable $exception) {
             $this->assertStringContainsString('delete failure', $exception->getMessage());

--- a/wwwroot/classes/Admin/GameDetailFormParser.php
+++ b/wwwroot/classes/Admin/GameDetailFormParser.php
@@ -148,14 +148,10 @@ final class GameDetailFormParser
             $selected[$platform] = true;
         }
 
-        $ordered = [];
-        foreach (self::PLATFORM_OPTIONS as $platform) {
-            if (isset($selected[$platform])) {
-                $ordered[] = $platform;
-            }
-        }
-
-        return implode(',', $ordered);
+        return implode(',', array_values(array_filter(
+            self::PLATFORM_OPTIONS,
+            static fn (string $platform): bool => isset($selected[$platform])
+        )));
     }
 
     public function normalizeOptionalString(mixed $value): ?string

--- a/wwwroot/classes/Admin/GameResetRequestHandler.php
+++ b/wwwroot/classes/Admin/GameResetRequestHandler.php
@@ -6,15 +6,13 @@ require_once __DIR__ . '/../Html.php';
 
 require_once __DIR__ . '/AdminRequest.php';
 require_once __DIR__ . '/GameResetRequestResult.php';
+require_once __DIR__ . '/../GameResetAction.php';
 require_once __DIR__ . '/../GameResetService.php';
 
 class GameResetRequestHandler
 {
-    private GameResetService $gameResetService;
-
-    public function __construct(GameResetService $gameResetService)
+    public function __construct(private readonly GameResetService $gameResetService)
     {
-        $this->gameResetService = $gameResetService;
     }
 
     public function handleRequest(AdminRequest $request): GameResetRequestResult
@@ -28,7 +26,7 @@ class GameResetRequestHandler
             return GameResetRequestResult::error('<p>Please provide a valid game ID.</p>');
         }
 
-        $action = $request->getPostIntInSet('status', [0, 1]);
+        $action = GameResetAction::tryFrom($request->getPostInt('status') ?? PHP_INT_MIN);
         if ($action === null) {
             return GameResetRequestResult::error('<p>Please choose a valid action.</p>');
         }

--- a/wwwroot/classes/Admin/PsnGameLookupException.php
+++ b/wwwroot/classes/Admin/PsnGameLookupException.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 final class PsnGameLookupException extends RuntimeException
 {
-    private ?int $statusCode;
-
-    public function __construct(string $message, ?int $statusCode = null, ?Throwable $previous = null)
-    {
+    public function __construct(
+        string $message,
+        private readonly ?int $statusCode = null,
+        ?Throwable $previous = null,
+    ) {
         parent::__construct($message, 0, $previous);
-        $this->statusCode = $statusCode;
     }
 
     public function getStatusCode(): ?int

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -321,13 +321,10 @@ final class PsnGameLookupService
      */
     private function resolveAlternateQueryVariant(array $queryVariants, array $winningQuery): ?array
     {
-        foreach ($queryVariants as $queryVariant) {
-            if ($queryVariant !== $winningQuery) {
-                return $queryVariant;
-            }
-        }
-
-        return null;
+        return array_find(
+            $queryVariants,
+            static fn (array $queryVariant): bool => $queryVariant !== $winningQuery
+        );
     }
 
 }

--- a/wwwroot/classes/Admin/PsnPlayerLookupException.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupException.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 final class PsnPlayerLookupException extends RuntimeException
 {
-    private ?int $statusCode;
-
-    public function __construct(string $message, ?int $statusCode = null, ?Throwable $previous = null)
-    {
+    public function __construct(
+        string $message,
+        private readonly ?int $statusCode = null,
+        ?Throwable $previous = null,
+    ) {
         parent::__construct($message, 0, $previous);
-        $this->statusCode = $statusCode;
     }
 
     public function getStatusCode(): ?int

--- a/wwwroot/classes/Admin/PsnTrophyApiPayloadInspector.php
+++ b/wwwroot/classes/Admin/PsnTrophyApiPayloadInspector.php
@@ -178,13 +178,12 @@ final class PsnTrophyApiPayloadInspector
     private function extractNpCommunicationIdFromArray(array $payload): ?string
     {
         $topLevelCandidateKeys = ['npCommunicationId', 'np_communication_id'];
-        foreach ($topLevelCandidateKeys as $candidateKey) {
-            $candidate = $payload[$candidateKey] ?? null;
-            if (is_string($candidate) && trim($candidate) !== '') {
-                return $candidate;
-            }
-        }
+        $candidateKey = array_find(
+            $topLevelCandidateKeys,
+            fn (string $candidateKey): bool => is_string($payload[$candidateKey] ?? null)
+                && trim((string) $payload[$candidateKey]) !== ''
+        );
 
-        return null;
+        return $candidateKey === null ? null : (string) $payload[$candidateKey];
     }
 }

--- a/wwwroot/classes/Admin/TrophyGroupConflictResolver.php
+++ b/wwwroot/classes/Admin/TrophyGroupConflictResolver.php
@@ -93,23 +93,14 @@ final class TrophyGroupConflictResolver
             return null;
         }
 
-        foreach ($parentGroupTrophyNames as $parentGroupId => $parentNames) {
-            $parentGroupIdString = (string) $parentGroupId;
+        $parentGroupId = array_find_key(
+            $parentGroupTrophyNames,
+            fn (array $parentNames, int|string $parentGroupId): bool => (string) $parentGroupId !== $childGroupId
+                && !isset($usedParentGroups[(string) $parentGroupId])
+                && $parentNames === $childNames
+        );
 
-            if ($parentGroupIdString === $childGroupId) {
-                continue;
-            }
-
-            if (isset($usedParentGroups[$parentGroupIdString])) {
-                continue;
-            }
-
-            if ($parentNames === $childNames) {
-                return $parentGroupIdString;
-            }
-        }
-
-        return null;
+        return $parentGroupId === null ? null : (string) $parentGroupId;
     }
 
     /**

--- a/wwwroot/classes/AutomaticTrophyTitleMergeService.php
+++ b/wwwroot/classes/AutomaticTrophyTitleMergeService.php
@@ -284,15 +284,13 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
      */
     private function selectGameToClone(array $games): ?array
     {
-        $eligibleGames = array_values(array_filter(
-            $games,
-            static fn (array $game): bool => !str_starts_with($game['np_communication_id'], 'MERGE') && $game['status'] !== 2
-        ));
+        $isEligible = static fn (array $game): bool => !str_starts_with($game['np_communication_id'], 'MERGE')
+            && $game['status'] !== 2;
 
         return array_find(
-            $eligibleGames,
-            fn (array $game): bool => $this->hasPs5OrPsvr2($game['platforms'])
-        ) ?? array_first($eligibleGames);
+            $games,
+            fn (array $game): bool => $isEligible($game) && $this->hasPs5OrPsvr2($game['platforms'])
+        ) ?? array_find($games, $isEligible);
     }
 
     /**

--- a/wwwroot/classes/GameHistoryRenderer.php
+++ b/wwwroot/classes/GameHistoryRenderer.php
@@ -248,20 +248,9 @@ final class GameHistoryRenderer
                 return;
             }
 
-            $firstNonWhitespaceIndex = null;
-            $lastNonWhitespaceIndex = null;
-
-            foreach ($highlightTokens as $index => $token) {
-                if ($token['isWhitespace']) {
-                    continue;
-                }
-
-                if ($firstNonWhitespaceIndex === null) {
-                    $firstNonWhitespaceIndex = $index;
-                }
-
-                $lastNonWhitespaceIndex = $index;
-            }
+            $isNonWhitespace = static fn (array $token): bool => !$token['isWhitespace'];
+            $firstNonWhitespaceIndex = array_find_key($highlightTokens, $isNonWhitespace);
+            $lastNonWhitespaceIndex = array_find_key(array_reverse($highlightTokens, true), $isNonWhitespace);
 
             if ($firstNonWhitespaceIndex === null || $lastNonWhitespaceIndex === null) {
                 foreach ($highlightTokens as $token) {

--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -15,6 +15,7 @@ final readonly class GameLeaderboardFilter extends GamePlayerFilter
     /**
      * @param array<string, mixed> $queryParameters
      */
+    #[\Override]
     public static function fromArray(array $queryParameters): self
     {
         $baseFilter = parent::fromArray($queryParameters);

--- a/wwwroot/classes/GameLeaderboardPlayerNotFoundException.php
+++ b/wwwroot/classes/GameLeaderboardPlayerNotFoundException.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-class GameLeaderboardPlayerNotFoundException extends RuntimeException
+final class GameLeaderboardPlayerNotFoundException extends RuntimeException
 {
     public function __construct(
-        private int $gameId,
-        private string $gameName,
+        private readonly int $gameId,
+        private readonly string $gameName,
         string $message = 'Player not found for game',
     ) {
         parent::__construct($message);

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/GameListItem.php';
 require_once __DIR__ . '/GameListPageResult.php';
 require_once __DIR__ . '/PlatformSql.php';
+require_once __DIR__ . '/PlayerStatus.php';
 require_once __DIR__ . '/SearchQueryHelper.php';
 require_once __DIR__ . '/PsnOnlineIdValidator.php';
 
@@ -47,8 +48,7 @@ class GameListService
             return $onlineId;
         }
 
-        $status = (int) $status;
-        if ($status === 1 || $status === 3) {
+        if (PlayerStatus::fromValue((int) $status)->isRestricted()) {
             return null;
         }
 

--- a/wwwroot/classes/GameNotFoundException.php
+++ b/wwwroot/classes/GameNotFoundException.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-class GameNotFoundException extends RuntimeException
+final class GameNotFoundException extends RuntimeException
 {
 }

--- a/wwwroot/classes/GameResetAction.php
+++ b/wwwroot/classes/GameResetAction.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+enum GameResetAction: int
+{
+    case RESET = 0;
+    case DELETE = 1;
+}

--- a/wwwroot/classes/GameResetService.php
+++ b/wwwroot/classes/GameResetService.php
@@ -2,16 +2,15 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/GameResetAction.php';
+
 class GameResetService
 {
-    private const int ACTION_RESET = 0;
-    private const int ACTION_DELETE = 1;
-
     public function __construct(private readonly PDO $database)
     {
     }
 
-    public function process(int $gameId, int $action): string
+    public function process(int $gameId, GameResetAction $action): string
     {
         $npCommunicationId = $this->getGameNpCommunicationId($gameId);
 
@@ -24,9 +23,8 @@ class GameResetService
         }
 
         return match ($action) {
-            self::ACTION_RESET => $this->resetGame($gameId, $npCommunicationId),
-            self::ACTION_DELETE => $this->deleteGame($gameId, $npCommunicationId),
-            default => throw new InvalidArgumentException('Unknown method.'),
+            GameResetAction::RESET => $this->resetGame($gameId, $npCommunicationId),
+            GameResetAction::DELETE => $this->deleteGame($gameId, $npCommunicationId),
         };
     }
 

--- a/wwwroot/classes/ImageHashCalculator.php
+++ b/wwwroot/classes/ImageHashCalculator.php
@@ -51,8 +51,8 @@ final class ImageHashCalculator
 
             // Optional but helps ensure GD keeps alpha as expected
             // (No harm for hashing; makes behavior more predictable.)
-            imagesavealpha($image, true);
-            imagealphablending($image, false);
+            (void) imagesavealpha($image, true);
+            (void) imagealphablending($image, false);
 
             return $this->hashRgbaPixels($image, $width, $height);
         } finally {
@@ -103,11 +103,11 @@ final class ImageHashCalculator
             }
 
             // Prepare the sample to handle transparency correctly
-            imagealphablending($sample, false);
-            imagesavealpha($sample, true);
+            (void) imagealphablending($sample, false);
+            (void) imagesavealpha($sample, true);
 
             // Resize original image to the sampling grid
-            imagecopyresampled(
+            (void) imagecopyresampled(
                 $sample,
                 $image,
                 0,
@@ -247,7 +247,7 @@ final class ImageHashCalculator
             }
 
             // Stream into MD5 context to avoid a huge buffer
-            hash_update($ctx, $row);
+            (void) hash_update($ctx, $row);
         }
 
         return hash_final($ctx);

--- a/wwwroot/classes/ImageProcessor.php
+++ b/wwwroot/classes/ImageProcessor.php
@@ -77,7 +77,7 @@ final class GdImageProcessor implements ImageProcessorInterface
     #[\Override]
     public function convertPaletteToTrueColor(\GdImage $image): void
     {
-        @imagepalettetotruecolor($image);
+        (void) @imagepalettetotruecolor($image);
     }
 
     #[\Override]

--- a/wwwroot/classes/IpAddressResolver.php
+++ b/wwwroot/classes/IpAddressResolver.php
@@ -87,13 +87,9 @@ final class IpAddressResolver
             return '';
         }
 
-        foreach (CommaSeparatedValues::parseTrimmed($forwardedFor) as $candidate) {
-            $validatedAddress = self::resolve($candidate);
-            if ($validatedAddress !== '') {
-                return $validatedAddress;
-            }
-        }
-
-        return '';
+        return array_find(
+            array_map(self::resolve(...), CommaSeparatedValues::parseTrimmed($forwardedFor)),
+            static fn (string $validatedAddress): bool => $validatedAddress !== ''
+        ) ?? '';
     }
 }

--- a/wwwroot/classes/Leaderboard/InGameRarityLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/InGameRarityLeaderboardRow.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/AbstractLeaderboardRow.php';
 
-class InGameRarityLeaderboardRow extends AbstractLeaderboardRow
+final class InGameRarityLeaderboardRow extends AbstractLeaderboardRow
 {
     /**
      * @param array<string, mixed> $player

--- a/wwwroot/classes/Leaderboard/RarityLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/RarityLeaderboardRow.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/AbstractLeaderboardRow.php';
 
-class RarityLeaderboardRow extends AbstractLeaderboardRow
+final class RarityLeaderboardRow extends AbstractLeaderboardRow
 {
     /**
      * @param array<string, mixed> $player

--- a/wwwroot/classes/Leaderboard/TrophyLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/TrophyLeaderboardRow.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/AbstractLeaderboardRow.php';
 
-class TrophyLeaderboardRow extends AbstractLeaderboardRow
+final class TrophyLeaderboardRow extends AbstractLeaderboardRow
 {
     /**
      * @param array<string, mixed> $player

--- a/wwwroot/classes/PlayStationGraphqlPlayerSearch.php
+++ b/wwwroot/classes/PlayStationGraphqlPlayerSearch.php
@@ -92,15 +92,10 @@ final class PlayStationGraphqlPlayerSearch
             return null;
         }
 
-        foreach ($this->search($onlineId) as $player) {
-            $playerOnlineId = strtolower((string) ($player['onlineId'] ?? ''));
-
-            if ($playerOnlineId === $normalizedId) {
-                return $player;
-            }
-        }
-
-        return null;
+        return array_find(
+            $this->search($onlineId),
+            fn (array $player): bool => strtolower((string) ($player['onlineId'] ?? '')) === $normalizedId
+        );
     }
 
     private function performContextSearch(string $searchTerm): ?object

--- a/wwwroot/classes/PlayerHeaderViewModel.php
+++ b/wwwroot/classes/PlayerHeaderViewModel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/Html.php';
 
 require_once __DIR__ . '/PlayerSummary.php';
+require_once __DIR__ . '/PlayerStatus.php';
 require_once __DIR__ . '/Utility.php';
 require_once __DIR__ . '/PlayerLeaderboardRank.php';
 require_once __DIR__ . '/PlayerLeaderboardRankChange.php';
@@ -67,9 +68,7 @@ final readonly class PlayerHeaderViewModel
 
     public function canShowPlayerStats(): bool
     {
-        $status = $this->getStatus();
-
-        return $status !== 1 && $status !== 3;
+        return !$this->getStatus()->isRestricted();
     }
 
     /**
@@ -82,26 +81,26 @@ final readonly class PlayerHeaderViewModel
         $accountId = $this->getAccountId();
 
         $alerts = match ($status) {
-            1 => [
+            PlayerStatus::FLAGGED => [
                 PlayerStatusNotice::flagged($onlineId, (string) $accountId)->getMessage(),
             ],
-            3 => [
+            PlayerStatus::PRIVATE_PROFILE => [
                 PlayerStatusNotice::privateProfile()->getMessage()
                 . ' Make sure this player is no longer private, and then issue a new scan of the profile on the front page.',
             ],
-            4 => [
+            PlayerStatus::INACTIVE => [
                 'This player has not played a game in over a year and is considered inactive by this site. All data from this player will be excluded from site statistics and leaderboards.',
             ],
-            5 => [
+            PlayerStatus::UNAVAILABLE => [
                 'This player seems to no longer be available from Sony, maybe removed for some reason. We will recheck after 24h and if this player is still not available it will be removed from here as well.',
             ],
-            99 => [
+            PlayerStatus::NEW_PLAYER => [
                 'This is a new player currently being scanned for the first time. Rank and stats will be done once the scan is complete.',
             ],
-            default => [],
+            PlayerStatus::NORMAL => [],
         };
 
-        if ($status === 1 || $status === 3 || $status === 99) {
+        if ($status->isRestricted() || $status === PlayerStatus::NEW_PLAYER) {
             return $alerts;
         }
 
@@ -112,7 +111,7 @@ final readonly class PlayerHeaderViewModel
             );
         }
 
-        if ($status === 4) {
+        if ($status === PlayerStatus::INACTIVE) {
             return $alerts;
         }
 
@@ -226,14 +225,14 @@ final readonly class PlayerHeaderViewModel
         return (int) ($this->player['account_id'] ?? 0);
     }
 
-    private function getStatus(): int
+    private function getStatus(): PlayerStatus
     {
-        return (int) ($this->player['status'] ?? 0);
+        return PlayerStatus::fromValue((int) ($this->player['status'] ?? 0));
     }
 
     private function hasHiddenTrophies(): bool
     {
-        if ($this->getStatus() === 3) {
+        if ($this->getStatus()->isPrivateProfile()) {
             return false;
         }
 

--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -17,6 +17,7 @@ final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
     /**
      * @param array<string, mixed> $queryParameters
      */
+    #[\Override]
     public static function fromArray(array $queryParameters): self
     {
         $baseFilter = parent::fromArray($queryParameters);

--- a/wwwroot/classes/PlayerReportService.php
+++ b/wwwroot/classes/PlayerReportService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerReportResult.php';
+require_once __DIR__ . '/PlayerReportSubmitOutcome.php';
 require_once __DIR__ . '/IpSubmissionLockExecutor.php';
 require_once __DIR__ . '/IpSubmissionLockUnavailableException.php';
 
@@ -11,12 +12,6 @@ class PlayerReportService
     private const int MAX_PENDING_REPORTS_PER_IP = 10;
 
     public const int MAX_EXPLANATION_LENGTH = 256;
-
-    private const string SUBMIT_OUTCOME_SUCCESS = 'success';
-
-    private const string SUBMIT_OUTCOME_DUPLICATE = 'duplicate';
-
-    private const string SUBMIT_OUTCOME_LIMIT = 'limit';
 
     public function __construct(
         private readonly PDO $database,
@@ -35,26 +30,26 @@ class PlayerReportService
         try {
             $outcome = $this->getIpSubmissionLockExecutor()->execute(
                 $ipAddress,
-                function () use ($accountId, $ipAddress, $explanation): string {
+                function () use ($accountId, $ipAddress, $explanation): PlayerReportSubmitOutcome {
                     if ($this->hasExistingReport($accountId, $ipAddress)) {
-                        return self::SUBMIT_OUTCOME_DUPLICATE;
+                        return PlayerReportSubmitOutcome::DUPLICATE;
                     }
 
                     if ($this->getReportCountForIp($ipAddress) >= self::MAX_PENDING_REPORTS_PER_IP) {
-                        return self::SUBMIT_OUTCOME_LIMIT;
+                        return PlayerReportSubmitOutcome::LIMIT;
                     }
 
                     try {
                         $this->insertReport($accountId, $ipAddress, $explanation);
                     } catch (PDOException $exception) {
                         if ($this->isDuplicateReportException($exception)) {
-                            return self::SUBMIT_OUTCOME_DUPLICATE;
+                            return PlayerReportSubmitOutcome::DUPLICATE;
                         }
 
                         throw $exception;
                     }
 
-                    return self::SUBMIT_OUTCOME_SUCCESS;
+                    return PlayerReportSubmitOutcome::SUCCESS;
                 }
             );
         } catch (IpSubmissionLockUnavailableException) {
@@ -64,9 +59,9 @@ class PlayerReportService
         }
 
         return match ($outcome) {
-            self::SUBMIT_OUTCOME_SUCCESS => PlayerReportResult::success('Player reported successfully.'),
-            self::SUBMIT_OUTCOME_DUPLICATE => PlayerReportResult::error("You've already reported this player."),
-            self::SUBMIT_OUTCOME_LIMIT => PlayerReportResult::error(
+            PlayerReportSubmitOutcome::SUCCESS => PlayerReportResult::success('Player reported successfully.'),
+            PlayerReportSubmitOutcome::DUPLICATE => PlayerReportResult::error("You've already reported this player."),
+            PlayerReportSubmitOutcome::LIMIT => PlayerReportResult::error(
                 'You already have 10 reports waiting to be processed. Please try again later.'
             ),
         };

--- a/wwwroot/classes/PlayerReportSubmitOutcome.php
+++ b/wwwroot/classes/PlayerReportSubmitOutcome.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerReportSubmitOutcome: string
+{
+    case SUCCESS = 'success';
+    case DUPLICATE = 'duplicate';
+    case LIMIT = 'limit';
+}

--- a/wwwroot/classes/PlayerTimelineLayout.php
+++ b/wwwroot/classes/PlayerTimelineLayout.php
@@ -21,13 +21,10 @@ final class PlayerTimelineLayout
         $rowEndDates = [];
 
         foreach ($entries as $entry) {
-            $rowIndex = null;
-            foreach ($rowEndDates as $index => $rowEndDate) {
-                if ($entry->getFirstTrophyDate() > $rowEndDate) {
-                    $rowIndex = $index;
-                    break;
-                }
-            }
+            $rowIndex = array_find_key(
+                $rowEndDates,
+                fn (DateTimeImmutable $rowEndDate): bool => $entry->getFirstTrophyDate() > $rowEndDate
+            );
 
             if ($rowIndex === null) {
                 $rowIndex = count($rows);

--- a/wwwroot/classes/TrophyNotFoundException.php
+++ b/wwwroot/classes/TrophyNotFoundException.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-class TrophyNotFoundException extends RuntimeException
+final class TrophyNotFoundException extends RuntimeException
 {
 }

--- a/wwwroot/classes/TrophyPlayerNotFoundException.php
+++ b/wwwroot/classes/TrophyPlayerNotFoundException.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-class TrophyPlayerNotFoundException extends RuntimeException
+final class TrophyPlayerNotFoundException extends RuntimeException
 {
     public function __construct(
-        private string $trophyId,
-        private string $trophyName,
+        private readonly string $trophyId,
+        private readonly string $trophyName,
     ) {
         parent::__construct('Player not found for trophy.');
     }

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -11,7 +11,9 @@ final class TrophyTitleNameFormatter
 {
     public function format(string $name): string
     {
-        return $this->toApaTitleCase($this->sanitize($name));
+        return $name
+            |> $this->sanitize(...)
+            |> $this->toApaTitleCase(...);
     }
 
     public function sanitize(string $name): string

--- a/wwwroot/trophy.php
+++ b/wwwroot/trophy.php
@@ -106,7 +106,7 @@ require_once("header.php");
                                                     <?php
                                                     $progressTargetValue = $trophy->getProgressTargetValue();
                                                     if ($progressTargetValue !== null) {
-                                                        $progress = $playerTrophy !== null ? $playerTrophy->getProgress() : null;
+                                                        $progress = $playerTrophy?->getProgress();
                                                         ?>
                                                         <br><b><?= htmlspecialchars($progress ?? '0', ENT_QUOTES, 'UTF-8'); ?>/<?= htmlspecialchars($progressTargetValue, ENT_QUOTES, 'UTF-8'); ?></b>
                                                         <?php


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues PHP 8.5 modernization with no backward-compatibility constraints:

- Add backed enums `GameResetAction` and `PlayerReportSubmitOutcome`, and thread them through services/handlers
- Prefer existing `PlayerStatus` enum over magic ints in `PlayerHeaderViewModel` and `GameListService`
- Replace manual first-match loops with `array_find` / `array_find_key`
- Small 8.5-era cleanups: pipe in `TrophyTitleNameFormatter`, nullsafe in `trophy.php`, `(void)` for intentionally ignored GD/hash returns, constructor promotion, missing `#[\Override]`, and `final` on leaf exceptions/leaderboard rows

## Test plan

- [x] `php tests/run.php` — all 980 tests passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4fcb580-f8a2-4a30-a07f-c30b078c471b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4fcb580-f8a2-4a30-a07f-c30b078c471b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

