### PR TITLE
Finish PHP 8.5 enum and readonly filter adoption

### DIFF
--- a/tests/AboutPageContextTest.php
+++ b/tests/AboutPageContextTest.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPageContext.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPagePlayer.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPageScanSummary.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerStatus.php';
 require_once __DIR__ . '/../wwwroot/classes/Utility.php';
 
 final class AboutPageDataProviderStub implements AboutPageDataProviderInterface
@@ -91,7 +92,7 @@ final class AboutPageContextTest extends TestCase
                 100,
                 '50',
                 0,
-                0,
+                PlayerStatus::NORMAL,
                 1,
                 1,
                 1

--- a/tests/AboutPageScanLogControllerTest.php
+++ b/tests/AboutPageScanLogControllerTest.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../wwwroot/classes/AboutPageService.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPageScanSummary.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPagePlayer.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPagePlayerArraySerializer.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerStatus.php';
 require_once __DIR__ . '/../wwwroot/classes/Utility.php';
 require_once __DIR__ . '/../wwwroot/classes/JsonResponseEmitter.php';
 require_once __DIR__ . '/../wwwroot/classes/IpRateLimitService.php';
@@ -78,8 +79,8 @@ final class AboutPageScanLogControllerTest extends TestCase
         $utility = new Utility();
 
         $players = [
-            new AboutPagePlayer($utility, 'Ragowit', 'se', 'avatar1.png', '2024-01-01 00:00:00', 999, '50', 0, 0, 10, 10, 1),
-            new AboutPagePlayer($utility, 'Hunter', 'us', 'avatar2.png', '2024-01-02 12:00:00', 123, '25', 1, 0, 5, 10, 2),
+            new AboutPagePlayer($utility, 'Ragowit', 'se', 'avatar1.png', '2024-01-01 00:00:00', 999, '50', 0, PlayerStatus::NORMAL, 10, 10, 1),
+            new AboutPagePlayer($utility, 'Hunter', 'us', 'avatar2.png', '2024-01-02 12:00:00', 123, '25', 1, PlayerStatus::NORMAL, 5, 10, 2),
         ];
         $summary = new AboutPageScanSummary(25, 7);
         $service = new FakeAboutPageService($summary, $players);
@@ -112,7 +113,7 @@ final class AboutPageScanLogControllerTest extends TestCase
     {
         $utility = new Utility();
         $players = [
-            new AboutPagePlayer($utility, 'SoloPlayer', 'gb', 'avatar3.png', '2024-01-03 08:30:00', 75, '90', 0, 0, 1, 1, 5),
+            new AboutPagePlayer($utility, 'SoloPlayer', 'gb', 'avatar3.png', '2024-01-03 08:30:00', 75, '90', 0, PlayerStatus::NORMAL, 1, 1, 5),
         ];
         $summary = new AboutPageScanSummary(3, 1);
         $service = new FakeAboutPageService($summary, $players);
@@ -144,7 +145,7 @@ final class AboutPageScanLogControllerTest extends TestCase
 
         $utility = new Utility();
         $players = [
-            new AboutPagePlayer($utility, 'SoloPlayer', 'gb', 'avatar3.png', '2024-01-03 08:30:00', 75, '90', 0, 0, 1, 1, 5),
+            new AboutPagePlayer($utility, 'SoloPlayer', 'gb', 'avatar3.png', '2024-01-03 08:30:00', 75, '90', 0, PlayerStatus::NORMAL, 1, 1, 5),
         ];
         $summary = new AboutPageScanSummary(3, 1);
         $service = new FakeAboutPageService($summary, $players);

--- a/tests/AboutPageServiceTest.php
+++ b/tests/AboutPageServiceTest.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPageService.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPagePlayer.php';
 require_once __DIR__ . '/../wwwroot/classes/AboutPageScanSummary.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerStatus.php';
 require_once __DIR__ . '/../wwwroot/classes/Utility.php';
 
 /**
@@ -232,7 +233,7 @@ final class AboutPageServiceTest extends TestCase
         $this->assertTrue($firstPlayer->isRanked());
         $this->assertSame(8, $firstPlayer->getRanking());
         $this->assertTrue($firstPlayer->hasHiddenTrophies());
-        $this->assertSame(0, $firstPlayer->getStatus());
+        $this->assertSame(PlayerStatus::NORMAL, $firstPlayer->getStatus());
         $this->assertSame(null, $firstPlayer->getStatusLabel());
         $this->assertFalse($firstPlayer->isNew());
         $this->assertSame(2, $firstPlayer->getRankDelta());
@@ -250,7 +251,7 @@ final class AboutPageServiceTest extends TestCase
         $this->assertFalse($secondPlayer->isRanked());
         $this->assertSame(null, $secondPlayer->getRanking());
         $this->assertFalse($secondPlayer->hasHiddenTrophies());
-        $this->assertSame(3, $secondPlayer->getStatus());
+        $this->assertSame(PlayerStatus::PRIVATE_PROFILE, $secondPlayer->getStatus());
         $this->assertSame('Private', $secondPlayer->getStatusLabel());
         $this->assertTrue($secondPlayer->isNew());
         $this->assertSame(null, $secondPlayer->getRankDelta());

--- a/wwwroot/about.php
+++ b/wwwroot/about.php
@@ -161,7 +161,7 @@ require_once("header.php");
                                             </td>
                                             <td class="align-middle text-center">
                                                 <?php
-                                                if ($player->getStatus() == 1 || $player->getStatus() == 3) {
+                                                if ($player->getStatus()->isRestricted()) {
                                                     echo 'N/A';
                                                 } else {
                                                     echo '<img src="/img/star.svg" class="mb-1" alt="Level" title="Level" height="18"/> ' . $level;

--- a/wwwroot/classes/AboutPagePlayer.php
+++ b/wwwroot/classes/AboutPagePlayer.php
@@ -2,14 +2,10 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerStatus.php';
+
 final readonly class AboutPagePlayer
 {
-    private const array STATUS_LABELS = [
-        1 => 'Cheater',
-        3 => 'Private',
-        4 => 'Inactive',
-    ];
-
     public function __construct(
         private Utility $utility,
         private string $onlineId,
@@ -19,7 +15,7 @@ final readonly class AboutPagePlayer
         private ?int $level,
         private ?string $progress,
         private int $rankLastWeek,
-        private int $status,
+        private PlayerStatus $status,
         private int $trophyCountNpwr,
         private int $trophyCountSony,
         private ?int $ranking,
@@ -41,7 +37,7 @@ final readonly class AboutPagePlayer
             isset($row['level']) ? (int) $row['level'] : null,
             isset($row['progress']) ? (string) $row['progress'] : null,
             isset($row['rank_last_week']) ? (int) $row['rank_last_week'] : 0,
-            isset($row['status']) ? (int) $row['status'] : 0,
+            PlayerStatus::fromValue(isset($row['status']) ? (int) $row['status'] : 0),
             isset($row['trophy_count_npwr']) ? (int) $row['trophy_count_npwr'] : 0,
             isset($row['trophy_count_sony']) ? (int) $row['trophy_count_sony'] : 0,
             isset($row['ranking']) ? (int) $row['ranking'] : null,
@@ -85,7 +81,7 @@ final readonly class AboutPagePlayer
 
     public function isRanked(): bool
     {
-        return $this->status === 0 && $this->ranking !== null;
+        return $this->status === PlayerStatus::NORMAL && $this->ranking !== null;
     }
 
     public function getRanking(): ?int
@@ -98,14 +94,14 @@ final readonly class AboutPagePlayer
         return $this->trophyCountNpwr < $this->trophyCountSony;
     }
 
-    public function getStatus(): int
+    public function getStatus(): PlayerStatus
     {
         return $this->status;
     }
 
     public function getStatusLabel(): ?string
     {
-        return self::STATUS_LABELS[$this->status] ?? null;
+        return $this->status->label();
     }
 
     public function isNew(): bool

--- a/wwwroot/classes/AboutPagePlayerArraySerializer.php
+++ b/wwwroot/classes/AboutPagePlayerArraySerializer.php
@@ -26,7 +26,7 @@ final class AboutPagePlayerArraySerializer
             'rankDeltaColor' => $player->getRankDeltaColor(),
             'progress' => $player->getProgress(),
             'level' => $player->getLevel(),
-            'status' => $player->getStatus(),
+            'status' => $player->getStatus()->value,
         ];
     }
 

--- a/wwwroot/classes/Game/GameDetails.php
+++ b/wwwroot/classes/Game/GameDetails.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../CommaSeparatedValues.php';
+require_once __DIR__ . '/../GameAvailabilityStatus.php';
+require_once __DIR__ . '/../GameStatusBadge.php';
 
 final readonly class GameDetails
 {
@@ -27,7 +29,7 @@ final readonly class GameDetails
         private int $ownersCompleted,
         private int $owners,
         private string $difficulty,
-        private int $status,
+        private GameAvailabilityStatus $status,
         private int $rarityPoints,
         private int $inGameRarityPoints,
         private array $obsoleteGameIds,
@@ -60,7 +62,7 @@ final readonly class GameDetails
             (int) ($row['owners_completed'] ?? 0),
             (int) ($row['owners'] ?? 0),
             (string) ($row['difficulty'] ?? '0'),
-            (int) ($row['status'] ?? 0),
+            GameAvailabilityStatus::fromInt((int) ($row['status'] ?? 0)),
             (int) ($row['rarity_points'] ?? 0),
             (int) ($row['in_game_rarity_points'] ?? 0),
             self::parseObsoleteIds($row['obsolete_ids'] ?? null),
@@ -204,9 +206,26 @@ final readonly class GameDetails
         return $this->difficulty;
     }
 
-    public function getStatus(): int
+    public function getStatus(): GameAvailabilityStatus
     {
         return $this->status;
+    }
+
+    public function shouldShowRarityPoints(): bool
+    {
+        return $this->status === GameAvailabilityStatus::NORMAL;
+    }
+
+    public function getStatusBadge(): ?GameStatusBadge
+    {
+        $label = $this->status->badgeLabel();
+        $message = $this->status->warningMessage();
+
+        if ($label === null || $message === null) {
+            return null;
+        }
+
+        return new GameStatusBadge($label, $message);
     }
 
     public function getRarityPoints(): int

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/Game/GameHeaderData.php';
 require_once __DIR__ . '/Game/GameHeaderParent.php';
 require_once __DIR__ . '/Game/GameHeaderStack.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/PsnpPlusClient.php';
 require_once __DIR__ . '/Html.php';
 
@@ -25,7 +26,7 @@ class GameHeaderService
         $parentNpCommunicationId = $game->getParentNpCommunicationId();
 
         $parentGame = null;
-        if ($status === 2 && $parentNpCommunicationId !== null && $parentNpCommunicationId !== '') {
+        if ($status === GameAvailabilityStatus::MERGED && $parentNpCommunicationId !== null && $parentNpCommunicationId !== '') {
             $parentGame = $this->fetchParentGame($parentNpCommunicationId);
         }
 

--- a/wwwroot/classes/GameLeaderboardPage.php
+++ b/wwwroot/classes/GameLeaderboardPage.php
@@ -14,50 +14,20 @@ require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
 
 class GameLeaderboardPage
 {
-    private GameDetails $game;
-
-    private GameHeaderData $gameHeaderData;
-
-    private GameLeaderboardFilter $filter;
-
-    private int $totalPlayers;
-
-    private int $limit;
-
-    private int $offset;
-
-    private int $totalPagesCount;
-
-    /**
-     * @var GameLeaderboardRow[]
-     */
-    private array $rows;
-
-    private ?string $playerAccountId;
-
     /**
      * @param GameLeaderboardRow[] $rows
      */
     private function __construct(
-        GameDetails $game,
-        GameHeaderData $gameHeaderData,
-        GameLeaderboardFilter $filter,
-        int $totalPlayers,
-        int $limit,
-        int $offset,
-        int $totalPagesCount,
-        array $rows,
-        ?string $playerAccountId
+        private GameDetails $game,
+        private GameHeaderData $gameHeaderData,
+        private GameLeaderboardFilter $filter,
+        private int $totalPlayers,
+        private int $limit,
+        private int $offset,
+        private int $totalPagesCount,
+        private array $rows,
+        private ?string $playerAccountId
     ) {
-        $this->game = $game;
-        $this->gameHeaderData = $gameHeaderData;
-        $this->filter = $filter;
-        $this->totalPlayers = $totalPlayers;
-        $this->limit = $limit;
-        $this->offset = $offset;
-        $this->totalPagesCount = $totalPagesCount;
-        $this->rows = $rows;
-        $this->playerAccountId = $playerAccountId;
     }
 
     /**
@@ -66,6 +36,7 @@ class GameLeaderboardPage
      * @throws GameNotFoundException
      * @throws GameLeaderboardPlayerNotFoundException
      */
+    #[\NoDiscard]
     public static function create(
         GameLeaderboardService $leaderboardService,
         GameHeaderService $headerService,

--- a/wwwroot/classes/GameRecentPlayersPage.php
+++ b/wwwroot/classes/GameRecentPlayersPage.php
@@ -13,39 +13,18 @@ require_once __DIR__ . '/Utility.php';
 
 class GameRecentPlayersPage
 {
-    private GameDetails $game;
-
-    private GameHeaderData $gameHeaderData;
-
-    private GamePlayerFilter $filter;
-
-    /**
-     * @var GameRecentPlayer[]
-     */
-    private array $recentPlayers;
-
-    private ?string $playerAccountId;
-
-    private ?GamePlayerProgress $gamePlayer;
-
     /**
      * @param GameRecentPlayer[] $recentPlayers
      * @param GamePlayerProgress|null $gamePlayer
      */
     private function __construct(
-        GameDetails $game,
-        GameHeaderData $gameHeaderData,
-        GamePlayerFilter $filter,
-        array $recentPlayers,
-        ?string $playerAccountId,
-        ?GamePlayerProgress $gamePlayer
+        private GameDetails $game,
+        private GameHeaderData $gameHeaderData,
+        private GamePlayerFilter $filter,
+        private array $recentPlayers,
+        private ?string $playerAccountId,
+        private ?GamePlayerProgress $gamePlayer
     ) {
-        $this->game = $game;
-        $this->gameHeaderData = $gameHeaderData;
-        $this->filter = $filter;
-        $this->recentPlayers = $recentPlayers;
-        $this->playerAccountId = $playerAccountId;
-        $this->gamePlayer = $gamePlayer;
     }
 
     /**
@@ -54,6 +33,7 @@ class GameRecentPlayersPage
      * @throws GameNotFoundException
      * @throws GameLeaderboardPlayerNotFoundException
      */
+    #[\NoDiscard]
     public static function create(
         GameRecentPlayersService $recentPlayersService,
         GameHeaderService $gameHeaderService,

--- a/wwwroot/classes/PlayerGame.php
+++ b/wwwroot/classes/PlayerGame.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
+require_once __DIR__ . '/GameStatusBadge.php';
 
 class PlayerGame
 {
@@ -102,6 +103,23 @@ class PlayerGame
     public function isActive(): bool
     {
         return $this->status === GameAvailabilityStatus::NORMAL;
+    }
+
+    public function shouldShowRarityPoints(): bool
+    {
+        return $this->status === GameAvailabilityStatus::NORMAL;
+    }
+
+    public function getStatusBadge(): ?GameStatusBadge
+    {
+        $label = $this->status->badgeLabel();
+        $message = $this->status->warningMessage();
+
+        if ($label === null || $message === null) {
+            return null;
+        }
+
+        return new GameStatusBadge($label, $message);
     }
 
     public function isCompleted(): bool

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-class PlayerGamesFilter
+readonly class PlayerGamesFilter
 {
     public const string SORT_DATE = 'date';
     public const string SORT_IN_GAME_MAX_RARITY = 'max-in-game-rarity';
@@ -48,30 +48,20 @@ class PlayerGamesFilter
 
     private const int DEFAULT_LIMIT = 50;
 
-    private string $search;
-    private string $sort;
-    private bool $completed;
-    private bool $uncompleted;
-    private bool $base;
     /**
-     * @var array<int, string>
+     * @param list<string> $platforms
      */
-    private array $platforms;
-    private int $page;
-    private int $limit;
-    private bool $sortProvided;
-
-    private function __construct()
-    {
-        $this->search = '';
-        $this->sort = self::SORT_DATE;
-        $this->completed = false;
-        $this->uncompleted = false;
-        $this->base = false;
-        $this->platforms = [];
-        $this->page = 1;
-        $this->limit = self::DEFAULT_LIMIT;
-        $this->sortProvided = false;
+    private function __construct(
+        final private string $search,
+        final private string $sort,
+        final private bool $completed,
+        final private bool $uncompleted,
+        final private bool $base,
+        final private array $platforms,
+        final private int $page,
+        final private int $limit,
+        final private bool $sortProvided,
+    ) {
     }
 
     /**
@@ -80,40 +70,49 @@ class PlayerGamesFilter
     #[\NoDiscard]
     public static function fromArray(array $parameters): self
     {
-        $filter = new self();
-
-        $filter->search = isset($parameters['search']) ? (string) $parameters['search'] : '';
+        $search = isset($parameters['search']) ? (string) $parameters['search'] : '';
 
         $sort = isset($parameters['sort']) ? (string) $parameters['sort'] : '';
+        $sortProvided = false;
         if ($sort !== '' && in_array($sort, self::ALLOWED_SORTS, true)) {
-            $filter->sort = $sort;
-            $filter->sortProvided = true;
-        } elseif ($filter->search !== '') {
-            $filter->sort = self::SORT_SEARCH;
+            $sortProvided = true;
+        } elseif ($search !== '') {
+            $sort = self::SORT_SEARCH;
+        } else {
+            $sort = self::SORT_DATE;
         }
 
-        $filter->completed = !empty($parameters['completed']);
-        $filter->uncompleted = !empty($parameters['uncompleted']);
+        $completed = !empty($parameters['completed']);
+        $uncompleted = !empty($parameters['uncompleted']);
 
-        if ($filter->completed && $filter->uncompleted) {
+        if ($completed && $uncompleted) {
             // Selecting both checkboxes should behave like no completion filter at all.
-            $filter->completed = false;
-            $filter->uncompleted = false;
+            $completed = false;
+            $uncompleted = false;
         }
-        $filter->base = !empty($parameters['base']);
 
+        $platforms = [];
         foreach (self::PLATFORM_KEYS as $platformKey) {
             if (!empty($parameters[$platformKey])) {
-                $filter->platforms[] = $platformKey;
+                $platforms[] = $platformKey;
             }
         }
 
         $page = isset($parameters['page']) && is_numeric($parameters['page'])
             ? (int) $parameters['page']
             : 1;
-        $filter->page = max($page, 1);
 
-        return $filter;
+        return new self(
+            $search,
+            $sort,
+            $completed,
+            $uncompleted,
+            !empty($parameters['base']),
+            $platforms,
+            max($page, 1),
+            self::DEFAULT_LIMIT,
+            $sortProvided,
+        );
     }
 
     public function getSearch(): string
@@ -141,6 +140,11 @@ class PlayerGamesFilter
         return $this->sort;
     }
 
+    public function isSort(string $sort): bool
+    {
+        return $this->sort === $sort;
+    }
+
     public function isCompletedSelected(): bool
     {
         return $this->completed;
@@ -162,7 +166,7 @@ class PlayerGamesFilter
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function getPlatforms(): array
     {

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerScanProgress.php';
 require_once __DIR__ . '/PlayerScanStatus.php';
+require_once __DIR__ . '/PlayerStatus.php';
 require_once __DIR__ . '/IpSubmissionLockExecutor.php';
 require_once __DIR__ . '/IpSubmissionLockUnavailableException.php';
 require_once __DIR__ . '/Html.php';
@@ -12,7 +13,7 @@ require_once __DIR__ . '/PsnOnlineIdValidator.php';
 class PlayerQueueService
 {
     public const int MAX_QUEUE_SUBMISSIONS_PER_IP = 10;
-    public const int CHEATER_STATUS = 1;
+    public const int CHEATER_STATUS = PlayerStatus::FLAGGED->value;
     private const string SQL_IP_SUBMISSION_COUNT = <<<'SQL'
         SELECT
             COUNT(*)
@@ -326,7 +327,7 @@ class PlayerQueueService
 
     public function isCheaterStatus(?int $status): bool
     {
-        return $status === self::CHEATER_STATUS;
+        return $status !== null && PlayerStatus::fromValue($status)->isFlagged();
     }
 
     /**

--- a/wwwroot/classes/PlayerStatus.php
+++ b/wwwroot/classes/PlayerStatus.php
@@ -30,4 +30,16 @@ enum PlayerStatus: int
     {
         return $this->isFlagged() || $this->isPrivateProfile();
     }
+
+    public function label(): ?string
+    {
+        return match ($this) {
+            self::FLAGGED => 'Cheater',
+            self::PRIVATE_PROFILE => 'Private',
+            self::INACTIVE => 'Inactive',
+            self::NORMAL,
+            self::UNAVAILABLE,
+            self::NEW_PLAYER => null,
+        };
+    }
 }

--- a/wwwroot/classes/TrophyPage.php
+++ b/wwwroot/classes/TrophyPage.php
@@ -16,60 +16,25 @@ require_once __DIR__ . '/TrophyAchiever.php';
 
 class TrophyPage
 {
-    private TrophyDetails $trophy;
-
-    private ?PlayerTrophyProgress $playerTrophy;
-
-    /**
-     * @var list<TrophyAchiever>
-     */
-    private array $firstAchievers;
-
-    /**
-     * @var list<TrophyAchiever>
-     */
-    private array $latestAchievers;
-
-    private ?int $playerAccountId;
-
-    private ?string $playerOnlineId;
-
-    private PageMetaData $metaData;
-
-    private string $pageTitle;
-
-    private TrophyRarity $metaRarity;
-
-    private TrophyRarity $inGameRarity;
-
     /**
      * @param list<TrophyAchiever> $firstAchievers
      * @param list<TrophyAchiever> $latestAchievers
      */
     private function __construct(
-        TrophyDetails $trophy,
-        ?PlayerTrophyProgress $playerTrophy,
-        array $firstAchievers,
-        array $latestAchievers,
-        ?int $playerAccountId,
-        ?string $playerOnlineId,
-        PageMetaData $metaData,
-        string $pageTitle,
-        TrophyRarity $metaRarity,
-        TrophyRarity $inGameRarity
+        private TrophyDetails $trophy,
+        private ?PlayerTrophyProgress $playerTrophy,
+        private array $firstAchievers,
+        private array $latestAchievers,
+        private ?int $playerAccountId,
+        private ?string $playerOnlineId,
+        private PageMetaData $metaData,
+        private string $pageTitle,
+        private TrophyRarity $metaRarity,
+        private TrophyRarity $inGameRarity
     ) {
-        $this->trophy = $trophy;
-        $this->playerTrophy = $playerTrophy;
-        $this->firstAchievers = $firstAchievers;
-        $this->latestAchievers = $latestAchievers;
-        $this->playerAccountId = $playerAccountId;
-        $this->playerOnlineId = $playerOnlineId;
-        $this->metaData = $metaData;
-        $this->pageTitle = $pageTitle;
-        $this->metaRarity = $metaRarity;
-        $this->inGameRarity = $inGameRarity;
     }
 
+    #[\NoDiscard]
     public static function create(
         TrophyService $trophyService,
         Utility $utility,

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/classes/CommaSeparatedValues.php';
 require_once __DIR__ . '/classes/Html.php';
 
 require_once __DIR__ . '/classes/Game/GamePlayerProgress.php';
+require_once __DIR__ . '/classes/GameAvailabilityStatus.php';
 require_once __DIR__ . '/classes/GameMessageSanitizer.php';
 
 /** @var GameDetails $game */
@@ -82,7 +83,7 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
         }
     }
 
-    if ($status === 4) {
+    if ($status === GameAvailabilityStatus::DELISTED_AND_OBSOLETE) {
         ?>
         <div class="col-12">
             <div class="alert alert-warning" role="alert">
@@ -97,7 +98,7 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
             </div>
         </div>
         <?php
-    } elseif ($status === 1) {
+    } elseif ($status === GameAvailabilityStatus::DELISTED) {
         ?>
         <div class="col-12">
             <div class="alert alert-warning" role="alert">
@@ -265,15 +266,19 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
                     <?php
                     $details = [];
 
-                    if ($status === 0) {
+                    if ($game->shouldShowRarityPoints()) {
                         $details[] = number_format($game->getRarityPoints()) . ' Rarity Points';
                         $details[] = number_format($game->getInGameRarityPoints()) . ' Rarity (Game) Points';
-                    } elseif ($status === 1) {
-                        $details[] = "<span class='badge rounded-pill text-bg-warning' title='This game is delisted, no trophies will be accounted for on any leaderboard.'>Delisted</span>";
-                    } elseif ($status === 3) {
-                        $details[] = "<span class='badge rounded-pill text-bg-warning' title='This game is obsolete, no trophies will be accounted for on any leaderboard.'>Obsolete</span>";
-                    } elseif ($status === 4) {
-                        $details[] = "<span class='badge rounded-pill text-bg-warning' title='This game is delisted &amp; obsolete, no trophies will be accounted for on any leaderboard.'>Delisted &amp; Obsolete</span>";
+                    } else {
+                        $statusBadge = $game->getStatusBadge();
+                        if ($statusBadge !== null) {
+                            $details[] = sprintf(
+                                "<span class='%s' title='%s'>%s</span>",
+                                $statusBadge->getCssClass(),
+                                $statusBadge->getTooltip(),
+                                $statusBadge->getLabel()
+                            );
+                        }
                     }
 
                     echo implode('<br>', $details);

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -25,7 +25,6 @@ $playerGamesPage = $pageContext->getPlayerGamesPage();
 $playerGames = $pageContext->getGames();
 $metaData = $pageContext->getMetaData();
 $playerSearch = $pageContext->getSearch();
-$sort = $pageContext->getSort();
 $playerNavigation = $pageContext->getPlayerNavigation();
 $platformFilterOptions = $pageContext->getPlatformFilterOptions();
 $platformFilterRenderer = PlayerPlatformFilterRenderer::createDefault();
@@ -93,13 +92,13 @@ require_once("header.php");
 
                         <select class="form-select" name="sort" onChange="this.form.submit()">
                             <option disabled>Sort by...</option>
-                            <option value="search"<?= ($sort == "search" ? " selected" : ""); ?>>Best Match</option>
-                            <option value="date"<?= ($sort == "date" ? " selected" : ""); ?>>Date</option>
-                            <option value="max-rarity"<?= ($sort == "max-rarity" ? " selected" : ""); ?>>Max Rarity</option>
-                            <option value="max-in-game-rarity"<?= ($sort == "max-in-game-rarity" ? " selected" : ""); ?>>Max Rarity (Game)</option>
-                            <option value="name"<?= ($sort == "name" ? " selected" : ""); ?>>Name</option>
-                            <option value="rarity"<?= ($sort == "rarity" ? " selected" : ""); ?>>Rarity</option>
-                            <option value="in-game-rarity"<?= ($sort == "in-game-rarity" ? " selected" : ""); ?>>Rarity (Game)</option>
+                            <option value="search"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_SEARCH) ? ' selected' : ''); ?>>Best Match</option>
+                            <option value="date"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_DATE) ? ' selected' : ''); ?>>Date</option>
+                            <option value="max-rarity"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_MAX_RARITY) ? ' selected' : ''); ?>>Max Rarity</option>
+                            <option value="max-in-game-rarity"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_IN_GAME_MAX_RARITY) ? ' selected' : ''); ?>>Max Rarity (Game)</option>
+                            <option value="name"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_NAME) ? ' selected' : ''); ?>>Name</option>
+                            <option value="rarity"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_RARITY) ? ' selected' : ''); ?>>Rarity</option>
+                            <option value="in-game-rarity"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_IN_GAME_RARITY) ? ' selected' : ''); ?>>Rarity (Game)</option>
                         </select>
                     </div>
                 </form>
@@ -201,7 +200,7 @@ require_once("header.php");
                                         </td>
                                         <td class="align-middle text-center">
                                             <?php
-                                            if ($playerGame->getStatus() == 0) {
+                                            if ($playerGame->shouldShowRarityPoints()) {
                                                 echo number_format($playerGame->getRarityPoints());
                                                 if (!$playerGame->isCompleted()) {
                                                     echo '/'. number_format($playerGame->getMaxRarityPoints());
@@ -215,12 +214,13 @@ require_once("header.php");
                                                 }
 
                                                 echo ' <span class="text-body-secondary small">(Game)</span></div>';
-                                            } elseif ($playerGame->getStatus() == 1) {
-                                                echo "<span class=\"badge rounded-pill text-bg-warning\">Delisted</span>";
-                                            } elseif ($playerGame->getStatus() == 3) {
-                                                echo "<span class=\"badge rounded-pill text-bg-warning\">Obsolete</span>";
-                                            } elseif ($playerGame->getStatus() == 4) {
-                                                echo "<span class=\"badge rounded-pill text-bg-warning\">Delisted &amp; Obsolete</span>";
+                                            } else {
+                                                $statusBadge = $playerGame->getStatusBadge();
+                                                if ($statusBadge !== null) {
+                                                    echo '<span class="' . $statusBadge->getCssClass() . '" title="'
+                                                        . $statusBadge->getTooltip() . '">'
+                                                        . $statusBadge->getLabel() . '</span>';
+                                                }
                                             }
                                             ?>
                                         </td>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Continues the PHP 8.5 modernization work by finishing incomplete enum/read-only migrations that previous PRs left with magic ints and mutable filter state.

### Changes
- **`GameDetails` / game header**: store and expose `GameAvailabilityStatus` instead of raw ints; templates and `GameHeaderService` compare against enum cases and reuse badge helpers.
- **`PlayerGame` / `player.php`**: add `shouldShowRarityPoints()` / `getStatusBadge()` and strict `PlayerGamesFilter::isSort()` selected options (no loose `==` / magic status ints).
- **`AboutPagePlayer` / about page**: hydrate `PlayerStatus`, use `isRestricted()` / `label()`, keep JSON serialization on `->value` for the scan-log frontend.
- **`PlayerGamesFilter`**: convert to `readonly` with promoted `final private` props and `clone($this, …)` for page updates, matching `GameListFilter`.
- **`PlayerQueueService`**: alias cheater status to `PlayerStatus::FLAGGED` and check via the enum.
- **Page factories**: constructor property promotion + `#[\NoDiscard]` on `GameRecentPlayersPage`, `GameLeaderboardPage`, and `TrophyPage`.

### Testing
- `php tests/run.php` — all 984 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7c4635e-d552-4a88-9130-a4cc95b2d41e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7c4635e-d552-4a88-9130-a4cc95b2d41e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

