### PR TITLE
Adopt remaining PHP 8.5 idioms for readonly DTOs and URI ranks

### DIFF
--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -29,15 +29,14 @@ final class FakeRouter extends Router
     }
 }
 
-final class FixedHttpRequest extends HttpRequest
+final readonly class FixedHttpRequest extends HttpRequest
 {
-    private string $resolvedUri;
-
-    public function __construct(string $resolvedUri)
+    public function __construct(private string $resolvedUri)
     {
-        $this->resolvedUri = $resolvedUri;
+        parent::__construct();
     }
 
+    #[\Override]
     public function getResolvedUri(): string
     {
         return $this->resolvedUri;

--- a/wwwroot/classes/Admin/PossibleCheaterReport.php
+++ b/wwwroot/classes/Admin/PossibleCheaterReport.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../PlayerUrlBuilder.php';
 require_once __DIR__ . '/../Utility.php';
 
-final class PossibleCheaterReport
+final readonly class PossibleCheaterReport
 {
     /**
      * @param PossibleCheaterReportEntry[] $generalCheaters
@@ -34,7 +34,7 @@ final class PossibleCheaterReport
     }
 }
 
-final class PossibleCheaterReportEntry
+final readonly class PossibleCheaterReportEntry
 {
     public function __construct(
         final private int $gameId,
@@ -76,7 +76,7 @@ final class PossibleCheaterReportEntry
     }
 }
 
-final class PossibleCheaterReportSection
+final readonly class PossibleCheaterReportSection
 {
     /**
      * @param PossibleCheaterReportSectionEntry[] $entries
@@ -115,7 +115,7 @@ final class PossibleCheaterReportSection
     }
 }
 
-final class PossibleCheaterReportSectionEntry
+final readonly class PossibleCheaterReportSectionEntry
 {
     public function __construct(
         final private string $url,

--- a/wwwroot/classes/Admin/PossibleCheaterSectionDefinition.php
+++ b/wwwroot/classes/Admin/PossibleCheaterSectionDefinition.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-final class PossibleCheaterSectionDefinition
+final readonly class PossibleCheaterSectionDefinition
 {
     public function __construct(
-        private string $title,
-        private string $query,
-        private string $linkPattern
+        final private string $title,
+        final private string $query,
+        final private string $linkPattern
     ) {
     }
 

--- a/wwwroot/classes/Admin/PsnTrophyApiAdapter.php
+++ b/wwwroot/classes/Admin/PsnTrophyApiAdapter.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PsnTrophyTypeApiAdapter.php';
 
-final class PsnTrophyApiAdapter
+final readonly class PsnTrophyApiAdapter
 {
     /**
      * @param array<string, mixed> $rawTrophy
      */
-    public function __construct(private readonly array $rawTrophy)
+    public function __construct(private array $rawTrophy)
     {
     }
 

--- a/wwwroot/classes/Admin/PsnTrophyGroupApiAdapter.php
+++ b/wwwroot/classes/Admin/PsnTrophyGroupApiAdapter.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-final class PsnTrophyGroupApiAdapter
+final readonly class PsnTrophyGroupApiAdapter
 {
     /**
      * @param array<string, mixed> $rawGroup
      */
     public function __construct(
-        private readonly string $groupId,
-        private readonly array $rawGroup,
+        private string $groupId,
+        private array $rawGroup,
     ) {
     }
 

--- a/wwwroot/classes/Admin/PsnTrophyTypeApiAdapter.php
+++ b/wwwroot/classes/Admin/PsnTrophyTypeApiAdapter.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-final class PsnTrophyTypeApiAdapter
+final readonly class PsnTrophyTypeApiAdapter
 {
-    public function __construct(final public readonly string $value)
+    public function __construct(final public string $value)
     {
     }
 }

--- a/wwwroot/classes/Cron/PlayerScanCompletionResult.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionResult.php
@@ -7,9 +7,9 @@ require_once __DIR__ . '/PlayerScanCompletionStatus.php';
 /**
  * Outcome of post-scan player aggregation during a worker scan.
  */
-final class PlayerScanCompletionResult
+final readonly class PlayerScanCompletionResult
 {
-    private function __construct(final public readonly PlayerScanCompletionStatus $status)
+    private function __construct(final public PlayerScanCompletionStatus $status)
     {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanProfileSyncResult.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSyncResult.php
@@ -7,16 +7,16 @@ require_once __DIR__ . '/PlayerScanProfileSyncStatus.php';
 /**
  * Outcome of resolving and persisting a queued player's PSN profile during a scan.
  */
-final class PlayerScanProfileSyncResult
+final readonly class PlayerScanProfileSyncResult
 {
     /**
      * @param array<string, mixed> $player
      */
     private function __construct(
-        final public readonly PlayerScanProfileSyncStatus $status,
-        final public readonly array $player = [],
-        final public readonly ?object $user = null,
-        final public readonly ?string $country = null,
+        final public PlayerScanProfileSyncStatus $status,
+        final public array $player = [],
+        final public ?object $user = null,
+        final public ?string $country = null,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophySummaryAccessResult.php
@@ -7,11 +7,11 @@ require_once __DIR__ . '/PlayerScanTrophySummaryAccessStatus.php';
 /**
  * Outcome of reading a PSN user's trophy summary level during a player scan.
  */
-final class PlayerScanTrophySummaryAccessResult
+final readonly class PlayerScanTrophySummaryAccessResult
 {
     private function __construct(
-        final public readonly PlayerScanTrophySummaryAccessStatus $status,
-        final public readonly int $level = 0,
+        final public PlayerScanTrophySummaryAccessStatus $status,
+        final public int $level = 0,
     ) {
     }
 

--- a/wwwroot/classes/CsrfTokenManager.php
+++ b/wwwroot/classes/CsrfTokenManager.php
@@ -8,6 +8,7 @@ final class CsrfTokenManager
 {
     private const string SESSION_KEY_PREFIX = 'csrf_token_';
 
+    #[\NoDiscard]
     public static function getToken(string $scope): string
     {
         SessionManager::ensureStarted();

--- a/wwwroot/classes/GameLeaderboardPageContext.php
+++ b/wwwroot/classes/GameLeaderboardPageContext.php
@@ -9,30 +9,15 @@ require_once __DIR__ . '/Utility.php';
 require_once __DIR__ . '/GameNotFoundException.php';
 require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
 
-final class GameLeaderboardPageContext
+final readonly class GameLeaderboardPageContext
 {
-    private ?GameLeaderboardPage $page;
-
-    private ?string $title;
-
-    private ?string $gameSlug;
-
-    private ?string $redirectLocation;
-
-    private int $redirectStatusCode;
-
     private function __construct(
-        ?GameLeaderboardPage $page,
-        ?string $title,
-        ?string $gameSlug,
-        ?string $redirectLocation,
-        int $redirectStatusCode
+        private ?GameLeaderboardPage $page,
+        private ?string $title,
+        private ?string $gameSlug,
+        private ?string $redirectLocation,
+        private int $redirectStatusCode,
     ) {
-        $this->page = $page;
-        $this->title = $title;
-        $this->gameSlug = $gameSlug;
-        $this->redirectLocation = $redirectLocation;
-        $this->redirectStatusCode = $redirectStatusCode;
     }
 
     /**

--- a/wwwroot/classes/HomepageController.php
+++ b/wwwroot/classes/HomepageController.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/HomepagePopularGamesFilter.php';
 final readonly class HomepageController
 {
     public function __construct(
-        private HomepagePage $homepagePage,
+        final private HomepagePage $homepagePage,
     ) {
     }
 

--- a/wwwroot/classes/HttpRequest.php
+++ b/wwwroot/classes/HttpRequest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-class HttpRequest
+readonly class HttpRequest
 {
     /**
      * @param array<string, mixed> $server
      */
-    public function __construct(final private array $server = [])
+    public function __construct(private array $server = [])
     {
     }
 

--- a/wwwroot/classes/IpAddressResolver.php
+++ b/wwwroot/classes/IpAddressResolver.php
@@ -87,9 +87,12 @@ final class IpAddressResolver
             return '';
         }
 
-        return array_find(
-            array_map(self::resolve(...), CommaSeparatedValues::parseTrimmed($forwardedFor)),
-            static fn (string $validatedAddress): bool => $validatedAddress !== ''
-        ) ?? '';
+        return CommaSeparatedValues::parseTrimmed($forwardedFor)
+            |> (fn (array $addresses): array => array_map(self::resolve(...), $addresses))
+            |> (fn (array $addresses): ?string => array_find(
+                $addresses,
+                static fn (string $validatedAddress): bool => $validatedAddress !== ''
+            ))
+            ?? '';
     }
 }

--- a/wwwroot/classes/NavigationMenu.php
+++ b/wwwroot/classes/NavigationMenu.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 require_once __DIR__ . '/NavigationSection.php';
 require_once __DIR__ . '/NavigationState.php';
 
-final class NavigationMenu
+final readonly class NavigationMenu
 {
     /**
      * @param NavigationMenuItem[] $items
      */
-    private function __construct(private readonly array $items)
+    private function __construct(private array $items)
     {
     }
 

--- a/wwwroot/classes/PlayerAdvisableTrophy.php
+++ b/wwwroot/classes/PlayerAdvisableTrophy.php
@@ -5,28 +5,28 @@ declare(strict_types=1);
 require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/TrophyType.php';
 
-final class PlayerAdvisableTrophy
+final readonly class PlayerAdvisableTrophy
 {
     /**
      * @param string[] $platforms
      */
     private function __construct(
-        private readonly int $trophyId,
-        private readonly TrophyType $trophyType,
-        private readonly string $trophyName,
-        private readonly string $trophyDetail,
-        private readonly string $trophyIcon,
-        private readonly float $rarityPercent,
-        private readonly float $inGameRarityPercent,
-        private readonly ?int $progressTargetValue,
-        private readonly ?string $rewardName,
-        private readonly ?string $rewardImageUrl,
-        private readonly int $gameId,
-        private readonly string $gameName,
-        private readonly string $gameIcon,
-        private readonly array $platforms,
-        private readonly ?float $progress,
-        private readonly Utility $utility,
+        private int $trophyId,
+        private TrophyType $trophyType,
+        private string $trophyName,
+        private string $trophyDetail,
+        private string $trophyIcon,
+        private float $rarityPercent,
+        private float $inGameRarityPercent,
+        private ?int $progressTargetValue,
+        private ?string $rewardName,
+        private ?string $rewardImageUrl,
+        private int $gameId,
+        private string $gameName,
+        private string $gameIcon,
+        private array $platforms,
+        private ?float $progress,
+        private Utility $utility,
     ) {
     }
 

--- a/wwwroot/classes/PlayerAdvisorPageContext.php
+++ b/wwwroot/classes/PlayerAdvisorPageContext.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/TrophyRarityFormatter.php';
 require_once __DIR__ . '/Utility.php';
 require_once __DIR__ . '/PlayerStatus.php';
 
-final class PlayerAdvisorPageContext
+final readonly class PlayerAdvisorPageContext
 {
     private PlayerAdvisorPage $playerAdvisorPage;
 

--- a/wwwroot/classes/PlayerGame.php
+++ b/wwwroot/classes/PlayerGame.php
@@ -6,26 +6,26 @@ require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/GameStatusBadge.php';
 
-final class PlayerGame
+final readonly class PlayerGame
 {
     private function __construct(
-        private readonly int $id,
-        private readonly string $npCommunicationId,
-        private readonly string $name,
-        private readonly string $iconUrl,
-        private readonly string $platform,
-        private readonly GameAvailabilityStatus $status,
-        private readonly int $maxRarityPoints,
-        private readonly int $maxInGameRarityPoints,
-        private readonly int $bronze,
-        private readonly int $silver,
-        private readonly int $gold,
-        private readonly int $platinum,
-        private readonly int $progress,
-        private readonly string $lastUpdatedDate,
-        private readonly int $rarityPoints,
-        private readonly int $inGameRarityPoints,
-        private readonly ?string $completionDurationLabel,
+        private int $id,
+        private string $npCommunicationId,
+        private string $name,
+        private string $iconUrl,
+        private string $platform,
+        private GameAvailabilityStatus $status,
+        private int $maxRarityPoints,
+        private int $maxInGameRarityPoints,
+        private int $bronze,
+        private int $silver,
+        private int $gold,
+        private int $platinum,
+        private int $progress,
+        private string $lastUpdatedDate,
+        private int $rarityPoints,
+        private int $inGameRarityPoints,
+        private ?string $completionDurationLabel,
     ) {
     }
 

--- a/wwwroot/classes/PlayerGamesPageContext.php
+++ b/wwwroot/classes/PlayerGamesPageContext.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/PlayerSummaryService.php';
 require_once __DIR__ . '/PlayerStatus.php';
 require_once __DIR__ . '/PlayerUrlBuilder.php';
 
-final class PlayerGamesPageContext
+final readonly class PlayerGamesPageContext
 {
     private PlayerGamesPage $playerGamesPage;
 

--- a/wwwroot/classes/PlayerLeaderboardRank.php
+++ b/wwwroot/classes/PlayerLeaderboardRank.php
@@ -88,15 +88,24 @@ final readonly class PlayerLeaderboardRank
 
         $page = max(1, (int) ceil($this->rank / self::PAGE_SIZE));
 
-        $queryParameters = array_merge(
-            $this->additionalQueryParameters,
-            [
-                'page' => (string) $page,
-                'player' => $this->onlineId,
-            ]
+        $query = http_build_query(
+            array_merge(
+                $this->additionalQueryParameters,
+                [
+                    'page' => (string) $page,
+                    'player' => $this->onlineId,
+                ]
+            ),
+            '',
+            '&',
+            PHP_QUERY_RFC3986
         );
 
-        return $this->basePath . '?' . http_build_query($queryParameters) . '#' . rawurlencode($this->onlineId);
+        return Uri\Rfc3986\Uri::parse($this->basePath)
+            ?->withQuery($query)
+            ->withFragment(rawurlencode($this->onlineId))
+            ->toRawString()
+            ?? $this->basePath . '?' . $query . '#' . rawurlencode($this->onlineId);
     }
 
     public function getChange(): ?PlayerLeaderboardRankChange

--- a/wwwroot/classes/PlayerLogPageContext.php
+++ b/wwwroot/classes/PlayerLogPageContext.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/PlayerSummaryService.php';
 require_once __DIR__ . '/TrophyRarityFormatter.php';
 require_once __DIR__ . '/PlayerStatus.php';
 
-final class PlayerLogPageContext
+final readonly class PlayerLogPageContext
 {
 
     private PlayerLogPage $playerLogPage;

--- a/wwwroot/classes/PlayerPageAccessGuard.php
+++ b/wwwroot/classes/PlayerPageAccessGuard.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-final class PlayerPageAccessGuard
+final readonly class PlayerPageAccessGuard
 {
     private const string DEFAULT_REDIRECT_URL = '/player/';
     private const int REDIRECT_STATUS_CODE = 303;
 
     private function __construct(
-        private readonly ?int $accountId,
-        private readonly string $redirectUrl
+        private ?int $accountId,
+        private string $redirectUrl
     ) {}
 
     #[\NoDiscard]

--- a/wwwroot/classes/PlayerQueuePollTokenManager.php
+++ b/wwwroot/classes/PlayerQueuePollTokenManager.php
@@ -10,6 +10,7 @@ final class PlayerQueuePollTokenManager
 
     private const int TOKEN_TTL_SECONDS = 3600;
 
+    #[\NoDiscard]
     public function issue(string $playerName): string
     {
         SessionManager::ensureStarted();

--- a/wwwroot/classes/PlayerRandomGamesPageContext.php
+++ b/wwwroot/classes/PlayerRandomGamesPageContext.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
 require_once __DIR__ . '/Utility.php';
 require_once __DIR__ . '/PlayerStatus.php';
 
-final class PlayerRandomGamesPageContext
+final readonly class PlayerRandomGamesPageContext
 {
     private const int STATUS_FLAGGED = 1;
     private const int STATUS_PRIVATE = 3;

--- a/wwwroot/classes/PlayerTimelinePageContext.php
+++ b/wwwroot/classes/PlayerTimelinePageContext.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/PlayerNavigationSection.php';
 require_once __DIR__ . '/Utility.php';
 require_once __DIR__ . '/PlayerStatus.php';
 
-final class PlayerTimelinePageContext
+final readonly class PlayerTimelinePageContext
 {
     private PlayerTimelinePage $playerTimelinePage;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Continues the PHP 8.5 modernization pass on remaining immutable objects and a few safety/clarity wins. No backward compatibility is required.

### Changes
- Convert scan outcome DTOs, possible-cheater report/section DTOs, PSN trophy adapters, player value objects, navigation menu, page access guard, HTTP request, and page contexts to `readonly` (dropping redundant property-level `readonly` where the class is already readonly)
- Promote constructor properties on `GameLeaderboardPageContext` to match `GameRecentPlayersPageContext`
- Add `#[\NoDiscard]` to `CsrfTokenManager::getToken()` and `PlayerQueuePollTokenManager::issue()`
- Build `PlayerLeaderboardRank` URLs with `Uri\Rfc3986\Uri` (same pattern as dispute URLs)
- Read X-Forwarded-For IPs with a left-to-right pipe chain
- Update `FixedHttpRequest` test double for readonly inheritance

## Test plan
- [x] `php tests/run.php`
- [x] Existing `PlayerLeaderboardRankTest` URL assertions
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7663ad5-60fa-4a40-9539-774dfa0f1f0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7663ad5-60fa-4a40-9539-774dfa0f1f0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

