### PR TITLE
Adopt remaining PHP 8.5 idioms for trophy meta and changelogs

### DIFF
--- a/tests/TrophyListFilterTest.php
+++ b/tests/TrophyListFilterTest.php
@@ -50,4 +50,14 @@ final class TrophyListFilterTest extends TestCase
         $this->assertSame(['page' => 5], $filter->withPage(5));
         $this->assertSame(['page' => 1], $filter->withPage(0));
     }
+
+    public function testWithPageNumberReturnsClonedFilter(): void
+    {
+        $filter = new TrophyListFilter(2);
+        $updated = $filter->withPageNumber(5);
+
+        $this->assertSame(2, $filter->getPage());
+        $this->assertSame(5, $updated->getPage());
+        $this->assertSame(1, $filter->withPageNumber(0)->getPage());
+    }
 }

--- a/tests/TrophyMetaStatusTest.php
+++ b/tests/TrophyMetaStatusTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMetaStatus.php';
+require_once __DIR__ . '/../wwwroot/classes/ChangelogEntry.php';
+
+final class TrophyMetaStatusTest extends TestCase
+{
+    public function testFromValueFallsBackToObtainable(): void
+    {
+        $this->assertSame(TrophyMetaStatus::Obtainable, TrophyMetaStatus::fromValue(0));
+        $this->assertSame(TrophyMetaStatus::Unobtainable, TrophyMetaStatus::fromValue(1));
+        $this->assertSame(TrophyMetaStatus::Obtainable, TrophyMetaStatus::fromValue(99));
+    }
+
+    public function testFromMixedAcceptsEnumAndScalars(): void
+    {
+        $this->assertSame(
+            TrophyMetaStatus::Unobtainable,
+            TrophyMetaStatus::fromMixed(TrophyMetaStatus::Unobtainable)
+        );
+        $this->assertSame(TrophyMetaStatus::Unobtainable, TrophyMetaStatus::fromMixed('1'));
+        $this->assertSame(TrophyMetaStatus::Obtainable, TrophyMetaStatus::fromMixed(null));
+    }
+
+    public function testLabelAndChangeType(): void
+    {
+        $this->assertSame('unobtainable', TrophyMetaStatus::Unobtainable->label());
+        $this->assertSame('obtainable', TrophyMetaStatus::Obtainable->label());
+        $this->assertSame(
+            ChangelogEntryType::GAME_UNOBTAINABLE,
+            TrophyMetaStatus::Unobtainable->changeType()
+        );
+        $this->assertSame(
+            ChangelogEntryType::GAME_OBTAINABLE,
+            TrophyMetaStatus::Obtainable->changeType()
+        );
+    }
+}

--- a/tests/TrophyStatusServiceTest.php
+++ b/tests/TrophyStatusServiceTest.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyStatusService.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/TrophyStatusUpdateResult.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMetaStatus.php';
 
 final class TrophyStatusServiceTest extends TestCase
 {
@@ -47,7 +48,7 @@ final class TrophyStatusServiceTest extends TestCase
             [
                 [
                     'np_communication_id' => 'NPWR00001_00',
-                    'status' => 1,
+                    'status' => TrophyMetaStatus::Unobtainable,
                     'trophy_ids' => [10],
                 ],
             ],
@@ -64,7 +65,7 @@ final class TrophyStatusServiceTest extends TestCase
         $result = $service->updateTrophies([10], 0);
 
         $this->assertSame('obtainable', $result->getStatusText());
-        $this->assertSame(0, $recalculator->titleCalls[0]['status']);
+        $this->assertSame(TrophyMetaStatus::Obtainable, $recalculator->titleCalls[0]['status']);
     }
 }
 
@@ -73,7 +74,7 @@ final class RecordingTrophyStatusProgressRecalculator extends TrophyStatusProgre
     /** @var list<array{np_communication_id: string, group_id: string, trophy_ids: list<int>}> */
     public array $groupCalls = [];
 
-    /** @var list<array{np_communication_id: string, status: int, trophy_ids: list<int>}> */
+    /** @var list<array{np_communication_id: string, status: TrophyMetaStatus, trophy_ids: list<int>}> */
     public array $titleCalls = [];
 
     public function __construct()
@@ -91,11 +92,11 @@ final class RecordingTrophyStatusProgressRecalculator extends TrophyStatusProgre
         ];
     }
 
-    public function recalculateTitle(string $npCommunicationId, int $status, array $affectedTrophyIds): void
+    public function recalculateTitle(string $npCommunicationId, int|TrophyMetaStatus $status, array $affectedTrophyIds): void
     {
         $this->titleCalls[] = [
             'np_communication_id' => $npCommunicationId,
-            'status' => $status,
+            'status' => TrophyMetaStatus::fromMixed($status),
             'trophy_ids' => $affectedTrophyIds,
         ];
     }

--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
+require_once __DIR__ . '/../ChangelogEntry.php';
 require_once __DIR__ . '/MergeTrophyCopier.php';
 require_once __DIR__ . '/MergeTrophyGroupCopier.php';
 require_once __DIR__ . '/TrophyGroupConflictResolver.php';
@@ -374,7 +375,10 @@ class GameCopyService
 
     private function recordCopyAction(int $childId, int $parentId): void
     {
-        $query = $this->database->prepare("INSERT INTO `psn100_change` (`change_type`, `param_1`, `param_2`) VALUES ('GAME_COPY', :param_1, :param_2)");
+        $query = $this->database->prepare(
+            'INSERT INTO `psn100_change` (`change_type`, `param_1`, `param_2`) VALUES (:change_type, :param_1, :param_2)'
+        );
+        $query->bindValue(':change_type', ChangelogEntryType::GAME_COPY->value, PDO::PARAM_STR);
         $query->bindValue(':param_1', $childId, PDO::PARAM_INT);
         $query->bindValue(':param_2', $parentId, PDO::PARAM_INT);
         $query->execute();

--- a/wwwroot/classes/Admin/GameDetailService.php
+++ b/wwwroot/classes/Admin/GameDetailService.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../ChangelogEntry.php';
+
 class GameDetailService
 {
     public function __construct(
@@ -169,8 +171,9 @@ class GameDetailService
     private function recordChange(int $gameId): void
     {
         $query = $this->database->prepare(
-            "INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES ('GAME_UPDATE', :param_1)"
+            'INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES (:change_type, :param_1)'
         );
+        $query->bindValue(':change_type', ChangelogEntryType::GAME_UPDATE->value, PDO::PARAM_STR);
         $query->bindValue(':param_1', $gameId, PDO::PARAM_INT);
         $query->execute();
     }

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/../TrophyMetaRepository.php';
 require_once __DIR__ . '/../TrophyImageDirectories.php';
 require_once __DIR__ . '/../TrophyImageDownloader.php';
 require_once __DIR__ . '/../TrophyCatalogSynchronizer.php';
+require_once __DIR__ . '/../ChangelogEntry.php';
 require_once __DIR__ . '/PsnGameLookupService.php';
 require_once __DIR__ . '/PsnTrophyLookupGroupDataProvider.php';
 require_once __DIR__ . '/GameRescanPsnAccessor.php';
@@ -308,8 +309,9 @@ class GameRescanService
     private function recordRescan(int $gameId): void
     {
         $query = $this->database->prepare(
-            "INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES ('GAME_RESCAN', :param_1)"
+            'INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES (:change_type, :param_1)'
         );
+        $query->bindValue(':change_type', ChangelogEntryType::GAME_RESCAN->value, PDO::PARAM_STR);
         $query->bindValue(':param_1', $gameId, PDO::PARAM_INT);
         $query->execute();
     }

--- a/wwwroot/classes/Admin/PsnpPlusGame.php
+++ b/wwwroot/classes/Admin/PsnpPlusGame.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 final readonly class PsnpPlusGame
 {
     public function __construct(
-        private int $id,
-        private string $npCommunicationId,
-        private string $name
+        final private int $id,
+        final private string $npCommunicationId,
+        final private string $name
     ) {}
 
     #[\NoDiscard]

--- a/wwwroot/classes/Admin/TrophyStatusPage.php
+++ b/wwwroot/classes/Admin/TrophyStatusPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/TrophyStatusInputParser.php';
 require_once __DIR__ . '/TrophyStatusService.php';
 require_once __DIR__ . '/TrophyStatusUpdateResultPresenter.php';
+require_once __DIR__ . '/../TrophyMetaStatus.php';
 
 final readonly class TrophyStatusPageResult
 {
@@ -60,8 +61,8 @@ final readonly class TrophyStatusPage
         $hasGamePost = array_key_exists('game', $postData);
 
         if ($normalizedMethod === 'POST' && ($hasTrophyPost || $hasGamePost)) {
-            $status = isset($postData['status']) ? (int) $postData['status'] : 1;
-            $statusInput = (string) $status;
+            $status = TrophyMetaStatus::fromMixed($postData['status'] ?? TrophyMetaStatus::Unobtainable->value);
+            $statusInput = (string) $status->value;
 
             try {
                 $gameValue = trim((string) ($postData['game'] ?? ''));

--- a/wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php
+++ b/wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../TrophyMetaStatus.php';
+require_once __DIR__ . '/../ChangelogEntry.php';
+
 /**
  * Recalculates trophy group/title aggregates and player progress after a status change.
  *
@@ -105,7 +108,7 @@ SQL,
     /**
      * @param int[] $affectedTrophyIds
      */
-    public function recalculateTitle(string $npCommunicationId, int $status, array $affectedTrophyIds): void
+    public function recalculateTitle(string $npCommunicationId, int|TrophyMetaStatus $status, array $affectedTrophyIds): void
     {
         $statement = $this->database->prepare(
             <<<'SQL'
@@ -217,11 +220,11 @@ SQL
         $gameId = $this->findGameId($npCommunicationId);
 
         if ($gameId !== null) {
-            $changeType = $status === 1 ? 'GAME_UNOBTAINABLE' : 'GAME_OBTAINABLE';
+            $changeType = TrophyMetaStatus::fromMixed($status)->changeType();
             $statement = $this->database->prepare(
                 'INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES (:change_type, :param_1)'
             );
-            $statement->bindValue(':change_type', $changeType, PDO::PARAM_STR);
+            $statement->bindValue(':change_type', $changeType->value, PDO::PARAM_STR);
             $statement->bindValue(':param_1', $gameId, PDO::PARAM_INT);
             $statement->execute();
         }

--- a/wwwroot/classes/Admin/TrophyStatusService.php
+++ b/wwwroot/classes/Admin/TrophyStatusService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/TrophyStatusUpdateResult.php';
 require_once __DIR__ . '/TrophyStatusProgressRecalculator.php';
+require_once __DIR__ . '/../TrophyMetaStatus.php';
 
 class TrophyStatusService
 {
@@ -19,8 +20,9 @@ class TrophyStatusService
     /**
      * @param int[] $trophyIds
      */
-    public function updateTrophies(array $trophyIds, int $status): TrophyStatusUpdateResult
+    public function updateTrophies(array $trophyIds, int|TrophyMetaStatus $status): TrophyStatusUpdateResult
     {
+        $metaStatus = TrophyMetaStatus::fromMixed($status);
         $trophyIds = $trophyIds
             |> (fn(array $ids): array => array_map(intval(...), $ids))
             |> array_unique(...)
@@ -35,7 +37,7 @@ class TrophyStatusService
         $trophyTitles = [];
 
         foreach ($trophyIds as $trophyId) {
-            $trophy = $this->updateTrophyStatus((int) $trophyId, $status);
+            $trophy = $this->updateTrophyStatus((int) $trophyId, $metaStatus);
             $trophyNames[] = $trophy['label'];
             if (!isset($trophyGroups[$trophy['groupKey']])) {
                 $trophyGroups[$trophy['groupKey']] = [
@@ -57,24 +59,22 @@ class TrophyStatusService
         }
 
         foreach ($trophyTitles as $npCommunicationId => $titleTrophyIds) {
-            $this->progressRecalculator->recalculateTitle((string) $npCommunicationId, $status, $titleTrophyIds);
+            $this->progressRecalculator->recalculateTitle((string) $npCommunicationId, $metaStatus, $titleTrophyIds);
         }
 
-        $statusText = $status === 1 ? 'unobtainable' : 'obtainable';
-
-        return new TrophyStatusUpdateResult($trophyNames, $statusText);
+        return new TrophyStatusUpdateResult($trophyNames, $metaStatus->label());
     }
 
     /**
      * @return array{id: int, name: string, np_communication_id: string, group_id: string, label: string, groupKey: string}
      */
-    private function updateTrophyStatus(int $trophyId, int $status): array
+    private function updateTrophyStatus(int $trophyId, TrophyMetaStatus $status): array
     {
         try {
             $this->database->beginTransaction();
 
             $query = $this->database->prepare('UPDATE trophy_meta SET status = :status WHERE trophy_id = :trophy_id');
-            $query->bindValue(':status', $status, PDO::PARAM_INT);
+            $query->bindValue(':status', $status->value, PDO::PARAM_INT);
             $query->bindValue(':trophy_id', $trophyId, PDO::PARAM_INT);
             $query->execute();
 

--- a/wwwroot/classes/ChangelogService.php
+++ b/wwwroot/classes/ChangelogService.php
@@ -8,12 +8,33 @@ require_once __DIR__ . '/ChangelogPaginator.php';
 final class ChangelogService
 {
     public const int PAGE_SIZE = 50;
-    private const string FILTERED_CHANGE_TYPES = "('GAME_RESCAN', 'GAME_VERSION')";
 
     private ?int $cachedTotalChangeCount = null;
 
     public function __construct(private readonly PDO $database)
     {
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function filteredChangeTypes(): array
+    {
+        return [
+            ChangelogEntryType::GAME_RESCAN->value,
+            ChangelogEntryType::GAME_VERSION->value,
+        ];
+    }
+
+    private static function filteredChangeTypesSql(): string
+    {
+        return '(' . implode(
+            ', ',
+            array_map(
+                static fn (string $type): string => "'" . $type . "'",
+                self::filteredChangeTypes()
+            )
+        ) . ')';
     }
 
     public function getTotalChangeCount(): int
@@ -23,7 +44,7 @@ final class ChangelogService
         }
 
         $query = $this->database->prepare(
-            sprintf('SELECT COUNT(*) FROM psn100_change WHERE change_type NOT IN %s', self::FILTERED_CHANGE_TYPES)
+            sprintf('SELECT COUNT(*) FROM psn100_change WHERE change_type NOT IN %s', self::filteredChangeTypesSql())
         );
         $query->execute();
 
@@ -38,7 +59,8 @@ final class ChangelogService
     public function getChanges(ChangelogPaginator $paginator): array
     {
         $query = $this->database->prepare(
-            <<<'SQL'
+            sprintf(
+                <<<'SQL'
             SELECT
                 c.time,
                 c.change_type,
@@ -57,10 +79,12 @@ final class ChangelogService
             LEFT JOIN trophy_title_meta ttm1 ON ttm1.np_communication_id = tt1.np_communication_id
             LEFT JOIN trophy_title tt2 ON tt2.id = c.param_2
             LEFT JOIN trophy_title_meta ttm2 ON ttm2.np_communication_id = tt2.np_communication_id
-            WHERE c.change_type NOT IN ('GAME_RESCAN', 'GAME_VERSION')
+            WHERE c.change_type NOT IN %s
             ORDER BY c.time DESC
             LIMIT :limit OFFSET :offset
-            SQL
+            SQL,
+                self::filteredChangeTypesSql()
+            )
         );
         $query->bindValue(':offset', $paginator->getOffset(), PDO::PARAM_INT);
         $query->bindValue(':limit', $paginator->getLimit(), PDO::PARAM_INT);

--- a/wwwroot/classes/Cron/PlayerScanCatalogSideEffects.php
+++ b/wwwroot/classes/Cron/PlayerScanCatalogSideEffects.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../AutomaticTrophyTitleMergeService.php';
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../TrophyMergeService.php';
+require_once __DIR__ . '/../ChangelogEntry.php';
 require_once __DIR__ . '/PlayerScanCatalogSideEffectResult.php';
 require_once __DIR__ . '/PlayerScanNewTitleMergeHandler.php';
 
@@ -85,8 +86,9 @@ final class PlayerScanCatalogSideEffects
     private function insertGameVersionChangelog(int $titleId): void
     {
         $query = $this->database->prepare(
-            "INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES ('GAME_VERSION', :param_1)"
+            'INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES (:change_type, :param_1)'
         );
+        $query->bindValue(':change_type', ChangelogEntryType::GAME_VERSION->value, PDO::PARAM_STR);
         $query->bindValue(':param_1', $titleId, PDO::PARAM_INT);
         $query->execute();
     }

--- a/wwwroot/classes/ExecutionEnvironmentConfigurator.php
+++ b/wwwroot/classes/ExecutionEnvironmentConfigurator.php
@@ -19,6 +19,7 @@ final class ExecutionEnvironmentConfigurator
         return new self();
     }
 
+    #[\NoDiscard]
     public function addIniSetting(string $option, string $value): self
     {
         $this->iniSettings[$option] = $value;
@@ -26,6 +27,7 @@ final class ExecutionEnvironmentConfigurator
         return $this;
     }
 
+    #[\NoDiscard]
     public function enableUnlimitedExecution(): self
     {
         $this->unlimitedExecution = true;
@@ -33,6 +35,7 @@ final class ExecutionEnvironmentConfigurator
         return $this;
     }
 
+    #[\NoDiscard]
     public function enableIgnoreUserAbort(): self
     {
         $this->shouldIgnoreUserAbort = true;

--- a/wwwroot/classes/Game/GameTrophyRow.php
+++ b/wwwroot/classes/Game/GameTrophyRow.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../Utility.php';
 require_once __DIR__ . '/../TrophyType.php';
+require_once __DIR__ . '/../TrophyMetaStatus.php';
 
 final readonly class GameTrophyRow
 {
-    private const int UNOBTAINABLE_STATUS = 1;
     private const string UNOBTAINABLE_TITLE = 'This trophy is unobtainable and not accounted for on any leaderboard.';
 
     private int $id;
@@ -18,7 +18,7 @@ final readonly class GameTrophyRow
     private string $iconUrl;
     private float $rarityPercent;
     private ?float $inGameRarityPercent;
-    private int $status;
+    private TrophyMetaStatus $status;
     private ?int $progressTargetValue;
     private ?int $progress;
     private ?string $rewardName;
@@ -52,7 +52,7 @@ final readonly class GameTrophyRow
         $this->iconUrl = (string) ($data['icon_url'] ?? '');
         $this->rarityPercent = (float) ($data['rarity_percent'] ?? 0.0);
         $this->inGameRarityPercent = (float) ($data['in_game_rarity_percent'] ?? 0.0);
-        $this->status = (int) ($data['status'] ?? 0);
+        $this->status = TrophyMetaStatus::fromMixed($data['status'] ?? 0);
         $this->progressTargetValue = isset($data['progress_target_value'])
             ? (int) $data['progress_target_value']
             : null;
@@ -181,7 +181,7 @@ final readonly class GameTrophyRow
         return $this->inGameRarityPercent;
     }
 
-    public function getStatus(): int
+    public function getStatus(): TrophyMetaStatus
     {
         return $this->status;
     }
@@ -221,6 +221,6 @@ final readonly class GameTrophyRow
 
     private function isUnobtainable(): bool
     {
-        return $this->status === self::UNOBTAINABLE_STATUS;
+        return $this->status->isUnobtainable();
     }
 }

--- a/wwwroot/classes/GameAvailabilityStatus.php
+++ b/wwwroot/classes/GameAvailabilityStatus.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/ChangelogEntry.php';
+
 enum GameAvailabilityStatus: int
 {
     case NORMAL = 0;
@@ -27,14 +29,14 @@ enum GameAvailabilityStatus: int
         };
     }
 
-    public function changeType(): string
+    public function changeType(): ChangelogEntryType
     {
         return match ($this) {
-            self::DELISTED => 'GAME_DELISTED',
-            self::MERGED => 'GAME_MERGE',
-            self::OBSOLETE => 'GAME_OBSOLETE',
-            self::DELISTED_AND_OBSOLETE => 'GAME_DELISTED_AND_OBSOLETE',
-            self::NORMAL => 'GAME_NORMAL',
+            self::DELISTED => ChangelogEntryType::GAME_DELISTED,
+            self::MERGED => ChangelogEntryType::GAME_MERGE,
+            self::OBSOLETE => ChangelogEntryType::GAME_OBSOLETE,
+            self::DELISTED_AND_OBSOLETE => ChangelogEntryType::GAME_DELISTED_AND_OBSOLETE,
+            self::NORMAL => ChangelogEntryType::GAME_NORMAL,
         };
     }
 

--- a/wwwroot/classes/GameHistoryService.php
+++ b/wwwroot/classes/GameHistoryService.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/TrophyMetaStatus.php';
+
 final class GameHistoryService
 {
     private const int INVALID_HISTORY_ID = 0;
@@ -181,7 +183,7 @@ final class GameHistoryService
                 'detail' => self::toNullableString($row, 'detail'),
                 'icon_url' => self::toNullableString($row, 'icon_url'),
                 'progress_target_value' => self::toNullableInt($row, 'progress_target_value'),
-                'is_unobtainable' => self::toInt($row, 'trophy_status') === 1,
+                'is_unobtainable' => TrophyMetaStatus::fromMixed(self::toInt($row, 'trophy_status'))->isUnobtainable(),
             ];
         }
 

--- a/wwwroot/classes/GameStatusService.php
+++ b/wwwroot/classes/GameStatusService.php
@@ -53,12 +53,12 @@ class GameStatusService
         $query->execute();
     }
 
-    private function logStatusChange(int $gameId, string $changeType): void
+    private function logStatusChange(int $gameId, ChangelogEntryType $changeType): void
     {
         $query = $this->database->prepare(
             "INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES (:change_type, :param_1)"
         );
-        $query->bindValue(':change_type', $changeType, PDO::PARAM_STR);
+        $query->bindValue(':change_type', $changeType->value, PDO::PARAM_STR);
         $query->bindValue(':param_1', $gameId, PDO::PARAM_INT);
         $query->execute();
     }

--- a/wwwroot/classes/HomepageViewModel.php
+++ b/wwwroot/classes/HomepageViewModel.php
@@ -17,10 +17,10 @@ final readonly class HomepageViewModel
      * @param HomepagePopularGame[] $popularGames
      */
     public function __construct(
-        private string $title,
-        private array $newGames,
-        private array $newDlcs,
-        private array $popularGames,
+        final private string $title,
+        final private array $newGames,
+        final private array $newDlcs,
+        final private array $popularGames,
         ?HomepagePopularGamesFilter $popularGamesFilter = null,
     ) {
         $this->popularGamesFilter = $popularGamesFilter ?? HomepagePopularGamesFilter::fromArray([]);

--- a/wwwroot/classes/HttpRequest.php
+++ b/wwwroot/classes/HttpRequest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-readonly class HttpRequest
+final readonly class HttpRequest
 {
     /**
      * @param array<string, mixed> $server
      */
-    public function __construct(private array $server = [])
+    public function __construct(final private array $server = [])
     {
     }
 

--- a/wwwroot/classes/HttpRequest.php
+++ b/wwwroot/classes/HttpRequest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-final readonly class HttpRequest
+readonly class HttpRequest
 {
     /**
      * @param array<string, mixed> $server

--- a/wwwroot/classes/NavigationSectionState.php
+++ b/wwwroot/classes/NavigationSectionState.php
@@ -6,8 +6,10 @@ require_once __DIR__ . '/NavigationSection.php';
 
 final readonly class NavigationSectionState
 {
-    public function __construct(private NavigationSection $section, private bool $active)
-    {
+    public function __construct(
+        final private NavigationSection $section,
+        final private bool $active,
+    ) {
     }
 
     public function getSection(): NavigationSection

--- a/wwwroot/classes/Platform.php
+++ b/wwwroot/classes/Platform.php
@@ -34,6 +34,24 @@ enum Platform: string
     }
 
     /**
+     * Display / merge sort order for platform labels (e.g. "PS5", "PC").
+     *
+     * @return list<string>
+     */
+    public static function labelOrder(): array
+    {
+        return [
+            self::Ps3->label(),
+            self::PsVita->label(),
+            self::Ps4->label(),
+            self::PsVr->label(),
+            self::Ps5->label(),
+            self::PsVr2->label(),
+            self::Pc->label(),
+        ];
+    }
+
+    /**
      * @return array<string, string>
      */
     public static function labelsByValue(): array

--- a/wwwroot/classes/PlayerHeaderViewModel.php
+++ b/wwwroot/classes/PlayerHeaderViewModel.php
@@ -17,9 +17,9 @@ final readonly class PlayerHeaderViewModel
      * @param array<string, mixed> $player
      */
     public function __construct(
-        private array $player,
-        private PlayerSummary $playerSummary,
-        private Utility $utility
+        final private array $player,
+        final private PlayerSummary $playerSummary,
+        final private Utility $utility
     ) {}
 
     public function getAboutMe(): string

--- a/wwwroot/classes/PlayerPageAccessGuard.php
+++ b/wwwroot/classes/PlayerPageAccessGuard.php
@@ -8,8 +8,8 @@ final readonly class PlayerPageAccessGuard
     private const int REDIRECT_STATUS_CODE = 303;
 
     private function __construct(
-        private ?int $accountId,
-        private string $redirectUrl
+        final private ?int $accountId,
+        final private string $redirectUrl
     ) {}
 
     #[\NoDiscard]

--- a/wwwroot/classes/PlayerPlatformFilterOptions.php
+++ b/wwwroot/classes/PlayerPlatformFilterOptions.php
@@ -7,9 +7,9 @@ require_once __DIR__ . '/Platform.php';
 readonly final class PlayerPlatformFilterOption
 {
     public function __construct(
-        private string $key,
-        private string $label,
-        private bool $selected
+        final private string $key,
+        final private string $label,
+        final private bool $selected
     ) {}
 
     public function getInputName(): string
@@ -38,7 +38,7 @@ readonly final class PlayerPlatformFilterOptions
     /**
      * @param PlayerPlatformFilterOption[] $options
      */
-    private function __construct(private array $options)
+    private function __construct(final private array $options)
     {
     }
 

--- a/wwwroot/classes/PlayerRandomGamesPageContext.php
+++ b/wwwroot/classes/PlayerRandomGamesPageContext.php
@@ -16,9 +16,6 @@ require_once __DIR__ . '/PlayerStatus.php';
 
 final readonly class PlayerRandomGamesPageContext
 {
-    private const int STATUS_FLAGGED = 1;
-    private const int STATUS_PRIVATE = 3;
-
     private PlayerRandomGamesPage $playerRandomGamesPage;
 
     private PlayerSummary $playerSummary;

--- a/wwwroot/classes/PlayerScanStatus.php
+++ b/wwwroot/classes/PlayerScanStatus.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final readonly class PlayerScanStatus
 {
-    public function __construct(private ?PlayerScanProgress $progress)
+    public function __construct(final private ?PlayerScanProgress $progress)
     {
     }
 

--- a/wwwroot/classes/TrophyDetails.php
+++ b/wwwroot/classes/TrophyDetails.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/PlayerUrlBuilder.php';
 require_once __DIR__ . '/TrophyType.php';
+require_once __DIR__ . '/TrophyMetaStatus.php';
 require_once __DIR__ . '/Utility.php';
 
 final readonly class TrophyDetails
@@ -24,7 +25,7 @@ final readonly class TrophyDetails
         final private string $iconFileName,
         final private float $rarityPercent,
         final private ?float $inGameRarityPercent,
-        final private int $status,
+        final private TrophyMetaStatus $status,
         final private ?string $progressTargetValue,
         final private ?string $rewardName,
         final private ?string $rewardImageUrl,
@@ -51,7 +52,7 @@ final readonly class TrophyDetails
             (string) ($data['trophy_icon'] ?? ''),
             (float) ($data['rarity_percent'] ?? 0.0),
             (float) ($data['in_game_rarity_percent'] ?? 0.0),
-            (int) ($data['status'] ?? 0),
+            TrophyMetaStatus::fromMixed($data['status'] ?? 0),
             isset($data['progress_target_value']) ? (string) $data['progress_target_value'] : null,
             isset($data['reward_name']) ? (string) $data['reward_name'] : null,
             isset($data['reward_image_url']) ? (string) $data['reward_image_url'] : null,
@@ -112,7 +113,7 @@ final readonly class TrophyDetails
         return $this->inGameRarityPercent;
     }
 
-    public function getStatus(): int
+    public function getStatus(): TrophyMetaStatus
     {
         return $this->status;
     }
@@ -184,7 +185,7 @@ final readonly class TrophyDetails
 
     public function isUnobtainable(): bool
     {
-        return $this->status === 1;
+        return $this->status->isUnobtainable();
     }
 
     public function getGameSlug(Utility $utility): string

--- a/wwwroot/classes/TrophyHistoryRecorder.php
+++ b/wwwroot/classes/TrophyHistoryRecorder.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Psn100Logger.php';
+require_once __DIR__ . '/ChangelogEntry.php';
 
 class TrophyHistoryRecorder
 {
@@ -130,8 +131,9 @@ class TrophyHistoryRecorder
     private function recordHistorySnapshotChange(int $titleId): void
     {
         $changeStatement = $this->database->prepare(
-            "INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES ('GAME_HISTORY_SNAPSHOT', :title_id)"
+            'INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES (:change_type, :title_id)'
         );
+        $changeStatement->bindValue(':change_type', ChangelogEntryType::GAME_HISTORY_SNAPSHOT->value, PDO::PARAM_STR);
         $changeStatement->bindValue(':title_id', $titleId, PDO::PARAM_INT);
         $changeStatement->execute();
     }

--- a/wwwroot/classes/TrophyListFilter.php
+++ b/wwwroot/classes/TrophyListFilter.php
@@ -63,4 +63,10 @@ final readonly class TrophyListFilter
 
         return $parameters;
     }
+
+    #[\NoDiscard]
+    public function withPageNumber(int $page): self
+    {
+        return clone($this, ['page' => max($page, 1)]);
+    }
 }

--- a/wwwroot/classes/TrophyMergeMetadataRepository.php
+++ b/wwwroot/classes/TrophyMergeMetadataRepository.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
+require_once __DIR__ . '/Platform.php';
 
 /**
  * Persists trophy-title merge metadata: merged status, parent links, platform union, and changelog rows.
  */
 final class TrophyMergeMetadataRepository
 {
-    private const array PLATFORM_ORDER = ['PS3', 'PSVITA', 'PS4', 'PSVR', 'PS5', 'PSVR2', 'PC'];
-
     public function __construct(
         private readonly PDO $database,
         private readonly NestedDatabaseTransactionRunner $transactionRunner
@@ -188,7 +187,7 @@ SQL
      */
     private function sortPlatforms(array $platforms): array
     {
-        $order = array_flip(self::PLATFORM_ORDER);
+        $order = array_flip(Platform::labelOrder());
 
         usort(
             $platforms,

--- a/wwwroot/classes/TrophyMetaStatus.php
+++ b/wwwroot/classes/TrophyMetaStatus.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/ChangelogEntry.php';
+
+enum TrophyMetaStatus: int
+{
+    case Obtainable = 0;
+    case Unobtainable = 1;
+
+    #[\NoDiscard]
+    public static function fromValue(int $status): self
+    {
+        return self::tryFrom($status) ?? self::Obtainable;
+    }
+
+    #[\NoDiscard]
+    public static function fromMixed(mixed $status): self
+    {
+        if ($status instanceof self) {
+            return $status;
+        }
+
+        if (is_int($status) || (is_string($status) && is_numeric($status))) {
+            return self::fromValue((int) $status);
+        }
+
+        return self::Obtainable;
+    }
+
+    public function isUnobtainable(): bool
+    {
+        return $this === self::Unobtainable;
+    }
+
+    public function isObtainable(): bool
+    {
+        return $this === self::Obtainable;
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Unobtainable => 'unobtainable',
+            self::Obtainable => 'obtainable',
+        };
+    }
+
+    public function changeType(): ChangelogEntryType
+    {
+        return match ($this) {
+            self::Unobtainable => ChangelogEntryType::GAME_UNOBTAINABLE,
+            self::Obtainable => ChangelogEntryType::GAME_OBTAINABLE,
+        };
+    }
+}

--- a/wwwroot/classes/TrophyRarityFormatter.php
+++ b/wwwroot/classes/TrophyRarityFormatter.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/TrophyRarity.php';
+require_once __DIR__ . '/TrophyMetaStatus.php';
 
 final class TrophyRarityFormatter
 {
@@ -29,24 +30,30 @@ final class TrophyRarityFormatter
     /**
      * @param float|int|string|null $rarityPercent
      */
-    public function format(float|int|string|null $rarityPercent, int $status = 0): TrophyRarity
-    {
+    public function format(
+        float|int|string|null $rarityPercent,
+        int|TrophyMetaStatus $status = 0,
+    ): TrophyRarity {
         return $this->formatMeta($rarityPercent, $status);
     }
 
     /**
      * @param float|int|string|null $rarityPercent
      */
-    public function formatMeta(float|int|string|null $rarityPercent, int $status = 0): TrophyRarity
-    {
+    public function formatMeta(
+        float|int|string|null $rarityPercent,
+        int|TrophyMetaStatus $status = 0,
+    ): TrophyRarity {
         return $this->formatWithThresholds($rarityPercent, $status, self::META_THRESHOLDS);
     }
 
     /**
      * @param float|int|string|null $rarityPercent
      */
-    public function formatInGame(float|int|string|null $rarityPercent, int $status = 0): TrophyRarity
-    {
+    public function formatInGame(
+        float|int|string|null $rarityPercent,
+        int|TrophyMetaStatus $status = 0,
+    ): TrophyRarity {
         return $this->formatWithThresholds($rarityPercent, $status, self::IN_GAME_THRESHOLDS);
     }
 
@@ -110,13 +117,14 @@ final class TrophyRarityFormatter
      */
     private function formatWithThresholds(
         float|int|string|null $rarityPercent,
-        int $status,
+        int|TrophyMetaStatus $status,
         array $thresholds
     ): TrophyRarity {
         $value = $this->toFloat($rarityPercent);
         $percentageString = $this->normalizePercentage($rarityPercent, $value);
+        $metaStatus = TrophyMetaStatus::fromMixed($status);
 
-        if ($status === 1) {
+        if ($metaStatus->isUnobtainable()) {
             return new TrophyRarity($percentageString, 'Unobtainable', null, true);
         }
 

--- a/wwwroot/classes/TrophyTitleCloneService.php
+++ b/wwwroot/classes/TrophyTitleCloneService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
+require_once __DIR__ . '/ChangelogEntry.php';
 
 /**
  * Clones a trophy title into a new MERGE_* title, including catalog rows and history.
@@ -385,7 +386,7 @@ SQL
         $query = $this->database->prepare(
             "INSERT INTO `psn100_change` (`change_type`, `param_1`, `param_2`) VALUES (:change_type, :param_1, :param_2)"
         );
-        $query->bindValue(':change_type', 'GAME_CLONE', PDO::PARAM_STR);
+        $query->bindValue(':change_type', ChangelogEntryType::GAME_CLONE->value, PDO::PARAM_STR);
         $query->bindValue(':param_1', $childGameId, PDO::PARAM_INT);
         $query->bindValue(':param_2', $cloneGameId, PDO::PARAM_INT);
         $query->execute();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues PHP 8.5 modernization on top of prior enum/readonly work:

- Add `TrophyMetaStatus` and wire it through trophy rows, rarity formatting, admin status updates, and game history
- Bind changelog write sites and filters through `ChangelogEntryType` (including `GameAvailabilityStatus::changeType()`)
- Add `Platform::labelOrder()` as the single source of truth for merge platform sorting
- Promote `final` on constructor-promoted readonly DTO properties; mark fluent env configurator methods with `#[\NoDiscard]`
- Add `TrophyListFilter::withPageNumber()` via clone-with; drop unused player status constants

## Test plan

- [x] `php tests/run.php` — all 990 tests passed
- [x] Focused coverage for `TrophyMetaStatus`, trophy status service, trophy list filter, changelog, and rarity formatting

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8325fb9-d9ab-468e-8cb8-9f5b3c4996ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8325fb9-d9ab-468e-8cb8-9f5b3c4996ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

