### PR TITLE
Adopt domain enums for platforms, trophies, and scan outcomes

### DIFF
--- a/tests/IpRateLimitServiceTest.php
+++ b/tests/IpRateLimitServiceTest.php
@@ -32,7 +32,7 @@ final class IpRateLimitServiceTest extends TestCase
     {
         for ($index = 0; $index < 60; $index++) {
             $this->assertTrue(
-                $this->service->checkAndRecord('192.0.2.10', IpRateLimitService::BUCKET_QUEUE_POLL)
+                $this->service->checkAndRecord('192.0.2.10', IpRateLimitBucket::QueuePoll)
             );
         }
     }
@@ -40,25 +40,25 @@ final class IpRateLimitServiceTest extends TestCase
     public function testCheckAndRecordBlocksRequestsAboveLimit(): void
     {
         for ($index = 0; $index < 60; $index++) {
-            $this->service->checkAndRecord('192.0.2.11', IpRateLimitService::BUCKET_QUEUE_POLL);
+            $this->service->checkAndRecord('192.0.2.11', IpRateLimitBucket::QueuePoll);
         }
 
         $this->assertFalse(
-            $this->service->checkAndRecord('192.0.2.11', IpRateLimitService::BUCKET_QUEUE_POLL)
+            $this->service->checkAndRecord('192.0.2.11', IpRateLimitBucket::QueuePoll)
         );
     }
 
     public function testDifferentBucketsTrackSeparately(): void
     {
         for ($index = 0; $index < 30; $index++) {
-            $this->service->checkAndRecord('192.0.2.12', IpRateLimitService::BUCKET_SCAN_LOG_POLL);
+            $this->service->checkAndRecord('192.0.2.12', IpRateLimitBucket::ScanLogPoll);
         }
 
         $this->assertFalse(
-            $this->service->checkAndRecord('192.0.2.12', IpRateLimitService::BUCKET_SCAN_LOG_POLL)
+            $this->service->checkAndRecord('192.0.2.12', IpRateLimitBucket::ScanLogPoll)
         );
         $this->assertTrue(
-            $this->service->checkAndRecord('192.0.2.12', IpRateLimitService::BUCKET_QUEUE_POLL)
+            $this->service->checkAndRecord('192.0.2.12', IpRateLimitBucket::QueuePoll)
         );
     }
 
@@ -66,26 +66,26 @@ final class IpRateLimitServiceTest extends TestCase
     {
         for ($index = 0; $index < 10; $index++) {
             $this->assertTrue(
-                $this->service->checkAndRecord('192.0.2.13', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+                $this->service->checkAndRecord('192.0.2.13', IpRateLimitBucket::QueueSubmit)
             );
         }
 
         $this->assertFalse(
-            $this->service->checkAndRecord('192.0.2.13', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+            $this->service->checkAndRecord('192.0.2.13', IpRateLimitBucket::QueueSubmit)
         );
     }
 
     public function testQueueSubmitBucketTracksSeparatelyFromQueuePoll(): void
     {
         for ($index = 0; $index < 10; $index++) {
-            $this->service->checkAndRecord('192.0.2.14', IpRateLimitService::BUCKET_QUEUE_SUBMIT);
+            $this->service->checkAndRecord('192.0.2.14', IpRateLimitBucket::QueueSubmit);
         }
 
         $this->assertFalse(
-            $this->service->checkAndRecord('192.0.2.14', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+            $this->service->checkAndRecord('192.0.2.14', IpRateLimitBucket::QueueSubmit)
         );
         $this->assertTrue(
-            $this->service->checkAndRecord('192.0.2.14', IpRateLimitService::BUCKET_QUEUE_POLL)
+            $this->service->checkAndRecord('192.0.2.14', IpRateLimitBucket::QueuePoll)
         );
     }
 
@@ -93,26 +93,26 @@ final class IpRateLimitServiceTest extends TestCase
     {
         for ($index = 0; $index < 10; $index++) {
             $this->assertTrue(
-                $this->service->checkAndRecord('', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+                $this->service->checkAndRecord('', IpRateLimitBucket::QueueSubmit)
             );
         }
 
         $this->assertFalse(
-            $this->service->checkAndRecord('', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+            $this->service->checkAndRecord('', IpRateLimitBucket::QueueSubmit)
         );
     }
 
     public function testUnknownClientBucketIsSeparateFromKnownIp(): void
     {
         for ($index = 0; $index < 10; $index++) {
-            $this->service->checkAndRecord('', IpRateLimitService::BUCKET_QUEUE_SUBMIT);
+            $this->service->checkAndRecord('', IpRateLimitBucket::QueueSubmit);
         }
 
         $this->assertFalse(
-            $this->service->checkAndRecord('', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+            $this->service->checkAndRecord('', IpRateLimitBucket::QueueSubmit)
         );
         $this->assertTrue(
-            $this->service->checkAndRecord('192.0.2.15', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+            $this->service->checkAndRecord('192.0.2.15', IpRateLimitBucket::QueueSubmit)
         );
     }
 
@@ -120,26 +120,26 @@ final class IpRateLimitServiceTest extends TestCase
     {
         for ($index = 0; $index < 5; $index++) {
             $this->assertTrue(
-                $this->service->checkAndRecord('192.0.2.16', IpRateLimitService::BUCKET_PLAYER_REPORT)
+                $this->service->checkAndRecord('192.0.2.16', IpRateLimitBucket::PlayerReport)
             );
         }
 
         $this->assertFalse(
-            $this->service->checkAndRecord('192.0.2.16', IpRateLimitService::BUCKET_PLAYER_REPORT)
+            $this->service->checkAndRecord('192.0.2.16', IpRateLimitBucket::PlayerReport)
         );
     }
 
     public function testPlayerReportBucketTracksSeparatelyFromQueueSubmit(): void
     {
         for ($index = 0; $index < 5; $index++) {
-            $this->service->checkAndRecord('192.0.2.17', IpRateLimitService::BUCKET_PLAYER_REPORT);
+            $this->service->checkAndRecord('192.0.2.17', IpRateLimitBucket::PlayerReport);
         }
 
         $this->assertFalse(
-            $this->service->checkAndRecord('192.0.2.17', IpRateLimitService::BUCKET_PLAYER_REPORT)
+            $this->service->checkAndRecord('192.0.2.17', IpRateLimitBucket::PlayerReport)
         );
         $this->assertTrue(
-            $this->service->checkAndRecord('192.0.2.17', IpRateLimitService::BUCKET_QUEUE_SUBMIT)
+            $this->service->checkAndRecord('192.0.2.17', IpRateLimitBucket::QueueSubmit)
         );
     }
 }

--- a/wwwroot/admin/psn-trophy-title-compare.php
+++ b/wwwroot/admin/psn-trophy-title-compare.php
@@ -8,9 +8,10 @@ require_once '../classes/Admin/PsnTrophyTitleComparisonException.php';
 require_once '../classes/Admin/PsnTrophyTitleComparisonRequestHandler.php';
 require_once '../classes/Admin/PsnTrophyTitleComparisonRequestResult.php';
 require_once '../classes/Admin/PsnTrophyTitleComparisonService.php';
+require_once '../classes/Admin/PsnTrophyTitleComparisonSource.php';
 
 $accountId = isset($_GET['accountId']) ? (string) $_GET['accountId'] : '';
-$source = isset($_GET['source']) ? (string) $_GET['source'] : PsnTrophyTitleComparisonService::SOURCE_DIRECT;
+$source = isset($_GET['source']) ? (string) $_GET['source'] : PsnTrophyTitleComparisonSource::Direct->value;
 $service = PsnTrophyTitleComparisonService::fromDatabase($database);
 $handledRequest = PsnTrophyTitleComparisonRequestHandler::handle($service, $accountId, $source);
 
@@ -43,11 +44,11 @@ $errorMessage = $handledRequest->getErrorMessage();
                 <div class="mb-2">
                     <span class="form-label d-block">Source</span>
                     <div class="btn-group" role="group" aria-label="Source toggle">
-                        <input type="radio" class="btn-check" name="source" id="source-direct" value="direct" autocomplete="off" <?= $normalizedSource === PsnTrophyTitleComparisonService::SOURCE_DIRECT ? 'checked' : ''; ?>>
-                        <label class="btn btn-outline-secondary" for="source-direct">Direct endpoint</label>
+                        <input type="radio" class="btn-check" name="source" id="source-direct" value="<?= Html::escape(PsnTrophyTitleComparisonSource::Direct->value); ?>" autocomplete="off" <?= $normalizedSource === PsnTrophyTitleComparisonSource::Direct->value ? 'checked' : ''; ?>>
+                        <label class="btn btn-outline-secondary" for="source-direct"><?= Html::escape(PsnTrophyTitleComparisonSource::Direct->label()); ?></label>
 
-                        <input type="radio" class="btn-check" name="source" id="source-tustin" value="tustin" autocomplete="off" <?= $normalizedSource === PsnTrophyTitleComparisonService::SOURCE_TUSTIN ? 'checked' : ''; ?>>
-                        <label class="btn btn-outline-secondary" for="source-tustin">tustin/psn-php</label>
+                        <input type="radio" class="btn-check" name="source" id="source-tustin" value="<?= Html::escape(PsnTrophyTitleComparisonSource::Tustin->value); ?>" autocomplete="off" <?= $normalizedSource === PsnTrophyTitleComparisonSource::Tustin->value ? 'checked' : ''; ?>>
+                        <label class="btn btn-outline-secondary" for="source-tustin"><?= Html::escape(PsnTrophyTitleComparisonSource::Tustin->label()); ?></label>
                     </div>
                 </div>
             </form>
@@ -65,11 +66,11 @@ $errorMessage = $handledRequest->getErrorMessage();
                     <div class="col-md-6">
                         <div class="card h-100">
                             <div class="card-body">
-                                <h2 class="h5"><?= $normalizedSource === PsnTrophyTitleComparisonService::SOURCE_DIRECT ? 'Direct endpoint' : 'tustin/psn-php'; ?></h2>
+                                <h2 class="h5"><?= Html::escape((PsnTrophyTitleComparisonSource::tryFrom($normalizedSource) ?? PsnTrophyTitleComparisonSource::Direct)->label()); ?></h2>
                                 <dl class="row mb-0">
                                     <dt class="col-sm-5">Titles fetched</dt>
                                     <dd class="col-sm-7"><?= Html::escape((string) ($result['result']['count'] ?? 0)); ?></dd>
-                                    <?php if ($normalizedSource === PsnTrophyTitleComparisonService::SOURCE_DIRECT) { ?>
+                                    <?php if ($normalizedSource === PsnTrophyTitleComparisonSource::Direct->value) { ?>
                                         <dt class="col-sm-5">Pages fetched</dt>
                                         <dd class="col-sm-7"><?= Html::escape((string) ($result['result']['pagesFetched'] ?? 0)); ?></dd>
                                         <dt class="col-sm-5">Total item count</dt>

--- a/wwwroot/classes/AboutPageScanLogController.php
+++ b/wwwroot/classes/AboutPageScanLogController.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/AboutPageScanSummary.php';
 require_once __DIR__ . '/AboutPagePlayerArraySerializer.php';
 require_once __DIR__ . '/JsonResponseEmitter.php';
 require_once __DIR__ . '/IpRateLimitService.php';
+require_once __DIR__ . '/IpRateLimitBucket.php';
 require_once __DIR__ . '/IpAddressResolver.php';
 
 final class AboutPageScanLogController
@@ -58,7 +59,7 @@ final class AboutPageScanLogController
             if (
                 !$this->rateLimitService->checkAndRecord(
                     $ipAddress,
-                    IpRateLimitService::BUCKET_SCAN_LOG_POLL
+                    IpRateLimitBucket::ScanLogPoll
                 )
             ) {
                 $this->jsonResponder->respond([

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestHandler.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/PsnTrophyTitleComparisonException.php';
 require_once __DIR__ . '/PsnTrophyTitleComparisonRequestResult.php';
 require_once __DIR__ . '/PsnTrophyTitleComparisonService.php';
+require_once __DIR__ . '/PsnTrophyTitleComparisonSource.php';
 
 final class PsnTrophyTitleComparisonRequestHandler
 {
@@ -12,7 +13,7 @@ final class PsnTrophyTitleComparisonRequestHandler
     {
         $normalizedAccountId = trim($accountId);
         $normalizedSource = PsnTrophyTitleComparisonService::normalizeSource($source)
-            ?? PsnTrophyTitleComparisonService::SOURCE_DIRECT;
+            ?? PsnTrophyTitleComparisonSource::Direct;
         $result = null;
         $errorMessage = null;
 
@@ -31,6 +32,11 @@ final class PsnTrophyTitleComparisonRequestHandler
             }
         }
 
-        return new PsnTrophyTitleComparisonRequestResult($normalizedAccountId, $normalizedSource, $result, $errorMessage);
+        return new PsnTrophyTitleComparisonRequestResult(
+            $normalizedAccountId,
+            $normalizedSource->value,
+            $result,
+            $errorMessage
+        );
     }
 }

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 require_once __DIR__ . '/Worker.php';
 require_once __DIR__ . '/WorkerService.php';
 require_once __DIR__ . '/PsnTrophyTitleComparisonException.php';
+require_once __DIR__ . '/PsnTrophyTitleComparisonSource.php';
 require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
 
 use Tustin\PlayStation\Client;
 
 final class PsnTrophyTitleComparisonService
 {
-    public const string SOURCE_DIRECT = 'direct';
-    public const string SOURCE_TUSTIN = 'tustin';
+    public const string SOURCE_DIRECT = PsnTrophyTitleComparisonSource::Direct->value;
+    public const string SOURCE_TUSTIN = PsnTrophyTitleComparisonSource::Tustin->value;
 
     private const \Closure DEFAULT_CLIENT_FACTORY = static function (): object {
         return new Client();
@@ -80,10 +81,12 @@ final class PsnTrophyTitleComparisonService
     /**
      * @return array<string, mixed>
      */
-    public function compareByAccountId(string $accountId, string $source): array
+    public function compareByAccountId(string $accountId, string|PsnTrophyTitleComparisonSource $source): array
     {
         $normalizedAccountId = trim($accountId);
-        $normalizedSource = self::normalizeSource($source);
+        $normalizedSource = $source instanceof PsnTrophyTitleComparisonSource
+            ? $source
+            : self::normalizeSource($source);
 
         if ($normalizedAccountId === '' || !ctype_digit($normalizedAccountId)) {
             throw new InvalidArgumentException('Account ID must be a numeric value.');
@@ -94,26 +97,20 @@ final class PsnTrophyTitleComparisonService
         }
 
         $client = $this->createAuthenticatedClient();
-        $fetchResult = $normalizedSource === self::SOURCE_DIRECT
+        $fetchResult = $normalizedSource === PsnTrophyTitleComparisonSource::Direct
             ? $this->fetchTitlesViaEndpoint($client, $normalizedAccountId)
             : $this->fetchTitlesViaTustin($client, $normalizedAccountId);
 
         return [
             'accountId' => $normalizedAccountId,
-            'source' => $normalizedSource,
+            'source' => $normalizedSource->value,
             'result' => $fetchResult,
         ];
     }
 
-    public static function normalizeSource(string $source): ?string
+    public static function normalizeSource(string $source): ?PsnTrophyTitleComparisonSource
     {
-        $normalizedSource = $source |> trim(...) |> strtolower(...);
-
-        if ($normalizedSource === self::SOURCE_DIRECT || $normalizedSource === self::SOURCE_TUSTIN) {
-            return $normalizedSource;
-        }
-
-        return null;
+        return PsnTrophyTitleComparisonSource::tryFrom($source |> trim(...) |> strtolower(...));
     }
 
     private function createAuthenticatedClient(): object

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonSource.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonSource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+enum PsnTrophyTitleComparisonSource: string
+{
+    case Direct = 'direct';
+    case Tustin = 'tustin';
+
+    public static function fromMixed(mixed $value): self
+    {
+        if (!is_string($value) && !is_numeric($value)) {
+            return self::Direct;
+        }
+
+        return self::tryFrom(((string) $value) |> trim(...) |> strtolower(...)) ?? self::Direct;
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Direct => 'Direct endpoint',
+            self::Tustin => 'tustin/psn-php',
+        };
+    }
+}

--- a/wwwroot/classes/Cron/PlayerScanCompletionResult.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionResult.php
@@ -2,32 +2,31 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerScanCompletionStatus.php';
+
 /**
  * Outcome of post-scan player aggregation during a worker scan.
  */
 final class PlayerScanCompletionResult
 {
-    public const string STATUS_COMPLETED = 'completed';
-    public const string STATUS_CONTINUE_SCAN = 'continue_scan';
-
-    private function __construct(final public readonly string $status)
+    private function __construct(final public readonly PlayerScanCompletionStatus $status)
     {
     }
 
     #[\NoDiscard]
     public static function completed(): self
     {
-        return new self(self::STATUS_COMPLETED);
+        return new self(PlayerScanCompletionStatus::Completed);
     }
 
     #[\NoDiscard]
     public static function continueScan(): self
     {
-        return new self(self::STATUS_CONTINUE_SCAN);
+        return new self(PlayerScanCompletionStatus::ContinueScan);
     }
 
     public function shouldContinueScan(): bool
     {
-        return $this->status === self::STATUS_CONTINUE_SCAN;
+        return $this->status === PlayerScanCompletionStatus::ContinueScan;
     }
 }

--- a/wwwroot/classes/Cron/PlayerScanCompletionStatus.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerScanCompletionStatus: string
+{
+    case Completed = 'completed';
+    case ContinueScan = 'continue_scan';
+}

--- a/wwwroot/classes/Cron/PlayerScanProfileSyncResult.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSyncResult.php
@@ -2,19 +2,18 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerScanProfileSyncStatus.php';
+
 /**
  * Outcome of resolving and persisting a queued player's PSN profile during a scan.
  */
 final class PlayerScanProfileSyncResult
 {
-    public const string STATUS_SUCCESS = 'success';
-    public const string STATUS_SKIP_PLAYER = 'skip_player';
-
     /**
      * @param array<string, mixed> $player
      */
     private function __construct(
-        final public readonly string $status,
+        final public readonly PlayerScanProfileSyncStatus $status,
         final public readonly array $player = [],
         final public readonly ?object $user = null,
         final public readonly ?string $country = null,
@@ -27,22 +26,22 @@ final class PlayerScanProfileSyncResult
     #[\NoDiscard]
     public static function success(array $player, object $user, string $country): self
     {
-        return new self(self::STATUS_SUCCESS, $player, $user, $country);
+        return new self(PlayerScanProfileSyncStatus::Success, $player, $user, $country);
     }
 
     #[\NoDiscard]
     public static function skipPlayer(): self
     {
-        return new self(self::STATUS_SKIP_PLAYER);
+        return new self(PlayerScanProfileSyncStatus::SkipPlayer);
     }
 
     public function isSuccess(): bool
     {
-        return $this->status === self::STATUS_SUCCESS;
+        return $this->status === PlayerScanProfileSyncStatus::Success;
     }
 
     public function shouldSkipPlayer(): bool
     {
-        return $this->status === self::STATUS_SKIP_PLAYER;
+        return $this->status === PlayerScanProfileSyncStatus::SkipPlayer;
     }
 }

--- a/wwwroot/classes/Cron/PlayerScanProfileSyncStatus.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSyncStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerScanProfileSyncStatus: string
+{
+    case Success = 'success';
+    case SkipPlayer = 'skip_player';
+}

--- a/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php
@@ -2,17 +2,15 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerScanTrophySummaryAccessStatus.php';
+
 /**
  * Outcome of reading a PSN user's trophy summary level during a player scan.
  */
 final class PlayerScanTrophySummaryAccessResult
 {
-    public const string STATUS_ACCESSIBLE = 'accessible';
-    public const string STATUS_PRIVATE = 'private';
-    public const string STATUS_ABORT_SCAN = 'abort_scan';
-
     private function __construct(
-        final public readonly string $status,
+        final public readonly PlayerScanTrophySummaryAccessStatus $status,
         final public readonly int $level = 0,
     ) {
     }
@@ -20,33 +18,33 @@ final class PlayerScanTrophySummaryAccessResult
     #[\NoDiscard]
     public static function accessible(int $level): self
     {
-        return new self(self::STATUS_ACCESSIBLE, $level);
+        return new self(PlayerScanTrophySummaryAccessStatus::Accessible, $level);
     }
 
     #[\NoDiscard]
     public static function privateProfile(): self
     {
-        return new self(self::STATUS_PRIVATE);
+        return new self(PlayerScanTrophySummaryAccessStatus::Private);
     }
 
     #[\NoDiscard]
     public static function abortScan(): self
     {
-        return new self(self::STATUS_ABORT_SCAN);
+        return new self(PlayerScanTrophySummaryAccessStatus::AbortScan);
     }
 
     public function isAccessible(): bool
     {
-        return $this->status === self::STATUS_ACCESSIBLE;
+        return $this->status === PlayerScanTrophySummaryAccessStatus::Accessible;
     }
 
     public function isPrivateProfile(): bool
     {
-        return $this->status === self::STATUS_PRIVATE;
+        return $this->status === PlayerScanTrophySummaryAccessStatus::Private;
     }
 
     public function shouldAbortScan(): bool
     {
-        return $this->status === self::STATUS_ABORT_SCAN;
+        return $this->status === PlayerScanTrophySummaryAccessStatus::AbortScan;
     }
 }

--- a/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessStatus.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerScanTrophySummaryAccessStatus: string
+{
+    case Accessible = 'accessible';
+    case Private = 'private';
+    case AbortScan = 'abort_scan';
+}

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoopAction.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoopAction.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerScanTrophyTitleLoopAction: string
+{
+    case Continue = 'continue';
+    case Proceed = 'proceed';
+}

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoopResult.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoopResult.php
@@ -2,32 +2,31 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerScanTrophyTitleLoopAction.php';
+
 /**
  * Outcome of processing a player's trophy titles during a worker scan.
  */
 final readonly class PlayerScanTrophyTitleLoopResult
 {
-    public const string ACTION_CONTINUE = 'continue';
-    public const string ACTION_PROCEED = 'proceed';
-
-    private function __construct(final public string $action)
+    private function __construct(final public PlayerScanTrophyTitleLoopAction $action)
     {
     }
 
     #[\NoDiscard]
     public static function continueLoop(): self
     {
-        return new self(self::ACTION_CONTINUE);
+        return new self(PlayerScanTrophyTitleLoopAction::Continue);
     }
 
     #[\NoDiscard]
     public static function proceedToFinalize(): self
     {
-        return new self(self::ACTION_PROCEED);
+        return new self(PlayerScanTrophyTitleLoopAction::Proceed);
     }
 
     public function shouldContinueLoop(): bool
     {
-        return $this->action === self::ACTION_CONTINUE;
+        return $this->action === PlayerScanTrophyTitleLoopAction::Continue;
     }
 }

--- a/wwwroot/classes/Game/GameTrophyRow.php
+++ b/wwwroot/classes/Game/GameTrophyRow.php
@@ -3,29 +3,16 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../Utility.php';
+require_once __DIR__ . '/../TrophyType.php';
 
 final readonly class GameTrophyRow
 {
-    private const array TROPHY_TYPE_COLORS = [
-        'bronze' => '#c46438',
-        'silver' => '#777777',
-        'gold' => '#c2903e',
-        'platinum' => '#667fb2',
-    ];
-
-    private const array TROPHY_TYPE_ICONS = [
-        'bronze' => '/img/trophy-bronze.svg',
-        'silver' => '/img/trophy-silver.svg',
-        'gold' => '/img/trophy-gold.svg',
-        'platinum' => '/img/trophy-platinum.svg',
-    ];
-
     private const int UNOBTAINABLE_STATUS = 1;
     private const string UNOBTAINABLE_TITLE = 'This trophy is unobtainable and not accounted for on any leaderboard.';
 
     private int $id;
     private int $orderId;
-    private string $type;
+    private TrophyType $type;
     private string $name;
     private string $detail;
     private string $iconUrl;
@@ -59,7 +46,7 @@ final readonly class GameTrophyRow
     {
         $this->id = (int) ($data['id'] ?? 0);
         $this->orderId = (int) ($data['order_id'] ?? 0);
-        $this->type = (string) ($data['type'] ?? '');
+        $this->type = TrophyType::fromMixed($data['type'] ?? null);
         $this->name = (string) ($data['name'] ?? '');
         $this->detail = (string) ($data['detail'] ?? '');
         $this->iconUrl = (string) ($data['icon_url'] ?? '');
@@ -97,12 +84,17 @@ final readonly class GameTrophyRow
 
     public function getType(): string
     {
+        return $this->type->value;
+    }
+
+    public function getTrophyType(): TrophyType
+    {
         return $this->type;
     }
 
     public function getTypeIconPath(): string
     {
-        return self::TROPHY_TYPE_ICONS[$this->type] ?? self::TROPHY_TYPE_ICONS['bronze'];
+        return $this->type->iconPath();
     }
 
     public function getName(): string
@@ -206,7 +198,7 @@ final readonly class GameTrophyRow
 
     public function getTypeColor(): string
     {
-        return self::TROPHY_TYPE_COLORS[$this->type] ?? self::TROPHY_TYPE_COLORS['bronze'];
+        return $this->type->color();
     }
 
     public function getRowAttributes(?int $accountId): string

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Platform.php';
+
 readonly class GameListFilter
 {
     public const string SORT_ADDED = 'added';
@@ -11,26 +13,13 @@ readonly class GameListFilter
     public const string SORT_IN_GAME_RARITY = 'in-game-rarity';
     public const string SORT_SEARCH = 'search';
 
-    public const string PLATFORM_PC = 'pc';
-    public const string PLATFORM_PS3 = 'ps3';
-    public const string PLATFORM_PS4 = 'ps4';
-    public const string PLATFORM_PS5 = 'ps5';
-    public const string PLATFORM_PSVITA = 'psvita';
-    public const string PLATFORM_PSVR = 'psvr';
-    public const string PLATFORM_PSVR2 = 'psvr2';
-
-    /**
-     * @var list<string>
-     */
-    private const array PLATFORM_KEYS = [
-        self::PLATFORM_PC,
-        self::PLATFORM_PS3,
-        self::PLATFORM_PS4,
-        self::PLATFORM_PS5,
-        self::PLATFORM_PSVITA,
-        self::PLATFORM_PSVR,
-        self::PLATFORM_PSVR2,
-    ];
+    public const string PLATFORM_PC = Platform::Pc->value;
+    public const string PLATFORM_PS3 = Platform::Ps3->value;
+    public const string PLATFORM_PS4 = Platform::Ps4->value;
+    public const string PLATFORM_PS5 = Platform::Ps5->value;
+    public const string PLATFORM_PSVITA = Platform::PsVita->value;
+    public const string PLATFORM_PSVR = Platform::PsVr->value;
+    public const string PLATFORM_PSVR2 = Platform::PsVr2->value;
 
     private function __construct(
         final private ?string $player,
@@ -66,7 +55,7 @@ readonly class GameListFilter
         $uncompletedOnly = self::toBool($queryParameters['filter'] ?? null);
 
         $platformFilters = [];
-        foreach (self::PLATFORM_KEYS as $platform) {
+        foreach (Platform::values() as $platform) {
             $platformFilters[$platform] = self::toBool($queryParameters[$platform] ?? null);
         }
 
@@ -179,7 +168,7 @@ readonly class GameListFilter
     {
         $platforms = [];
 
-        foreach (self::PLATFORM_KEYS as $platform) {
+        foreach (Platform::values() as $platform) {
             if ($this->platformFilters[$platform]) {
                 $platforms[] = $platform;
             }
@@ -219,7 +208,7 @@ readonly class GameListFilter
             unset($parameters['filter']);
         }
 
-        foreach (self::PLATFORM_KEYS as $platform) {
+        foreach (Platform::values() as $platform) {
             if ($this->platformFilters[$platform]) {
                 $parameters[$platform] = 'true';
             } else {

--- a/wwwroot/classes/GameService.php
+++ b/wwwroot/classes/GameService.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/Game/GamePlayerProgress.php';
 require_once __DIR__ . '/Game/GameTrophyGroupPlayer.php';
+require_once __DIR__ . '/TrophyType.php';
 
 class GameService
 {
-    private const string TROPHY_TYPE_ORDER_SQL = "FIELD(%s, 'bronze', 'silver', 'gold', 'platinum')";
-
     public function __construct(private readonly PDO $database) {}
 
     public function getGame(int $gameId): ?GameDetails
@@ -285,7 +284,7 @@ class GameService
 
     private function buildAccountSortSql(string $sort): string
     {
-        $trophyTypeSort = sprintf(self::TROPHY_TYPE_ORDER_SQL, 't.type');
+        $trophyTypeSort = TrophyType::sqlFieldOrder('t.type');
 
         return match ($sort) {
             'date' => " ORDER BY te.earned_date IS NULL, te.earned_date, {$trophyTypeSort}, t.order_id",
@@ -300,7 +299,7 @@ class GameService
             return ' ORDER BY t.order_id';
         }
 
-        $trophyTypeSort = sprintf(self::TROPHY_TYPE_ORDER_SQL, 't.type');
+        $trophyTypeSort = TrophyType::sqlFieldOrder('t.type');
 
         return " ORDER BY tm.rarity_percent DESC, {$trophyTypeSort}, t.order_id";
     }

--- a/wwwroot/classes/HomepagePopularGamesFilter.php
+++ b/wwwroot/classes/HomepagePopularGamesFilter.php
@@ -2,43 +2,18 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Platform.php';
+
 final readonly class HomepagePopularGamesFilter
 {
     public const string PLATFORM_ALL = '';
-    public const string PLATFORM_PC = 'pc';
-    public const string PLATFORM_PS3 = 'ps3';
-    public const string PLATFORM_PS4 = 'ps4';
-    public const string PLATFORM_PS5 = 'ps5';
-    public const string PLATFORM_PSVITA = 'psvita';
-    public const string PLATFORM_PSVR = 'psvr';
-    public const string PLATFORM_PSVR2 = 'psvr2';
-
-    /**
-     * @var list<string>
-     */
-    private const array PLATFORM_KEYS = [
-        self::PLATFORM_PC,
-        self::PLATFORM_PS3,
-        self::PLATFORM_PS4,
-        self::PLATFORM_PS5,
-        self::PLATFORM_PSVITA,
-        self::PLATFORM_PSVR,
-        self::PLATFORM_PSVR2,
-    ];
-
-    /**
-     * @var array<string, string>
-     */
-    private const array PLATFORM_LABELS = [
-        self::PLATFORM_ALL => 'All',
-        self::PLATFORM_PC => 'PC',
-        self::PLATFORM_PS3 => 'PS3',
-        self::PLATFORM_PS4 => 'PS4',
-        self::PLATFORM_PS5 => 'PS5',
-        self::PLATFORM_PSVITA => 'PSVITA',
-        self::PLATFORM_PSVR => 'PSVR',
-        self::PLATFORM_PSVR2 => 'PSVR2',
-    ];
+    public const string PLATFORM_PC = Platform::Pc->value;
+    public const string PLATFORM_PS3 = Platform::Ps3->value;
+    public const string PLATFORM_PS4 = Platform::Ps4->value;
+    public const string PLATFORM_PS5 = Platform::Ps5->value;
+    public const string PLATFORM_PSVITA = Platform::PsVita->value;
+    public const string PLATFORM_PSVR = Platform::PsVr->value;
+    public const string PLATFORM_PSVR2 = Platform::PsVr2->value;
 
     private function __construct(
         final private string $platform,
@@ -80,7 +55,7 @@ final readonly class HomepagePopularGamesFilter
 
     public function getPlatformDatabaseValue(): string
     {
-        return self::PLATFORM_LABELS[$this->platform] ?? '';
+        return Platform::tryFrom($this->platform)?->label() ?? '';
     }
 
     /**
@@ -106,7 +81,7 @@ final readonly class HomepagePopularGamesFilter
      */
     public static function getPlatformOptions(): array
     {
-        return self::PLATFORM_LABELS;
+        return [self::PLATFORM_ALL => 'All'] + Platform::labelsByValue();
     }
 
     private static function normalizePlatform(mixed $value): string
@@ -117,11 +92,7 @@ final readonly class HomepagePopularGamesFilter
 
         $platform = ((string) $value) |> trim(...) |> strtolower(...);
 
-        if ($platform === '' || !in_array($platform, self::PLATFORM_KEYS, true)) {
-            return self::PLATFORM_ALL;
-        }
-
-        return $platform;
+        return Platform::tryFrom($platform)?->value ?? self::PLATFORM_ALL;
     }
 
     private static function toBool(mixed $value): bool

--- a/wwwroot/classes/IpRateLimitBucket.php
+++ b/wwwroot/classes/IpRateLimitBucket.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+enum IpRateLimitBucket: string
+{
+    case QueuePoll = 'queue_poll';
+    case QueueSubmit = 'queue_submit';
+    case PlayerReport = 'player_report';
+    case ScanLogPoll = 'scan_log_poll';
+
+    private const int QUEUE_POLL_MAX_REQUESTS = 60;
+    private const int QUEUE_POLL_WINDOW_SECONDS = 60;
+    private const int QUEUE_SUBMIT_MAX_REQUESTS = 10;
+    private const int QUEUE_SUBMIT_WINDOW_SECONDS = 60;
+    private const int PLAYER_REPORT_MAX_REQUESTS = 5;
+    private const int PLAYER_REPORT_WINDOW_SECONDS = 60;
+    private const int SCAN_LOG_POLL_MAX_REQUESTS = 30;
+    private const int SCAN_LOG_POLL_WINDOW_SECONDS = 60;
+
+    /**
+     * @return array{0: int, 1: int}
+     */
+    public function limits(): array
+    {
+        return match ($this) {
+            self::ScanLogPoll => [
+                self::SCAN_LOG_POLL_MAX_REQUESTS,
+                self::SCAN_LOG_POLL_WINDOW_SECONDS,
+            ],
+            self::QueuePoll => [
+                self::QUEUE_POLL_MAX_REQUESTS,
+                self::QUEUE_POLL_WINDOW_SECONDS,
+            ],
+            self::QueueSubmit => [
+                self::QUEUE_SUBMIT_MAX_REQUESTS,
+                self::QUEUE_SUBMIT_WINDOW_SECONDS,
+            ],
+            self::PlayerReport => [
+                self::PLAYER_REPORT_MAX_REQUESTS,
+                self::PLAYER_REPORT_WINDOW_SECONDS,
+            ],
+        };
+    }
+}

--- a/wwwroot/classes/IpRateLimitService.php
+++ b/wwwroot/classes/IpRateLimitService.php
@@ -3,43 +3,20 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/IpAddressResolver.php';
+require_once __DIR__ . '/IpRateLimitBucket.php';
 
 /**
  * Fixed-window IP rate limiting backed by the ip_rate_limit table.
  */
 final class IpRateLimitService
 {
-    public const string BUCKET_QUEUE_POLL = 'queue_poll';
-
-    public const string BUCKET_QUEUE_SUBMIT = 'queue_submit';
-
-    public const string BUCKET_PLAYER_REPORT = 'player_report';
-
-    public const string BUCKET_SCAN_LOG_POLL = 'scan_log_poll';
-
-    private const int QUEUE_POLL_MAX_REQUESTS = 60;
-
-    private const int QUEUE_POLL_WINDOW_SECONDS = 60;
-
-    private const int QUEUE_SUBMIT_MAX_REQUESTS = 10;
-
-    private const int QUEUE_SUBMIT_WINDOW_SECONDS = 60;
-
-    private const int PLAYER_REPORT_MAX_REQUESTS = 5;
-
-    private const int PLAYER_REPORT_WINDOW_SECONDS = 60;
-
-    private const int SCAN_LOG_POLL_MAX_REQUESTS = 30;
-
-    private const int SCAN_LOG_POLL_WINDOW_SECONDS = 60;
-
     public function __construct(private readonly PDO $database)
     {
     }
 
-    public function isAllowed(string $ipAddress, string $bucket): bool
+    public function isAllowed(string $ipAddress, IpRateLimitBucket $bucket): bool
     {
-        [$maxRequests, $windowSeconds] = $this->resolveLimits($bucket);
+        [$maxRequests, $windowSeconds] = $bucket->limits();
         $bucketKey = $this->buildBucketKey($ipAddress, $bucket);
         $row = $this->fetchBucketRow($bucketKey);
 
@@ -57,14 +34,14 @@ final class IpRateLimitService
         return $requestCount < $maxRequests;
     }
 
-    public function recordRequest(string $ipAddress, string $bucket): void
+    public function recordRequest(string $ipAddress, IpRateLimitBucket $bucket): void
     {
         $this->checkAndRecord($ipAddress, $bucket);
     }
 
-    public function checkAndRecord(string $ipAddress, string $bucket): bool
+    public function checkAndRecord(string $ipAddress, IpRateLimitBucket $bucket): bool
     {
-        [$maxRequests, $windowSeconds] = $this->resolveLimits($bucket);
+        [$maxRequests, $windowSeconds] = $bucket->limits();
         $bucketKey = $this->buildBucketKey($ipAddress, $bucket);
 
         $startedTransaction = false;
@@ -90,37 +67,11 @@ final class IpRateLimitService
         }
     }
 
-    /**
-     * @return array{0: int, 1: int}
-     */
-    private function resolveLimits(string $bucket): array
-    {
-        return match ($bucket) {
-            self::BUCKET_SCAN_LOG_POLL => [
-                self::SCAN_LOG_POLL_MAX_REQUESTS,
-                self::SCAN_LOG_POLL_WINDOW_SECONDS,
-            ],
-            self::BUCKET_QUEUE_POLL => [
-                self::QUEUE_POLL_MAX_REQUESTS,
-                self::QUEUE_POLL_WINDOW_SECONDS,
-            ],
-            self::BUCKET_QUEUE_SUBMIT => [
-                self::QUEUE_SUBMIT_MAX_REQUESTS,
-                self::QUEUE_SUBMIT_WINDOW_SECONDS,
-            ],
-            self::BUCKET_PLAYER_REPORT => [
-                self::PLAYER_REPORT_MAX_REQUESTS,
-                self::PLAYER_REPORT_WINDOW_SECONDS,
-            ],
-            default => throw new InvalidArgumentException(sprintf('Unknown rate-limit bucket "%s".', $bucket)),
-        };
-    }
-
-    private function buildBucketKey(string $ipAddress, string $bucket): string
+    private function buildBucketKey(string $ipAddress, IpRateLimitBucket $bucket): string
     {
         $normalizedIpAddress = IpAddressResolver::normalizeForAbuseControls($ipAddress);
 
-        return hash('sha256', $bucket . '|' . $normalizedIpAddress);
+        return hash('sha256', $bucket->value . '|' . $normalizedIpAddress);
     }
 
     private function consumeSlotIfAvailable(string $bucketKey, int $maxRequests, int $windowSeconds): bool

--- a/wwwroot/classes/Leaderboard/AbstractLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/AbstractLeaderboardRow.php
@@ -10,53 +10,22 @@ abstract class AbstractLeaderboardRow
     private const int NEW_PLAYER_RANK_VALUE = 16777215;
 
     /**
-     * @var array<string, mixed>
-     */
-    protected array $player;
-
-    private PlayerLeaderboardFilter $filter;
-
-    private Utility $utility;
-
-    private ?string $highlightedPlayerId;
-
-    /**
-     * @var array<string, int|string>
-     */
-    private array $filterParameters;
-
-    private string $rankingField;
-
-    private string $rankingLastWeekField;
-
-    private string $countryRankingField;
-
-    private string $countryRankingLastWeekField;
-
-    /**
      * @param array<string, mixed> $player
      * @param array<string, int|string> $filterParameters
      */
     public function __construct(
-        array $player,
-        PlayerLeaderboardFilter $filter,
-        Utility $utility,
-        ?string $highlightedPlayerId,
-        array $filterParameters,
-        string $rankingField,
-        string $rankingLastWeekField,
-        string $countryRankingField,
-        string $countryRankingLastWeekField
+        protected array $player,
+        private PlayerLeaderboardFilter $filter,
+        private Utility $utility,
+        private ?string $highlightedPlayerId,
+        /** @var array<string, int|string> */
+        private array $filterParameters,
+        private string $rankingField,
+        private string $rankingLastWeekField,
+        private string $countryRankingField,
+        private string $countryRankingLastWeekField,
     ) {
-        $this->player = $player;
-        $this->filter = $filter;
-        $this->utility = $utility;
         $this->highlightedPlayerId = $highlightedPlayerId !== null ? trim($highlightedPlayerId) : null;
-        $this->filterParameters = $filterParameters;
-        $this->rankingField = $rankingField;
-        $this->rankingLastWeekField = $rankingLastWeekField;
-        $this->countryRankingField = $countryRankingField;
-        $this->countryRankingLastWeekField = $countryRankingLastWeekField;
     }
 
     public function getRowId(): string

--- a/wwwroot/classes/Platform.php
+++ b/wwwroot/classes/Platform.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+enum Platform: string
+{
+    case Pc = 'pc';
+    case Ps3 = 'ps3';
+    case Ps4 = 'ps4';
+    case Ps5 = 'ps5';
+    case PsVita = 'psvita';
+    case PsVr = 'psvr';
+    case PsVr2 = 'psvr2';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Pc => 'PC',
+            self::Ps3 => 'PS3',
+            self::Ps4 => 'PS4',
+            self::Ps5 => 'PS5',
+            self::PsVita => 'PSVITA',
+            self::PsVr => 'PSVR',
+            self::PsVr2 => 'PSVR2',
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function labelsByValue(): array
+    {
+        $labels = [];
+
+        foreach (self::cases() as $platform) {
+            $labels[$platform->value] = $platform->label();
+        }
+
+        return $labels;
+    }
+}

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Platform.php';
+
 readonly class PlayerGamesFilter
 {
     public const string SORT_DATE = 'date';
@@ -12,13 +14,13 @@ readonly class PlayerGamesFilter
     public const string SORT_RARITY = 'rarity';
     public const string SORT_SEARCH = 'search';
 
-    public const string PLATFORM_PC = 'pc';
-    public const string PLATFORM_PS3 = 'ps3';
-    public const string PLATFORM_PS4 = 'ps4';
-    public const string PLATFORM_PS5 = 'ps5';
-    public const string PLATFORM_PSVITA = 'psvita';
-    public const string PLATFORM_PSVR = 'psvr';
-    public const string PLATFORM_PSVR2 = 'psvr2';
+    public const string PLATFORM_PC = Platform::Pc->value;
+    public const string PLATFORM_PS3 = Platform::Ps3->value;
+    public const string PLATFORM_PS4 = Platform::Ps4->value;
+    public const string PLATFORM_PS5 = Platform::Ps5->value;
+    public const string PLATFORM_PSVITA = Platform::PsVita->value;
+    public const string PLATFORM_PSVR = Platform::PsVr->value;
+    public const string PLATFORM_PSVR2 = Platform::PsVr2->value;
 
     /**
      * @var list<string>
@@ -31,19 +33,6 @@ readonly class PlayerGamesFilter
         self::SORT_NAME,
         self::SORT_RARITY,
         self::SORT_SEARCH,
-    ];
-
-    /**
-     * @var list<string>
-     */
-    private const array PLATFORM_KEYS = [
-        self::PLATFORM_PC,
-        self::PLATFORM_PS3,
-        self::PLATFORM_PS4,
-        self::PLATFORM_PS5,
-        self::PLATFORM_PSVITA,
-        self::PLATFORM_PSVR,
-        self::PLATFORM_PSVR2,
     ];
 
     private const int DEFAULT_LIMIT = 50;
@@ -92,7 +81,7 @@ readonly class PlayerGamesFilter
         }
 
         $platforms = [];
-        foreach (self::PLATFORM_KEYS as $platformKey) {
+        foreach (Platform::values() as $platformKey) {
             if (!empty($parameters[$platformKey])) {
                 $platforms[] = $platformKey;
             }

--- a/wwwroot/classes/PlayerLogFilter.php
+++ b/wwwroot/classes/PlayerLogFilter.php
@@ -2,22 +2,13 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Platform.php';
+
 readonly class PlayerLogFilter
 {
     public const string SORT_DATE = 'date';
     public const string SORT_RARITY = 'rarity';
     public const string SORT_IN_GAME_RARITY = 'in-game-rarity';
-
-    /** @var array<int, string> */
-    private const array ALLOWED_PLATFORMS = [
-        'pc',
-        'ps3',
-        'ps4',
-        'ps5',
-        'psvita',
-        'psvr',
-        'psvr2',
-    ];
 
     private function __construct(
         final private string $sort,
@@ -38,7 +29,7 @@ readonly class PlayerLogFilter
         }
 
         $platforms = [];
-        foreach (self::ALLOWED_PLATFORMS as $platform) {
+        foreach (Platform::values() as $platform) {
             if (!empty($parameters[$platform])) {
                 $platforms[] = $platform;
             }

--- a/wwwroot/classes/PlayerPlatformFilterOptions.php
+++ b/wwwroot/classes/PlayerPlatformFilterOptions.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Platform.php';
+
 readonly final class PlayerPlatformFilterOption
 {
     public function __construct(
@@ -34,19 +36,6 @@ readonly final class PlayerPlatformFilterOption
 readonly final class PlayerPlatformFilterOptions
 {
     /**
-     * @var array<string, string>
-     */
-    private const array PLATFORM_LABELS = [
-        'pc' => 'PC',
-        'ps3' => 'PS3',
-        'ps4' => 'PS4',
-        'ps5' => 'PS5',
-        'psvita' => 'PSVITA',
-        'psvr' => 'PSVR',
-        'psvr2' => 'PSVR2',
-    ];
-
-    /**
      * @param PlayerPlatformFilterOption[] $options
      */
     private function __construct(private array $options)
@@ -60,12 +49,12 @@ readonly final class PlayerPlatformFilterOptions
     {
         return new self(
             array_map(
-                static fn (string $key): PlayerPlatformFilterOption => new PlayerPlatformFilterOption(
-                    $key,
-                    self::PLATFORM_LABELS[$key],
-                    (bool) $selectionCallback($key)
+                static fn (Platform $platform): PlayerPlatformFilterOption => new PlayerPlatformFilterOption(
+                    $platform->value,
+                    $platform->label(),
+                    (bool) $selectionCallback($platform->value)
                 ),
-                array_keys(self::PLATFORM_LABELS)
+                Platform::cases()
             )
         );
     }

--- a/wwwroot/classes/PlayerQueueController.php
+++ b/wwwroot/classes/PlayerQueueController.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/PlayerQueueHandler.php';
 require_once __DIR__ . '/PlayerQueueResponseFactory.php';
 require_once __DIR__ . '/PlayerQueuePollTokenManager.php';
 require_once __DIR__ . '/IpRateLimitService.php';
+require_once __DIR__ . '/IpRateLimitBucket.php';
 
 class PlayerQueueController
 {
@@ -38,7 +39,7 @@ class PlayerQueueController
             $this->rateLimitService !== null
             && !$this->rateLimitService->checkAndRecord(
                 $request->getIpAddress(),
-                IpRateLimitService::BUCKET_QUEUE_SUBMIT
+                IpRateLimitBucket::QueueSubmit
             )
         ) {
             return PlayerQueueResponse::rateLimited(
@@ -57,7 +58,7 @@ class PlayerQueueController
             $this->rateLimitService !== null
             && !$this->rateLimitService->checkAndRecord(
                 $request->getIpAddress(),
-                IpRateLimitService::BUCKET_QUEUE_POLL
+                IpRateLimitBucket::QueuePoll
             )
         ) {
             return PlayerQueueResponse::rateLimited(

--- a/wwwroot/classes/PlayerRandomGamesFilter.php
+++ b/wwwroot/classes/PlayerRandomGamesFilter.php
@@ -2,28 +2,17 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Platform.php';
+
 final readonly class PlayerRandomGamesFilter
 {
-    public const string PLATFORM_PC = 'pc';
-    public const string PLATFORM_PS3 = 'ps3';
-    public const string PLATFORM_PS4 = 'ps4';
-    public const string PLATFORM_PS5 = 'ps5';
-    public const string PLATFORM_PSVITA = 'psvita';
-    public const string PLATFORM_PSVR = 'psvr';
-    public const string PLATFORM_PSVR2 = 'psvr2';
-
-    /**
-     * @var list<string>
-     */
-    private const array PLATFORM_KEYS = [
-        self::PLATFORM_PC,
-        self::PLATFORM_PS3,
-        self::PLATFORM_PS4,
-        self::PLATFORM_PS5,
-        self::PLATFORM_PSVITA,
-        self::PLATFORM_PSVR,
-        self::PLATFORM_PSVR2,
-    ];
+    public const string PLATFORM_PC = Platform::Pc->value;
+    public const string PLATFORM_PS3 = Platform::Ps3->value;
+    public const string PLATFORM_PS4 = Platform::Ps4->value;
+    public const string PLATFORM_PS5 = Platform::Ps5->value;
+    public const string PLATFORM_PSVITA = Platform::PsVita->value;
+    public const string PLATFORM_PSVR = Platform::PsVr->value;
+    public const string PLATFORM_PSVR2 = Platform::PsVr2->value;
 
     /**
      * @var array<string, bool>
@@ -42,7 +31,7 @@ final readonly class PlayerRandomGamesFilter
     public static function fromArray(array $parameters): self
     {
         $selectedPlatforms = [];
-        foreach (self::PLATFORM_KEYS as $platformKey) {
+        foreach (Platform::values() as $platformKey) {
             $selectedPlatforms[$platformKey] = self::toBool($parameters[$platformKey] ?? null);
         }
 

--- a/wwwroot/classes/PlayerReportHandler.php
+++ b/wwwroot/classes/PlayerReportHandler.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/PlayerReportService.php';
 require_once __DIR__ . '/PlayerReportResult.php';
 require_once __DIR__ . '/PlayerReportRequest.php';
 require_once __DIR__ . '/IpRateLimitService.php';
+require_once __DIR__ . '/IpRateLimitBucket.php';
 
 class PlayerReportHandler
 {
@@ -42,7 +43,7 @@ class PlayerReportHandler
             $this->rateLimitService !== null
             && !$this->rateLimitService->checkAndRecord(
                 $request->getIpAddress(),
-                IpRateLimitService::BUCKET_PLAYER_REPORT
+                IpRateLimitBucket::PlayerReport
             )
         ) {
             return PlayerReportResult::error(

--- a/wwwroot/classes/TrophyType.php
+++ b/wwwroot/classes/TrophyType.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+enum TrophyType: string
+{
+    case Bronze = 'bronze';
+    case Silver = 'silver';
+    case Gold = 'gold';
+    case Platinum = 'platinum';
+
+    public static function fromMixed(mixed $value): self
+    {
+        if (!is_string($value) && !is_numeric($value)) {
+            return self::Bronze;
+        }
+
+        return self::tryFrom(((string) $value) |> trim(...) |> strtolower(...)) ?? self::Bronze;
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::Bronze => '#c46438',
+            self::Silver => '#777777',
+            self::Gold => '#c2903e',
+            self::Platinum => '#667fb2',
+        };
+    }
+
+    public function iconPath(): string
+    {
+        return '/img/trophy-' . $this->value . '.svg';
+    }
+
+    public function label(): string
+    {
+        return $this->value |> ucfirst(...);
+    }
+
+    /**
+     * SQL FIELD() argument list for trophy type ordering.
+     */
+    public static function sqlFieldOrder(string $columnExpression): string
+    {
+        $quotedValues = array_map(
+            static fn (self $type): string => "'" . $type->value . "'",
+            self::cases()
+        );
+
+        return 'FIELD(' . $columnExpression . ', ' . implode(', ', $quotedValues) . ')';
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Introduce shared backed enums for `Platform`, `TrophyType`, `IpRateLimitBucket`, player-scan result statuses/actions, and `PsnTrophyTitleComparisonSource`, replacing duplicated string constants.
- Wire filters, rate limiting, trophy rows/SQL ordering, scan result objects, and the admin trophy-title compare UI through those enums.
- Promote `AbstractLeaderboardRow` constructor properties to match the rest of the PHP 8.5 codebase style.

## Test plan
- [x] `php tests/run.php` — all 984 tests passed
- [x] `php -l` on modified/new class files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b9c5bbd-69e8-4419-8718-72fcc5a1a540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b9c5bbd-69e8-4419-8718-72fcc5a1a540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

