### PR TITLE
Adopt remaining PHP 8.5 idioms for request bools, pipes, and escaping

### DIFF
--- a/tests/GameTrophyFilterTest.php
+++ b/tests/GameTrophyFilterTest.php
@@ -116,11 +116,11 @@ final class GameTrophyFilterTest extends TestCase
         $this->assertFalse($filter->shouldDisplayTrophy($earnedTrophy));
     }
 
-    public function testFromQueryParametersTreatsUnexpectedTypesAsTruthy(): void
+    public function testFromQueryParametersTreatsUnexpectedTypesAsFalsy(): void
     {
         $filter = GameTrophyFilter::fromQueryParameters(['unearned' => ['unexpected']], true);
 
-        $this->assertTrue($filter->shouldShowUnearnedOnly());
+        $this->assertFalse($filter->shouldShowUnearnedOnly());
     }
 
     private function createGroupPlayer(array $overrides = []): GameTrophyGroupPlayer

--- a/tests/HomepagePopularGamesFilterTest.php
+++ b/tests/HomepagePopularGamesFilterTest.php
@@ -47,6 +47,18 @@ final class HomepagePopularGamesFilterTest extends TestCase
         $this->assertSame(['exclusive' => 'true'], $filter->getQueryParameters());
     }
 
+    public function testFromArrayTreatsExclusiveFalseAsDisabled(): void
+    {
+        $filter = HomepagePopularGamesFilter::fromArray([
+            'platform' => 'ps4',
+            'exclusive' => 'false',
+        ]);
+
+        $this->assertTrue($filter->isPlatformSelected(HomepagePopularGamesFilter::PLATFORM_PS4));
+        $this->assertFalse($filter->isExclusiveOnly());
+        $this->assertSame(['platform' => 'ps4'], $filter->getQueryParameters());
+    }
+
     public function testGetPlatformOptionsListsAllFirstThenAlphabeticalPlatforms(): void
     {
         $this->assertSame(

--- a/tests/PlayerAdvisorFilterTest.php
+++ b/tests/PlayerAdvisorFilterTest.php
@@ -25,6 +25,7 @@ final class PlayerAdvisorFilterTest extends TestCase
             'ps4' => '',
             'ps5' => 'true',
             'pc' => 'yes',
+            'psvr' => 'false',
             'unknown' => 'true',
         ]);
 
@@ -35,6 +36,7 @@ final class PlayerAdvisorFilterTest extends TestCase
         $this->assertTrue($filter->isPlatformSelected('ps3'));
         $this->assertTrue($filter->isPlatformSelected('ps5'));
         $this->assertFalse($filter->isPlatformSelected('ps4'));
+        $this->assertFalse($filter->isPlatformSelected('psvr'));
         $this->assertFalse($filter->isPlatformSelected('unknown'));
     }
 

--- a/tests/RequestParameterTest.php
+++ b/tests/RequestParameterTest.php
@@ -30,4 +30,24 @@ final class RequestParameterTest extends TestCase
     {
         $this->assertSame(null, RequestParameter::lastScalar([]));
     }
+
+    public function testToBoolTreatsCommonTruthyValuesAsTrue(): void
+    {
+        foreach ([true, 1, '1', 'true', 'yes', 'on', ' TRUE '] as $value) {
+            $this->assertTrue(
+                RequestParameter::toBool($value),
+                sprintf('Expected %s to be truthy.', var_export($value, true))
+            );
+        }
+    }
+
+    public function testToBoolTreatsCommonFalsyValuesAsFalse(): void
+    {
+        foreach ([null, false, 0, '0', 'false', 'off', 'no', '', '  False  ', []] as $value) {
+            $this->assertFalse(
+                RequestParameter::toBool($value),
+                sprintf('Expected %s to be falsy.', var_export($value, true))
+            );
+        }
+    }
 }

--- a/wwwroot/classes/AboutPagePlayerArraySerializer.php
+++ b/wwwroot/classes/AboutPagePlayerArraySerializer.php
@@ -37,16 +37,12 @@ final class AboutPagePlayerArraySerializer
      */
     public static function serializeCollection(array $players): array
     {
-        $serializedPlayers = [];
-
-        foreach ($players as $player) {
-            if (!$player instanceof AboutPagePlayer) {
-                continue;
-            }
-
-            $serializedPlayers[] = self::serialize($player);
-        }
-
-        return $serializedPlayers;
+        return $players
+            |> (fn (array $players): array => array_filter(
+                $players,
+                static fn (mixed $player): bool => $player instanceof AboutPagePlayer,
+            ))
+            |> (fn (array $players): array => array_map(self::serialize(...), $players))
+            |> array_values(...);
     }
 }

--- a/wwwroot/classes/Admin/AdminBootstrap.php
+++ b/wwwroot/classes/Admin/AdminBootstrap.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../CsrfTokenManager.php';
 require_once __DIR__ . '/../SessionManager.php';
+require_once __DIR__ . '/../Html.php';
 require_once __DIR__ . '/AdminAuthService.php';
 require_once __DIR__ . '/AdminLoginThrottleService.php';
 require_once __DIR__ . '/AdminUserRepository.php';
@@ -51,7 +52,7 @@ final class AdminBootstrap
 
     public static function renderCsrfMetaTag(): void
     {
-        $token = htmlspecialchars(self::getCsrfToken(), ENT_QUOTES, 'UTF-8');
+        $token = Html::escape(self::getCsrfToken());
         echo '<meta name="csrf-token" content="' . $token . '">';
     }
 

--- a/wwwroot/classes/Admin/DeletePlayerRequestHandler.php
+++ b/wwwroot/classes/Admin/DeletePlayerRequestHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/AdminRequest.php';
 require_once __DIR__ . '/DeletePlayerRequestResult.php';
 require_once __DIR__ . '/DeletePlayerService.php';
+require_once __DIR__ . '/../Html.php';
 
 final class DeletePlayerRequestHandler
 {
@@ -85,6 +86,6 @@ final class DeletePlayerRequestHandler
 
     private function escape(string $value): string
     {
-        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+        return Html::escape($value);
     }
 }

--- a/wwwroot/classes/Admin/GameDetailFormParser.php
+++ b/wwwroot/classes/Admin/GameDetailFormParser.php
@@ -72,9 +72,7 @@ final class GameDetailFormParser
             return '';
         }
 
-        $trimmed = trim($value);
-
-        return $trimmed === '' ? '' : strtolower($trimmed);
+        return $value |> trim(...) |> strtolower(...);
     }
 
     public function parseStatus(mixed $value): ?GameAvailabilityStatus

--- a/wwwroot/classes/Admin/LogEntryFormatter.php
+++ b/wwwroot/classes/Admin/LogEntryFormatter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../PlayerUrlBuilder.php';
 require_once __DIR__ . '/../Utility.php';
+require_once __DIR__ . '/../Html.php';
 
 final class LogEntryFormatter
 {
@@ -181,14 +182,14 @@ final class LogEntryFormatter
     {
         return sprintf(
             '<a href="%s">%s</a>',
-            htmlspecialchars($url, ENT_QUOTES, 'UTF-8'),
-            htmlspecialchars($displayText, ENT_QUOTES, 'UTF-8')
+            Html::escape($url),
+            Html::escape($displayText)
         );
     }
 
     private function escape(string $text): string
     {
-        return htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+        return Html::escape($text);
     }
 
     private function createSlug(?string $name): string

--- a/wwwroot/classes/Admin/TrophyGroupConflictResolver.php
+++ b/wwwroot/classes/Admin/TrophyGroupConflictResolver.php
@@ -31,19 +31,21 @@ final class TrophyGroupConflictResolver
      */
     public function determinePreferredGroupOffset(array $existingGroupMappings): ?int
     {
-        foreach ($existingGroupMappings as $parentGroupId) {
-            $numericGroupId = $this->parseNumericGroupId($parentGroupId);
+        $parentGroupId = array_find(
+            $existingGroupMappings,
+            fn (string $id): bool => $this->parseNumericGroupId($id) !== null,
+        );
 
-            if ($numericGroupId === null) {
-                continue;
-            }
-
-            $block = intdiv($numericGroupId, 100);
-
-            return $block * 100;
+        if ($parentGroupId === null) {
+            return null;
         }
 
-        return null;
+        $numericGroupId = $this->parseNumericGroupId($parentGroupId);
+        if ($numericGroupId === null) {
+            return null;
+        }
+
+        return intdiv($numericGroupId, 100) * 100;
     }
 
     /**

--- a/wwwroot/classes/Admin/TrophyStatusPage.php
+++ b/wwwroot/classes/Admin/TrophyStatusPage.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/TrophyStatusInputParser.php';
 require_once __DIR__ . '/TrophyStatusService.php';
 require_once __DIR__ . '/TrophyStatusUpdateResultPresenter.php';
 require_once __DIR__ . '/../TrophyMetaStatus.php';
+require_once __DIR__ . '/../Html.php';
 
 final readonly class TrophyStatusPageResult
 {
@@ -82,7 +83,7 @@ final readonly class TrophyStatusPage
                 $result = $this->trophyStatusService->updateTrophies($trophyIds, $status);
                 $message = $this->trophyStatusUpdateResultPresenter->renderToHtml($result);
             } catch (\Throwable $exception) {
-                $message = '<p>' . htmlspecialchars($exception->getMessage(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</p>';
+                $message = '<p>' . Html::escape($exception->getMessage()) . '</p>';
             }
         } else {
             if (array_key_exists('trophy', $queryData)) {

--- a/wwwroot/classes/Cron/PlayerCountryResolver.php
+++ b/wwwroot/classes/Cron/PlayerCountryResolver.php
@@ -37,7 +37,7 @@ final class PlayerCountryResolver
             return null;
         }
 
-        return strtolower(substr($trimmed, -2));
+        return substr($trimmed, -2) |> strtolower(...);
     }
 
     public function resolveCountry(

--- a/wwwroot/classes/CsrfTokenManager.php
+++ b/wwwroot/classes/CsrfTokenManager.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/SessionManager.php';
+require_once __DIR__ . '/Html.php';
 
 final class CsrfTokenManager
 {
@@ -44,7 +45,7 @@ final class CsrfTokenManager
 
     public static function hiddenField(string $scope): string
     {
-        $token = htmlspecialchars(self::getToken($scope), ENT_QUOTES, 'UTF-8');
+        $token = Html::escape(self::getToken($scope));
 
         return '<input type="hidden" name="_csrf_token" value="' . $token . '">';
     }

--- a/wwwroot/classes/FooterRenderer.php
+++ b/wwwroot/classes/FooterRenderer.php
@@ -3,19 +3,20 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/FooterViewModel.php';
+require_once __DIR__ . '/Html.php';
 
 final class FooterRenderer
 {
     public function render(FooterViewModel $viewModel): string
     {
-        $yearRangeLabel = htmlspecialchars($viewModel->getYearRangeLabel(), ENT_QUOTES, 'UTF-8');
-        $releaseUrl = htmlspecialchars($viewModel->getReleaseUrl(), ENT_QUOTES, 'UTF-8');
-        $versionLabel = htmlspecialchars($viewModel->getVersionLabel(), ENT_QUOTES, 'UTF-8');
-        $changelogUrl = htmlspecialchars($viewModel->getChangelogUrl(), ENT_QUOTES, 'UTF-8');
-        $issuesUrl = htmlspecialchars($viewModel->getIssuesUrl(), ENT_QUOTES, 'UTF-8');
-        $creatorProfileUrl = htmlspecialchars($viewModel->getCreatorProfileUrl(), ENT_QUOTES, 'UTF-8');
-        $creatorName = htmlspecialchars($viewModel->getCreatorName(), ENT_QUOTES, 'UTF-8');
-        $contributorsUrl = htmlspecialchars($viewModel->getContributorsUrl(), ENT_QUOTES, 'UTF-8');
+        $yearRangeLabel = Html::escape($viewModel->getYearRangeLabel());
+        $releaseUrl = Html::escape($viewModel->getReleaseUrl());
+        $versionLabel = Html::escape($viewModel->getVersionLabel());
+        $changelogUrl = Html::escape($viewModel->getChangelogUrl());
+        $issuesUrl = Html::escape($viewModel->getIssuesUrl());
+        $creatorProfileUrl = Html::escape($viewModel->getCreatorProfileUrl());
+        $creatorName = Html::escape($viewModel->getCreatorName());
+        $contributorsUrl = Html::escape($viewModel->getContributorsUrl());
 
         return <<<HTML
         <footer class="container">

--- a/wwwroot/classes/Game/GameTrophyRow.php
+++ b/wwwroot/classes/Game/GameTrophyRow.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../Utility.php';
 require_once __DIR__ . '/../TrophyType.php';
 require_once __DIR__ . '/../TrophyMetaStatus.php';
+require_once __DIR__ . '/../Html.php';
 
 final readonly class GameTrophyRow
 {
@@ -207,7 +208,7 @@ final readonly class GameTrophyRow
 
         if ($this->isUnobtainable()) {
             $attributes[] = 'class="table-warning"';
-            $attributes[] = 'title="' . htmlspecialchars(self::UNOBTAINABLE_TITLE, ENT_QUOTES, 'UTF-8') . '"';
+            $attributes[] = 'title="' . Html::escape(self::UNOBTAINABLE_TITLE) . '"';
         } elseif ($accountId !== null && $this->isEarned) {
             $attributes[] = 'class="table-success"';
         }

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -272,17 +272,13 @@ class GameHeaderService
             return [];
         }
 
-        $psnprofilesIds = [];
-        foreach ($rows as $psnprofilesId) {
-            $stringValue = (string) $psnprofilesId;
-            if ($stringValue === '' || !ctype_digit($stringValue)) {
-                continue;
-            }
-
-            $psnprofilesIds[] = (int) $stringValue;
-        }
-
-        return $psnprofilesIds
+        return $rows
+            |> (fn (array $rows): array => array_map(strval(...), $rows))
+            |> (fn (array $rows): array => array_filter(
+                $rows,
+                static fn (string $value): bool => $value !== '' && ctype_digit($value),
+            ))
+            |> (fn (array $rows): array => array_map(intval(...), $rows))
             |> array_unique(...)
             |> array_values(...);
     }

--- a/wwwroot/classes/GameHistoryPage.php
+++ b/wwwroot/classes/GameHistoryPage.php
@@ -120,6 +120,7 @@ final class GameHistoryPage
         return $this->historyEntries;
     }
 
+    #[\NoDiscard]
     public function createMetaData(): PageMetaData
     {
         return (new PageMetaData())

--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -49,6 +49,7 @@ final readonly class GameLeaderboardFilter extends GamePlayerFilter
      * @return array<string, int|string>
      */
     #[\Override]
+    #[\NoDiscard]
     public function toQueryParameters(): array
     {
         $parameters = parent::getFilterParameters();

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/GameListSort.php';
+require_once __DIR__ . '/RequestParameter.php';
 
 final readonly class GameListFilter
 {
@@ -53,11 +54,11 @@ final readonly class GameListFilter
         $search = self::sanitizeString($queryParameters['search'] ?? null);
         $page = self::sanitizePage($queryParameters['page'] ?? null);
         $sort = self::normalizeSort($queryParameters['sort'] ?? null, $search, $sortSpecified);
-        $uncompletedOnly = self::toBool($queryParameters['filter'] ?? null);
+        $uncompletedOnly = RequestParameter::toBool($queryParameters['filter'] ?? null);
 
         $platformFilters = [];
         foreach (Platform::values() as $platform) {
-            $platformFilters[$platform] = self::toBool($queryParameters[$platform] ?? null);
+            $platformFilters[$platform] = RequestParameter::toBool($queryParameters[$platform] ?? null);
         }
 
         return new self(
@@ -167,15 +168,10 @@ final readonly class GameListFilter
      */
     public function getSelectedPlatforms(): array
     {
-        $platforms = [];
-
-        foreach (Platform::values() as $platform) {
-            if ($this->platformFilters[$platform]) {
-                $platforms[] = $platform;
-            }
-        }
-
-        return $platforms;
+        return array_keys(array_filter(
+            $this->platformFilters,
+            static fn (bool $selected): bool => $selected,
+        ));
     }
 
     /**
@@ -301,32 +297,5 @@ final readonly class GameListFilter
             GameListSort::Search => ($search !== '' || $sortSpecified) ? GameListSort::Search : GameListSort::Added,
             null => $search !== '' ? GameListSort::Search : GameListSort::Added,
         };
-    }
-
-    private static function toBool(mixed $value): bool
-    {
-        if ($value === null) {
-            return false;
-        }
-
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return $value !== 0;
-        }
-
-        if (is_string($value)) {
-            $value = $value |> trim(...) |> strtolower(...);
-
-            if ($value === '' || $value === 'false' || $value === '0') {
-                return false;
-            }
-
-            return true;
-        }
-
-        return false;
     }
 }

--- a/wwwroot/classes/GamePage.php
+++ b/wwwroot/classes/GamePage.php
@@ -196,6 +196,7 @@ class GamePage
         );
     }
 
+    #[\NoDiscard]
     public function createMetaData(): PageMetaData
     {
         return (new PageMetaData())

--- a/wwwroot/classes/GamePlayerFilter.php
+++ b/wwwroot/classes/GamePlayerFilter.php
@@ -67,6 +67,7 @@ readonly class GamePlayerFilter
     /**
      * @return array<string, string>
      */
+    #[\NoDiscard]
     public function toQueryParameters(): array
     {
         return $this->getFilterParameters();

--- a/wwwroot/classes/GameTrophyFilter.php
+++ b/wwwroot/classes/GameTrophyFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/Game/GameTrophyGroupPlayer.php';
 require_once __DIR__ . '/Game/GameTrophyRow.php';
+require_once __DIR__ . '/RequestParameter.php';
 
 final readonly class GameTrophyFilter
 {
@@ -21,7 +22,7 @@ final readonly class GameTrophyFilter
             return new self(false);
         }
 
-        $unearnedOnly = self::resolveBoolean($queryParameters['unearned'] ?? null);
+        $unearnedOnly = RequestParameter::toBool($queryParameters['unearned'] ?? null);
 
         return new self($unearnedOnly);
     }
@@ -54,32 +55,5 @@ final readonly class GameTrophyFilter
         }
 
         return (int) ($trophy['earned'] ?? 0) !== 1;
-    }
-
-    private static function resolveBoolean(mixed $value): bool
-    {
-        if ($value === null) {
-            return false;
-        }
-
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return $value !== 0;
-        }
-
-        if (is_string($value)) {
-            $normalized = $value |> trim(...) |> strtolower(...);
-
-            if ($normalized === '' || in_array($normalized, ['0', 'false', 'off', 'no'], true)) {
-                return false;
-            }
-
-            return true;
-        }
-
-        return true;
     }
 }

--- a/wwwroot/classes/HomepagePopularGamesFilter.php
+++ b/wwwroot/classes/HomepagePopularGamesFilter.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Platform.php';
+require_once __DIR__ . '/RequestParameter.php';
 
 final readonly class HomepagePopularGamesFilter
 {
@@ -28,7 +29,7 @@ final readonly class HomepagePopularGamesFilter
     public static function fromArray(array $queryParameters): self
     {
         $platform = self::normalizePlatform($queryParameters['platform'] ?? null);
-        $exclusiveOnly = self::toBool($queryParameters['exclusive'] ?? null);
+        $exclusiveOnly = RequestParameter::toBool($queryParameters['exclusive'] ?? null);
 
         return new self($platform, $exclusiveOnly);
     }
@@ -95,30 +96,4 @@ final readonly class HomepagePopularGamesFilter
         return Platform::tryFrom($platform)?->value ?? self::PLATFORM_ALL;
     }
 
-    private static function toBool(mixed $value): bool
-    {
-        if ($value === null) {
-            return false;
-        }
-
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return $value !== 0;
-        }
-
-        if (is_string($value)) {
-            $value = $value |> trim(...) |> strtolower(...);
-
-            if ($value === '' || $value === 'false' || $value === '0') {
-                return false;
-            }
-
-            return true;
-        }
-
-        return false;
-    }
 }

--- a/wwwroot/classes/MaintenancePageRenderer.php
+++ b/wwwroot/classes/MaintenancePageRenderer.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/MaintenancePage.php';
+require_once __DIR__ . '/Html.php';
 
 final class MaintenancePageRenderer
 {
@@ -78,6 +79,6 @@ HTML
 
     private function escape(string $value): string
     {
-        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+        return Html::escape($value);
     }
 }

--- a/wwwroot/classes/NavigationBarRenderer.php
+++ b/wwwroot/classes/NavigationBarRenderer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/NavigationState.php';
 require_once __DIR__ . '/NavigationMenu.php';
+require_once __DIR__ . '/Html.php';
 
 final class NavigationBarRenderer
 {
@@ -65,9 +66,9 @@ HTML;
         $items = [];
 
         foreach ($this->menu->getItems() as $item) {
-            $linkClass = htmlspecialchars($item->getLinkCssClass(), ENT_QUOTES, 'UTF-8');
-            $href = htmlspecialchars($item->getHref(), ENT_QUOTES, 'UTF-8');
-            $label = htmlspecialchars($item->getLabel(), ENT_QUOTES, 'UTF-8');
+            $linkClass = Html::escape($item->getLinkCssClass());
+            $href = Html::escape($item->getHref());
+            $label = Html::escape($item->getLabel());
             $ariaAttribute = $this->renderAriaAttribute($item->getAriaCurrentValue());
 
             $items[] = sprintf(
@@ -88,7 +89,7 @@ HTML;
             return '';
         }
 
-        $value = htmlspecialchars($ariaCurrent, ENT_QUOTES, 'UTF-8');
+        $value = Html::escape($ariaCurrent);
 
         return ' aria-current="' . $value . '"';
     }

--- a/wwwroot/classes/NavigationState.php
+++ b/wwwroot/classes/NavigationState.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/NavigationSection.php';
 require_once __DIR__ . '/NavigationSectionState.php';
 require_once __DIR__ . '/RequestParameter.php';
+require_once __DIR__ . '/Html.php';
 
 final readonly class NavigationState
 {
@@ -135,7 +136,7 @@ final readonly class NavigationState
     {
         $value = RequestParameter::firstScalar($value) ?? '';
 
-        return htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
+        return Html::escape((string) $value);
     }
 
     private static function resolveActiveSection(string $requestPath): NavigationSection

--- a/wwwroot/classes/PageMetaDataRenderer.php
+++ b/wwwroot/classes/PageMetaDataRenderer.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PageMetaData.php';
+require_once __DIR__ . '/Html.php';
 
 class PageMetaDataRenderer
 {
@@ -52,6 +53,6 @@ class PageMetaDataRenderer
             return null;
         }
 
-        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+        return Html::escape($value);
     }
 }

--- a/wwwroot/classes/PaginationItem.php
+++ b/wwwroot/classes/PaginationItem.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Html.php';
+
 final readonly class PaginationItem
 {
     private function __construct(
@@ -71,7 +73,7 @@ final readonly class PaginationItem
         }
 
         if ($this->ariaLabel !== null && $this->ariaLabel !== '') {
-            $attributes[] = 'aria-label="' . htmlspecialchars($this->ariaLabel, ENT_QUOTES, 'UTF-8') . '"';
+            $attributes[] = 'aria-label="' . Html::escape($this->ariaLabel) . '"';
         }
 
         if ($this->disabled) {
@@ -83,9 +85,9 @@ final readonly class PaginationItem
             ? ''
             : ' ' . implode(' ', $attributes);
 
-        $label = htmlspecialchars($this->label, ENT_QUOTES, 'UTF-8');
-        $href = htmlspecialchars($href, ENT_QUOTES, 'UTF-8');
-        $classAttribute = htmlspecialchars(implode(' ', $classNames), ENT_QUOTES, 'UTF-8');
+        $label = Html::escape($this->label);
+        $href = Html::escape($href);
+        $classAttribute = Html::escape(implode(' ', $classNames));
 
         return '<li class="' . $classAttribute . '"><a class="page-link" href="' . $href . '"'
             . $attributesString . '>' . $label . '</a></li>';

--- a/wwwroot/classes/PaginationRenderer.php
+++ b/wwwroot/classes/PaginationRenderer.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Pagination.php';
+require_once __DIR__ . '/Html.php';
 
 /**
  * Responsible for rendering Bootstrap pagination controls that match the site's
@@ -24,7 +25,7 @@ class PaginationRenderer
         $navAttributes = '';
 
         if ($ariaLabel !== null && $ariaLabel !== '') {
-            $navAttributes = ' aria-label="' . htmlspecialchars($ariaLabel, ENT_QUOTES, 'UTF-8') . '"';
+            $navAttributes = ' aria-label="' . Html::escape($ariaLabel) . '"';
         }
 
         $buildUrl = static function (int $page) use ($queryParametersFactory): string {

--- a/wwwroot/classes/PlayerAdvisorFilter.php
+++ b/wwwroot/classes/PlayerAdvisorFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/PlayerAdvisorSort.php';
+require_once __DIR__ . '/RequestParameter.php';
 
 final readonly class PlayerAdvisorFilter
 {
@@ -35,7 +36,7 @@ final readonly class PlayerAdvisorFilter
 
         $platforms = [];
         foreach (Platform::values() as $platform) {
-            if (!empty($parameters[$platform])) {
+            if (RequestParameter::toBool($parameters[$platform] ?? null)) {
                 $platforms[] = $platform;
             }
         }

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/PlayerGamesSort.php';
+require_once __DIR__ . '/RequestParameter.php';
 
 final readonly class PlayerGamesFilter
 {
@@ -54,8 +55,8 @@ final readonly class PlayerGamesFilter
         $sort = $parsedSort
             ?? ($search !== '' ? PlayerGamesSort::Search : PlayerGamesSort::Date);
 
-        $completed = !empty($parameters['completed']);
-        $uncompleted = !empty($parameters['uncompleted']);
+        $completed = RequestParameter::toBool($parameters['completed'] ?? null);
+        $uncompleted = RequestParameter::toBool($parameters['uncompleted'] ?? null);
 
         if ($completed && $uncompleted) {
             // Selecting both checkboxes should behave like no completion filter at all.
@@ -65,7 +66,7 @@ final readonly class PlayerGamesFilter
 
         $platforms = [];
         foreach (Platform::values() as $platformKey) {
-            if (!empty($parameters[$platformKey])) {
+            if (RequestParameter::toBool($parameters[$platformKey] ?? null)) {
                 $platforms[] = $platformKey;
             }
         }
@@ -79,7 +80,7 @@ final readonly class PlayerGamesFilter
             $sort,
             $completed,
             $uncompleted,
-            !empty($parameters['base']),
+            RequestParameter::toBool($parameters['base'] ?? null),
             $platforms,
             max($page, 1),
             self::DEFAULT_LIMIT,
@@ -202,6 +203,7 @@ final readonly class PlayerGamesFilter
     /**
      * @return array<string, int|string>
      */
+    #[\NoDiscard]
     public function toQueryParameters(): array
     {
         return $this->withPage($this->page);

--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -52,6 +52,7 @@ final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
      * @return array<string, int|string>
      */
     #[\Override]
+    #[\NoDiscard]
     public function toQueryParameters(): array
     {
         return $this->withPage($this->page);

--- a/wwwroot/classes/PlayerLogFilter.php
+++ b/wwwroot/classes/PlayerLogFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/PlayerLogSort.php';
+require_once __DIR__ . '/RequestParameter.php';
 
 final readonly class PlayerLogFilter
 {
@@ -29,7 +30,7 @@ final readonly class PlayerLogFilter
 
         $platforms = [];
         foreach (Platform::values() as $platform) {
-            if (!empty($parameters[$platform])) {
+            if (RequestParameter::toBool($parameters[$platform] ?? null)) {
                 $platforms[] = $platform;
             }
         }
@@ -98,6 +99,7 @@ final readonly class PlayerLogFilter
     /**
      * @return array<string, int|string>
      */
+    #[\NoDiscard]
     public function toQueryParameters(): array
     {
         return $this->withPage($this->page);

--- a/wwwroot/classes/PlayerNavigationRenderer.php
+++ b/wwwroot/classes/PlayerNavigationRenderer.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerNavigation.php';
+require_once __DIR__ . '/Html.php';
 
 final class PlayerNavigationRenderer
 {
@@ -24,9 +25,9 @@ HTML;
 
     private function renderLink(PlayerNavigationLink $link): string
     {
-        $cssClass = htmlspecialchars($link->getButtonCssClass() . ' d-flex align-items-center justify-content-center', ENT_QUOTES, 'UTF-8');
-        $url = htmlspecialchars($link->getUrl(), ENT_QUOTES, 'UTF-8');
-        $label = htmlspecialchars($link->getLabel(), ENT_QUOTES, 'UTF-8');
+        $cssClass = Html::escape($link->getButtonCssClass() . ' d-flex align-items-center justify-content-center');
+        $url = Html::escape($link->getUrl());
+        $label = Html::escape($link->getLabel());
         $ariaAttribute = $this->renderAriaAttribute($link->getAriaCurrent());
 
         return sprintf(
@@ -44,7 +45,7 @@ HTML;
             return '';
         }
 
-        $value = htmlspecialchars($ariaCurrent, ENT_QUOTES, 'UTF-8');
+        $value = Html::escape($ariaCurrent);
 
         return ' aria-current="' . $value . '"';
     }

--- a/wwwroot/classes/PlayerPlatformFilterRenderer.php
+++ b/wwwroot/classes/PlayerPlatformFilterRenderer.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
+require_once __DIR__ . '/Html.php';
 
 final class PlayerPlatformFilterRenderer
 {
@@ -36,7 +37,7 @@ HTML;
 
     public function renderDropdownControls(PlayerPlatformFilterOptions $options): string
     {
-        $buttonLabel = htmlspecialchars($this->buttonLabel, ENT_QUOTES, 'UTF-8');
+        $buttonLabel = Html::escape($this->buttonLabel);
         $optionItems = $this->renderOptionItems($options);
 
         return <<<HTML
@@ -61,9 +62,9 @@ HTML;
 
     private function renderOption(PlayerPlatformFilterOption $option): string
     {
-        $inputId = htmlspecialchars($option->getInputId(), ENT_QUOTES, 'UTF-8');
-        $inputName = htmlspecialchars($option->getInputName(), ENT_QUOTES, 'UTF-8');
-        $label = htmlspecialchars($option->getLabel(), ENT_QUOTES, 'UTF-8');
+        $inputId = Html::escape($option->getInputId());
+        $inputName = Html::escape($option->getInputName());
+        $label = Html::escape($option->getLabel());
         $checkedAttribute = $option->isSelected() ? ' checked' : '';
 
         return <<<HTML
@@ -95,8 +96,8 @@ HTML;
         foreach ($hiddenInputs as $name => $value) {
             $inputs[] = sprintf(
                 '<input type="hidden" name="%s" value="%s">',
-                htmlspecialchars($name, ENT_QUOTES, 'UTF-8'),
-                htmlspecialchars($value, ENT_QUOTES, 'UTF-8')
+                Html::escape($name),
+                Html::escape($value)
             );
         }
 

--- a/wwwroot/classes/PlayerRandomGamesFilter.php
+++ b/wwwroot/classes/PlayerRandomGamesFilter.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Platform.php';
+require_once __DIR__ . '/RequestParameter.php';
 
 final readonly class PlayerRandomGamesFilter
 {
@@ -32,33 +33,10 @@ final readonly class PlayerRandomGamesFilter
     {
         $selectedPlatforms = [];
         foreach (Platform::values() as $platformKey) {
-            $selectedPlatforms[$platformKey] = self::toBool($parameters[$platformKey] ?? null);
+            $selectedPlatforms[$platformKey] = RequestParameter::toBool($parameters[$platformKey] ?? null);
         }
 
         return new self($selectedPlatforms);
-    }
-
-    private static function toBool(mixed $value): bool
-    {
-        if ($value === null) {
-            return false;
-        }
-
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return $value !== 0;
-        }
-
-        if (!is_string($value) && !is_numeric($value)) {
-            return false;
-        }
-
-        $normalized = ((string) $value) |> trim(...) |> strtolower(...);
-
-        return !in_array($normalized, ['', '0', 'false', 'off', 'no'], true);
     }
 
     public function isPlatformSelected(string $platform): bool

--- a/wwwroot/classes/PlayerReportResult.php
+++ b/wwwroot/classes/PlayerReportResult.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Html.php';
+
 final readonly class PlayerReportResult
 {
     private function __construct(private bool $hasMessage, private bool $success, private string $message)
@@ -43,6 +45,6 @@ final readonly class PlayerReportResult
 
     public function getEscapedMessage(): string
     {
-        return htmlspecialchars($this->message, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        return Html::escape($this->message);
     }
 }

--- a/wwwroot/classes/PlayerStatusNotice.php
+++ b/wwwroot/classes/PlayerStatusNotice.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerStatusNoticeType.php';
+require_once __DIR__ . '/Html.php';
 
 final readonly class PlayerStatusNotice
 {
@@ -20,7 +21,7 @@ final readonly class PlayerStatusNotice
         $disputeUrl = self::createDisputeUrl($onlineId, $accountId);
         $message = sprintf(
             "This player has some funny looking trophy data. This doesn't necessarily mean cheating, but all data from this player will be excluded from site statistics and leaderboards. <a href=\"%s\">Dispute</a>?",
-            htmlspecialchars($disputeUrl, ENT_QUOTES, 'UTF-8')
+            Html::escape($disputeUrl)
         );
 
         return new self(PlayerStatusNoticeType::Flagged, $message);
@@ -31,7 +32,7 @@ final readonly class PlayerStatusNotice
     {
         $message = sprintf(
             'This player seems to have a <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="%s">private</a> profile.',
-            htmlspecialchars(self::PRIVATE_PROFILE_URL, ENT_QUOTES, 'UTF-8')
+            Html::escape(self::PRIVATE_PROFILE_URL)
         );
 
         return new self(PlayerStatusNoticeType::Private, $message);

--- a/wwwroot/classes/RequestParameter.php
+++ b/wwwroot/classes/RequestParameter.php
@@ -21,4 +21,34 @@ final class RequestParameter
 
         return $value;
     }
+
+    /**
+     * Parse common request/query boolean representations.
+     *
+     * Treats empty strings and the values "0", "false", "off", and "no"
+     * (case-insensitive) as false. Unexpected non-scalar types are false.
+     */
+    #[\NoDiscard]
+    public static function toBool(mixed $value): bool
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value !== 0;
+        }
+
+        if (!is_string($value) && !is_numeric($value)) {
+            return false;
+        }
+
+        $normalized = ((string) $value) |> trim(...) |> strtolower(...);
+
+        return !in_array($normalized, ['', '0', 'false', 'off', 'no'], true);
+    }
 }

--- a/wwwroot/classes/TrophyListFilter.php
+++ b/wwwroot/classes/TrophyListFilter.php
@@ -47,6 +47,7 @@ final readonly class TrophyListFilter
     /**
      * @return array<string, int>
      */
+    #[\NoDiscard]
     public function toQueryParameters(): array
     {
         return $this->withPage($this->page);

--- a/wwwroot/classes/TrophyListService.php
+++ b/wwwroot/classes/TrophyListService.php
@@ -69,9 +69,6 @@ class TrophyListService
         /** @var array<int, array<string, mixed>> $trophies */
         $trophies = $query->fetchAll(PDO::FETCH_ASSOC);
 
-        return array_map(
-            static fn (array $trophy): TrophyListItem => TrophyListItem::fromArray($trophy),
-            $trophies
-        );
+        return array_map(TrophyListItem::fromArray(...), $trophies);
     }
 }

--- a/wwwroot/classes/Utility.php
+++ b/wwwroot/classes/Utility.php
@@ -13,6 +13,7 @@ class Utility
         . '[:Separator:] > \'-\'';
     private static ?\Transliterator $slugTransliterator = null;
 
+    #[\NoDiscard]
     public function slugify(?string $text): string
     {
         $text = ($text ?? '')
@@ -33,6 +34,7 @@ class Utility
         return $slug;
     }
 
+    #[\NoDiscard]
     public function getCountryName(?string $countryCode): string
     {
         $countryCode = ($countryCode ?? '')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the PHP 8.5 modernization pass with no backward-compat constraint.

- **Shared request bool parsing:** `RequestParameter::toBool()` consolidates duplicated filter helpers and replaces `!empty()` platform/checkbox parsing so values like `"false"` / `"off"` / `"no"` are treated as false.
- **PHP 8.5 idioms:** more `|>` pipes, first-class callables (`TrophyListItem::fromArray(...)`), `array_find`, and `#[\NoDiscard]` on query/meta factory methods.
- **Safer escaping:** class-layer `htmlspecialchars(..., ENT_QUOTES)` call sites now use `Html::escape()` (`ENT_QUOTES | ENT_SUBSTITUTE`).

## Test plan

- [x] `php tests/run.php` (998 passed)
- [ ] Spot-check platform filters with `?ps5=false` / `?exclusive=false`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d05c616a-6f9c-4003-9cf3-a3234d590d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d05c616a-6f9c-4003-9cf3-a3234d590d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

