### PR TITLE
Adopt remaining PHP 8.5 sort enums and NoDiscard factories

### DIFF
--- a/wwwroot/classes/AboutPagePlayer.php
+++ b/wwwroot/classes/AboutPagePlayer.php
@@ -7,18 +7,18 @@ require_once __DIR__ . '/PlayerStatus.php';
 final readonly class AboutPagePlayer
 {
     public function __construct(
-        private Utility $utility,
-        private string $onlineId,
-        private string $countryCode,
-        private string $avatarUrl,
-        private ?string $lastUpdatedDate,
-        private ?int $level,
-        private ?string $progress,
-        private int $rankLastWeek,
-        private PlayerStatus $status,
-        private int $trophyCountNpwr,
-        private int $trophyCountSony,
-        private ?int $ranking,
+        final private Utility $utility,
+        final private string $onlineId,
+        final private string $countryCode,
+        final private string $avatarUrl,
+        final private ?string $lastUpdatedDate,
+        final private ?int $level,
+        final private ?string $progress,
+        final private int $rankLastWeek,
+        final private PlayerStatus $status,
+        final private int $trophyCountNpwr,
+        final private int $trophyCountSony,
+        final private ?int $ranking,
     ) {
     }
 

--- a/wwwroot/classes/ApplicationContainer.php
+++ b/wwwroot/classes/ApplicationContainer.php
@@ -27,6 +27,7 @@ class ApplicationContainer
 
     private ?TemplateRenderer $templateRenderer = null;
 
+    #[\NoDiscard]
     public static function create(): self
     {
         return new self(

--- a/wwwroot/classes/ApplicationRunner.php
+++ b/wwwroot/classes/ApplicationRunner.php
@@ -18,6 +18,7 @@ final readonly class ApplicationRunner
         $this->maintenanceResponder = $maintenanceResponder ?? new MaintenanceResponder();
     }
 
+    #[\NoDiscard]
     public static function create(
         ApplicationContainer $applicationContainer,
         MaintenanceMode $maintenanceMode,

--- a/wwwroot/classes/Avatar.php
+++ b/wwwroot/classes/Avatar.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 readonly class Avatar
 {
     public function __construct(
-        private string $url,
-        private int $count
+        final private string $url,
+        final private int $count
     ) {}
 
     public function getUrl(): string

--- a/wwwroot/classes/Cron/CronJobApplication.php
+++ b/wwwroot/classes/Cron/CronJobApplication.php
@@ -20,6 +20,7 @@ final class CronJobApplication
         $this->runner = $runner;
     }
 
+    #[\NoDiscard]
     public static function create(?CronJobRunner $runner = null): self
     {
         return new self($runner ?? CronJobRunner::create());

--- a/wwwroot/classes/Cron/CronJobBootstrapper.php
+++ b/wwwroot/classes/Cron/CronJobBootstrapper.php
@@ -19,6 +19,7 @@ final class CronJobBootstrapper
         $this->application = $application;
     }
 
+    #[\NoDiscard]
     public static function create(string $projectRoot, ?CronJobApplication $application = null): self
     {
         return new self($projectRoot, $application ?? CronJobApplication::create());

--- a/wwwroot/classes/Cron/CronJobEntryPoint.php
+++ b/wwwroot/classes/Cron/CronJobEntryPoint.php
@@ -21,6 +21,7 @@ final class CronJobEntryPoint
         $this->bootstrapper = $bootstrapper;
     }
 
+    #[\NoDiscard]
     public static function create(string $projectRoot, ?CronJobBootstrapper $bootstrapper = null): self
     {
         return new self($bootstrapper ?? CronJobBootstrapper::create($projectRoot));

--- a/wwwroot/classes/Cron/CronJobRunner.php
+++ b/wwwroot/classes/Cron/CronJobRunner.php
@@ -11,6 +11,7 @@ final class CronJobRunner
 
     private bool $environmentConfigured = false;
 
+    #[\NoDiscard]
     public static function create(): self
     {
         return new self();

--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -60,6 +60,7 @@ final readonly class GameLeaderboardFilter extends GamePlayerFilter
     /**
      * @return array<string, int|string>
      */
+    #[\NoDiscard]
     public function withPage(int $page): array
     {
         $parameters = parent::getFilterParameters();

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -3,15 +3,16 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Platform.php';
+require_once __DIR__ . '/GameListSort.php';
 
 readonly class GameListFilter
 {
-    public const string SORT_ADDED = 'added';
-    public const string SORT_COMPLETION = 'completion';
-    public const string SORT_OWNERS = 'owners';
-    public const string SORT_RARITY = 'rarity';
-    public const string SORT_IN_GAME_RARITY = 'in-game-rarity';
-    public const string SORT_SEARCH = 'search';
+    public const string SORT_ADDED = GameListSort::Added->value;
+    public const string SORT_COMPLETION = GameListSort::Completion->value;
+    public const string SORT_OWNERS = GameListSort::Owners->value;
+    public const string SORT_RARITY = GameListSort::Rarity->value;
+    public const string SORT_IN_GAME_RARITY = GameListSort::InGameRarity->value;
+    public const string SORT_SEARCH = GameListSort::Search->value;
 
     public const string PLATFORM_PC = Platform::Pc->value;
     public const string PLATFORM_PS3 = Platform::Ps3->value;
@@ -23,7 +24,7 @@ readonly class GameListFilter
 
     private function __construct(
         final private ?string $player,
-        final private string $sort,
+        final private GameListSort $sort,
         final private bool $sortSpecified,
         final private string $search,
         final private int $page,
@@ -100,12 +101,12 @@ readonly class GameListFilter
 
     public function getSort(): string
     {
-        return $this->sort;
+        return $this->sort->value;
     }
 
     public function isSort(string $sort): bool
     {
-        return $this->sort === $sort;
+        return $this->sort->value === $sort;
     }
 
     public function hasExplicitSort(): bool
@@ -125,7 +126,7 @@ readonly class GameListFilter
 
     public function shouldApplySearch(): bool
     {
-        return $this->hasSearch() || $this->sort === self::SORT_SEARCH;
+        return $this->hasSearch() || $this->sort === GameListSort::Search;
     }
 
     public function getPage(): int
@@ -191,7 +192,7 @@ readonly class GameListFilter
         }
 
         if ($this->sortSpecified) {
-            $parameters['sort'] = $this->sort;
+            $parameters['sort'] = $this->sort->value;
         } else {
             unset($parameters['sort']);
         }
@@ -287,18 +288,18 @@ readonly class GameListFilter
         return max($page, 1);
     }
 
-    private static function normalizeSort(mixed $value, string $search, bool $sortSpecified): string
+    private static function normalizeSort(mixed $value, string $search, bool $sortSpecified): GameListSort
     {
-        $sort = is_string($value) ? ($value |> trim(...) |> strtolower(...)) : '';
+        $sort = GameListSort::tryFromMixed($value);
 
         return match ($sort) {
-            self::SORT_ADDED,
-            self::SORT_COMPLETION,
-            self::SORT_OWNERS,
-            self::SORT_RARITY,
-            self::SORT_IN_GAME_RARITY => $sort,
-            self::SORT_SEARCH => ($search !== '' || $sortSpecified) ? self::SORT_SEARCH : self::SORT_ADDED,
-            default => $search !== '' ? self::SORT_SEARCH : self::SORT_ADDED,
+            GameListSort::Added,
+            GameListSort::Completion,
+            GameListSort::Owners,
+            GameListSort::Rarity,
+            GameListSort::InGameRarity => $sort,
+            GameListSort::Search => ($search !== '' || $sortSpecified) ? GameListSort::Search : GameListSort::Added,
+            null => $search !== '' ? GameListSort::Search : GameListSort::Added,
         };
     }
 

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/GameListItem.php';
 require_once __DIR__ . '/GameListPageResult.php';
+require_once __DIR__ . '/GameListSort.php';
 require_once __DIR__ . '/PlatformSql.php';
 require_once __DIR__ . '/PlayerStatus.php';
 require_once __DIR__ . '/SearchQueryHelper.php';
@@ -202,9 +203,9 @@ class GameListService
     private function buildConditions(GameListFilter $filter): string
     {
         $conditions = [
-            match ($filter->getSort()) {
-                GameListFilter::SORT_COMPLETION => "ttm.status = 0 AND (tt.bronze + tt.silver + tt.gold + tt.platinum) != 0",
-                GameListFilter::SORT_RARITY, GameListFilter::SORT_IN_GAME_RARITY => 'ttm.status = 0',
+            match (GameListSort::from($filter->getSort())) {
+                GameListSort::Completion => "ttm.status = 0 AND (tt.bronze + tt.silver + tt.gold + tt.platinum) != 0",
+                GameListSort::Rarity, GameListSort::InGameRarity => 'ttm.status = 0',
                 default => 'ttm.status != 2',
             },
         ];
@@ -242,12 +243,12 @@ class GameListService
 
     private function buildOrderByClause(GameListFilter $filter): string
     {
-        return match ($filter->getSort()) {
-            GameListFilter::SORT_COMPLETION => 'ORDER BY difficulty DESC, owners DESC, `name`',
-            GameListFilter::SORT_OWNERS => 'ORDER BY owners DESC, `name`',
-            GameListFilter::SORT_RARITY => 'ORDER BY rarity_points DESC, owners DESC, `name`',
-            GameListFilter::SORT_IN_GAME_RARITY => 'ORDER BY in_game_rarity_points DESC, owners DESC, `name`',
-            GameListFilter::SORT_SEARCH => 'ORDER BY exact_match DESC, prefix_match DESC, score DESC, `name`, tt.id',
+        return match (GameListSort::from($filter->getSort())) {
+            GameListSort::Completion => 'ORDER BY difficulty DESC, owners DESC, `name`',
+            GameListSort::Owners => 'ORDER BY owners DESC, `name`',
+            GameListSort::Rarity => 'ORDER BY rarity_points DESC, owners DESC, `name`',
+            GameListSort::InGameRarity => 'ORDER BY in_game_rarity_points DESC, owners DESC, `name`',
+            GameListSort::Search => 'ORDER BY exact_match DESC, prefix_match DESC, score DESC, `name`, tt.id',
             default => 'ORDER BY id DESC',
         };
     }

--- a/wwwroot/classes/GameListSort.php
+++ b/wwwroot/classes/GameListSort.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+enum GameListSort: string
+{
+    case Added = 'added';
+    case Completion = 'completion';
+    case Owners = 'owners';
+    case Rarity = 'rarity';
+    case InGameRarity = 'in-game-rarity';
+    case Search = 'search';
+
+    public static function tryFromMixed(mixed $value): ?self
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return self::tryFrom($value |> trim(...) |> strtolower(...));
+    }
+}

--- a/wwwroot/classes/GamePlayerFilter.php
+++ b/wwwroot/classes/GamePlayerFilter.php
@@ -75,6 +75,7 @@ readonly class GamePlayerFilter
     /**
      * @return array<string, string>
      */
+    #[\NoDiscard]
     public function withCountry(?string $country): array
     {
         $parameters = $this->getFilterParameters();
@@ -92,6 +93,7 @@ readonly class GamePlayerFilter
     /**
      * @return array<string, string>
      */
+    #[\NoDiscard]
     public function withAvatar(?string $avatar): array
     {
         $parameters = $this->getFilterParameters();

--- a/wwwroot/classes/PlayerAdvisorFilter.php
+++ b/wwwroot/classes/PlayerAdvisorFilter.php
@@ -2,35 +2,17 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Platform.php';
+require_once __DIR__ . '/PlayerAdvisorSort.php';
+
 readonly class PlayerAdvisorFilter
 {
-    public const string SORT_RARITY = 'rarity';
-    public const string SORT_IN_GAME_RARITY = 'in_game_rarity';
-
-    /**
-     * @var list<string>
-     */
-    private const array ALLOWED_SORTS = [
-        self::SORT_RARITY,
-        self::SORT_IN_GAME_RARITY,
-    ];
-
-    /**
-     * @var list<string>
-     */
-    private const array SUPPORTED_PLATFORMS = [
-        'pc',
-        'ps3',
-        'ps4',
-        'ps5',
-        'psvita',
-        'psvr',
-        'psvr2',
-    ];
+    public const string SORT_RARITY = PlayerAdvisorSort::Rarity->value;
+    public const string SORT_IN_GAME_RARITY = PlayerAdvisorSort::InGameRarity->value;
 
     private function __construct(
         final private int $page,
-        final private string $sort,
+        final private PlayerAdvisorSort $sort,
         /**
          * @var array<int, string>
          */
@@ -49,13 +31,10 @@ readonly class PlayerAdvisorFilter
             $page = max((int) $parameters['page'], 1);
         }
 
-        $sort = self::SORT_RARITY;
-        if (isset($parameters['sort']) && in_array($parameters['sort'], self::ALLOWED_SORTS, true)) {
-            $sort = (string) $parameters['sort'];
-        }
+        $sort = PlayerAdvisorSort::tryFromMixed($parameters['sort'] ?? null) ?? PlayerAdvisorSort::Rarity;
 
         $platforms = [];
-        foreach (self::SUPPORTED_PLATFORMS as $platform) {
+        foreach (Platform::values() as $platform) {
             if (!empty($parameters[$platform])) {
                 $platforms[] = $platform;
             }
@@ -100,7 +79,7 @@ readonly class PlayerAdvisorFilter
 
     public function getSort(): string
     {
-        return $this->sort;
+        return $this->sort->value;
     }
 
     /**
@@ -114,7 +93,7 @@ readonly class PlayerAdvisorFilter
             $parameters[$platform] = 'true';
         }
 
-        $parameters['sort'] = $this->sort;
+        $parameters['sort'] = $this->sort->value;
 
         return $parameters;
     }

--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerAdvisableTrophy.php';
+require_once __DIR__ . '/PlayerAdvisorSort.php';
 require_once __DIR__ . '/PlatformSql.php';
 require_once __DIR__ . '/Utility.php';
 
@@ -119,10 +120,9 @@ class PlayerAdvisorService
 
     private function buildOrderByClause(PlayerAdvisorFilter $filter): string
     {
-        if ($filter->getSort() === PlayerAdvisorFilter::SORT_IN_GAME_RARITY) {
-            return ' ORDER BY tm.in_game_rarity_percent DESC, ttp.last_updated_date DESC';
-        }
-
-        return ' ORDER BY tm.rarity_percent DESC, ttp.last_updated_date DESC';
+        return match (PlayerAdvisorSort::from($filter->getSort())) {
+            PlayerAdvisorSort::InGameRarity => ' ORDER BY tm.in_game_rarity_percent DESC, ttp.last_updated_date DESC',
+            PlayerAdvisorSort::Rarity => ' ORDER BY tm.rarity_percent DESC, ttp.last_updated_date DESC',
+        };
     }
 }

--- a/wwwroot/classes/PlayerAdvisorSort.php
+++ b/wwwroot/classes/PlayerAdvisorSort.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerAdvisorSort: string
+{
+    case Rarity = 'rarity';
+    case InGameRarity = 'in_game_rarity';
+
+    public static function tryFromMixed(mixed $value): ?self
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return self::tryFrom($value |> trim(...) |> strtolower(...));
+    }
+}

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -3,16 +3,17 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Platform.php';
+require_once __DIR__ . '/PlayerGamesSort.php';
 
 readonly class PlayerGamesFilter
 {
-    public const string SORT_DATE = 'date';
-    public const string SORT_IN_GAME_MAX_RARITY = 'max-in-game-rarity';
-    public const string SORT_IN_GAME_RARITY = 'in-game-rarity';
-    public const string SORT_MAX_RARITY = 'max-rarity';
-    public const string SORT_NAME = 'name';
-    public const string SORT_RARITY = 'rarity';
-    public const string SORT_SEARCH = 'search';
+    public const string SORT_DATE = PlayerGamesSort::Date->value;
+    public const string SORT_IN_GAME_MAX_RARITY = PlayerGamesSort::InGameMaxRarity->value;
+    public const string SORT_IN_GAME_RARITY = PlayerGamesSort::InGameRarity->value;
+    public const string SORT_MAX_RARITY = PlayerGamesSort::MaxRarity->value;
+    public const string SORT_NAME = PlayerGamesSort::Name->value;
+    public const string SORT_RARITY = PlayerGamesSort::Rarity->value;
+    public const string SORT_SEARCH = PlayerGamesSort::Search->value;
 
     public const string PLATFORM_PC = Platform::Pc->value;
     public const string PLATFORM_PS3 = Platform::Ps3->value;
@@ -22,19 +23,6 @@ readonly class PlayerGamesFilter
     public const string PLATFORM_PSVR = Platform::PsVr->value;
     public const string PLATFORM_PSVR2 = Platform::PsVr2->value;
 
-    /**
-     * @var list<string>
-     */
-    private const array ALLOWED_SORTS = [
-        self::SORT_DATE,
-        self::SORT_IN_GAME_MAX_RARITY,
-        self::SORT_IN_GAME_RARITY,
-        self::SORT_MAX_RARITY,
-        self::SORT_NAME,
-        self::SORT_RARITY,
-        self::SORT_SEARCH,
-    ];
-
     private const int DEFAULT_LIMIT = 50;
 
     /**
@@ -42,7 +30,7 @@ readonly class PlayerGamesFilter
      */
     private function __construct(
         final private string $search,
-        final private string $sort,
+        final private PlayerGamesSort $sort,
         final private bool $completed,
         final private bool $uncompleted,
         final private bool $base,
@@ -61,15 +49,10 @@ readonly class PlayerGamesFilter
     {
         $search = isset($parameters['search']) ? (string) $parameters['search'] : '';
 
-        $sort = isset($parameters['sort']) ? (string) $parameters['sort'] : '';
-        $sortProvided = false;
-        if ($sort !== '' && in_array($sort, self::ALLOWED_SORTS, true)) {
-            $sortProvided = true;
-        } elseif ($search !== '') {
-            $sort = self::SORT_SEARCH;
-        } else {
-            $sort = self::SORT_DATE;
-        }
+        $parsedSort = PlayerGamesSort::tryFromMixed($parameters['sort'] ?? null);
+        $sortProvided = $parsedSort !== null;
+        $sort = $parsedSort
+            ?? ($search !== '' ? PlayerGamesSort::Search : PlayerGamesSort::Date);
 
         $completed = !empty($parameters['completed']);
         $uncompleted = !empty($parameters['uncompleted']);
@@ -116,7 +99,7 @@ readonly class PlayerGamesFilter
 
     public function shouldApplyFulltextCondition(): bool
     {
-        return $this->hasSearchTerm() || $this->sort === self::SORT_SEARCH;
+        return $this->hasSearchTerm() || $this->sort === PlayerGamesSort::Search;
     }
 
     public function shouldIncludeScoreColumn(): bool
@@ -126,12 +109,12 @@ readonly class PlayerGamesFilter
 
     public function getSort(): string
     {
-        return $this->sort;
+        return $this->sort->value;
     }
 
     public function isSort(string $sort): bool
     {
-        return $this->sort === $sort;
+        return $this->sort->value === $sort;
     }
 
     public function isCompletedSelected(): bool
@@ -193,8 +176,8 @@ readonly class PlayerGamesFilter
             $parameters['search'] = $this->search;
         }
 
-        if ($this->sortProvided || $this->sort !== self::SORT_DATE) {
-            $parameters['sort'] = $this->sort;
+        if ($this->sortProvided || $this->sort !== PlayerGamesSort::Date) {
+            $parameters['sort'] = $this->sort->value;
         }
 
         if ($this->completed) {
@@ -227,6 +210,7 @@ readonly class PlayerGamesFilter
     /**
      * @return array<string, int|string>
      */
+    #[\NoDiscard]
     public function withPage(int $page): array
     {
         $parameters = $this->getFilterParameters();

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerGame.php';
 require_once __DIR__ . '/PlayerGamesFilter.php';
+require_once __DIR__ . '/PlayerGamesSort.php';
 require_once __DIR__ . '/PlatformSql.php';
 require_once __DIR__ . '/SearchQueryHelper.php';
 require_once __DIR__ . '/DateDurationSummary.php';
@@ -156,13 +157,13 @@ final class PlayerGamesService
 
     private function buildOrderByClause(PlayerGamesFilter $filter): string
     {
-        return match ($filter->getSort()) {
-            PlayerGamesFilter::SORT_IN_GAME_MAX_RARITY => 'ORDER BY max_in_game_rarity_points DESC, `name`',
-            PlayerGamesFilter::SORT_IN_GAME_RARITY => 'ORDER BY in_game_rarity_points DESC, `name`',
-            PlayerGamesFilter::SORT_MAX_RARITY => 'ORDER BY max_rarity_points DESC, `name`',
-            PlayerGamesFilter::SORT_NAME => 'ORDER BY `name`',
-            PlayerGamesFilter::SORT_RARITY => 'ORDER BY rarity_points DESC, `name`',
-            PlayerGamesFilter::SORT_SEARCH => 'ORDER BY exact_match DESC, prefix_match DESC, score DESC, `name`, tt.id',
+        return match (PlayerGamesSort::from($filter->getSort())) {
+            PlayerGamesSort::InGameMaxRarity => 'ORDER BY max_in_game_rarity_points DESC, `name`',
+            PlayerGamesSort::InGameRarity => 'ORDER BY in_game_rarity_points DESC, `name`',
+            PlayerGamesSort::MaxRarity => 'ORDER BY max_rarity_points DESC, `name`',
+            PlayerGamesSort::Name => 'ORDER BY `name`',
+            PlayerGamesSort::Rarity => 'ORDER BY rarity_points DESC, `name`',
+            PlayerGamesSort::Search => 'ORDER BY exact_match DESC, prefix_match DESC, score DESC, `name`, tt.id',
             default => 'ORDER BY last_updated_date DESC',
         };
     }

--- a/wwwroot/classes/PlayerGamesSort.php
+++ b/wwwroot/classes/PlayerGamesSort.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerGamesSort: string
+{
+    case Date = 'date';
+    case InGameMaxRarity = 'max-in-game-rarity';
+    case InGameRarity = 'in-game-rarity';
+    case MaxRarity = 'max-rarity';
+    case Name = 'name';
+    case Rarity = 'rarity';
+    case Search = 'search';
+
+    public static function tryFromMixed(mixed $value): ?self
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return self::tryFrom($value |> trim(...) |> strtolower(...));
+    }
+}

--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -60,6 +60,7 @@ final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
     /**
      * @return array<string, int|string>
      */
+    #[\NoDiscard]
     public function withPage(int $page): array
     {
         $parameters = $this->getFilterParameters();

--- a/wwwroot/classes/PlayerLogFilter.php
+++ b/wwwroot/classes/PlayerLogFilter.php
@@ -3,15 +3,16 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Platform.php';
+require_once __DIR__ . '/PlayerLogSort.php';
 
 readonly class PlayerLogFilter
 {
-    public const string SORT_DATE = 'date';
-    public const string SORT_RARITY = 'rarity';
-    public const string SORT_IN_GAME_RARITY = 'in-game-rarity';
+    public const string SORT_DATE = PlayerLogSort::Date->value;
+    public const string SORT_RARITY = PlayerLogSort::Rarity->value;
+    public const string SORT_IN_GAME_RARITY = PlayerLogSort::InGameRarity->value;
 
     private function __construct(
-        final private string $sort,
+        final private PlayerLogSort $sort,
         final private int $page,
         /** @var array<int, string> */
         final private array $platforms,
@@ -21,8 +22,6 @@ readonly class PlayerLogFilter
     #[\NoDiscard]
     public static function fromArray(array $parameters): self
     {
-        $sort = is_string($parameters['sort'] ?? null) ? (string) $parameters['sort'] : self::SORT_DATE;
-
         $page = 1;
         if (isset($parameters['page']) && is_numeric((string) $parameters['page'])) {
             $page = (int) $parameters['page'];
@@ -36,7 +35,7 @@ readonly class PlayerLogFilter
         }
 
         return new self(
-            self::normaliseSort($sort),
+            PlayerLogSort::fromMixed($parameters['sort'] ?? null),
             max($page, 1),
             $platforms |> array_unique(...) |> array_values(...),
         );
@@ -44,12 +43,12 @@ readonly class PlayerLogFilter
 
     public function getSort(): string
     {
-        return $this->sort;
+        return $this->sort->value;
     }
 
     public function isSort(string $sort): bool
     {
-        return $this->sort === self::normaliseSort($sort);
+        return $this->sort === PlayerLogSort::fromMixed($sort);
     }
 
     public function getPage(): int
@@ -91,7 +90,7 @@ readonly class PlayerLogFilter
             $parameters[$platform] = 'true';
         }
 
-        $parameters['sort'] = $this->sort;
+        $parameters['sort'] = $this->sort->value;
 
         return $parameters;
     }
@@ -107,6 +106,7 @@ readonly class PlayerLogFilter
     /**
      * @return array<string, int|string>
      */
+    #[\NoDiscard]
     public function withPage(int $page): array
     {
         $parameters = $this->getFilterParameters();
@@ -119,18 +119,5 @@ readonly class PlayerLogFilter
     public function withPageNumber(int $page): self
     {
         return clone($this, ['page' => max($page, 1)]);
-    }
-
-    private static function normaliseSort(string $sort): string
-    {
-        if ($sort === self::SORT_RARITY) {
-            return self::SORT_RARITY;
-        }
-
-        if ($sort === self::SORT_IN_GAME_RARITY) {
-            return self::SORT_IN_GAME_RARITY;
-        }
-
-        return self::SORT_DATE;
     }
 }

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerLogEntry.php';
+require_once __DIR__ . '/PlayerLogSort.php';
 require_once __DIR__ . '/PlatformSql.php';
 
 class PlayerLogService
@@ -106,9 +107,9 @@ class PlayerLogService
 
     private function buildOrderByClause(PlayerLogFilter $filter): string
     {
-        return match ($filter->getSort()) {
-            PlayerLogFilter::SORT_RARITY => PHP_EOL . '            ORDER BY tm.rarity_percent, te.earned_date',
-            PlayerLogFilter::SORT_IN_GAME_RARITY => PHP_EOL . '            ORDER BY tm.in_game_rarity_percent, te.earned_date',
+        return match (PlayerLogSort::from($filter->getSort())) {
+            PlayerLogSort::Rarity => PHP_EOL . '            ORDER BY tm.rarity_percent, te.earned_date',
+            PlayerLogSort::InGameRarity => PHP_EOL . '            ORDER BY tm.in_game_rarity_percent, te.earned_date',
             default => PHP_EOL . '            ORDER BY te.earned_date DESC',
         };
     }

--- a/wwwroot/classes/PlayerLogSort.php
+++ b/wwwroot/classes/PlayerLogSort.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerLogSort: string
+{
+    case Date = 'date';
+    case Rarity = 'rarity';
+    case InGameRarity = 'in-game-rarity';
+
+    public static function fromMixed(mixed $value): self
+    {
+        if (!is_string($value)) {
+            return self::Date;
+        }
+
+        return self::tryFrom($value |> trim(...) |> strtolower(...)) ?? self::Date;
+    }
+}

--- a/wwwroot/classes/PlayerStatusNotice.php
+++ b/wwwroot/classes/PlayerStatusNotice.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerStatusNoticeType.php';
+
 readonly class PlayerStatusNotice
 {
-    private const string TYPE_FLAGGED = 'flagged';
-    private const string TYPE_PRIVATE = 'private';
     private const string DISPUTE_BASE_URL = 'https://github.com/Ragowit/psn100/issues';
     private const string PRIVATE_PROFILE_URL = 'https://www.playstation.com/en-us/support/account/privacy-settings-psn/';
 
     private function __construct(
-        private string $type,
-        private string $message,
+        final private PlayerStatusNoticeType $type,
+        final private string $message,
     ) {}
 
     #[\NoDiscard]
@@ -23,7 +23,7 @@ readonly class PlayerStatusNotice
             htmlspecialchars($disputeUrl, ENT_QUOTES, 'UTF-8')
         );
 
-        return new self(self::TYPE_FLAGGED, $message);
+        return new self(PlayerStatusNoticeType::Flagged, $message);
     }
 
     #[\NoDiscard]
@@ -34,7 +34,7 @@ readonly class PlayerStatusNotice
             htmlspecialchars(self::PRIVATE_PROFILE_URL, ENT_QUOTES, 'UTF-8')
         );
 
-        return new self(self::TYPE_PRIVATE, $message);
+        return new self(PlayerStatusNoticeType::Private, $message);
     }
 
     #[\NoDiscard]
@@ -60,17 +60,17 @@ readonly class PlayerStatusNotice
 
     public function getType(): string
     {
-        return $this->type;
+        return $this->type->value;
     }
 
     public function isFlagged(): bool
     {
-        return $this->type === self::TYPE_FLAGGED;
+        return $this->type === PlayerStatusNoticeType::Flagged;
     }
 
     public function isPrivateProfile(): bool
     {
-        return $this->type === self::TYPE_PRIVATE;
+        return $this->type === PlayerStatusNoticeType::Private;
     }
 
     private static function buildDisputeQuery(string $onlineId, ?string $accountId): string

--- a/wwwroot/classes/PlayerStatusNoticeType.php
+++ b/wwwroot/classes/PlayerStatusNoticeType.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerStatusNoticeType: string
+{
+    case Flagged = 'flagged';
+    case Private = 'private';
+}

--- a/wwwroot/classes/Routing/PlayerRouteHandler.php
+++ b/wwwroot/classes/Routing/PlayerRouteHandler.php
@@ -36,7 +36,7 @@ final readonly class PlayerRouteHandler implements RouteHandlerInterface
             return RouteResult::redirect('/player/');
         }
 
-        $view = $segments !== [] ? (string) array_shift($segments) : '';
+        $view = (string) (array_first($segments) ?? '');
 
         $variables = [
             'accountId' => $accountId,

--- a/wwwroot/classes/TrophyListFilter.php
+++ b/wwwroot/classes/TrophyListFilter.php
@@ -55,6 +55,7 @@ final readonly class TrophyListFilter
     /**
      * @return array<string, int>
      */
+    #[\NoDiscard]
     public function withPage(int $page): array
     {
         $parameters = $this->getFilterParameters();

--- a/wwwroot/classes/TrophyRarity.php
+++ b/wwwroot/classes/TrophyRarity.php
@@ -7,10 +7,10 @@ require_once __DIR__ . '/Html.php';
 final readonly class TrophyRarity
 {
     public function __construct(
-        private ?string $percentage,
-        private string $label,
-        private ?string $cssClass,
-        private bool $unobtainable,
+        final private ?string $percentage,
+        final private string $label,
+        final private ?string $cssClass,
+        final private bool $unobtainable,
     ) {
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add backed enums for game/player list sort modes (`GameListSort`, `PlayerGamesSort`, `PlayerLogSort`, `PlayerAdvisorSort`) and `PlayerStatusNoticeType`, wiring filters and ORDER BY matches through them while keeping existing string constants for templates.
- Mark array-returning filter withers and app/cron `create()` factories with `#[\NoDiscard]`, and finish `final` constructor property promotion on key DTOs (`TrophyRarity`, `Avatar`, `AboutPagePlayer`, notices).
- Small cleanup: prefer `array_first` for player route view segments; advisor filter platforms now come from the shared `Platform` enum.

## Test plan
- [x] `php tests/run.php` — all 984 tests passed
- [ ] Spot-check games/player sort dropdowns still round-trip query params
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f1a0d39-e918-4dd7-98b1-5e2dbfc0138f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f1a0d39-e918-4dd7-98b1-5e2dbfc0138f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

