### PR TITLE
Adopt remaining PHP 8.5 idioms for TrophyType, finals, and callables

### DIFF
--- a/tests/GameTrophyRowTest.php
+++ b/tests/GameTrophyRowTest.php
@@ -101,4 +101,14 @@ final class GameTrophyRowTest extends TestCase
 
         $this->assertSame(0.0, $row->getInGameRarityPercent());
     }
+
+    public function testGetTypeReturnsTrophyTypeEnum(): void
+    {
+        $row = $this->createRow(['type' => 'platinum']);
+
+        $this->assertSame(TrophyType::Platinum, $row->getType());
+        $this->assertSame(TrophyType::Platinum, $row->getTrophyType());
+        $this->assertSame('/img/trophy-platinum.svg', $row->getTypeIconPath());
+        $this->assertSame('#667fb2', $row->getTypeColor());
+    }
 }

--- a/tests/PlayerQueueResponseFactoryTest.php
+++ b/tests/PlayerQueueResponseFactoryTest.php
@@ -115,8 +115,8 @@ final class PlayerQueueResponseFactoryTest extends TestCase
         $this->assertStringContainsString('Working on Game <Title> (5/34)', $response->getMessage());
 
         $parts = $response->getMessageParts();
-        $emphasisPart = array_first(array_filter($parts ?? [], static fn (array $part): bool => ($part['type'] ?? '') === 'emphasis'));
-        $progressPart = array_first(array_filter($parts ?? [], static fn (array $part): bool => ($part['type'] ?? '') === 'progress'));
+        $emphasisPart = array_find($parts ?? [], static fn (array $part): bool => ($part['type'] ?? '') === 'emphasis');
+        $progressPart = array_find($parts ?? [], static fn (array $part): bool => ($part['type'] ?? '') === 'progress');
         $this->assertSame('Game <Title>', $emphasisPart['value'] ?? null);
         $this->assertSame(15, $progressPart['percentage'] ?? null);
     }

--- a/tests/TrophyListItemTest.php
+++ b/tests/TrophyListItemTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyListItem.php';
+
+final class TrophyListItemTest extends TestCase
+{
+    public function testFromArrayUsesTrophyTypeEnum(): void
+    {
+        $item = TrophyListItem::fromArray([
+            'trophy_id' => 7,
+            'trophy_type' => 'GOLD',
+            'trophy_name' => 'Gold Trophy',
+            'trophy_detail' => 'Earn gold',
+            'trophy_icon' => 'gold.png',
+            'rarity_percent' => 3.5,
+            'in_game_rarity_percent' => 4.0,
+            'game_id' => 11,
+            'game_name' => 'Example Game',
+            'game_icon' => 'game.png',
+            'platform' => 'PS5',
+        ]);
+
+        $this->assertSame(TrophyType::Gold, $item->getTrophyType());
+        $this->assertSame('/img/trophy-gold.svg', $item->getTrophyType()->iconPath());
+        $this->assertSame('Gold', $item->getTrophyType()->label());
+    }
+}

--- a/wwwroot/classes/Admin/AdminNavigation.php
+++ b/wwwroot/classes/Admin/AdminNavigation.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
-readonly class AdminNavigationItem
+final readonly class AdminNavigationItem
 {
-    public function __construct(private string $label, private string $href)
-    {
+    public function __construct(
+        private string $label,
+        private string $href,
+    ) {
     }
 
     public function getLabel(): string
@@ -19,7 +21,7 @@ readonly class AdminNavigationItem
     }
 }
 
-class AdminNavigation
+final class AdminNavigation
 {
     /**
      * @var AdminNavigationItem[]
@@ -31,11 +33,7 @@ class AdminNavigation
      */
     public function __construct(array $items = [])
     {
-        if ($items === []) {
-            $items = $this->createDefaultItems();
-        }
-
-        $this->items = $items;
+        $this->items = $items === [] ? self::createDefaultItems() : $items;
     }
 
     public function addItem(AdminNavigationItem $item): void
@@ -54,7 +52,7 @@ class AdminNavigation
     /**
      * @return AdminNavigationItem[]
      */
-    private function createDefaultItems(): array
+    private static function createDefaultItems(): array
     {
         return [
             new AdminNavigationItem('Cheater', '/admin/cheater.php'),

--- a/wwwroot/classes/Admin/PossibleCheaterReport.php
+++ b/wwwroot/classes/Admin/PossibleCheaterReport.php
@@ -96,10 +96,7 @@ final class PossibleCheaterReportSection
         $title = (string) ($data['title'] ?? '');
         $entryData = is_array($data['entries'] ?? null) ? $data['entries'] : [];
 
-        $entries = array_map(
-            static fn(array $entry): PossibleCheaterReportSectionEntry => PossibleCheaterReportSectionEntry::fromArray($entry),
-            $entryData
-        );
+        $entries = array_map(PossibleCheaterReportSectionEntry::fromArray(...), $entryData);
 
         return new self($title, $entries);
     }

--- a/wwwroot/classes/Admin/PossibleCheaterRulesCatalog.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRulesCatalog.php
@@ -33,7 +33,7 @@ final class PossibleCheaterRulesCatalog
     {
         if ($this->generalRuleGroups === null) {
             $this->generalRuleGroups = array_map(
-                static fn(array $group): PossibleCheaterRuleGroup => PossibleCheaterRuleGroup::fromArray($group),
+                PossibleCheaterRuleGroup::fromArray(...),
                 $this->loadArrayFile($this->generalRulesFile)
             );
         }
@@ -48,7 +48,7 @@ final class PossibleCheaterRulesCatalog
     {
         if ($this->sectionDefinitions === null) {
             $this->sectionDefinitions = array_map(
-                static fn(array $definition): PossibleCheaterSectionDefinition => PossibleCheaterSectionDefinition::fromArray($definition),
+                PossibleCheaterSectionDefinition::fromArray(...),
                 $this->loadArrayFile($this->sectionsFile)
             );
         }

--- a/wwwroot/classes/Admin/PossibleCheaterService.php
+++ b/wwwroot/classes/Admin/PossibleCheaterService.php
@@ -45,10 +45,7 @@ class PossibleCheaterService
      */
     private function buildGeneralReportEntries(): array
     {
-        return array_map(
-            static fn(array $row): PossibleCheaterReportEntry => PossibleCheaterReportEntry::fromArray($row),
-            $this->fetchGeneralPossibleCheaterRows()
-        );
+        return array_map(PossibleCheaterReportEntry::fromArray(...), $this->fetchGeneralPossibleCheaterRows());
     }
 
     /**

--- a/wwwroot/classes/Admin/PsnpPlusGame.php
+++ b/wwwroot/classes/Admin/PsnpPlusGame.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-readonly class PsnpPlusGame
+final readonly class PsnpPlusGame
 {
     public function __construct(
         private int $id,

--- a/wwwroot/classes/Admin/PsnpPlusMissingGame.php
+++ b/wwwroot/classes/Admin/PsnpPlusMissingGame.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-readonly class PsnpPlusMissingGame
+final readonly class PsnpPlusMissingGame
 {
     public function __construct(private int $psnprofilesId)
     {

--- a/wwwroot/classes/Admin/PsnpPlusReport.php
+++ b/wwwroot/classes/Admin/PsnpPlusReport.php
@@ -6,31 +6,18 @@ require_once __DIR__ . '/PsnpPlusMissingGame.php';
 require_once __DIR__ . '/PsnpPlusGameDifference.php';
 require_once __DIR__ . '/PsnpPlusFixedGame.php';
 
-class PsnpPlusReport
+final readonly class PsnpPlusReport
 {
-    /**
-     * @var PsnpPlusMissingGame[]
-     */
-    private array $missingGames;
-    /**
-     * @var PsnpPlusGameDifference[]
-     */
-    private array $gameDifferences;
-    /**
-     * @var PsnpPlusFixedGame[]
-     */
-    private array $fixedGames;
-
     /**
      * @param PsnpPlusMissingGame[] $missingGames
      * @param PsnpPlusGameDifference[] $gameDifferences
      * @param PsnpPlusFixedGame[] $fixedGames
      */
-    public function __construct(array $missingGames, array $gameDifferences, array $fixedGames)
-    {
-        $this->missingGames = $missingGames;
-        $this->gameDifferences = $gameDifferences;
-        $this->fixedGames = $fixedGames;
+    public function __construct(
+        private array $missingGames,
+        private array $gameDifferences,
+        private array $fixedGames,
+    ) {
     }
 
     /**

--- a/wwwroot/classes/Admin/ReportedPlayer.php
+++ b/wwwroot/classes/Admin/ReportedPlayer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-readonly class ReportedPlayer
+final readonly class ReportedPlayer
 {
     public function __construct(
         private int $reportId,

--- a/wwwroot/classes/Admin/TrophyStatusPage.php
+++ b/wwwroot/classes/Admin/TrophyStatusPage.php
@@ -6,19 +6,13 @@ require_once __DIR__ . '/TrophyStatusInputParser.php';
 require_once __DIR__ . '/TrophyStatusService.php';
 require_once __DIR__ . '/TrophyStatusUpdateResultPresenter.php';
 
-class TrophyStatusPageResult
+final readonly class TrophyStatusPageResult
 {
-    private string $trophyInput;
-
-    private string $statusInput;
-
-    private ?string $message;
-
-    public function __construct(string $trophyInput, string $statusInput, ?string $message)
-    {
-        $this->trophyInput = $trophyInput;
-        $this->statusInput = $statusInput;
-        $this->message = $message;
+    public function __construct(
+        private string $trophyInput,
+        private string $statusInput,
+        private ?string $message,
+    ) {
     }
 
     public function getTrophyInput(): string

--- a/wwwroot/classes/ChangelogService.php
+++ b/wwwroot/classes/ChangelogService.php
@@ -79,9 +79,6 @@ final class ChangelogService
             }
         }
 
-        return array_map(
-            static fn(array $row): ChangelogEntry => ChangelogEntry::fromArray($row),
-            $rows
-        );
+        return array_map(ChangelogEntry::fromArray(...), $rows);
     }
 }

--- a/wwwroot/classes/Game/GameTrophyRow.php
+++ b/wwwroot/classes/Game/GameTrophyRow.php
@@ -82,9 +82,9 @@ final readonly class GameTrophyRow
         return $this->orderId;
     }
 
-    public function getType(): string
+    public function getType(): TrophyType
     {
-        return $this->type->value;
+        return $this->type;
     }
 
     public function getTrophyType(): TrophyType

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -107,10 +107,7 @@ class GameHeaderService
             return [];
         }
 
-        return array_map(
-            static fn(array $row): GameHeaderStack => GameHeaderStack::fromArray($row),
-            $rows
-        );
+        return array_map(GameHeaderStack::fromArray(...), $rows);
     }
 
     private function countUnobtainableTrophies(string $npCommunicationId): int

--- a/wwwroot/classes/GameLeaderboardService.php
+++ b/wwwroot/classes/GameLeaderboardService.php
@@ -170,10 +170,7 @@ class GameLeaderboardService
             return [];
         }
 
-        return array_map(
-            static fn(array $row): GameLeaderboardRow => GameLeaderboardRow::fromArray($row),
-            $rows
-        );
+        return array_map(GameLeaderboardRow::fromArray(...), $rows);
     }
 
     private function buildFilterSql(GamePlayerFilter $filter): string

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/GameListSort.php';
 
-readonly class GameListFilter
+final readonly class GameListFilter
 {
     public const string SORT_ADDED = GameListSort::Added->value;
     public const string SORT_COMPLETION = GameListSort::Completion->value;

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -97,10 +97,7 @@ class GameListService
             $totalGames = $this->fetchCount($filter);
         }
 
-        $items = array_map(
-            static fn(array $row): GameListItem => GameListItem::fromArray($row),
-            $games
-        );
+        $items = array_map(GameListItem::fromArray(...), $games);
 
         return new GameListPageResult($items, $totalGames);
     }

--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -141,10 +141,7 @@ class GameRecentPlayersService
             return [];
         }
 
-        return array_map(
-            static fn(array $row): GameRecentPlayer => GameRecentPlayer::fromArray($row),
-            $rows
-        );
+        return array_map(GameRecentPlayer::fromArray(...), $rows);
     }
 
 }

--- a/wwwroot/classes/Homepage/HomepageDlc.php
+++ b/wwwroot/classes/Homepage/HomepageDlc.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-readonly class HomepageDlc extends HomepageTitle
+final readonly class HomepageDlc extends HomepageTitle
 {
     private function __construct(
         int $id,

--- a/wwwroot/classes/Homepage/HomepageNewGame.php
+++ b/wwwroot/classes/Homepage/HomepageNewGame.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-readonly class HomepageNewGame extends HomepageTitle
+final readonly class HomepageNewGame extends HomepageTitle
 {
     private function __construct(
         int $id,

--- a/wwwroot/classes/Homepage/HomepagePopularGame.php
+++ b/wwwroot/classes/Homepage/HomepagePopularGame.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-readonly class HomepagePopularGame extends HomepageTitle
+final readonly class HomepagePopularGame extends HomepageTitle
 {
     private function __construct(
         int $id,

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -52,10 +52,7 @@ class HomepageContentService
 
         $rows = $query->fetchAll(PDO::FETCH_ASSOC);
 
-        return array_map(
-            static fn(array $row): HomepageNewGame => HomepageNewGame::fromArray($row),
-            $rows
-        );
+        return array_map(HomepageNewGame::fromArray(...), $rows);
     }
 
     /**
@@ -93,10 +90,7 @@ class HomepageContentService
 
         $rows = $query->fetchAll(PDO::FETCH_ASSOC);
 
-        return array_map(
-            static fn(array $row): HomepageDlc => HomepageDlc::fromArray($row),
-            $rows
-        );
+        return array_map(HomepageDlc::fromArray(...), $rows);
     }
 
     /**
@@ -133,10 +127,7 @@ class HomepageContentService
 
         $rows = $query->fetchAll(PDO::FETCH_ASSOC);
 
-        return array_map(
-            static fn(array $row): HomepagePopularGame => HomepagePopularGame::fromArray($row),
-            $rows
-        );
+        return array_map(HomepagePopularGame::fromArray(...), $rows);
     }
 
     /**

--- a/wwwroot/classes/PlayerAdvisableTrophy.php
+++ b/wwwroot/classes/PlayerAdvisableTrophy.php
@@ -3,78 +3,31 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/CommaSeparatedValues.php';
+require_once __DIR__ . '/TrophyType.php';
 
-class PlayerAdvisableTrophy
+final class PlayerAdvisableTrophy
 {
-    private int $trophyId;
-
-    private string $trophyType;
-
-    private string $trophyName;
-
-    private string $trophyDetail;
-
-    private string $trophyIcon;
-
-    private float $rarityPercent;
-
-    private float $inGameRarityPercent;
-
-    private ?int $progressTargetValue;
-
-    private ?string $rewardName;
-
-    private ?string $rewardImageUrl;
-
-    private int $gameId;
-
-    private string $gameName;
-
-    private string $gameIcon;
-
     /**
-     * @var string[]
+     * @param string[] $platforms
      */
-    private array $platforms;
-
-    private ?float $progress;
-
-    private Utility $utility;
-
     private function __construct(
-        int $trophyId,
-        string $trophyType,
-        string $trophyName,
-        string $trophyDetail,
-        string $trophyIcon,
-        float $rarityPercent,
-        float $inGameRarityPercent,
-        ?int $progressTargetValue,
-        ?string $rewardName,
-        ?string $rewardImageUrl,
-        int $gameId,
-        string $gameName,
-        string $gameIcon,
-        string $platformsRaw,
-        ?float $progress,
-        Utility $utility
+        private readonly int $trophyId,
+        private readonly TrophyType $trophyType,
+        private readonly string $trophyName,
+        private readonly string $trophyDetail,
+        private readonly string $trophyIcon,
+        private readonly float $rarityPercent,
+        private readonly float $inGameRarityPercent,
+        private readonly ?int $progressTargetValue,
+        private readonly ?string $rewardName,
+        private readonly ?string $rewardImageUrl,
+        private readonly int $gameId,
+        private readonly string $gameName,
+        private readonly string $gameIcon,
+        private readonly array $platforms,
+        private readonly ?float $progress,
+        private readonly Utility $utility,
     ) {
-        $this->trophyId = $trophyId;
-        $this->trophyType = $trophyType;
-        $this->trophyName = $trophyName;
-        $this->trophyDetail = $trophyDetail;
-        $this->trophyIcon = $trophyIcon;
-        $this->rarityPercent = $rarityPercent;
-        $this->inGameRarityPercent = $inGameRarityPercent;
-        $this->progressTargetValue = $progressTargetValue;
-        $this->rewardName = $rewardName;
-        $this->rewardImageUrl = $rewardImageUrl;
-        $this->gameId = $gameId;
-        $this->gameName = $gameName;
-        $this->gameIcon = $gameIcon;
-        $this->platforms = $this->parsePlatforms($platformsRaw);
-        $this->progress = $progress;
-        $this->utility = $utility;
     }
 
     #[\NoDiscard]
@@ -82,7 +35,7 @@ class PlayerAdvisableTrophy
     {
         return new self(
             (int) ($data['trophy_id'] ?? 0),
-            (string) ($data['trophy_type'] ?? ''),
+            TrophyType::fromMixed($data['trophy_type'] ?? null),
             (string) ($data['trophy_name'] ?? ''),
             (string) ($data['trophy_detail'] ?? ''),
             (string) ($data['trophy_icon'] ?? ''),
@@ -94,7 +47,7 @@ class PlayerAdvisableTrophy
             (int) ($data['game_id'] ?? 0),
             (string) ($data['game_name'] ?? ''),
             (string) ($data['game_icon'] ?? ''),
-            (string) ($data['platform'] ?? ''),
+            CommaSeparatedValues::parseTrimmed((string) ($data['platform'] ?? '')),
             isset($data['progress']) ? (float) $data['progress'] : null,
             $utility
         );
@@ -105,7 +58,7 @@ class PlayerAdvisableTrophy
         return $this->trophyId;
     }
 
-    public function getTrophyType(): string
+    public function getTrophyType(): TrophyType
     {
         return $this->trophyType;
     }
@@ -225,11 +178,6 @@ class PlayerAdvisableTrophy
     public function getPlatforms(): array
     {
         return $this->platforms;
-    }
-
-    private function parsePlatforms(string $platformsRaw): array
-    {
-        return CommaSeparatedValues::parseTrimmed($platformsRaw);
     }
 
     private function usesPlayStation5Assets(): bool

--- a/wwwroot/classes/PlayerAdvisorFilter.php
+++ b/wwwroot/classes/PlayerAdvisorFilter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/PlayerAdvisorSort.php';
 
-readonly class PlayerAdvisorFilter
+final readonly class PlayerAdvisorFilter
 {
     public const string SORT_RARITY = PlayerAdvisorSort::Rarity->value;
     public const string SORT_IN_GAME_RARITY = PlayerAdvisorSort::InGameRarity->value;

--- a/wwwroot/classes/PlayerGame.php
+++ b/wwwroot/classes/PlayerGame.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/GameStatusBadge.php';
 
-class PlayerGame
+final class PlayerGame
 {
     private function __construct(
         private readonly int $id,

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/PlayerGamesSort.php';
 
-readonly class PlayerGamesFilter
+final readonly class PlayerGamesFilter
 {
     public const string SORT_DATE = PlayerGamesSort::Date->value;
     public const string SORT_IN_GAME_MAX_RARITY = PlayerGamesSort::InGameMaxRarity->value;

--- a/wwwroot/classes/PlayerLogEntry.php
+++ b/wwwroot/classes/PlayerLogEntry.php
@@ -3,12 +3,13 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/CommaSeparatedValues.php';
+require_once __DIR__ . '/TrophyType.php';
 
 final readonly class PlayerLogEntry
 {
     public function __construct(
         final private int $trophyId,
-        final private string $trophyType,
+        final private TrophyType $trophyType,
         final private string $trophyName,
         final private string $trophyDetail,
         final private string $trophyIcon,
@@ -37,7 +38,7 @@ final readonly class PlayerLogEntry
     {
         return new self(
             trophyId: (int) ($row['trophy_id'] ?? 0),
-            trophyType: (string) ($row['trophy_type'] ?? ''),
+            trophyType: TrophyType::fromMixed($row['trophy_type'] ?? null),
             trophyName: (string) ($row['trophy_name'] ?? ''),
             trophyDetail: (string) ($row['trophy_detail'] ?? ''),
             trophyIcon: (string) ($row['trophy_icon'] ?? ''),
@@ -63,7 +64,7 @@ final readonly class PlayerLogEntry
         return $this->trophyId;
     }
 
-    public function getTrophyType(): string
+    public function getTrophyType(): TrophyType
     {
         return $this->trophyType;
     }

--- a/wwwroot/classes/PlayerLogFilter.php
+++ b/wwwroot/classes/PlayerLogFilter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/PlayerLogSort.php';
 
-readonly class PlayerLogFilter
+final readonly class PlayerLogFilter
 {
     public const string SORT_DATE = PlayerLogSort::Date->value;
     public const string SORT_RARITY = PlayerLogSort::Rarity->value;

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -90,10 +90,7 @@ class PlayerLogService
             return [];
         }
 
-        return array_map(
-            static fn(array $row): PlayerLogEntry => PlayerLogEntry::fromArray($row),
-            $rows
-        );
+        return array_map(PlayerLogEntry::fromArray(...), $rows);
     }
 
     private function buildPlatformClause(PlayerLogFilter $filter): string

--- a/wwwroot/classes/TrophyDetails.php
+++ b/wwwroot/classes/TrophyDetails.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/PlayerUrlBuilder.php';
+require_once __DIR__ . '/TrophyType.php';
 require_once __DIR__ . '/Utility.php';
 
 final readonly class TrophyDetails
@@ -17,7 +18,7 @@ final readonly class TrophyDetails
         final private string $npCommunicationId,
         final private int $groupId,
         final private int $orderId,
-        final private string $type,
+        final private TrophyType $type,
         final private string $name,
         final private string $detail,
         final private string $iconFileName,
@@ -44,7 +45,7 @@ final readonly class TrophyDetails
             (string) ($data['np_communication_id'] ?? ''),
             (int) ($data['group_id'] ?? 0),
             (int) ($data['order_id'] ?? 0),
-            (string) ($data['trophy_type'] ?? ''),
+            TrophyType::fromMixed($data['trophy_type'] ?? null),
             (string) ($data['trophy_name'] ?? ''),
             (string) ($data['trophy_detail'] ?? ''),
             (string) ($data['trophy_icon'] ?? ''),
@@ -81,7 +82,7 @@ final readonly class TrophyDetails
         return $this->orderId;
     }
 
-    public function getType(): string
+    public function getType(): TrophyType
     {
         return $this->type;
     }

--- a/wwwroot/classes/TrophyListItem.php
+++ b/wwwroot/classes/TrophyListItem.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/CommaSeparatedValues.php';
+require_once __DIR__ . '/TrophyType.php';
 require_once __DIR__ . '/Utility.php';
 
 final readonly class TrophyListItem
@@ -13,7 +14,7 @@ final readonly class TrophyListItem
 
     public function __construct(
         final private int $trophyId,
-        final private string $trophyType,
+        final private TrophyType $trophyType,
         final private string $trophyName,
         final private string $trophyDetail,
         final private string $trophyIcon,
@@ -34,7 +35,7 @@ final readonly class TrophyListItem
     {
         return new self(
             (int) ($data['trophy_id'] ?? 0),
-            (string) ($data['trophy_type'] ?? ''),
+            TrophyType::fromMixed($data['trophy_type'] ?? null),
             (string) ($data['trophy_name'] ?? ''),
             (string) ($data['trophy_detail'] ?? ''),
             (string) ($data['trophy_icon'] ?? ''),
@@ -55,7 +56,7 @@ final readonly class TrophyListItem
         return $this->trophyId;
     }
 
-    public function getTrophyType(): string
+    public function getTrophyType(): TrophyType
     {
         return $this->trophyType;
     }

--- a/wwwroot/classes/TrophyService.php
+++ b/wwwroot/classes/TrophyService.php
@@ -161,6 +161,6 @@ class TrophyService
         /** @var array<int, array<string, mixed>> $achievers */
         $achievers = $query->fetchAll(PDO::FETCH_ASSOC);
 
-        return array_map(static fn (array $row): TrophyAchiever => TrophyAchiever::fromArray($row), $achievers);
+        return array_map(TrophyAchiever::fromArray(...), $achievers);
     }
 }

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -53,11 +53,12 @@ final class TrophyTitleNameFormatter
             '/\s*Trophy$/i',
         ];
 
-        foreach ($suffixPatterns as $pattern) {
-            if (preg_match($pattern, $name)) {
-                $name = preg_replace($pattern, '', $name);
-                break;
-            }
+        $matchingSuffix = array_find(
+            $suffixPatterns,
+            static fn(string $pattern): bool => preg_match($pattern, $name) === 1
+        );
+        if ($matchingSuffix !== null) {
+            $name = preg_replace($matchingSuffix, '', $name) ?? $name;
         }
 
         if (str_ends_with($name, ' -')) {

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -161,8 +161,7 @@ require_once("header.php");
                                         ?>
                                         </td>
                                         <td class="text-center align-middle">
-                                            <?php $trophyTypeLabel = ucfirst($trophy->getTrophyType()); ?>
-                                            <img src="/img/trophy-<?= htmlspecialchars($trophy->getTrophyType(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= htmlspecialchars($trophyTypeLabel, ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlspecialchars($trophyTypeLabel, ENT_QUOTES, 'UTF-8'); ?>" height="50" />
+                                            <img src="<?= Html::escape($trophy->getTrophyType()->iconPath()); ?>" alt="<?= Html::escape($trophy->getTrophyType()->label()); ?>" title="<?= Html::escape($trophy->getTrophyType()->label()); ?>" height="50" />
                                         </td>
                                     </tr>
                                     <?php

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -192,7 +192,7 @@ require_once("header.php");
                                             </div>
                                         </td>
                                         <td class="text-center align-middle">
-                                            <img src="/img/trophy-<?= htmlspecialchars($trophy->getTrophyType(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= Html::escape(ucfirst($trophy->getTrophyType())); ?>" title="<?= Html::escape(ucfirst($trophy->getTrophyType())); ?>" height="50" />
+                                            <img src="<?= Html::escape($trophy->getTrophyType()->iconPath()); ?>" alt="<?= Html::escape($trophy->getTrophyType()->label()); ?>" title="<?= Html::escape($trophy->getTrophyType()->label()); ?>" height="50" />
                                         </td>
                                     </tr>
                                     <?php

--- a/wwwroot/trophies.php
+++ b/wwwroot/trophies.php
@@ -110,7 +110,7 @@ require_once('header.php');
                                         <div><?= $inGameRarity->renderSpan(); ?></div>
                                     </td>
                                     <td class="text-center align-middle">
-                                        <img src="/img/trophy-<?= htmlspecialchars($trophy->getTrophyType(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= ucfirst($trophy->getTrophyType()); ?>" title="<?= ucfirst($trophy->getTrophyType()); ?>" height="50" />
+                                        <img src="<?= Html::escape($trophy->getTrophyType()->iconPath()); ?>" alt="<?= Html::escape($trophy->getTrophyType()->label()); ?>" title="<?= Html::escape($trophy->getTrophyType()->label()); ?>" height="50" />
                                     </td>
                                 </tr>
                                 <?php

--- a/wwwroot/trophy.php
+++ b/wwwroot/trophy.php
@@ -161,7 +161,7 @@ require_once("header.php");
                                 </div>
 
                                 <div class="col-1 text-center align-self-center">
-                                    <img src="/img/trophy-<?= htmlspecialchars($trophy->getType(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= ucfirst($trophy->getType()); ?>" title="<?= ucfirst($trophy->getType()); ?>" height="50" />
+                                    <img src="<?= Html::escape($trophy->getType()->iconPath()); ?>" alt="<?= Html::escape($trophy->getType()->label()); ?>" title="<?= Html::escape($trophy->getType()->label()); ?>" height="50" />
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adopt `TrophyType` on remaining trophy DTOs (`TrophyListItem`, `TrophyDetails`, `PlayerLogEntry`, `PlayerAdvisableTrophy`, `GameTrophyRow::getType()`) and render icons/labels via `iconPath()` / `label()` in templates.
- Seal remaining leaf filters/DTOs as `final` (and promote leftover constructors on `PlayerAdvisableTrophy`, `PsnpPlusReport`, `TrophyStatusPageResult`, `AdminNavigation`).
- Replace single-argument `array_map(...::fromArray)` closures with first-class callables; use `array_find` where it clarifies intent.
- Add focused tests for `TrophyType` on `TrophyListItem` and `GameTrophyRow`.

## Test plan
- [x] `php tests/run.php` (986 tests passed)
- [ ] Spot-check trophy type icons on `/trophies/`, `/trophy/<id>`, player log, and player advisor pages when seeded data is available.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de3ee4fe-9e00-45a5-a571-a707cf26977e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de3ee4fe-9e00-45a5-a571-a707cf26977e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

