### PR TITLE
Adopt TrophyMergeMethod enum for PHP 8.5 merge flows

### DIFF
--- a/tests/AutomaticTrophyTitleMergeServiceTest.php
+++ b/tests/AutomaticTrophyTitleMergeServiceTest.php
@@ -46,7 +46,7 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
         ], $this->mergeService->copiedGames);
 
         $this->assertSame([
-            [1, 2, 'order'],
+            [1, 2, TrophyMergeMethod::Order],
         ], $this->mergeService->mergedGames);
     }
 
@@ -89,7 +89,7 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
 
         $this->assertSame([], $this->mergeService->copiedGames);
         $this->assertSame([
-            [1, 2, 'order'],
+            [1, 2, TrophyMergeMethod::Order],
         ], $this->mergeService->mergedGames);
     }
 
@@ -111,7 +111,7 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
         $parentsToRecompute = $this->service->handleNewTitle('NP_NEW');
 
         $this->assertSame([
-            [1, 2, 'order'],
+            [1, 2, TrophyMergeMethod::Order],
         ], $this->mergeService->mergedGames);
     }
 
@@ -165,8 +165,8 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
 
         $this->assertSame([1], $this->mergeService->clonedGames);
         $this->assertSame([
-            [1, 99, 'order'],
-            [2, 99, 'order'],
+            [1, 99, TrophyMergeMethod::Order],
+            [2, 99, TrophyMergeMethod::Order],
         ], $this->mergeService->mergedGames);
     }
 
@@ -200,8 +200,8 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
 
         $this->assertSame([1], $this->mergeService->clonedGames);
         $this->assertSame([
-            [1, 99, 'order'],
-            [2, 99, 'order'],
+            [1, 99, TrophyMergeMethod::Order],
+            [2, 99, TrophyMergeMethod::Order],
         ], $this->mergeService->mergedGames);
         $this->assertSame(['MERGE_000099'], $parentsToRecompute);
     }
@@ -250,8 +250,8 @@ final class AutomaticTrophyTitleMergeServiceTest extends TestCase
 
         $this->assertSame([2], $this->mergeService->clonedGames);
         $this->assertSame([
-            [1, 99, 'order'],
-            [2, 99, 'order'],
+            [1, 99, TrophyMergeMethod::Order],
+            [2, 99, TrophyMergeMethod::Order],
         ], $this->mergeService->mergedGames);
     }
 
@@ -491,9 +491,9 @@ final class RecordingTrophyMergeService extends TrophyMergeService
         $this->copiedGames[] = [$sourceNpCommunicationId, $targetNpCommunicationId];
     }
 
-    public function mergeGames(int $childGameId, int $parentGameId, string $method, ?TrophyMergeProgressListener $progressListener = null): string
+    public function mergeGames(int $childGameId, int $parentGameId, TrophyMergeMethod|string $method, ?TrophyMergeProgressListener $progressListener = null): string
     {
-        $this->mergedGames[] = [$childGameId, $parentGameId, $method];
+        $this->mergedGames[] = [$childGameId, $parentGameId, TrophyMergeMethod::fromMixed($method)];
 
         return 'The games have been merged.';
     }

--- a/tests/TrophyMergeMethodTest.php
+++ b/tests/TrophyMergeMethodTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMergeMethod.php';
+
+final class TrophyMergeMethodTest extends TestCase
+{
+    public function testTryFromMixedAcceptsKnownValues(): void
+    {
+        $this->assertSame(TrophyMergeMethod::Order, TrophyMergeMethod::tryFromMixed('order'));
+        $this->assertSame(TrophyMergeMethod::Name, TrophyMergeMethod::tryFromMixed(' Name '));
+        $this->assertSame(TrophyMergeMethod::Icon, TrophyMergeMethod::tryFromMixed('ICON'));
+        $this->assertSame(TrophyMergeMethod::Order, TrophyMergeMethod::tryFromMixed(TrophyMergeMethod::Order));
+    }
+
+    public function testTryFromMixedRejectsUnknownValues(): void
+    {
+        $this->assertSame(null, TrophyMergeMethod::tryFromMixed('unknown'));
+        $this->assertSame(null, TrophyMergeMethod::tryFromMixed([]));
+        $this->assertSame(null, TrophyMergeMethod::tryFromMixed(null));
+    }
+
+    public function testFromMixedDefaultsMissingValuesToOrder(): void
+    {
+        $this->assertSame(TrophyMergeMethod::Order, TrophyMergeMethod::fromMixed(null));
+        $this->assertSame(TrophyMergeMethod::Order, TrophyMergeMethod::fromMixed(''));
+    }
+
+    public function testFromMixedThrowsForUnknownValues(): void
+    {
+        try {
+            TrophyMergeMethod::fromMixed('unknown');
+            $this->fail('Expected InvalidArgumentException for unknown merge method.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('Wrong input', $exception->getMessage());
+        }
+    }
+
+    public function testProgressLabel(): void
+    {
+        $this->assertSame('Matching trophies by list order…', TrophyMergeMethod::Order->progressLabel());
+        $this->assertSame('Matching trophies by name…', TrophyMergeMethod::Name->progressLabel());
+        $this->assertSame('Matching trophies by icon…', TrophyMergeMethod::Icon->progressLabel());
+    }
+}

--- a/tests/TrophyMergeRequestHandlerTest.php
+++ b/tests/TrophyMergeRequestHandlerTest.php
@@ -97,7 +97,7 @@ final class ThrowingTrophyMergeService extends TrophyMergeService
     public function mergeGames(
         int $childGameId,
         int $parentGameId,
-        string $method,
+        TrophyMergeMethod|string $method,
         ?TrophyMergeProgressListener $progressListener = null
     ): string {
         throw $this->throwable;

--- a/tests/TrophyMergeServiceTransactionTest.php
+++ b/tests/TrophyMergeServiceTransactionTest.php
@@ -50,7 +50,7 @@ final class TrophyMergeServiceTransactionTest extends TestCase
         $service = new TrophyMergeService($database);
 
         try {
-            $service->mergeGames(10, 20, 'order');
+            $service->mergeGames(10, 20, TrophyMergeMethod::Order);
             $this->fail('Expected mergeGames to fail when marking the child game as merged.');
         } catch (RuntimeException $exception) {
             $this->assertSame('Failed while marking child game as merged.', $exception->getMessage());

--- a/tests/TrophySetComparatorTest.php
+++ b/tests/TrophySetComparatorTest.php
@@ -118,7 +118,7 @@ final class TrophySetComparatorTest extends TestCase
 
     public function testSelectMergeMethodPrefersOrder(): void
     {
-        $this->assertSame('order', $this->comparator->selectMergeMethod([
+        $this->assertSame(TrophyMergeMethod::Order, $this->comparator->selectMergeMethod([
             'matches' => true,
             'orderMatches' => true,
             'nameMatches' => true,
@@ -127,7 +127,7 @@ final class TrophySetComparatorTest extends TestCase
 
     public function testSelectMergeMethodFallsBackToName(): void
     {
-        $this->assertSame('name', $this->comparator->selectMergeMethod([
+        $this->assertSame(TrophyMergeMethod::Name, $this->comparator->selectMergeMethod([
             'matches' => true,
             'orderMatches' => false,
             'nameMatches' => true,

--- a/wwwroot/classes/Admin/TrophyMergeProcessor.php
+++ b/wwwroot/classes/Admin/TrophyMergeProcessor.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../ExecutionEnvironmentConfigurator.php';
+require_once __DIR__ . '/../TrophyMergeMethod.php';
 require_once __DIR__ . '/../TrophyMergeService.php';
 require_once __DIR__ . '/TrophyMergeRequestHandler.php';
 require_once __DIR__ . '/CallableTrophyMergeProgressListener.php';
@@ -43,12 +44,22 @@ class TrophyMergeProcessor
 
         $childId = $this->filterNumericValue($postData['child'] ?? null);
         $parentId = $this->filterNumericValue($postData['parent'] ?? null);
-        $mergeMethod = ((string) ($postData['method'] ?? 'order')) |> strtolower(...);
 
         if ($childId === null || $parentId === null) {
             $this->sendJsonResponse(400, [
                 'success' => false,
                 'error' => 'Please provide numeric child and parent game ids.',
+            ]);
+
+            return;
+        }
+
+        try {
+            $mergeMethod = TrophyMergeMethod::fromMixed($postData['method'] ?? null);
+        } catch (InvalidArgumentException $exception) {
+            $this->sendJsonResponse(400, [
+                'success' => false,
+                'error' => $exception->getMessage(),
             ]);
 
             return;
@@ -76,7 +87,7 @@ class TrophyMergeProcessor
                 [
                     'child' => (string) $childId,
                     'parent' => (string) $parentId,
-                    'method' => $mergeMethod,
+                    'method' => $mergeMethod->value,
                 ],
                 $progressListener
             );

--- a/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
+++ b/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../CommaSeparatedValues.php';
 require_once __DIR__ . '/../Html.php';
+require_once __DIR__ . '/../TrophyMergeMethod.php';
 
 require_once __DIR__ . '/TrophyMergeProgressListener.php';
 
@@ -97,7 +98,7 @@ class TrophyMergeRequestHandler
 
         $childId = (int) $postData['child'];
         $parentId = (int) $postData['parent'];
-        $method = ((string) ($postData['method'] ?? 'order')) |> strtolower(...);
+        $method = TrophyMergeMethod::fromMixed($postData['method'] ?? null);
 
         return $this->trophyMergeService->mergeGames($childId, $parentId, $method, $progressListener);
     }
@@ -106,7 +107,7 @@ class TrophyMergeRequestHandler
     {
         $childId = (int) $postData['child'];
         $parentId = (int) $postData['parent'];
-        $method = ((string) ($postData['method'] ?? 'order')) |> strtolower(...);
+        $method = TrophyMergeMethod::fromMixed($postData['method'] ?? null);
 
         return $this->trophyMergeService->mergeGames($childId, $parentId, $method);
     }

--- a/wwwroot/classes/AutomaticTrophyTitleMergeService.php
+++ b/wwwroot/classes/AutomaticTrophyTitleMergeService.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/CommaSeparatedValues.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
+require_once __DIR__ . '/TrophyMergeMethod.php';
 require_once __DIR__ . '/TrophyMergeService.php';
 require_once __DIR__ . '/TrophySetComparator.php';
 require_once __DIR__ . '/Cron/PlayerScanNewTitleMergeHandler.php';
@@ -158,11 +160,13 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
      */
     private function getTitleByNpCommunicationId(string $npCommunicationId): ?array
     {
+        $normalStatus = GameAvailabilityStatus::NORMAL->value;
+
         $query = $this->database->prepare(
-            'SELECT tt.id, tt.np_communication_id, tt.name, tt.platform, COALESCE(ttm.status, 0) AS status
+            "SELECT tt.id, tt.np_communication_id, tt.name, tt.platform, COALESCE(ttm.status, {$normalStatus}) AS status
             FROM trophy_title tt
             LEFT JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
-            WHERE tt.np_communication_id = :np_communication_id'
+            WHERE tt.np_communication_id = :np_communication_id"
         );
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->execute();
@@ -191,11 +195,14 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
      */
     private function findMatchingTitles(array $newTitle): array
     {
+        $normalStatus = GameAvailabilityStatus::NORMAL->value;
+        $mergedStatus = GameAvailabilityStatus::MERGED->value;
+
         $query = $this->database->prepare(
-            'SELECT tt.id, tt.np_communication_id, tt.platform, COALESCE(ttm.status, 0) AS status
+            "SELECT tt.id, tt.np_communication_id, tt.platform, COALESCE(ttm.status, {$normalStatus}) AS status
             FROM trophy_title tt
             LEFT JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
-            WHERE tt.name = :name AND tt.np_communication_id != :np_communication_id AND COALESCE(ttm.status, 0) != 2'
+            WHERE tt.name = :name AND tt.np_communication_id != :np_communication_id AND COALESCE(ttm.status, {$normalStatus}) != {$mergedStatus}"
         );
         $query->bindValue(':name', $newTitle['name'], PDO::PARAM_STR);
         $query->bindValue(':np_communication_id', $newTitle['np_communication_id'], PDO::PARAM_STR);
@@ -261,7 +268,7 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
                 continue;
             }
 
-            if ($match['status'] === 2) {
+            if ($match['status'] === GameAvailabilityStatus::MERGED->value) {
                 continue;
             }
 
@@ -285,7 +292,7 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
     private function selectGameToClone(array $games): ?array
     {
         $isEligible = static fn (array $game): bool => !str_starts_with($game['np_communication_id'], 'MERGE')
-            && $game['status'] !== 2;
+            && $game['status'] !== GameAvailabilityStatus::MERGED->value;
 
         return array_find(
             $games,
@@ -318,7 +325,7 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
     private function mergeAndReportWarnings(
         int $childGameId,
         int $parentGameId,
-        string $mergeMethod,
+        TrophyMergeMethod $mergeMethod,
         string $childNpCommunicationId,
         string $parentNpCommunicationId
     ): void {

--- a/wwwroot/classes/TrophyMergeMethod.php
+++ b/wwwroot/classes/TrophyMergeMethod.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+enum TrophyMergeMethod: string
+{
+    case Order = 'order';
+    case Name = 'name';
+    case Icon = 'icon';
+
+    #[\NoDiscard]
+    public static function tryFromMixed(mixed $value): ?self
+    {
+        if ($value instanceof self) {
+            return $value;
+        }
+
+        if (!is_string($value) && !is_numeric($value)) {
+            return null;
+        }
+
+        return self::tryFrom(((string) $value) |> trim(...) |> strtolower(...));
+    }
+
+    /**
+     * Parse a merge method from request input. Missing/empty values default to Order.
+     *
+     * @throws InvalidArgumentException when the value is present but not a known method
+     */
+    #[\NoDiscard]
+    public static function fromMixed(mixed $value): self
+    {
+        if ($value instanceof self) {
+            return $value;
+        }
+
+        if ($value === null || $value === '') {
+            return self::Order;
+        }
+
+        return self::tryFromMixed($value)
+            ?? throw new InvalidArgumentException('Wrong input');
+    }
+
+    public function progressLabel(): string
+    {
+        return match ($this) {
+            self::Name => 'Matching trophies by name…',
+            self::Icon => 'Matching trophies by icon…',
+            self::Order => 'Matching trophies by list order…',
+        };
+    }
+}

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
 require_once __DIR__ . '/TrophyMergeEarnedCopier.php';
 require_once __DIR__ . '/TrophyMergeMappingService.php';
 require_once __DIR__ . '/TrophyMergeMetadataRepository.php';
+require_once __DIR__ . '/TrophyMergeMethod.php';
 require_once __DIR__ . '/TrophyMergePlayerProgressUpdater.php';
 require_once __DIR__ . '/TrophyTitleCloneService.php';
 
@@ -95,10 +96,11 @@ class TrophyMergeService
     public function mergeGames(
         int $childGameId,
         int $parentGameId,
-        string $method,
+        TrophyMergeMethod|string $method,
         ?TrophyMergeProgressListener $progressListener = null
     ): string
     {
+        $method = TrophyMergeMethod::fromMixed($method);
         $childNpCommunicationId = $this->getGameNpCommunicationId($childGameId);
 
         if (str_starts_with($childNpCommunicationId, 'MERGE')) {
@@ -124,21 +126,22 @@ class TrophyMergeService
             $progressListener,
             &$message
         ): void {
-            $this->notifyProgress($progressListener, 30, match ($method) {
-                'name' => 'Matching trophies by name…',
-                'icon' => 'Matching trophies by icon…',
-                'order' => 'Matching trophies by list order…',
-                default => throw new InvalidArgumentException('Wrong input'),
-            });
+            $this->notifyProgress($progressListener, 30, $method->progressLabel());
 
-            if ($method === 'order') {
-                $this->mappingService()->insertMappingsByOrder($childGameId, $parentGameId);
-            } else {
-                $message .= match ($method) {
-                    'name' => $this->mappingService()->insertMappingsByName($childGameId, $parentGameId),
-                    'icon' => $this->mappingService()->insertMappingsByIcon($childGameId, $parentGameId),
-                };
-            }
+            match ($method) {
+                TrophyMergeMethod::Order => $this->mappingService()->insertMappingsByOrder(
+                    $childGameId,
+                    $parentGameId
+                ),
+                TrophyMergeMethod::Name => $message .= $this->mappingService()->insertMappingsByName(
+                    $childGameId,
+                    $parentGameId
+                ),
+                TrophyMergeMethod::Icon => $message .= $this->mappingService()->insertMappingsByIcon(
+                    $childGameId,
+                    $parentGameId
+                ),
+            };
 
             $this->notifyProgress($progressListener, 55, 'Trophy mappings saved.');
             $this->notifyProgress($progressListener, 60, 'Preparing to mark child game as merged…');

--- a/wwwroot/classes/TrophySetComparator.php
+++ b/wwwroot/classes/TrophySetComparator.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/TrophyMergeMethod.php';
+
 /**
  * Compares two trophy sets to decide whether automatic title merges are safe.
  */
@@ -38,14 +40,15 @@ final class TrophySetComparator
     /**
      * @param array{matches:bool, orderMatches:bool, nameMatches:bool} $comparison
      */
-    public function selectMergeMethod(array $comparison): ?string
+    #[\NoDiscard]
+    public function selectMergeMethod(array $comparison): ?TrophyMergeMethod
     {
         if ($comparison['orderMatches']) {
-            return 'order';
+            return TrophyMergeMethod::Order;
         }
 
         if ($comparison['nameMatches']) {
-            return 'name';
+            return TrophyMergeMethod::Name;
         }
 
         return null;
@@ -64,16 +67,14 @@ final class TrophySetComparator
             $lookup[$key] = $this->createTrophyKey($trophy['name'], $trophy['detail']);
         }
 
-        foreach ($right as $trophy) {
-            $key = $this->createOrderKey($trophy['group_id'], $trophy['order_id']);
-            $value = $this->createTrophyKey($trophy['name'], $trophy['detail']);
+        return array_all(
+            $right,
+            function (array $trophy) use ($lookup): bool {
+                $key = $this->createOrderKey($trophy['group_id'], $trophy['order_id']);
 
-            if (!isset($lookup[$key]) || $lookup[$key] !== $value) {
-                return false;
+                return ($lookup[$key] ?? null) === $this->createTrophyKey($trophy['name'], $trophy['detail']);
             }
-        }
-
-        return true;
+        );
     }
 
     /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continue the PHP 8.5 modernization work by replacing remaining magic merge-method strings (`order` / `name` / `icon`) with a typed backed enum.

- Add `TrophyMergeMethod` with `tryFromMixed()` / `fromMixed()` parsers (pipe-normalized) and `progressLabel()`
- Thread the enum through `TrophySetComparator`, `TrophyMergeService`, admin merge request handlers/processor, and `AutomaticTrophyTitleMergeService`
- Use `GameAvailabilityStatus` for merged/normal eligibility checks in automatic merges
- Use `array_all()` for trophy order matching in `TrophySetComparator`

## Tests

- `php tests/run.php` — all 995 tests passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc83d937-8d09-42ef-b579-92d2664e62c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc83d937-8d09-42ef-b579-92d2664e62c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

