### PR TITLE
Adopt remaining PHP 8.5 idioms across cron jobs and value objects

### DIFF
--- a/tests/PlayerGamesPageContextTest.php
+++ b/tests/PlayerGamesPageContextTest.php
@@ -37,7 +37,7 @@ final class PlayerGamesPageContextTest extends TestCase
         );
 
         $this->assertCount(1, $selectedPlatforms);
-        $this->assertSame('PS5', array_values($selectedPlatforms)[0]->getLabel());
+        $this->assertSame('PS5', array_first($selectedPlatforms)->getLabel());
     }
 
     public function testContextReflectsPlayerStatus(): void

--- a/tests/WeeklyCronJobTest.php
+++ b/tests/WeeklyCronJobTest.php
@@ -35,11 +35,11 @@ final class WeeklyCronJobTest extends TestCase
         $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/WeeklyCronJob.php');
         $this->assertTrue(is_string($source));
         $this->assertStringContainsString(
-            '$this->executeWithRetry([$this, \'updateLeaderboardsForActivePlayers\']);',
+            '$this->executeWithRetry($this->updateLeaderboardsForActivePlayers(...));',
             $source
         );
         $this->assertStringContainsString(
-            '$this->executeWithRetry([$this, \'resetRankingsForInactivePlayers\']);',
+            '$this->executeWithRetry($this->resetRankingsForInactivePlayers(...));',
             $source
         );
         $this->assertStringContainsString('while (true)', $source);

--- a/wwwroot/classes/Admin/GameDetailFormParser.php
+++ b/wwwroot/classes/Admin/GameDetailFormParser.php
@@ -148,10 +148,13 @@ final class GameDetailFormParser
             $selected[$platform] = true;
         }
 
-        return implode(',', array_values(array_filter(
-            self::PLATFORM_OPTIONS,
-            static fn (string $platform): bool => isset($selected[$platform])
-        )));
+        return self::PLATFORM_OPTIONS
+            |> (fn(array $platforms): array => array_filter(
+                $platforms,
+                static fn (string $platform): bool => isset($selected[$platform])
+            ))
+            |> array_values(...)
+            |> (fn(array $platforms): string => implode(',', $platforms));
     }
 
     public function normalizeOptionalString(mixed $value): ?string

--- a/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
+++ b/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
@@ -344,10 +344,12 @@ final class GameRescanCatalogUpdater
             }
 
             if (!in_array('PS5', $existingPlatforms, true)) {
-                $platforms = array_values(array_filter(
-                    $platforms,
-                    static fn(string $platform): bool => $platform !== 'PS5'
-                ));
+                $platforms = $platforms
+                    |> (fn(array $items): array => array_filter(
+                        $items,
+                        static fn(string $platform): bool => $platform !== 'PS5'
+                    ))
+                    |> array_values(...);
             }
         }
 
@@ -357,10 +359,12 @@ final class GameRescanCatalogUpdater
             }
 
             if (!in_array('PS4', $existingPlatforms, true)) {
-                $platforms = array_values(array_filter(
-                    $platforms,
-                    static fn(string $platform): bool => $platform !== 'PS4'
-                ));
+                $platforms = $platforms
+                    |> (fn(array $items): array => array_filter(
+                        $items,
+                        static fn(string $platform): bool => $platform !== 'PS4'
+                    ))
+                    |> array_values(...);
             }
         }
 

--- a/wwwroot/classes/Admin/GameRescanPsnAccessor.php
+++ b/wwwroot/classes/Admin/GameRescanPsnAccessor.php
@@ -12,8 +12,8 @@ require_once __DIR__ . '/PlayStationWorkerAuthenticator.php';
  */
 final class GameRescanPsnAccessor
 {
-    private const ORIGINAL_GAME_PREFIX = 'NPWR';
-    private const LOGIN_RETRY_DELAY_SECONDS = 300;
+    private const string ORIGINAL_GAME_PREFIX = 'NPWR';
+    private const int LOGIN_RETRY_DELAY_SECONDS = 300;
     private const int ACCESSIBLE_PLAYER_PROBE_BATCH_SIZE = 100;
 
     public function __construct(

--- a/wwwroot/classes/Admin/LogDeletionRequest.php
+++ b/wwwroot/classes/Admin/LogDeletionRequest.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 final readonly class LogDeletionRequest
 {
-    private const ACTION_SINGLE = 'single';
-    private const ACTION_BULK = 'bulk';
+    private const string ACTION_SINGLE = 'single';
+    private const string ACTION_BULK = 'bulk';
 
     /**
      * @param list<int> $bulkDeletionIds
      */
     private function __construct(
-        private ?string $action,
-        private ?int $singleDeletionId,
+        final private ?string $action,
+        final private ?int $singleDeletionId,
         /** @var list<int> */
-        private array $bulkDeletionIds,
-        private ?string $errorMessage
+        final private array $bulkDeletionIds,
+        final private ?string $errorMessage
     ) {
     }
 

--- a/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
+++ b/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
@@ -22,9 +22,7 @@ final class PlayStationWorkerAuthenticator
     private const \Closure DEFAULT_REFRESH_TOKEN_SAVER = static function (int $workerId, string $refreshToken): void {
     };
 
-    private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
-        sleep($seconds);
-    };
+    private const \Closure DEFAULT_SLEEPER = sleep(...);
 
     /**
      * @var \Closure(): iterable<Worker>

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -11,8 +11,8 @@ use Tustin\PlayStation\Client;
 
 final class PsnTrophyTitleComparisonService
 {
-    public const SOURCE_DIRECT = 'direct';
-    public const SOURCE_TUSTIN = 'tustin';
+    public const string SOURCE_DIRECT = 'direct';
+    public const string SOURCE_TUSTIN = 'tustin';
 
     /**
      * @var \Closure(): iterable<Worker>

--- a/wwwroot/classes/BootstrapAssets.php
+++ b/wwwroot/classes/BootstrapAssets.php
@@ -6,8 +6,8 @@ require_once __DIR__ . '/StaticAsset.php';
 
 final class BootstrapAssets
 {
-    public const VERSION = '5.3.8';
-    public const POPPER_VERSION = '2.11.8';
+    public const string VERSION = '5.3.8';
+    public const string POPPER_VERSION = '2.11.8';
 
     public static function stylesheetUrl(): string
     {

--- a/wwwroot/classes/ChangelogPage.php
+++ b/wwwroot/classes/ChangelogPage.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/Utility.php';
 
 class ChangelogPage
 {
-    private const DEFAULT_TITLE = 'Changelog ~ PSN 100%';
+    private const string DEFAULT_TITLE = 'Changelog ~ PSN 100%';
 
     private ChangelogPaginator $paginator;
 

--- a/wwwroot/classes/ChangelogService.php
+++ b/wwwroot/classes/ChangelogService.php
@@ -7,8 +7,8 @@ require_once __DIR__ . '/ChangelogPaginator.php';
 
 final class ChangelogService
 {
-    public const PAGE_SIZE = 50;
-    private const FILTERED_CHANGE_TYPES = "('GAME_RESCAN', 'GAME_VERSION')";
+    public const int PAGE_SIZE = 50;
+    private const string FILTERED_CHANGE_TYPES = "('GAME_RESCAN', 'GAME_VERSION')";
 
     private ?int $cachedTotalChangeCount = null;
 

--- a/wwwroot/classes/ContentSecurityPolicy.php
+++ b/wwwroot/classes/ContentSecurityPolicy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final class ContentSecurityPolicy
 {
-    public const HEADER_NAME = 'Content-Security-Policy';
+    public const string HEADER_NAME = 'Content-Security-Policy';
 
     public static function value(): string
     {

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -25,9 +25,7 @@ final readonly class DailyCronJob implements CronJobInterface
      */
     private const int RANKED_OWNER_BATCH_DELAY_SECONDS = 1;
 
-    private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
-        sleep($seconds);
-    };
+    private const \Closure DEFAULT_SLEEPER = sleep(...);
 
     private const string CREATE_RANKED_PLAYER_SNAPSHOT_QUERY = <<<'SQL'
         CREATE TEMPORARY TABLE tmp_daily_ranked_players (
@@ -200,8 +198,8 @@ final readonly class DailyCronJob implements CronJobInterface
         try {
             // Populate and apply retry independently so a trophy_meta lock/timeout
             // does not force another full scan of top-10k trophy_earned rows.
-            $this->executeWithRetry([$this, 'prepareAndPopulateRankedOwnerCounts']);
-            $this->executeWithRetry([$this, 'applyTrophyRarityFromTemporaryTableWithRecovery']);
+            $this->executeWithRetry($this->prepareAndPopulateRankedOwnerCounts(...));
+            $this->executeWithRetry($this->applyTrophyRarityFromTemporaryTableWithRecovery(...));
         } finally {
             // Best-effort: a transient DROP failure must not abort run() before
             // title rarity points. The tables are TEMPORARY/session-scoped anyway.
@@ -286,7 +284,7 @@ final readonly class DailyCronJob implements CronJobInterface
             // Otherwise a failed rebuild can leave an empty temp table (if DROP
             // cleanup also fails) and the next apply-first attempt would write
             // zero owners / LEGENDARY-style rarities for every trophy.
-            $this->executeWithRetry([$this, 'preparePopulateAndApplyRankedOwnerRarity']);
+            $this->executeWithRetry($this->preparePopulateAndApplyRankedOwnerRarity(...));
         }
     }
 
@@ -324,7 +322,7 @@ final readonly class DailyCronJob implements CronJobInterface
 
     private function recalculateTitleRarityPoints(): void
     {
-        $this->executeWithRetry([$this, 'updateTrophyTitleRarityPoints']);
+        $this->executeWithRetry($this->updateTrophyTitleRarityPoints(...));
     }
 
     private function updateTrophyTitleRarityPoints(): void

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -6,15 +6,15 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final readonly class HourlyCronJob implements CronJobInterface
 {
-    private const BATCH_SIZE = 500;
+    private const int BATCH_SIZE = 500;
 
-    private const CREATE_BATCH_TEMP_TABLE_QUERY = <<<'SQL'
+    private const string CREATE_BATCH_TEMP_TABLE_QUERY = <<<'SQL'
         CREATE TEMPORARY TABLE IF NOT EXISTS tmp_hourly_batch (
             np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci PRIMARY KEY
         )
         SQL;
 
-    private const CREATE_STATS_TEMP_TABLE_QUERY = <<<'SQL'
+    private const string CREATE_STATS_TEMP_TABLE_QUERY = <<<'SQL'
         CREATE TEMPORARY TABLE IF NOT EXISTS tmp_hourly_stats (
             np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci PRIMARY KEY,
             owners INT NOT NULL,
@@ -23,7 +23,7 @@ final readonly class HourlyCronJob implements CronJobInterface
         )
         SQL;
 
-    private const POPULATE_BATCH_STATS_QUERY = <<<'SQL'
+    private const string POPULATE_BATCH_STATS_QUERY = <<<'SQL'
         INSERT INTO tmp_hourly_stats (np_communication_id, owners, owners_completed, recent_players)
         SELECT
             ttp.np_communication_id,
@@ -36,7 +36,7 @@ final readonly class HourlyCronJob implements CronJobInterface
         GROUP BY ttp.np_communication_id
         SQL;
 
-    private const UPDATE_META_QUERY = <<<'SQL'
+    private const string UPDATE_META_QUERY = <<<'SQL'
         UPDATE trophy_title_meta ttm
         JOIN tmp_hourly_batch b ON b.np_communication_id = ttm.np_communication_id
         LEFT JOIN tmp_hourly_stats s ON s.np_communication_id = ttm.np_communication_id
@@ -58,7 +58,7 @@ final readonly class HourlyCronJob implements CronJobInterface
     #[\Override]
     public function run(): void
     {
-        $this->executeWithRetry([$this, 'updateTrophyTitleStatistics']);
+        $this->executeWithRetry($this->updateTrophyTitleStatistics(...));
     }
 
     private function updateTrophyTitleStatistics(): void

--- a/wwwroot/classes/Cron/PlayerRankingUpdater.php
+++ b/wwwroot/classes/Cron/PlayerRankingUpdater.php
@@ -12,9 +12,7 @@ class PlayerRankingUpdater
     private const string LOCK_NAME = 'psn100:player_ranking_recalc';
     private const int DEFAULT_RETRY_DELAY_SECONDS = 3;
     private const int DEFAULT_MAX_RETRY_DELAY_SECONDS = 60;
-    private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
-        sleep($seconds);
-    };
+    private const \Closure DEFAULT_SLEEPER = sleep(...);
     private const string INSERT_TEMPLATE = <<<'SQL'
 INSERT INTO %s (
     account_id,

--- a/wwwroot/classes/Cron/PlayerScanPrivacyService.php
+++ b/wwwroot/classes/Cron/PlayerScanPrivacyService.php
@@ -13,9 +13,7 @@ require_once __DIR__ . '/PlayerScanTrophySummaryAccessResult.php';
  */
 final class PlayerScanPrivacyService
 {
-    private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
-        sleep($seconds);
-    };
+    private const \Closure DEFAULT_SLEEPER = sleep(...);
 
     private readonly \Closure $sleeper;
 

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -20,7 +20,7 @@ use Tustin\PlayStation\Client;
  */
 final class PlayerScanProfileSynchronizer
 {
-    private const MAX_INVALID_API_RESPONSE_ATTEMPTS = 2;
+    private const int MAX_INVALID_API_RESPONSE_ATTEMPTS = 2;
 
     private readonly PlayerAvatarSynchronizer $avatarSynchronizer;
     private readonly PlayerCountryResolver $countryResolver;

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
@@ -19,9 +19,7 @@ require_once __DIR__ . '/WorkerScanCoordinator.php';
  */
 final class PlayerScanTrophyTitleLoop
 {
-    private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
-        sleep($seconds);
-    };
+    private const \Closure DEFAULT_SLEEPER = sleep(...);
 
     private readonly \Closure $sleeper;
 

--- a/wwwroot/classes/Cron/WeeklyCronJob.php
+++ b/wwwroot/classes/Cron/WeeklyCronJob.php
@@ -6,11 +6,9 @@ require_once __DIR__ . '/CronJobInterface.php';
 
 final readonly class WeeklyCronJob implements CronJobInterface
 {
-    private const \Closure DEFAULT_SLEEPER = static function (int $seconds): void {
-        sleep($seconds);
-    };
+    private const \Closure DEFAULT_SLEEPER = sleep(...);
 
-    private const UPDATE_PLAYER_RANKINGS_QUERY = <<<'SQL'
+    private const string UPDATE_PLAYER_RANKINGS_QUERY = <<<'SQL'
         UPDATE player p
         JOIN player_ranking r ON p.account_id = r.account_id
         SET
@@ -23,7 +21,7 @@ final readonly class WeeklyCronJob implements CronJobInterface
         WHERE p.status = 0
         SQL;
 
-    private const RESET_INACTIVE_RANKINGS_QUERY = <<<'SQL'
+    private const string RESET_INACTIVE_RANKINGS_QUERY = <<<'SQL'
         UPDATE
             player p
         SET
@@ -47,8 +45,8 @@ final readonly class WeeklyCronJob implements CronJobInterface
     #[\Override]
     public function run(): void
     {
-        $this->executeWithRetry([$this, 'updateLeaderboardsForActivePlayers']);
-        $this->executeWithRetry([$this, 'resetRankingsForInactivePlayers']);
+        $this->executeWithRetry($this->updateLeaderboardsForActivePlayers(...));
+        $this->executeWithRetry($this->resetRankingsForInactivePlayers(...));
     }
 
     private function updateLeaderboardsForActivePlayers(): void

--- a/wwwroot/classes/FooterViewModel.php
+++ b/wwwroot/classes/FooterViewModel.php
@@ -5,18 +5,19 @@ declare(strict_types=1);
 final readonly class FooterViewModel
 {
     public function __construct(
-        private int $startYear,
-        private int $currentYear,
-        private string $versionLabel,
-        private string $releaseUrl,
-        private string $changelogUrl,
-        private string $issuesUrl,
-        private string $creatorName,
-        private string $creatorProfileUrl,
-        private string $contributorsUrl
+        final private int $startYear,
+        final private int $currentYear,
+        final private string $versionLabel,
+        final private string $releaseUrl,
+        final private string $changelogUrl,
+        final private string $issuesUrl,
+        final private string $creatorName,
+        final private string $creatorProfileUrl,
+        final private string $contributorsUrl
     ) {
     }
 
+    #[\NoDiscard]
     public static function createDefault(): self
     {
         $currentYear = (int) date('Y');

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -284,7 +284,9 @@ class GameHeaderService
             $psnprofilesIds[] = (int) $stringValue;
         }
 
-        return array_values(array_unique($psnprofilesIds));
+        return $psnprofilesIds
+            |> array_unique(...)
+            |> array_values(...);
     }
 
     private function getPsnpPlusNote(int $psnprofilesId): ?string

--- a/wwwroot/classes/GameHistoryService.php
+++ b/wwwroot/classes/GameHistoryService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final class GameHistoryService
 {
-    private const INVALID_HISTORY_ID = 0;
+    private const int INVALID_HISTORY_ID = 0;
 
     public function __construct(private readonly PDO $database)
     {

--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -16,6 +16,7 @@ final readonly class GameLeaderboardFilter extends GamePlayerFilter
      * @param array<string, mixed> $queryParameters
      */
     #[\Override]
+    #[\NoDiscard]
     public static function fromArray(array $queryParameters): self
     {
         $baseFilter = parent::fromArray($queryParameters);

--- a/wwwroot/classes/GameLeaderboardService.php
+++ b/wwwroot/classes/GameLeaderboardService.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/GameLeaderboardRow.php';
 
 class GameLeaderboardService
 {
-    public const PAGE_SIZE = 50;
+    public const int PAGE_SIZE = 50;
 
     public function __construct(private readonly PDO $database)
     {

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -4,25 +4,25 @@ declare(strict_types=1);
 
 readonly class GameListFilter
 {
-    public const SORT_ADDED = 'added';
-    public const SORT_COMPLETION = 'completion';
-    public const SORT_OWNERS = 'owners';
-    public const SORT_RARITY = 'rarity';
-    public const SORT_IN_GAME_RARITY = 'in-game-rarity';
-    public const SORT_SEARCH = 'search';
+    public const string SORT_ADDED = 'added';
+    public const string SORT_COMPLETION = 'completion';
+    public const string SORT_OWNERS = 'owners';
+    public const string SORT_RARITY = 'rarity';
+    public const string SORT_IN_GAME_RARITY = 'in-game-rarity';
+    public const string SORT_SEARCH = 'search';
 
-    public const PLATFORM_PC = 'pc';
-    public const PLATFORM_PS3 = 'ps3';
-    public const PLATFORM_PS4 = 'ps4';
-    public const PLATFORM_PS5 = 'ps5';
-    public const PLATFORM_PSVITA = 'psvita';
-    public const PLATFORM_PSVR = 'psvr';
-    public const PLATFORM_PSVR2 = 'psvr2';
+    public const string PLATFORM_PC = 'pc';
+    public const string PLATFORM_PS3 = 'ps3';
+    public const string PLATFORM_PS4 = 'ps4';
+    public const string PLATFORM_PS5 = 'ps5';
+    public const string PLATFORM_PSVITA = 'psvita';
+    public const string PLATFORM_PSVR = 'psvr';
+    public const string PLATFORM_PSVR2 = 'psvr2';
 
     /**
      * @var list<string>
      */
-    private const PLATFORM_KEYS = [
+    private const array PLATFORM_KEYS = [
         self::PLATFORM_PC,
         self::PLATFORM_PS3,
         self::PLATFORM_PS4,
@@ -33,26 +33,27 @@ readonly class GameListFilter
     ];
 
     private function __construct(
-        private ?string $player,
-        private string $sort,
-        private bool $sortSpecified,
-        private string $search,
-        private int $page,
-        private bool $uncompletedOnly,
+        final private ?string $player,
+        final private string $sort,
+        final private bool $sortSpecified,
+        final private string $search,
+        final private int $page,
+        final private bool $uncompletedOnly,
         /**
          * @var array<string, bool>
          */
-        private array $platformFilters,
+        final private array $platformFilters,
         /**
          * @var array<string, string>
          */
-        private array $originalParameters
+        final private array $originalParameters
     ) {
     }
 
     /**
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function fromArray(array $queryParameters): self
     {
         $originalParameters = self::extractOriginalParameters($queryParameters);

--- a/wwwroot/classes/GameListItem.php
+++ b/wwwroot/classes/GameListItem.php
@@ -14,26 +14,27 @@ final readonly class GameListItem
     private const string MISSING_PS4_ICON = '../missing-ps4-game.png';
 
     private function __construct(
-        private readonly int $id,
-        private readonly string $name,
-        private readonly GameAvailabilityStatus $status,
-        private readonly string $iconUrl,
-        private readonly string $platformValue,
-        private readonly int $owners,
-        private readonly int $rarityPoints,
-        private readonly int $inGameRarityPoints,
-        private readonly string $difficulty,
-        private readonly int $platinum,
-        private readonly int $gold,
-        private readonly int $silver,
-        private readonly int $bronze,
-        private readonly int $progress,
+        final private int $id,
+        final private string $name,
+        final private GameAvailabilityStatus $status,
+        final private string $iconUrl,
+        final private string $platformValue,
+        final private int $owners,
+        final private int $rarityPoints,
+        final private int $inGameRarityPoints,
+        final private string $difficulty,
+        final private int $platinum,
+        final private int $gold,
+        final private int $silver,
+        final private int $bronze,
+        final private int $progress,
     ) {
     }
 
     /**
      * @param array<string, mixed> $row
      */
+    #[\NoDiscard]
     public static function fromArray(array $row): self
     {
         return new self(

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/PsnOnlineIdValidator.php';
 
 class GameListService
 {
-    private const PAGE_LIMIT = 40;
+    private const int PAGE_LIMIT = 40;
 
     public function __construct(
         private readonly PDO $database,

--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/GameRecentPlayersQueryBuilder.php';
 
 class GameRecentPlayersService
 {
-    public const RECENT_PLAYERS_LIMIT = 10;
+    public const int RECENT_PLAYERS_LIMIT = 10;
 
     public function __construct(private readonly PDO $database)
     {

--- a/wwwroot/classes/GameService.php
+++ b/wwwroot/classes/GameService.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/Game/GameTrophyGroupPlayer.php';
 
 class GameService
 {
-    private const TROPHY_TYPE_ORDER_SQL = "FIELD(%s, 'bronze', 'silver', 'gold', 'platinum')";
+    private const string TROPHY_TYPE_ORDER_SQL = "FIELD(%s, 'bronze', 'silver', 'gold', 'platinum')";
 
     public function __construct(private readonly PDO $database) {}
 

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -12,9 +12,9 @@ require_once __DIR__ . '/PlatformSql.php';
 
 class HomepageContentService
 {
-    private const DEFAULT_NEW_GAME_LIMIT = 8;
-    private const DEFAULT_NEW_DLCS_LIMIT = 8;
-    private const DEFAULT_POPULAR_GAME_LIMIT = 10;
+    private const int DEFAULT_NEW_GAME_LIMIT = 8;
+    private const int DEFAULT_NEW_DLCS_LIMIT = 8;
+    private const int DEFAULT_POPULAR_GAME_LIMIT = 10;
 
     public function __construct(private readonly PDO $database)
     {

--- a/wwwroot/classes/HomepagePage.php
+++ b/wwwroot/classes/HomepagePage.php
@@ -8,15 +8,15 @@ require_once __DIR__ . '/HomepagePopularGamesFilter.php';
 
 final readonly class HomepagePage
 {
-    private const DEFAULT_TITLE = 'PSN 100% ~ PlayStation Leaderboards & Trophies';
+    private const string DEFAULT_TITLE = 'PSN 100% ~ PlayStation Leaderboards & Trophies';
 
     public function __construct(
-        private HomepageContentService $contentService,
-        private string $title = self::DEFAULT_TITLE,
-        private ?int $newGamesLimit = null,
-        private ?int $newDlcsLimit = null,
-        private ?int $popularGamesLimit = null,
-        private ?HomepagePopularGamesFilter $popularGamesFilter = null,
+        final private HomepageContentService $contentService,
+        final private string $title = self::DEFAULT_TITLE,
+        final private ?int $newGamesLimit = null,
+        final private ?int $newDlcsLimit = null,
+        final private ?int $popularGamesLimit = null,
+        final private ?HomepagePopularGamesFilter $popularGamesFilter = null,
     ) {
     }
 

--- a/wwwroot/classes/HomepagePopularGamesFilter.php
+++ b/wwwroot/classes/HomepagePopularGamesFilter.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 final readonly class HomepagePopularGamesFilter
 {
-    public const PLATFORM_ALL = '';
-    public const PLATFORM_PC = 'pc';
-    public const PLATFORM_PS3 = 'ps3';
-    public const PLATFORM_PS4 = 'ps4';
-    public const PLATFORM_PS5 = 'ps5';
-    public const PLATFORM_PSVITA = 'psvita';
-    public const PLATFORM_PSVR = 'psvr';
-    public const PLATFORM_PSVR2 = 'psvr2';
+    public const string PLATFORM_ALL = '';
+    public const string PLATFORM_PC = 'pc';
+    public const string PLATFORM_PS3 = 'ps3';
+    public const string PLATFORM_PS4 = 'ps4';
+    public const string PLATFORM_PS5 = 'ps5';
+    public const string PLATFORM_PSVITA = 'psvita';
+    public const string PLATFORM_PSVR = 'psvr';
+    public const string PLATFORM_PSVR2 = 'psvr2';
 
     /**
      * @var list<string>
      */
-    private const PLATFORM_KEYS = [
+    private const array PLATFORM_KEYS = [
         self::PLATFORM_PC,
         self::PLATFORM_PS3,
         self::PLATFORM_PS4,
@@ -29,7 +29,7 @@ final readonly class HomepagePopularGamesFilter
     /**
      * @var array<string, string>
      */
-    private const PLATFORM_LABELS = [
+    private const array PLATFORM_LABELS = [
         self::PLATFORM_ALL => 'All',
         self::PLATFORM_PC => 'PC',
         self::PLATFORM_PS3 => 'PS3',
@@ -41,14 +41,15 @@ final readonly class HomepagePopularGamesFilter
     ];
 
     private function __construct(
-        private readonly string $platform,
-        private readonly bool $exclusiveOnly,
+        final private string $platform,
+        final private bool $exclusiveOnly,
     ) {
     }
 
     /**
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function fromArray(array $queryParameters): self
     {
         $platform = self::normalizePlatform($queryParameters['platform'] ?? null);

--- a/wwwroot/classes/HttpRequest.php
+++ b/wwwroot/classes/HttpRequest.php
@@ -7,10 +7,11 @@ class HttpRequest
     /**
      * @param array<string, mixed> $server
      */
-    public function __construct(private array $server = [])
+    public function __construct(final private array $server = [])
     {
     }
 
+    #[\NoDiscard]
     public static function fromGlobals(): self
     {
         return new self($_SERVER ?? []);

--- a/wwwroot/classes/ImageHashCalculator.php
+++ b/wwwroot/classes/ImageHashCalculator.php
@@ -6,8 +6,8 @@ require_once __DIR__ . '/ImageProcessor.php';
 
 final class ImageHashCalculator
 {
-    private const GD_ALPHA_MAX = 127;
-    private const RGBA_CHANNEL_MAX = 255;
+    private const int GD_ALPHA_MAX = 127;
+    private const int RGBA_CHANNEL_MAX = 255;
 
     private ImageProcessorInterface $imageProcessor;
 

--- a/wwwroot/classes/MaintenancePage.php
+++ b/wwwroot/classes/MaintenancePage.php
@@ -10,15 +10,16 @@ final readonly class MaintenancePage
      * @param MaintenancePageStylesheet[] $stylesheets
      */
     private function __construct(
-        private string $title,
-        private string $heading,
-        private string $description,
-        private string $author,
-        private string $message,
-        private array $stylesheets,
+        final private string $title,
+        final private string $heading,
+        final private string $description,
+        final private string $author,
+        final private string $message,
+        final private array $stylesheets,
     ) {
     }
 
+    #[\NoDiscard]
     public static function createDefault(): self
     {
         return new self(

--- a/wwwroot/classes/NotFoundPage.php
+++ b/wwwroot/classes/NotFoundPage.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 final readonly class NotFoundPage
 {
     private function __construct(
-        private string $title,
-        private string $heading,
-        private string $message,
+        final private string $title,
+        final private string $heading,
+        final private string $message,
     ) {
     }
 
+    #[\NoDiscard]
     public static function createDefault(): self
     {
         return new self(

--- a/wwwroot/classes/PaginationItem.php
+++ b/wwwroot/classes/PaginationItem.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 final readonly class PaginationItem
 {
     private function __construct(
-        private ?int $page,
-        private string $label,
-        private bool $active = false,
-        private bool $disabled = false,
-        private ?string $ariaLabel = null,
+        final private ?int $page,
+        final private string $label,
+        final private bool $active = false,
+        final private bool $disabled = false,
+        final private ?string $ariaLabel = null,
     ) {
     }
 

--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -18,6 +18,7 @@ final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
      * @param array<string, mixed> $queryParameters
      */
     #[\Override]
+    #[\NoDiscard]
     public static function fromArray(array $queryParameters): self
     {
         $baseFilter = parent::fromArray($queryParameters);

--- a/wwwroot/classes/PlayerLeaderboardRank.php
+++ b/wwwroot/classes/PlayerLeaderboardRank.php
@@ -12,16 +12,17 @@ final readonly class PlayerLeaderboardRank
      * @param array<string, string> $additionalQueryParameters
      */
     private function __construct(
-        private string $label,
-        private string $basePath,
-        private array $additionalQueryParameters,
-        private string $onlineId,
-        private int $rank,
-        private int $previousRank,
-        private bool $isActive,
+        final private string $label,
+        final private string $basePath,
+        final private array $additionalQueryParameters,
+        final private string $onlineId,
+        final private int $rank,
+        final private int $previousRank,
+        final private bool $isActive,
     ) {
     }
 
+    #[\NoDiscard]
     public static function createWorldRank(
         string $basePath,
         string $onlineId,
@@ -40,6 +41,7 @@ final readonly class PlayerLeaderboardRank
         );
     }
 
+    #[\NoDiscard]
     public static function createCountryRank(
         string $basePath,
         string $onlineId,

--- a/wwwroot/classes/PlayerLogFilter.php
+++ b/wwwroot/classes/PlayerLogFilter.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 readonly class PlayerLogFilter
 {
-    public const SORT_DATE = 'date';
-    public const SORT_RARITY = 'rarity';
-    public const SORT_IN_GAME_RARITY = 'in-game-rarity';
+    public const string SORT_DATE = 'date';
+    public const string SORT_RARITY = 'rarity';
+    public const string SORT_IN_GAME_RARITY = 'in-game-rarity';
 
     /** @var array<int, string> */
-    private const ALLOWED_PLATFORMS = [
+    private const array ALLOWED_PLATFORMS = [
         'pc',
         'ps3',
         'ps4',
@@ -20,13 +20,14 @@ readonly class PlayerLogFilter
     ];
 
     private function __construct(
-        private string $sort,
-        private int $page,
+        final private string $sort,
+        final private int $page,
         /** @var array<int, string> */
-        private array $platforms,
+        final private array $platforms,
     ) {
     }
 
+    #[\NoDiscard]
     public static function fromArray(array $parameters): self
     {
         $sort = is_string($parameters['sort'] ?? null) ? (string) $parameters['sort'] : self::SORT_DATE;
@@ -46,7 +47,7 @@ readonly class PlayerLogFilter
         return new self(
             self::normaliseSort($sort),
             max($page, 1),
-            array_values(array_unique($platforms)),
+            $platforms |> array_unique(...) |> array_values(...),
         );
     }
 

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/PlatformSql.php';
 
 class PlayerLogService
 {
-    public const PAGE_SIZE = 50;
+    public const int PAGE_SIZE = 50;
 
     public function __construct(private readonly PDO $database)
     {

--- a/wwwroot/classes/PlayerPageAccessGuard.php
+++ b/wwwroot/classes/PlayerPageAccessGuard.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 final class PlayerPageAccessGuard
 {
-    private const DEFAULT_REDIRECT_URL = '/player/';
-    private const REDIRECT_STATUS_CODE = 303;
+    private const string DEFAULT_REDIRECT_URL = '/player/';
+    private const int REDIRECT_STATUS_CODE = 303;
 
     private function __construct(
         private readonly ?int $accountId,

--- a/wwwroot/classes/PlayerQueueResponse.php
+++ b/wwwroot/classes/PlayerQueueResponse.php
@@ -10,11 +10,11 @@ readonly class PlayerQueueResponse implements \JsonSerializable
      * @param list<array<string, mixed>>|null $messageParts
      */
     private function __construct(
-        private PlayerQueueStatus $status,
-        private string $message,
-        private ?array $messageParts = null,
-        private ?string $pollToken = null,
-        private int $httpStatusCode = 200,
+        final private PlayerQueueStatus $status,
+        final private string $message,
+        final private ?array $messageParts = null,
+        final private ?string $pollToken = null,
+        final private int $httpStatusCode = 200,
     ) {}
 
     /**

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -193,7 +193,7 @@ final class PlayerQueueResponseFactory
         }
 
         if (preg_match('/^(Updating|Fetching)\b/i', $normalizedTitle) === 1) {
-            return ucfirst(strtolower($normalizedTitle));
+            return $normalizedTitle |> strtolower(...) |> ucfirst(...);
         }
 
         if ($this->isErrorProgressTitle($normalizedTitle)) {

--- a/wwwroot/classes/PlayerRandomGamesFilter.php
+++ b/wwwroot/classes/PlayerRandomGamesFilter.php
@@ -15,7 +15,7 @@ final readonly class PlayerRandomGamesFilter
     /**
      * @var list<string>
      */
-    private const PLATFORM_KEYS = [
+    private const array PLATFORM_KEYS = [
         self::PLATFORM_PC,
         self::PLATFORM_PS3,
         self::PLATFORM_PS4,

--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -213,7 +213,9 @@ class PlayerRandomGamesService
             return [];
         }
 
-        $rows = array_values(array_filter($rows, 'is_array'));
+        $rows = $rows
+            |> (fn(array $rows): array => array_filter($rows, is_array(...)))
+            |> array_values(...);
 
         $rows = $this->randomizer->shuffleArray($rows);
 
@@ -280,7 +282,9 @@ class PlayerRandomGamesService
             return [];
         }
 
-        return array_values(array_filter($rows, 'is_array'));
+        return $rows
+            |> (fn(array $rows): array => array_filter($rows, is_array(...)))
+            |> array_values(...);
     }
 
     /**

--- a/wwwroot/classes/PlayerTimelineService.php
+++ b/wwwroot/classes/PlayerTimelineService.php
@@ -54,8 +54,9 @@ class PlayerTimelineService
             return null;
         }
 
-        $timelineStart = new DateTimeImmutable((string) array_first($rows)['timeline_start']);
-        $timelineEnd = new DateTimeImmutable((string) array_first($rows)['timeline_end']);
+        $bounds = array_first($rows);
+        $timelineStart = new DateTimeImmutable((string) $bounds['timeline_start']);
+        $timelineEnd = new DateTimeImmutable((string) $bounds['timeline_end']);
         $startDate = $timelineStart->modify('first day of this month');
         $endDate = $timelineEnd->modify('first day of next month');
 

--- a/wwwroot/classes/PsnpPlusClient.php
+++ b/wwwroot/classes/PsnpPlusClient.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 class PsnpPlusClient
 {
-    private const DATA_URL = 'https://psnp-plus.huskycode.dev/list.json';
+    private const string DATA_URL = 'https://psnp-plus.huskycode.dev/list.json';
 
     /**
      * @var array<int, array<string, mixed>>|null

--- a/wwwroot/classes/RouteResult.php
+++ b/wwwroot/classes/RouteResult.php
@@ -8,11 +8,11 @@ readonly class RouteResult
      * @param array<string, mixed> $variables
      */
     private function __construct(
-        private ?string $include,
-        private ?string $redirect,
-        private bool $notFound,
-        private array $variables = [],
-        private ?int $statusCode = null,
+        final private ?string $include,
+        final private ?string $redirect,
+        final private bool $notFound,
+        final private array $variables = [],
+        final private ?int $statusCode = null,
     ) {
     }
 

--- a/wwwroot/classes/Routing/LeaderboardRouteHandler.php
+++ b/wwwroot/classes/Routing/LeaderboardRouteHandler.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/RouteHandlerInterface.php';
 
 final readonly class LeaderboardRouteHandler implements RouteHandlerInterface
 {
-    private const DEFAULT_REDIRECT = '/leaderboard/trophy';
+    private const string DEFAULT_REDIRECT = '/leaderboard/trophy';
 
     /**
      * @param list<string> $segments

--- a/wwwroot/classes/TrophyListService.php
+++ b/wwwroot/classes/TrophyListService.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/TrophyListItem.php';
 
 class TrophyListService
 {
-    public const PAGE_SIZE = 50;
+    public const int PAGE_SIZE = 50;
 
     public function __construct(private readonly PDO $database)
     {

--- a/wwwroot/classes/TrophyMergeMetadataRepository.php
+++ b/wwwroot/classes/TrophyMergeMetadataRepository.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
  */
 final class TrophyMergeMetadataRepository
 {
-    private const PLATFORM_ORDER = ['PS3', 'PSVITA', 'PS4', 'PSVR', 'PS5', 'PSVR2', 'PC'];
+    private const array PLATFORM_ORDER = ['PS3', 'PSVITA', 'PS4', 'PSVR', 'PS5', 'PSVR2', 'PC'];
 
     public function __construct(
         private readonly PDO $database,

--- a/wwwroot/classes/Utility.php
+++ b/wwwroot/classes/Utility.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 class Utility
 {
-    private const SLUG_TRANSLITERATOR_RULES = ':: Any-Latin;'
+    private const string SLUG_TRANSLITERATOR_RULES = ':: Any-Latin;'
         . ':: NFD;'
         . ':: [:Nonspacing Mark:] Remove;'
         . ':: NFC;'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues PHP 8.5 modernization (no backward compatibility) after prior passes that already adopted `clone($obj, [...])`, pipes, `array_first`/`array_last`, and URI helpers.

### Changes
- **First-class callables in constant expressions**: `DEFAULT_SLEEPER = sleep(...)` in cron/admin retry helpers
- **First-class method callables**: `$this->method(...)` instead of `[$this, 'method']` for `executeWithRetry` targets (Weekly/Hourly/Daily)
- **Pipe operator**: nested `array_values(array_unique/filter(...))` chains in game/player/admin helpers
- **`array_first()`**: remaining test leftover; timeline bounds read once
- **Typed class constants**: `string`/`int`/`array` on filters, services, assets, CSP, cron SQL, etc.
- **Final property promotion**: leaf readonly DTOs (`RouteResult`, `NotFoundPage`, filters, ranks, pagination, etc.)
- **`#[\NoDiscard]`**: factories/withers whose return values must not be discarded

Infinite cron retry loops (`while (true)`) are intentionally unchanged.

### Testing
- `php tests/run.php` — all 980 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9025fc72-dd52-4760-b937-3e53b5e0066c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9025fc72-dd52-4760-b937-3e53b5e0066c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

