### PR TITLE
Adopt remaining PHP 8.5 idioms for factories, secrets, and DTOs

### DIFF
--- a/tests/AboutPageScanLogControllerTest.php
+++ b/tests/AboutPageScanLogControllerTest.php
@@ -33,6 +33,7 @@ final class FakeAboutPageService implements AboutPageDataProviderInterface
         $this->players = $players;
     }
 
+    #[\Override]
     public function getScanSummary(): AboutPageScanSummary
     {
         return $this->summary;
@@ -41,6 +42,7 @@ final class FakeAboutPageService implements AboutPageDataProviderInterface
     /**
      * @return array<int, AboutPagePlayer>
      */
+    #[\Override]
     public function getScanLogPlayers(int $limit = 10): array
     {
         $this->capturedLimit = $limit;
@@ -56,11 +58,13 @@ final class FakeAboutPageService implements AboutPageDataProviderInterface
 
 final class FailingAboutPageService implements AboutPageDataProviderInterface
 {
+    #[\Override]
     public function getScanSummary(): AboutPageScanSummary
     {
         throw new \RuntimeException('Failed to load summary');
     }
 
+    #[\Override]
     public function getScanLogPlayers(int $limit): array
     {
         throw new \RuntimeException('Failed to load scan log players');

--- a/tests/GameRescanCatalogUpdaterTest.php
+++ b/tests/GameRescanCatalogUpdaterTest.php
@@ -212,6 +212,7 @@ final class StubGameRescanGroupDataFetcher implements GameRescanGroupDataFetcher
         $this->groupData = $groupData;
     }
 
+    #[\Override]
     public function fetchGroupData(\Tustin\PlayStation\Client $client, string $npCommunicationId): array
     {
         return $this->groupData;

--- a/tests/GameRescanProgressReporterTest.php
+++ b/tests/GameRescanProgressReporterTest.php
@@ -28,6 +28,7 @@ final class GameRescanProgressReporterTest extends TestCase
             {
             }
 
+            #[\Override]
             public function onProgress(int $percent, string $message): void
             {
                 $this->events[] = [$percent, $message];
@@ -60,6 +61,7 @@ final class GameRescanProgressReporterTest extends TestCase
             {
             }
 
+            #[\Override]
             public function onProgress(int $percent, string $message): void
             {
                 $this->events[] = [$percent, $message];
@@ -204,6 +206,7 @@ final class GameRescanProgressReporterTest extends TestCase
             {
             }
 
+            #[\Override]
             public function onProgress(int $percent, string $message): void
             {
                 $this->events[] = [$percent, $message];

--- a/tests/LeaderboardPageContextTest.php
+++ b/tests/LeaderboardPageContextTest.php
@@ -144,11 +144,13 @@ final class FakeLeaderboardPageContext extends AbstractLeaderboardPageContext
         self::$dataProvider = null;
     }
 
+    #[\Override]
     public function getTitle(): string
     {
         return self::TITLE;
     }
 
+    #[\Override]
     protected static function createDataProvider(PDO $database): PlayerLeaderboardDataProvider
     {
         if (self::$dataProvider === null) {
@@ -158,6 +160,7 @@ final class FakeLeaderboardPageContext extends AbstractLeaderboardPageContext
         return self::$dataProvider;
     }
 
+    #[\Override]
     protected function createRow(
         array $player,
         PlayerLeaderboardFilter $filter,

--- a/wwwroot/classes/AboutPagePlayer.php
+++ b/wwwroot/classes/AboutPagePlayer.php
@@ -29,6 +29,7 @@ final readonly class AboutPagePlayer
     /**
      * @param array<string, mixed> $row
      */
+    #[\NoDiscard]
     public static function fromArray(array $row, Utility $utility): self
     {
         return new self(

--- a/wwwroot/classes/Admin/AdminAuthService.php
+++ b/wwwroot/classes/Admin/AdminAuthService.php
@@ -47,7 +47,7 @@ final class AdminAuthService
         return $this->loginThrottle?->getLockoutRemainingSeconds($ipAddress) ?? 0;
     }
 
-    public function login(string $username, string $password, string $ipAddress = ''): bool
+    public function login(string $username, #[\SensitiveParameter] string $password, string $ipAddress = ''): bool
     {
         if ($ipAddress !== '' && $this->isLoginLocked($ipAddress)) {
             return false;

--- a/wwwroot/classes/Admin/AdminRequest.php
+++ b/wwwroot/classes/Admin/AdminRequest.php
@@ -21,6 +21,7 @@ final readonly class AdminRequest
      * @param array<string, mixed> $serverData
      * @param array<string, mixed> $postData
      */
+    #[\NoDiscard]
     public static function fromGlobals(array $serverData, array $postData): self
     {
         $method = $serverData['REQUEST_METHOD'] ?? 'GET';

--- a/wwwroot/classes/Admin/AdminUserRepository.php
+++ b/wwwroot/classes/Admin/AdminUserRepository.php
@@ -29,7 +29,7 @@ final class AdminUserRepository
         return (int) $this->database->query(self::SQL_ADMIN_COUNT)->fetchColumn() > 0;
     }
 
-    public function verifyCredentials(string $username, string $password): bool
+    public function verifyCredentials(string $username, #[\SensitiveParameter] string $password): bool
     {
         if ($username === '' || $password === '') {
             return false;

--- a/wwwroot/classes/Admin/GameDetail.php
+++ b/wwwroot/classes/Admin/GameDetail.php
@@ -21,6 +21,7 @@ final readonly class GameDetail
     ) {
     }
 
+    #[\NoDiscard]
     public static function fromArray(int $id, array $row): self
     {
         $npCommunicationId = isset($row['np_communication_id']) ? (string) $row['np_communication_id'] : null;

--- a/wwwroot/classes/Admin/LogEntryFormatter.php
+++ b/wwwroot/classes/Admin/LogEntryFormatter.php
@@ -28,22 +28,18 @@ final class LogEntryFormatter
 
     public function format(string $message): string
     {
-        $formatters = [
-            fn (string $message) => $this->formatTrophyHistoryMessage($message),
-            fn (string $message) => $this->formatSetVersionMessage($message),
-            fn (string $message) => $this->formatNewTrophiesAddedMessage($message),
-            fn (string $message) => $this->formatSonyIssuesMessage($message),
-        ];
-
-        foreach ($formatters as $formatter) {
-            $formatted = $formatter($message);
-
-            if ($formatted !== null) {
-                return $formatted;
-            }
-        }
-
-        return $this->escape($message);
+        return array_find(
+            array_map(
+                static fn (callable $formatter): ?string => $formatter($message),
+                [
+                    $this->formatTrophyHistoryMessage(...),
+                    $this->formatSetVersionMessage(...),
+                    $this->formatNewTrophiesAddedMessage(...),
+                    $this->formatSonyIssuesMessage(...),
+                ]
+            ),
+            static fn (?string $formatted): bool => $formatted !== null
+        ) ?? $this->escape($message);
     }
 
     private function formatTrophyHistoryMessage(string $message): ?string

--- a/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
+++ b/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
@@ -19,7 +19,10 @@ final class PlayStationWorkerAuthenticator
         return new Client();
     };
 
-    private const \Closure DEFAULT_REFRESH_TOKEN_SAVER = static function (int $workerId, string $refreshToken): void {
+    private const \Closure DEFAULT_REFRESH_TOKEN_SAVER = static function (
+        int $workerId,
+        #[\SensitiveParameter] string $refreshToken,
+    ): void {
     };
 
     private const \Closure DEFAULT_SLEEPER = sleep(...);
@@ -149,7 +152,11 @@ final class PlayStationWorkerAuthenticator
         }
     }
 
-    private function loginClient(object $client, string $refreshToken, string $npsso): void
+    private function loginClient(
+        object $client,
+        #[\SensitiveParameter] string $refreshToken,
+        #[\SensitiveParameter] string $npsso,
+    ): void
     {
         if ($refreshToken !== '' && method_exists($client, 'loginWithRefreshToken')) {
             try {

--- a/wwwroot/classes/Admin/PossibleCheaterReport.php
+++ b/wwwroot/classes/Admin/PossibleCheaterReport.php
@@ -46,6 +46,7 @@ class PossibleCheaterReportEntry
     /**
      * @param array<string, mixed> $data
      */
+    #[\NoDiscard]
     public static function fromArray(array $data): self
     {
         return new self(
@@ -89,6 +90,7 @@ class PossibleCheaterReportSection
     /**
      * @param array<string, mixed> $data
      */
+    #[\NoDiscard]
     public static function fromArray(array $data): self
     {
         $title = (string) ($data['title'] ?? '');
@@ -128,6 +130,7 @@ class PossibleCheaterReportSectionEntry
     /**
      * @param array<string, mixed> $data
      */
+    #[\NoDiscard]
     public static function fromArray(array $data): self
     {
         return new self(

--- a/wwwroot/classes/Admin/PossibleCheaterRuleGroup.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleGroup.php
@@ -8,6 +8,7 @@ final readonly class PossibleCheaterRule
     {
     }
 
+    #[\NoDiscard]
     public static function fromString(string $condition): self
     {
         return new self($condition);
@@ -31,6 +32,7 @@ final readonly class PossibleCheaterRuleGroup
     /**
      * @param array<string, mixed> $data
      */
+    #[\NoDiscard]
     public static function fromArray(array $data): self
     {
         $label = (string) ($data['label'] ?? '');

--- a/wwwroot/classes/Admin/PossibleCheaterSectionDefinition.php
+++ b/wwwroot/classes/Admin/PossibleCheaterSectionDefinition.php
@@ -14,6 +14,7 @@ final class PossibleCheaterSectionDefinition
     /**
      * @param array<string, mixed> $data
      */
+    #[\NoDiscard]
     public static function fromArray(array $data): self
     {
         return new self(

--- a/wwwroot/classes/Admin/PsnTrophyTypeApiAdapter.php
+++ b/wwwroot/classes/Admin/PsnTrophyTypeApiAdapter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final class PsnTrophyTypeApiAdapter
 {
-    public function __construct(public readonly string $value)
+    public function __construct(final public readonly string $value)
     {
     }
 }

--- a/wwwroot/classes/Admin/PsnpPlusGame.php
+++ b/wwwroot/classes/Admin/PsnpPlusGame.php
@@ -10,6 +10,7 @@ readonly class PsnpPlusGame
         private string $name
     ) {}
 
+    #[\NoDiscard]
     public static function fromArray(array $row): self
     {
         return new self(

--- a/wwwroot/classes/Admin/Worker.php
+++ b/wwwroot/classes/Admin/Worker.php
@@ -8,7 +8,9 @@ final readonly class Worker
 {
     public function __construct(
         private int $id,
+        #[\SensitiveParameter]
         private string $refreshToken,
+        #[\SensitiveParameter]
         private string $npsso,
         private string $scanning,
         private DateTimeImmutable $scanStart,

--- a/wwwroot/classes/Admin/WorkerCredentialMasker.php
+++ b/wwwroot/classes/Admin/WorkerCredentialMasker.php
@@ -8,7 +8,7 @@ final class WorkerCredentialMasker
     private const int MASK_LENGTH = 8;
     private const int VISIBLE_SUFFIX_LENGTH = 4;
 
-    public static function mask(string $secret): string
+    public static function mask(#[\SensitiveParameter] string $secret): string
     {
         if ($secret === '') {
             return 'Not configured';
@@ -22,7 +22,7 @@ final class WorkerCredentialMasker
             . substr($secret, -self::VISIBLE_SUFFIX_LENGTH);
     }
 
-    public static function isConfigured(string $secret): bool
+    public static function isConfigured(#[\SensitiveParameter] string $secret): bool
     {
         return $secret !== '';
     }

--- a/wwwroot/classes/Admin/WorkerScanProgress.php
+++ b/wwwroot/classes/Admin/WorkerScanProgress.php
@@ -34,6 +34,7 @@ final readonly class WorkerScanProgress
     /**
      * @param array<string, mixed> $data
      */
+    #[\NoDiscard]
     public static function fromArray(array $data): ?self
     {
         $current = self::sanitizeInt($data['current'] ?? null);

--- a/wwwroot/classes/Admin/WorkerService.php
+++ b/wwwroot/classes/Admin/WorkerService.php
@@ -76,7 +76,7 @@ final class WorkerService
         return WorkerScanProgress::fromJson($value);
     }
 
-    public function updateWorkerNpsso(int $workerId, string $npsso): bool
+    public function updateWorkerNpsso(int $workerId, #[\SensitiveParameter] string $npsso): bool
     {
         $statement = $this->database->prepare('UPDATE setting SET npsso = :npsso WHERE id = :id');
 
@@ -92,7 +92,7 @@ final class WorkerService
         return $statement->rowCount() > 0;
     }
 
-    public function updateWorkerRefreshToken(int $workerId, string $refreshToken): bool
+    public function updateWorkerRefreshToken(int $workerId, #[\SensitiveParameter] string $refreshToken): bool
     {
         $statement = $this->database->prepare('UPDATE setting SET refresh_token = :refresh_token WHERE id = :id');
 

--- a/wwwroot/classes/ChangelogEntry.php
+++ b/wwwroot/classes/ChangelogEntry.php
@@ -48,6 +48,7 @@ readonly class ChangelogEntry
     /**
      * @param array<string, mixed> $row
      */
+    #[\NoDiscard]
     public static function fromArray(array $row): self
     {
         return new self(

--- a/wwwroot/classes/Cron/CronJobCliArguments.php
+++ b/wwwroot/classes/Cron/CronJobCliArguments.php
@@ -14,6 +14,7 @@ final readonly class CronJobCliArguments
     /**
      * @param list<string> $argv
      */
+    #[\NoDiscard]
     public static function fromArgv(array $argv): self
     {
         $arguments = [];

--- a/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
@@ -61,7 +61,7 @@ final class PlayerAvatarSynchronizer
                 }
 
                 $path = Uri\Rfc3986\Uri::parse($avatarUrl)?->getPath() ?? '';
-                $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+                $extension = pathinfo($path, PATHINFO_EXTENSION) |> strtolower(...);
                 $avatarFilename = $newPHash . '.' . $extension;
                 $avatarPath = $this->avatarStorageDirectory . $avatarFilename;
 

--- a/wwwroot/classes/Cron/PlayerScanCatalogSideEffectResult.php
+++ b/wwwroot/classes/Cron/PlayerScanCatalogSideEffectResult.php
@@ -11,8 +11,8 @@ final readonly class PlayerScanCatalogSideEffectResult
      * @param list<string> $mergeParentsToRecompute
      */
     private function __construct(
-        public ?int $titleId,
-        public array $mergeParentsToRecompute,
+        final public ?int $titleId,
+        final public array $mergeParentsToRecompute,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanCompletionResult.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionResult.php
@@ -10,7 +10,7 @@ final class PlayerScanCompletionResult
     public const STATUS_COMPLETED = 'completed';
     public const STATUS_CONTINUE_SCAN = 'continue_scan';
 
-    private function __construct(public readonly string $status)
+    private function __construct(final public readonly string $status)
     {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanProfileSyncResult.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSyncResult.php
@@ -14,10 +14,10 @@ final class PlayerScanProfileSyncResult
      * @param array<string, mixed> $player
      */
     private function __construct(
-        public readonly string $status,
-        public readonly array $player = [],
-        public readonly ?object $user = null,
-        public readonly ?string $country = null,
+        final public readonly string $status,
+        final public readonly array $player = [],
+        final public readonly ?object $user = null,
+        final public readonly ?string $country = null,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanTitleCatalogSyncResult.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleCatalogSyncResult.php
@@ -11,11 +11,11 @@ final readonly class PlayerScanTitleCatalogSyncResult
      * @param list<string> $mergeParentsToRecompute
      */
     private function __construct(
-        public bool $restartScan,
-        public bool $newTrophies,
-        public bool $isNewTitle,
-        public ?int $titleId,
-        public array $mergeParentsToRecompute,
+        final public bool $restartScan,
+        final public bool $newTrophies,
+        final public bool $isNewTitle,
+        final public ?int $titleId,
+        final public array $mergeParentsToRecompute,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanTitleHeaderSyncResult.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleHeaderSyncResult.php
@@ -8,9 +8,9 @@ declare(strict_types=1);
 final readonly class PlayerScanTitleHeaderSyncResult
 {
     public function __construct(
-        public bool $titleDataChanged,
-        public bool $titleNeedsUpdate,
-        public bool $isNewTitle,
+        final public bool $titleDataChanged,
+        final public bool $titleNeedsUpdate,
+        final public bool $isNewTitle,
     ) {
     }
 }

--- a/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php
@@ -12,8 +12,8 @@ final class PlayerScanTrophySummaryAccessResult
     public const STATUS_ABORT_SCAN = 'abort_scan';
 
     private function __construct(
-        public readonly string $status,
-        public readonly int $level = 0,
+        final public readonly string $status,
+        final public readonly int $level = 0,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoopResult.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoopResult.php
@@ -10,7 +10,7 @@ final readonly class PlayerScanTrophyTitleLoopResult
     public const ACTION_CONTINUE = 'continue';
     public const ACTION_PROCEED = 'proceed';
 
-    private function __construct(public string $action)
+    private function __construct(final public string $action)
     {
     }
 

--- a/wwwroot/classes/GameLeaderboardPageContext.php
+++ b/wwwroot/classes/GameLeaderboardPageContext.php
@@ -38,6 +38,7 @@ final class GameLeaderboardPageContext
     /**
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function fromGlobals(
         PDO $database,
         Utility $utility,

--- a/wwwroot/classes/GameLeaderboardRow.php
+++ b/wwwroot/classes/GameLeaderboardRow.php
@@ -26,6 +26,7 @@ final readonly class GameLeaderboardRow
     /**
      * @param array<string, mixed> $row
      */
+    #[\NoDiscard]
     public static function fromArray(array $row): self
     {
         return new self(

--- a/wwwroot/classes/GameListPageResult.php
+++ b/wwwroot/classes/GameListPageResult.php
@@ -8,8 +8,8 @@ final readonly class GameListPageResult
      * @param list<GameListItem> $games
      */
     public function __construct(
-        public array $games,
-        public int $totalGames
+        final public array $games,
+        final public int $totalGames,
     ) {
     }
 }

--- a/wwwroot/classes/GameRecentPlayer.php
+++ b/wwwroot/classes/GameRecentPlayer.php
@@ -26,6 +26,7 @@ final readonly class GameRecentPlayer
     /**
      * @param array<string, mixed> $row
      */
+    #[\NoDiscard]
     public static function fromArray(array $row): self
     {
         return new self(

--- a/wwwroot/classes/GameRecentPlayersPageContext.php
+++ b/wwwroot/classes/GameRecentPlayersPageContext.php
@@ -23,6 +23,7 @@ final readonly class GameRecentPlayersPageContext
     /**
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function fromGlobals(
         PDO $database,
         Utility $utility,

--- a/wwwroot/classes/GameService.php
+++ b/wwwroot/classes/GameService.php
@@ -64,7 +64,7 @@ class GameService
      */
     public function resolveSort(array $queryParameters): string
     {
-        $sort = strtolower((string) ($queryParameters['sort'] ?? 'default'));
+        $sort = ((string) ($queryParameters['sort'] ?? 'default')) |> strtolower(...);
 
         return match ($sort) {
             'date', 'rarity' => $sort,

--- a/wwwroot/classes/Leaderboard/AbstractLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/AbstractLeaderboardPageContext.php
@@ -54,6 +54,7 @@ abstract class AbstractLeaderboardPageContext
     /**
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     final public static function fromGlobals(PDO $database, Utility $utility, array $queryParameters): static
     {
         $dataProvider = static::createDataProvider($database);

--- a/wwwroot/classes/NavigationMenu.php
+++ b/wwwroot/classes/NavigationMenu.php
@@ -14,6 +14,7 @@ final class NavigationMenu
     {
     }
 
+    #[\NoDiscard]
     public static function createDefault(NavigationState $state): self
     {
         $items = [

--- a/wwwroot/classes/NavigationState.php
+++ b/wwwroot/classes/NavigationState.php
@@ -20,6 +20,7 @@ final readonly class NavigationState
     ) {
     }
 
+    #[\NoDiscard]
     public static function fromGlobals(array $server, array $queryParameters): self
     {
         $requestPath = Uri\Rfc3986\Uri::parse((string) ($server['REQUEST_URI'] ?? '/'))?->getPath() ?? '/';

--- a/wwwroot/classes/Pagination.php
+++ b/wwwroot/classes/Pagination.php
@@ -16,6 +16,7 @@ final readonly class Pagination
         $this->currentPage = min(max(1, $currentPage), $this->totalPages);
     }
 
+    #[\NoDiscard]
     public static function create(int $currentPage, int $totalPages): self
     {
         return new self($currentPage, $totalPages);

--- a/wwwroot/classes/PlayerAdvisableTrophy.php
+++ b/wwwroot/classes/PlayerAdvisableTrophy.php
@@ -77,6 +77,7 @@ class PlayerAdvisableTrophy
         $this->utility = $utility;
     }
 
+    #[\NoDiscard]
     public static function fromArray(array $data, Utility $utility): self
     {
         return new self(

--- a/wwwroot/classes/PlayerAdvisorPageContext.php
+++ b/wwwroot/classes/PlayerAdvisorPageContext.php
@@ -45,6 +45,7 @@ final class PlayerAdvisorPageContext
      * @param array<string, mixed> $playerData
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function fromGlobals(
         PDO $database,
         Utility $utility,

--- a/wwwroot/classes/PlayerGame.php
+++ b/wwwroot/classes/PlayerGame.php
@@ -31,6 +31,7 @@ class PlayerGame
     /**
      * @param array<string, mixed> $row
      */
+    #[\NoDiscard]
     public static function fromArray(array $row, ?string $completionDurationLabel = null): self
     {
         return new self(

--- a/wwwroot/classes/PlayerGamesPageContext.php
+++ b/wwwroot/classes/PlayerGamesPageContext.php
@@ -75,6 +75,7 @@ final class PlayerGamesPageContext
      * @param array<string, mixed> $playerData
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function fromGlobals(
         PDO $database,
         array $playerData,

--- a/wwwroot/classes/PlayerLeaderboardQueryResult.php
+++ b/wwwroot/classes/PlayerLeaderboardQueryResult.php
@@ -8,8 +8,8 @@ final readonly class PlayerLeaderboardQueryResult
      * @param array<int, array<string, mixed>> $players
      */
     public function __construct(
-        public array $players,
-        public ?int $totalPlayers,
+        final public array $players,
+        final public ?int $totalPlayers,
     ) {
     }
 }

--- a/wwwroot/classes/PlayerLogEntry.php
+++ b/wwwroot/classes/PlayerLogEntry.php
@@ -32,6 +32,7 @@ final readonly class PlayerLogEntry
     /**
      * @param array<string, mixed> $row
      */
+    #[\NoDiscard]
     public static function fromArray(array $row): self
     {
         return new self(

--- a/wwwroot/classes/PlayerLogPageContext.php
+++ b/wwwroot/classes/PlayerLogPageContext.php
@@ -40,6 +40,7 @@ final class PlayerLogPageContext
      * @param array<string, mixed> $playerData
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function fromGlobals(
         PDO $database,
         array $playerData,

--- a/wwwroot/classes/PlayerQueueRequest.php
+++ b/wwwroot/classes/PlayerQueueRequest.php
@@ -13,6 +13,7 @@ readonly class PlayerQueueRequest
         private string $pollToken,
     ) {}
 
+    #[\NoDiscard]
     public static function fromArrays(array $requestData, array $serverData): self
     {
         $playerName = self::sanitizeValue($requestData['q'] ?? '');

--- a/wwwroot/classes/PlayerRandomGame.php
+++ b/wwwroot/classes/PlayerRandomGame.php
@@ -28,6 +28,7 @@ final readonly class PlayerRandomGame
     /**
      * @param array<string, mixed> $data
      */
+    #[\NoDiscard]
     public static function fromArray(array $data, Utility $utility): self
     {
         return new self(

--- a/wwwroot/classes/PlayerRandomGamesFilter.php
+++ b/wwwroot/classes/PlayerRandomGamesFilter.php
@@ -38,6 +38,7 @@ final readonly class PlayerRandomGamesFilter
     /**
      * @param array<string, mixed> $parameters
      */
+    #[\NoDiscard]
     public static function fromArray(array $parameters): self
     {
         $selectedPlatforms = [];

--- a/wwwroot/classes/PlayerRandomGamesPageContext.php
+++ b/wwwroot/classes/PlayerRandomGamesPageContext.php
@@ -41,6 +41,7 @@ final class PlayerRandomGamesPageContext
      * @param array<string, mixed> $playerData
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function fromGlobals(
         PDO $database,
         Utility $utility,

--- a/wwwroot/classes/PlayerReportRequest.php
+++ b/wwwroot/classes/PlayerReportRequest.php
@@ -18,6 +18,7 @@ final readonly class PlayerReportRequest
      * @param array<string, mixed> $postParameters
      * @param array<string, mixed> $serverParameters
      */
+    #[\NoDiscard]
     public static function fromArrays(array $postParameters, array $serverParameters): self
     {
         $explanationSubmitted = array_key_exists('explanation', $postParameters);

--- a/wwwroot/classes/PlayerScanProgress.php
+++ b/wwwroot/classes/PlayerScanProgress.php
@@ -14,6 +14,7 @@ final readonly class PlayerScanProgress
     /**
      * @param array<string, mixed>|null $data
      */
+    #[\NoDiscard]
     public static function fromArray(?array $data): ?self
     {
         if ($data === null) {

--- a/wwwroot/classes/PlayerTimeline.php
+++ b/wwwroot/classes/PlayerTimeline.php
@@ -28,6 +28,7 @@ final readonly class PlayerTimeline
     /**
      * @param array<string, mixed> $data
      */
+    #[\NoDiscard]
     public static function fromArray(array $data, Utility $utility): self
     {
         return new self(

--- a/wwwroot/classes/PlayerTimelinePageContext.php
+++ b/wwwroot/classes/PlayerTimelinePageContext.php
@@ -33,6 +33,7 @@ final class PlayerTimelinePageContext
      * @param array<string, mixed> $playerData
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function fromGlobals(
         PDO $database,
         Utility $utility,

--- a/wwwroot/classes/PlayerTrophyProgress.php
+++ b/wwwroot/classes/PlayerTrophyProgress.php
@@ -13,6 +13,7 @@ readonly class PlayerTrophyProgress
     /**
      * @param array<string, mixed> $data
      */
+    #[\NoDiscard]
     public static function fromArray(array $data, ?string $progressTargetValue): self
     {
         $earned = ((int) ($data['earned'] ?? 0)) === 1;

--- a/wwwroot/classes/TrophyImageDirectories.php
+++ b/wwwroot/classes/TrophyImageDirectories.php
@@ -11,13 +11,14 @@ declare(strict_types=1);
 final readonly class TrophyImageDirectories
 {
     public function __construct(
-        public string $title,
-        public string $group,
-        public string $trophy,
-        public string $reward,
+        final public string $title,
+        final public string $group,
+        final public string $trophy,
+        final public string $reward,
     ) {
     }
 
+    #[\NoDiscard]
     public static function productionDefault(): self
     {
         return new self(

--- a/wwwroot/classes/TrophyImageDownloader.php
+++ b/wwwroot/classes/TrophyImageDownloader.php
@@ -178,7 +178,7 @@ final readonly class TrophyImageDownloader
         }
 
         $path = Uri\Rfc3986\Uri::parse($url)?->getPath() ?? '';
-        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        $extension = pathinfo($path, PATHINFO_EXTENSION) |> strtolower(...);
         $extension = $extension === '' ? '' : '.' . $extension;
 
         return $hash . $extension;

--- a/wwwroot/database.php
+++ b/wwwroot/database.php
@@ -8,10 +8,12 @@ final readonly class DatabaseConfig
         private string $host,
         private string $database,
         private string $user,
+        #[\SensitiveParameter]
         private string $password,
     ) {
     }
 
+    #[\NoDiscard]
     public static function createDefault(): self
     {
         return new self('', '', '', '');
@@ -20,6 +22,7 @@ final readonly class DatabaseConfig
     /**
      * @param array<string, string> $config
      */
+    #[\NoDiscard]
     public static function fromArray(array $config): self
     {
         return new self(
@@ -33,6 +36,7 @@ final readonly class DatabaseConfig
     /**
      * @param array<string, string> $environment
      */
+    #[\NoDiscard]
     public static function fromEnvironment(array $environment = []): self
     {
         return new self(
@@ -134,6 +138,7 @@ class Database extends PDO
         }
     }
 
+    #[\NoDiscard]
     public static function fromEnvironment(array $environment = []): self
     {
         return new self(DatabaseConfig::fromEnvironment($environment));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Continues the PHP 8.5-only modernization after prior waves that already adopted `array_first`/`array_last`, clone-with, pipes, and Uri parsing.

### Changes
- Add `#[\NoDiscard]` to remaining value-object factories (`fromArray` / `fromGlobals` / `fromArrays` / `create*` / `productionDefault`)
- Annotate credential parameters with `#[\SensitiveParameter]` (admin passwords, NPSSO, refresh tokens, DB password)
- Mark public promoted DTO properties as `final` (and `final public readonly` on non-readonly result classes)
- Prefer pipe for path-extension lowercasing and `array_find` + first-class callables in `LogEntryFormatter`
- Add missing `#[\Override]` on test doubles that implement project interfaces/abstracts

### Testing
- Full suite: `php tests/run.php`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7467a485-73f4-45f4-a20c-5d0f1ff58a54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7467a485-73f4-45f4-a20c-5d0f1ff58a54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

