### PR TITLE
Adopt remaining PHP 8.5 idioms across services and value objects

### DIFF
--- a/wwwroot/classes/AboutPageContext.php
+++ b/wwwroot/classes/AboutPageContext.php
@@ -7,9 +7,9 @@ require_once __DIR__ . '/AboutPagePlayerArraySerializer.php';
 
 final readonly class AboutPageContext
 {
-    private const DEFAULT_SCAN_LOG_LIMIT = 30;
-    private const DEFAULT_MAX_INITIAL_DISPLAY_COUNT = 10;
-    private const DEFAULT_TITLE = 'About ~ PSN 100%';
+    private const int DEFAULT_SCAN_LOG_LIMIT = 30;
+    private const int DEFAULT_MAX_INITIAL_DISPLAY_COUNT = 10;
+    private const string DEFAULT_TITLE = 'About ~ PSN 100%';
 
     /**
      * @param list<AboutPagePlayer> $scanLogPlayers
@@ -28,6 +28,7 @@ final readonly class AboutPageContext
     ) {
     }
 
+    #[\NoDiscard]
     public static function create(
         AboutPageDataProviderInterface $dataProvider,
         int $scanLogLimit = self::DEFAULT_SCAN_LOG_LIMIT,

--- a/wwwroot/classes/AboutPageScanLogController.php
+++ b/wwwroot/classes/AboutPageScanLogController.php
@@ -11,9 +11,9 @@ require_once __DIR__ . '/IpAddressResolver.php';
 
 final class AboutPageScanLogController
 {
-    private const DEFAULT_LIMIT = 30;
-    private const MIN_LIMIT = 1;
-    private const MAX_LIMIT = 100;
+    private const int DEFAULT_LIMIT = 30;
+    private const int MIN_LIMIT = 1;
+    private const int MAX_LIMIT = 100;
 
     private AboutPageDataProviderInterface $aboutPageService;
     private JsonResponseEmitter $jsonResponder;
@@ -38,6 +38,7 @@ final class AboutPageScanLogController
         $this->maxLimit = $maxLimit;
     }
 
+    #[\NoDiscard]
     public static function create(
         AboutPageDataProviderInterface $aboutPageService,
         JsonResponseEmitter $jsonResponder,

--- a/wwwroot/classes/AboutPageService.php
+++ b/wwwroot/classes/AboutPageService.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/AboutPageScanSummary.php';
 
 final readonly class AboutPageService implements AboutPageDataProviderInterface
 {
-    private const DEFAULT_SCAN_LOG_LIMIT = 10;
+    private const int DEFAULT_SCAN_LOG_LIMIT = 10;
 
     public function __construct(
         private readonly PDO $database,

--- a/wwwroot/classes/AbstractPlayerLeaderboardService.php
+++ b/wwwroot/classes/AbstractPlayerLeaderboardService.php
@@ -7,9 +7,9 @@ require_once __DIR__ . '/PlayerLeaderboardQueryResult.php';
 
 abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeaderboardDataProvider
 {
-    public const PAGE_SIZE = 50;
+    public const int PAGE_SIZE = 50;
 
-    private const COUNT_SQL = <<<'SQL'
+    private const string COUNT_SQL = <<<'SQL'
         SELECT
             COUNT(*)
         FROM

--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/TrophyGroupConflictResolver.php';
 
 class GameCopyService
 {
-    private const TROPHY_UPDATE_QUERY = <<<'SQL'
+    private const string TROPHY_UPDATE_QUERY = <<<'SQL'
         WITH
             tg_org AS(
             SELECT
@@ -46,7 +46,7 @@ class GameCopyService
             tg.np_communication_id = :parent_np_communication_id
         SQL;
 
-    private const TROPHY_INSERT_QUERY = <<<'SQL'
+    private const string TROPHY_INSERT_QUERY = <<<'SQL'
         INSERT INTO
             trophy (
                 np_communication_id,
@@ -99,7 +99,7 @@ class GameCopyService
             )
         SQL;
 
-    private const TROPHY_META_INSERT_QUERY = <<<'SQL'
+    private const string TROPHY_META_INSERT_QUERY = <<<'SQL'
         INSERT INTO
             trophy_meta (
                 trophy_id,

--- a/wwwroot/classes/Admin/GameDetailPage.php
+++ b/wwwroot/classes/Admin/GameDetailPage.php
@@ -62,7 +62,7 @@ class GameDetailPage
         $error = null;
 
         try {
-            $method = strtoupper((string) ($serverParameters['REQUEST_METHOD'] ?? 'GET'));
+            $method = ((string) ($serverParameters['REQUEST_METHOD'] ?? 'GET')) |> strtoupper(...);
 
             if ($method === 'POST') {
                 $action = $this->formParser->parseAction($postData['action'] ?? null);

--- a/wwwroot/classes/Admin/GameRescanRequestHandler.php
+++ b/wwwroot/classes/Admin/GameRescanRequestHandler.php
@@ -21,7 +21,7 @@ class GameRescanRequestHandler
      */
     public function handleRequest(array $postData, array $serverData): void
     {
-        $method = strtoupper((string) ($serverData['REQUEST_METHOD'] ?? ''));
+        $method = ((string) ($serverData['REQUEST_METHOD'] ?? '')) |> strtoupper(...);
         if ($method !== 'POST') {
             $this->sendJsonResponse(405, [
                 'success' => false,

--- a/wwwroot/classes/Admin/LogDeletionRequest.php
+++ b/wwwroot/classes/Admin/LogDeletionRequest.php
@@ -22,6 +22,7 @@ final readonly class LogDeletionRequest
     /**
      * @param array<string, mixed> $postData
      */
+    #[\NoDiscard]
     public static function fromPostData(array $postData): self
     {
         $action = null;

--- a/wwwroot/classes/Admin/MergeTrophyGroupCopier.php
+++ b/wwwroot/classes/Admin/MergeTrophyGroupCopier.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/TrophyGroupConflictResolver.php';
  */
 final class MergeTrophyGroupCopier
 {
-    private const TROPHY_GROUP_UPDATE_QUERY = <<<'SQL'
+    private const string TROPHY_GROUP_UPDATE_QUERY = <<<'SQL'
         WITH
             tg_org AS(
             SELECT
@@ -33,7 +33,7 @@ final class MergeTrophyGroupCopier
             tg.np_communication_id = :parent_np_communication_id
         SQL;
 
-    private const TROPHY_GROUP_INSERT_QUERY = <<<'SQL'
+    private const string TROPHY_GROUP_INSERT_QUERY = <<<'SQL'
         INSERT INTO
             trophy_group (
                 np_communication_id,

--- a/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
+++ b/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
@@ -68,6 +68,7 @@ final class PlayStationWorkerAuthenticator
             : null;
     }
 
+    #[\NoDiscard]
     public static function fromWorkerService(
         WorkerService $workerService,
         ?callable $clientFactory = null,
@@ -76,7 +77,7 @@ final class PlayStationWorkerAuthenticator
         return new self(
             static fn (): array => $workerService->fetchWorkers(),
             $clientFactory,
-            static function (int $workerId, string $refreshToken) use ($workerService): void {
+            static function (int $workerId, #[\SensitiveParameter] string $refreshToken) use ($workerService): void {
                 $workerService->updateWorkerRefreshToken($workerId, $refreshToken);
             },
             null,

--- a/wwwroot/classes/Admin/PlayerReportDeletionRequest.php
+++ b/wwwroot/classes/Admin/PlayerReportDeletionRequest.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 final readonly class PlayerReportDeletionRequest
 {
     private function __construct(
-        private ?int $deleteId,
-        private ?string $errorMessage
+        final private ?int $deleteId,
+        final private ?string $errorMessage,
     ) {
     }
 
     /**
      * @param array<string, mixed> $postData
      */
+    #[\NoDiscard]
     public static function fromPostData(array $postData): self
     {
         if (!array_key_exists('delete_id', $postData)) {

--- a/wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/PossibleCheaterRuleTuple.php';
 
 final class PossibleCheaterRuleConditionParser
 {
-    private const CONDITION_PATTERN = '/^te\.np_communication_id = \'([^\']+)\' AND te\.order_id = (\d+)(?: AND te\.earned_date (>=|<=|<) \'([^\']+)\')?$/';
+    private const string CONDITION_PATTERN = '/^te\.np_communication_id = \'([^\']+)\' AND te\.order_id = (\d+)(?: AND te\.earned_date (>=|<=|<) \'([^\']+)\')?$/';
 
     public function parse(string $condition): PossibleCheaterRuleTuple
     {

--- a/wwwroot/classes/Admin/PossibleCheaterRulesCatalog.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRulesCatalog.php
@@ -7,8 +7,8 @@ require_once __DIR__ . '/PossibleCheaterSectionDefinition.php';
 
 final class PossibleCheaterRulesCatalog
 {
-    private const DEFAULT_GENERAL_RULES_FILE = __DIR__ . '/../../config/possible-cheater-general-rules.php';
-    private const DEFAULT_SECTIONS_FILE = __DIR__ . '/../../config/possible-cheater-sections.php';
+    private const string DEFAULT_GENERAL_RULES_FILE = __DIR__ . '/../../config/possible-cheater-general-rules.php';
+    private const string DEFAULT_SECTIONS_FILE = __DIR__ . '/../../config/possible-cheater-sections.php';
 
     /**
      * @var PossibleCheaterRuleGroup[]|null

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -37,6 +37,7 @@ final class PsnGameLookupService
         $this->trophyGroupAssembler = $trophyGroupAssembler ?? new PsnTrophyGroupAssembler();
     }
 
+    #[\NoDiscard]
     public static function fromDatabase(PDO $database): self
     {
         $workerService = new WorkerService($database);

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -11,6 +11,16 @@ use Tustin\PlayStation\Client;
 
 final class PsnPlayerLookupService
 {
+    private const \Closure DEFAULT_CLIENT_FACTORY = static function (): object {
+        return new Client();
+    };
+
+    private const \Closure DEFAULT_REFRESH_TOKEN_SAVER = static function (
+        int $workerId,
+        #[\SensitiveParameter] string $refreshToken,
+    ): void {
+    };
+
     /**
      * @var \Closure(): iterable<Worker>
      */
@@ -32,15 +42,11 @@ final class PsnPlayerLookupService
     public function __construct(callable $workerFetcher, ?callable $clientFactory = null, ?callable $refreshTokenSaver = null)
     {
         $this->workerFetcher = \Closure::fromCallable($workerFetcher);
-        $this->clientFactory = \Closure::fromCallable(
-            $clientFactory ?? static function (): object {
-                return new Client();
-            }
-        );
-        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? static function (int $workerId, string $refreshToken): void {
-        });
+        $this->clientFactory = \Closure::fromCallable($clientFactory ?? self::DEFAULT_CLIENT_FACTORY);
+        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? self::DEFAULT_REFRESH_TOKEN_SAVER);
     }
 
+    #[\NoDiscard]
     public static function fromDatabase(PDO $database): self
     {
         $workerService = new WorkerService($database);
@@ -48,7 +54,7 @@ final class PsnPlayerLookupService
         return new self(
             static fn (): array => $workerService->fetchWorkers(),
             null,
-            static fn (int $workerId, string $refreshToken): bool => $workerService->updateWorkerRefreshToken($workerId, $refreshToken)
+            static fn (int $workerId, #[\SensitiveParameter] string $refreshToken): bool => $workerService->updateWorkerRefreshToken($workerId, $refreshToken)
         );
     }
 

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -14,6 +14,20 @@ final class PsnTrophyTitleComparisonService
     public const string SOURCE_DIRECT = 'direct';
     public const string SOURCE_TUSTIN = 'tustin';
 
+    private const \Closure DEFAULT_CLIENT_FACTORY = static function (): object {
+        return new Client();
+    };
+
+    private const \Closure DEFAULT_TIME_PROVIDER = static function (): float {
+        return microtime(true);
+    };
+
+    private const \Closure DEFAULT_REFRESH_TOKEN_SAVER = static function (
+        int $workerId,
+        #[\SensitiveParameter] string $refreshToken,
+    ): void {
+    };
+
     /**
      * @var \Closure(): iterable<Worker>
      */
@@ -45,12 +59,12 @@ final class PsnTrophyTitleComparisonService
         ?callable $refreshTokenSaver = null,
     ) {
         $this->workerFetcher = \Closure::fromCallable($workerFetcher);
-        $this->clientFactory = \Closure::fromCallable($clientFactory ?? static fn (): object => new Client());
-        $this->timeProvider = \Closure::fromCallable($timeProvider ?? static fn (): float => microtime(true));
-        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? static function (int $workerId, string $refreshToken): void {
-        });
+        $this->clientFactory = \Closure::fromCallable($clientFactory ?? self::DEFAULT_CLIENT_FACTORY);
+        $this->timeProvider = \Closure::fromCallable($timeProvider ?? self::DEFAULT_TIME_PROVIDER);
+        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? self::DEFAULT_REFRESH_TOKEN_SAVER);
     }
 
+    #[\NoDiscard]
     public static function fromDatabase(PDO $database): self
     {
         $workerService = new WorkerService($database);
@@ -59,7 +73,7 @@ final class PsnTrophyTitleComparisonService
             static fn (): array => $workerService->fetchWorkers(),
             null,
             null,
-            static fn (int $workerId, string $refreshToken): bool => $workerService->updateWorkerRefreshToken($workerId, $refreshToken)
+            static fn (int $workerId, #[\SensitiveParameter] string $refreshToken): bool => $workerService->updateWorkerRefreshToken($workerId, $refreshToken)
         );
     }
 

--- a/wwwroot/classes/Admin/PsnpPlusService.php
+++ b/wwwroot/classes/Admin/PsnpPlusService.php
@@ -12,9 +12,9 @@ require_once __DIR__ . '/../PsnpPlusClient.php';
 class PsnpPlusService
 {
     /**
-     * @var int[]
+     * @var list<int>
      */
-    private const UNRELEASED_GAMES = [
+    private const array UNRELEASED_GAMES = [
         2409, 2410, 2414, 2552, 4234, 4236, 4237, 4240, 4241, 5012, 5318, 5925, 6420, 7082, 7272, 8352, 8644, 8672,
         10225, 10314, 10519, 10601, 10834, 11153, 13787, 13788, 14299, 16636, 16827, 16907, 16935, 17071, 17166, 17244,
         17359, 17420, 17575, 17745, 18171, 18552, 18895,

--- a/wwwroot/classes/Admin/TrophyMergeProcessor.php
+++ b/wwwroot/classes/Admin/TrophyMergeProcessor.php
@@ -30,7 +30,7 @@ class TrophyMergeProcessor
      */
     public function processRequest(array $postData, array $serverData): void
     {
-        $method = strtoupper((string) ($serverData['REQUEST_METHOD'] ?? ''));
+        $method = ((string) ($serverData['REQUEST_METHOD'] ?? '')) |> strtoupper(...);
         if ($method !== 'POST') {
             $this->sendJsonResponse(405, [
                 'success' => false,
@@ -42,7 +42,7 @@ class TrophyMergeProcessor
 
         $childId = $this->filterNumericValue($postData['child'] ?? null);
         $parentId = $this->filterNumericValue($postData['parent'] ?? null);
-        $mergeMethod = strtolower((string) ($postData['method'] ?? 'order'));
+        $mergeMethod = ((string) ($postData['method'] ?? 'order')) |> strtolower(...);
 
         if ($childId === null || $parentId === null) {
             $this->sendJsonResponse(400, [

--- a/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
+++ b/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
@@ -97,7 +97,7 @@ class TrophyMergeRequestHandler
 
         $childId = (int) $postData['child'];
         $parentId = (int) $postData['parent'];
-        $method = strtolower((string) ($postData['method'] ?? 'order'));
+        $method = ((string) ($postData['method'] ?? 'order')) |> strtolower(...);
 
         return $this->trophyMergeService->mergeGames($childId, $parentId, $method, $progressListener);
     }
@@ -106,7 +106,7 @@ class TrophyMergeRequestHandler
     {
         $childId = (int) $postData['child'];
         $parentId = (int) $postData['parent'];
-        $method = strtolower((string) ($postData['method'] ?? 'order'));
+        $method = ((string) ($postData['method'] ?? 'order')) |> strtolower(...);
 
         return $this->trophyMergeService->mergeGames($childId, $parentId, $method);
     }

--- a/wwwroot/classes/AvatarPage.php
+++ b/wwwroot/classes/AvatarPage.php
@@ -38,6 +38,7 @@ class AvatarPage
     /**
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function fromQueryParameters(AvatarService $avatarService, array $queryParameters, int $limit = 48): self
     {
         $page = 1;

--- a/wwwroot/classes/ChangelogPage.php
+++ b/wwwroot/classes/ChangelogPage.php
@@ -30,6 +30,7 @@ class ChangelogPage
     /**
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function create(PDO $database, Utility $utility, array $queryParameters): self
     {
         $service = new ChangelogService($database);
@@ -40,6 +41,7 @@ class ChangelogPage
     /**
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function fromService(ChangelogService $service, Utility $utility, array $queryParameters): self
     {
         $requestedPage = self::resolvePageNumber($queryParameters['page'] ?? null);

--- a/wwwroot/classes/Cron/PlayerScanCompletionResult.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionResult.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
  */
 final class PlayerScanCompletionResult
 {
-    public const STATUS_COMPLETED = 'completed';
-    public const STATUS_CONTINUE_SCAN = 'continue_scan';
+    public const string STATUS_COMPLETED = 'completed';
+    public const string STATUS_CONTINUE_SCAN = 'continue_scan';
 
     private function __construct(final public readonly string $status)
     {

--- a/wwwroot/classes/Cron/PlayerScanCompletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionService.php
@@ -102,7 +102,7 @@ final class PlayerScanCompletionService
         $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
         $withinAYear = $query->fetchColumn();
-        if ($withinAYear == 0) {
+        if ((int) $withinAYear === 0) {
             $playerStatus = 4;
         }
 
@@ -159,7 +159,7 @@ final class PlayerScanCompletionService
         $query->execute();
         $playerStatus = $query->fetchColumn();
 
-        if ($playerStatus != 0) {
+        if ((int) $playerStatus !== 0) {
             return;
         }
 

--- a/wwwroot/classes/Cron/PlayerScanPrivacyService.php
+++ b/wwwroot/classes/Cron/PlayerScanPrivacyService.php
@@ -15,14 +15,11 @@ final class PlayerScanPrivacyService
 {
     private const \Closure DEFAULT_SLEEPER = sleep(...);
 
-    private readonly \Closure $sleeper;
-
     public function __construct(
         private readonly PDO $database,
         private readonly WorkerScanCoordinator $workerScanCoordinator,
-        ?callable $sleeper = null,
+        private readonly \Closure $sleeper = self::DEFAULT_SLEEPER,
     ) {
-        $this->sleeper = \Closure::fromCallable($sleeper ?? self::DEFAULT_SLEEPER);
     }
 
     public function markAsPrivateByOnlineId(string $onlineId): void

--- a/wwwroot/classes/Cron/PlayerScanProfileSyncResult.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSyncResult.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
  */
 final class PlayerScanProfileSyncResult
 {
-    public const STATUS_SUCCESS = 'success';
-    public const STATUS_SKIP_PLAYER = 'skip_player';
+    public const string STATUS_SUCCESS = 'success';
+    public const string STATUS_SKIP_PLAYER = 'skip_player';
 
     /**
      * @param array<string, mixed> $player

--- a/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
@@ -317,7 +317,7 @@ final class PlayerScanTitleCatalogSynchronizer
                 $query->bindValue(':np_communication_id', $npid, PDO::PARAM_STR);
                 $query->execute();
                 $status = $query->fetchColumn();
-                if ($status == 2) {
+                if ((int) $status === 2) {
                     $this->logger->log('New trophies added for ' . $trophyTitle->name() . '. ' . $npid . ', ' . $trophyGroupId . ', ' . $trophyGroupName);
                 } else {
                     $this->logger->log('SET VERSION for ' . $trophyTitle->name() . '. ' . $npid . ', ' . $trophyGroupId . ', ' . $trophyGroupName);

--- a/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php
@@ -7,9 +7,9 @@ declare(strict_types=1);
  */
 final class PlayerScanTrophySummaryAccessResult
 {
-    public const STATUS_ACCESSIBLE = 'accessible';
-    public const STATUS_PRIVATE = 'private';
-    public const STATUS_ABORT_SCAN = 'abort_scan';
+    public const string STATUS_ACCESSIBLE = 'accessible';
+    public const string STATUS_PRIVATE = 'private';
+    public const string STATUS_ABORT_SCAN = 'abort_scan';
 
     private function __construct(
         final public readonly string $status,

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
@@ -21,8 +21,6 @@ final class PlayerScanTrophyTitleLoop
 {
     private const \Closure DEFAULT_SLEEPER = sleep(...);
 
-    private readonly \Closure $sleeper;
-
     public function __construct(
         private readonly PDO $database,
         private readonly Psn100Logger $logger,
@@ -33,11 +31,8 @@ final class PlayerScanTrophyTitleLoop
         private readonly PlayerScanStaleGameDeletionService $staleGameDeletionService,
         private readonly PlayerScanCompletionService $scanCompletionService,
         private readonly PlayerScanTrophyTitleRefresher $trophyTitleRefresher,
-        ?callable $sleeper = null,
+        private readonly \Closure $sleeper = self::DEFAULT_SLEEPER,
     ) {
-        $this->sleeper = $sleeper === null
-            ? self::DEFAULT_SLEEPER
-            : \Closure::fromCallable($sleeper);
     }
 
     /**

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoopResult.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoopResult.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
  */
 final readonly class PlayerScanTrophyTitleLoopResult
 {
-    public const ACTION_CONTINUE = 'continue';
-    public const ACTION_PROCEED = 'proceed';
+    public const string ACTION_CONTINUE = 'continue';
+    public const string ACTION_PROCEED = 'proceed';
 
     private function __construct(final public string $action)
     {

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -174,10 +174,10 @@ final readonly class ThirtyMinuteCronJob implements CronJobInterface
                 continue;
             }
 
-            if ($recheck == $player["online_id"]) {
-                $recheck = "";
+            if ($recheck === $player['online_id']) {
+                $recheck = '';
             } else {
-                $recheck = $player["online_id"];
+                $recheck = $player['online_id'];
             }
 
             $onlineId = (string) $player['online_id'];

--- a/wwwroot/classes/GameRecentPlayersQueryBuilder.php
+++ b/wwwroot/classes/GameRecentPlayersQueryBuilder.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/GamePlayerFilter.php';
 
 final class GameRecentPlayersQueryBuilder
 {
-    private const BASE_QUERY = <<<'SQL'
+    private const string BASE_QUERY = <<<'SQL'
         WITH eligible_players AS (
             SELECT
                 p.account_id,
@@ -38,7 +38,7 @@ final class GameRecentPlayersQueryBuilder
         WHERE ttp.np_communication_id = :np_communication_id
     SQL;
 
-    private const ORDER_BY_QUERY = <<<'SQL'
+    private const string ORDER_BY_QUERY = <<<'SQL'
         ORDER BY
             ttp.last_updated_date DESC
         LIMIT :limit

--- a/wwwroot/classes/GameTrophyFilter.php
+++ b/wwwroot/classes/GameTrophyFilter.php
@@ -14,6 +14,7 @@ readonly class GameTrophyFilter
     /**
      * @param array<string, mixed> $queryParameters
      */
+    #[\NoDiscard]
     public static function fromQueryParameters(array $queryParameters, bool $allowUnearnedFilter): self
     {
         if (!$allowUnearnedFilter) {

--- a/wwwroot/classes/Homepage/HomepageItem.php
+++ b/wwwroot/classes/Homepage/HomepageItem.php
@@ -6,8 +6,8 @@ require_once __DIR__ . '/../CommaSeparatedValues.php';
 
 abstract readonly class HomepageItem
 {
-    private const MISSING_PS5_ICON = '/img/missing-ps5-game-and-trophy.png';
-    private const MISSING_PS4_ICON = '/img/missing-ps4-game.png';
+    private const string MISSING_PS5_ICON = '/img/missing-ps5-game-and-trophy.png';
+    private const string MISSING_PS4_ICON = '/img/missing-ps4-game.png';
 
     private string $iconDirectory;
 

--- a/wwwroot/classes/HomepageController.php
+++ b/wwwroot/classes/HomepageController.php
@@ -14,6 +14,7 @@ final readonly class HomepageController
     ) {
     }
 
+    #[\NoDiscard]
     public static function fromDatabase(PDO $database): self
     {
         $contentService = new HomepageContentService($database);

--- a/wwwroot/classes/Leaderboard/InGameRarityLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/InGameRarityLeaderboardPageContext.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/InGameRarityLeaderboardRow.php';
 
 class InGameRarityLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
-    private const TITLE = 'PSN Rarity (Game) Leaderboard ~ PSN 100%';
+    private const string TITLE = 'PSN Rarity (Game) Leaderboard ~ PSN 100%';
 
     #[\Override]
     public function getTitle(): string

--- a/wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/RarityLeaderboardRow.php';
 
 class RarityLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
-    private const TITLE = 'PSN Rarity Leaderboard ~ PSN 100%';
+    private const string TITLE = 'PSN Rarity Leaderboard ~ PSN 100%';
 
     #[\Override]
     public function getTitle(): string

--- a/wwwroot/classes/Leaderboard/TrophyLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/TrophyLeaderboardPageContext.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/TrophyLeaderboardRow.php';
 
 class TrophyLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
-    private const TITLE = 'PSN Trophy Leaderboard ~ PSN 100%';
+    private const string TITLE = 'PSN Trophy Leaderboard ~ PSN 100%';
 
     #[\Override]
     public function getTitle(): string

--- a/wwwroot/classes/MaintenanceResponder.php
+++ b/wwwroot/classes/MaintenanceResponder.php
@@ -6,6 +6,20 @@ require_once __DIR__ . '/MaintenanceMode.php';
 
 final readonly class MaintenanceResponder
 {
+    private const \Closure DEFAULT_STATUS_EMITTER = http_response_code(...);
+
+    private const \Closure DEFAULT_HEADER_EMITTER = header(...);
+
+    private const \Closure DEFAULT_TEMPLATE_INCLUDER = static function (string $template): void {
+        require_once $template;
+    };
+
+    private const \Closure DEFAULT_TERMINATOR = static function (): void {
+        exit();
+    };
+
+    private const \Closure DEFAULT_HEADERS_SENT_DETECTOR = headers_sent(...);
+
     private \Closure $statusEmitter;
 
     private \Closure $headerEmitter;
@@ -23,40 +37,11 @@ final readonly class MaintenanceResponder
         ?callable $terminator = null,
         ?callable $headersSentDetector = null
     ) {
-        $this->statusEmitter = $this->toClosure(
-            $statusEmitter,
-            static function (int $status): void {
-                http_response_code($status);
-            }
-        );
-
-        $this->headerEmitter = $this->toClosure(
-            $headerEmitter,
-            static function (string $header): void {
-                header($header);
-            }
-        );
-
-        $this->templateIncluder = $this->toClosure(
-            $templateIncluder,
-            static function (string $template): void {
-                require_once $template;
-            }
-        );
-
-        $this->terminator = $this->toClosure(
-            $terminator,
-            static function (): void {
-                exit();
-            }
-        );
-
-        $this->headersSentDetector = $this->toClosure(
-            $headersSentDetector,
-            static function (): bool {
-                return headers_sent();
-            }
-        );
+        $this->statusEmitter = $this->toClosure($statusEmitter, self::DEFAULT_STATUS_EMITTER);
+        $this->headerEmitter = $this->toClosure($headerEmitter, self::DEFAULT_HEADER_EMITTER);
+        $this->templateIncluder = $this->toClosure($templateIncluder, self::DEFAULT_TEMPLATE_INCLUDER);
+        $this->terminator = $this->toClosure($terminator, self::DEFAULT_TERMINATOR);
+        $this->headersSentDetector = $this->toClosure($headersSentDetector, self::DEFAULT_HEADERS_SENT_DETECTOR);
     }
 
     public function respond(MaintenanceMode $maintenanceMode): void

--- a/wwwroot/classes/PageMetaDataRenderer.php
+++ b/wwwroot/classes/PageMetaDataRenderer.php
@@ -6,8 +6,8 @@ require_once __DIR__ . '/PageMetaData.php';
 
 class PageMetaDataRenderer
 {
-    private const OG_SITE_NAME = 'PSN 100%';
-    private const TWITTER_CARD = 'summary_large_image';
+    private const string OG_SITE_NAME = 'PSN 100%';
+    private const string TWITTER_CARD = 'summary_large_image';
 
     public function render(PageMetaData $metaData): string
     {

--- a/wwwroot/classes/PlayStationGraphqlPlayerSearch.php
+++ b/wwwroot/classes/PlayStationGraphqlPlayerSearch.php
@@ -4,27 +4,33 @@ declare(strict_types=1);
 
 final class PlayStationGraphqlPlayerSearch
 {
-    private const GRAPHQL_OPERATION_CONTEXT = 'metGetContextSearchResults';
+    private const string GRAPHQL_OPERATION_CONTEXT = 'metGetContextSearchResults';
 
-    private const GRAPHQL_OPERATION_DOMAIN = 'metGetDomainSearchResults';
+    private const string GRAPHQL_OPERATION_DOMAIN = 'metGetDomainSearchResults';
 
-    private const GRAPHQL_PERSISTED_QUERY_HASHES = [
+    /**
+     * @var array<string, string>
+     */
+    private const array GRAPHQL_PERSISTED_QUERY_HASHES = [
         self::GRAPHQL_OPERATION_CONTEXT => 'ac5fb2b82c4d086ca0d272fba34418ab327a7762dd2cd620e63f175bbc5aff10',
         self::GRAPHQL_OPERATION_DOMAIN => '23ece284bf8bdc50bfa30a4d97fd4d733e723beb7a42dff8c1ee883f8461a2e1',
     ];
 
-    private const GRAPHQL_HEADERS = [
+    /**
+     * @var array<string, string>
+     */
+    private const array GRAPHQL_HEADERS = [
         'apollographql-client-name' => 'PlayStationApp-Android',
         'content-type' => 'application/json',
     ];
 
-    private const GRAPHQL_SEARCH_CONTEXT = 'MobileUniversalSearchSocial';
+    private const string GRAPHQL_SEARCH_CONTEXT = 'MobileUniversalSearchSocial';
 
-    private const GRAPHQL_SEARCH_LOCALE = 'en-US';
+    private const string GRAPHQL_SEARCH_LOCALE = 'en-US';
 
-    private const GRAPHQL_SEARCH_DOMAIN = 'SocialAllAccounts';
+    private const string GRAPHQL_SEARCH_DOMAIN = 'SocialAllAccounts';
 
-    private const GRAPHQL_PAGE_SIZE = 20;
+    private const int GRAPHQL_PAGE_SIZE = 20;
 
     private object $client;
 

--- a/wwwroot/classes/PlayerAdvisorFilter.php
+++ b/wwwroot/classes/PlayerAdvisorFilter.php
@@ -4,18 +4,21 @@ declare(strict_types=1);
 
 readonly class PlayerAdvisorFilter
 {
-    public const SORT_RARITY = 'rarity';
-    public const SORT_IN_GAME_RARITY = 'in_game_rarity';
+    public const string SORT_RARITY = 'rarity';
+    public const string SORT_IN_GAME_RARITY = 'in_game_rarity';
 
     /**
-     * @var array<int, string>
+     * @var list<string>
      */
-    private const ALLOWED_SORTS = [
+    private const array ALLOWED_SORTS = [
         self::SORT_RARITY,
         self::SORT_IN_GAME_RARITY,
     ];
 
-    private const SUPPORTED_PLATFORMS = [
+    /**
+     * @var list<string>
+     */
+    private const array SUPPORTED_PLATFORMS = [
         'pc',
         'ps3',
         'ps4',

--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/Utility.php';
 
 class PlayerAdvisorService
 {
-    public const PAGE_SIZE = 50;
+    public const int PAGE_SIZE = 50;
 
     private PDO $database;
 

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -4,23 +4,26 @@ declare(strict_types=1);
 
 class PlayerGamesFilter
 {
-    public const SORT_DATE = 'date';
-    public const SORT_IN_GAME_MAX_RARITY = 'max-in-game-rarity';
-    public const SORT_IN_GAME_RARITY = 'in-game-rarity';
-    public const SORT_MAX_RARITY = 'max-rarity';
-    public const SORT_NAME = 'name';
-    public const SORT_RARITY = 'rarity';
-    public const SORT_SEARCH = 'search';
+    public const string SORT_DATE = 'date';
+    public const string SORT_IN_GAME_MAX_RARITY = 'max-in-game-rarity';
+    public const string SORT_IN_GAME_RARITY = 'in-game-rarity';
+    public const string SORT_MAX_RARITY = 'max-rarity';
+    public const string SORT_NAME = 'name';
+    public const string SORT_RARITY = 'rarity';
+    public const string SORT_SEARCH = 'search';
 
-    public const PLATFORM_PC = 'pc';
-    public const PLATFORM_PS3 = 'ps3';
-    public const PLATFORM_PS4 = 'ps4';
-    public const PLATFORM_PS5 = 'ps5';
-    public const PLATFORM_PSVITA = 'psvita';
-    public const PLATFORM_PSVR = 'psvr';
-    public const PLATFORM_PSVR2 = 'psvr2';
+    public const string PLATFORM_PC = 'pc';
+    public const string PLATFORM_PS3 = 'ps3';
+    public const string PLATFORM_PS4 = 'ps4';
+    public const string PLATFORM_PS5 = 'ps5';
+    public const string PLATFORM_PSVITA = 'psvita';
+    public const string PLATFORM_PSVR = 'psvr';
+    public const string PLATFORM_PSVR2 = 'psvr2';
 
-    private const ALLOWED_SORTS = [
+    /**
+     * @var list<string>
+     */
+    private const array ALLOWED_SORTS = [
         self::SORT_DATE,
         self::SORT_IN_GAME_MAX_RARITY,
         self::SORT_IN_GAME_RARITY,
@@ -30,7 +33,10 @@ class PlayerGamesFilter
         self::SORT_SEARCH,
     ];
 
-    private const PLATFORM_KEYS = [
+    /**
+     * @var list<string>
+     */
+    private const array PLATFORM_KEYS = [
         self::PLATFORM_PC,
         self::PLATFORM_PS3,
         self::PLATFORM_PS4,
@@ -40,7 +46,7 @@ class PlayerGamesFilter
         self::PLATFORM_PSVR2,
     ];
 
-    private const DEFAULT_LIMIT = 50;
+    private const int DEFAULT_LIMIT = 50;
 
     private string $search;
     private string $sort;

--- a/wwwroot/classes/PlayerTimelineEntry.php
+++ b/wwwroot/classes/PlayerTimelineEntry.php
@@ -16,6 +16,7 @@ final readonly class PlayerTimelineEntry
     /**
      * @param array<string, mixed> $row
      */
+    #[\NoDiscard]
     public static function fromRow(array $row): self
     {
         return new self(

--- a/wwwroot/classes/TrophyMetaRepository.php
+++ b/wwwroot/classes/TrophyMetaRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final class TrophyMetaRepository
 {
-    private const SELECT_TROPHY_ID_SQL = <<<'SQL'
+    private const string SELECT_TROPHY_ID_SQL = <<<'SQL'
         SELECT id
         FROM trophy
         WHERE np_communication_id = :np_communication_id
@@ -12,7 +12,7 @@ final class TrophyMetaRepository
           AND order_id = :order_id
     SQL;
 
-    private const SQLITE_INSERT_META_SQL = <<<'SQL'
+    private const string SQLITE_INSERT_META_SQL = <<<'SQL'
         INSERT OR IGNORE INTO trophy_meta (
             trophy_id,
             rarity_percent,
@@ -30,7 +30,7 @@ final class TrophyMetaRepository
         )
     SQL;
 
-    private const MYSQL_INSERT_META_SQL = <<<'SQL'
+    private const string MYSQL_INSERT_META_SQL = <<<'SQL'
         INSERT INTO trophy_meta (
             trophy_id,
             rarity_percent,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the PHP 8.5-only modernization after recent merges. The codebase already used `array_first`/`array_last`, `clone($obj, [...])`, pipes, and URI helpers widely; this pass cleans up remaining consistency gaps:

- Promote cron sleeper defaults to `private const \Closure` + constructor defaults (matching `WorkerScanCoordinator`)
- Lift PSN lookup/comparison and maintenance responder callable fallbacks into const Closures, with `#[\SensitiveParameter]` on refresh tokens
- Finish typed class constants (`string`/`int`/`array`) on filters, GraphQL search, cron result tags, SQL heredocs, and related helpers
- Mark request/DTO/service factories with `#[\NoDiscard]`
- Prefer pipe for admin request-method normalization and strict comparisons in scan completion/recheck paths

## Test plan

- [x] `php tests/run.php` — all 984 tests passed
- [ ] Spot-check admin merge/rescan request method handling still treats GET/POST case-insensitively
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-804d95b4-bc27-42f1-995b-464eb1ba99ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-804d95b4-bc27-42f1-995b-464eb1ba99ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

