### PR TITLE
Adopt remaining PHP 8.5 idioms for sorts, HTTP methods, and enums

### DIFF
--- a/tests/AdminWorkerServiceTest.php
+++ b/tests/AdminWorkerServiceTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerService.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerScanProgress.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerSortField.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerSortDirection.php';
 
 final class AdminWorkerServiceTest extends TestCase
 {
@@ -44,7 +46,7 @@ SQL
         $database->exec("INSERT INTO setting (id, refresh_token, npsso, scanning, scan_start) VALUES (2, 'token-2', 'npsso-2', '', '2024-01-02 09:00:00')");
 
         $service = new WorkerService($database);
-        $workers = $service->fetchWorkers('id', 'DESC');
+        $workers = $service->fetchWorkers(WorkerSortField::Id, WorkerSortDirection::Desc);
 
         $this->assertCount(2, $workers);
         $this->assertSame(2, $workers[0]->getId());

--- a/tests/GameHistoryRendererTest.php
+++ b/tests/GameHistoryRendererTest.php
@@ -48,7 +48,7 @@ final class GameHistoryRendererTest extends TestCase
         $html = $renderer->renderIconDiff([
             'previous' => '.png',
             'current' => '.png',
-        ], $game, 'title', 'Sample');
+        ], $game, HistoryIconType::Title, 'Sample');
 
         $this->assertStringContainsString('missing-ps5-game-and-trophy.png', $html);
     }
@@ -58,7 +58,7 @@ final class GameHistoryRendererTest extends TestCase
         $renderer = new GameHistoryRenderer();
         $game = $this->createGameDetails();
 
-        $html = $renderer->renderSingleIcon(null, $game, 'trophy', 'Reward');
+        $html = $renderer->renderSingleIcon(null, $game, HistoryIconType::Trophy, 'Reward');
 
         $this->assertStringContainsString('history-diff__empty', $html);
     }

--- a/tests/PageMetaDataRendererTest.php
+++ b/tests/PageMetaDataRendererTest.php
@@ -16,14 +16,14 @@ final class PageMetaDataRendererTest extends TestCase
 
     public function testRenderReturnsEmptyStringWhenMetaDataIsEmpty(): void
     {
-        $result = $this->renderer->render(new PageMetaData());
+        $result = $this->renderer->render(new PageMetaData);
 
         $this->assertSame('', $result);
     }
 
     public function testRenderProducesExpectedTagsWithEscapedValues(): void
     {
-        $metaData = (new PageMetaData())
+        $metaData = (new PageMetaData)
             ->withTitle('Title "special" & more')
             ->withDescription("Description with 'quote' & <tag>")
             ->withImage('https://example.com/image.png?foo=1&bar=2')

--- a/tests/PageMetaDataTest.php
+++ b/tests/PageMetaDataTest.php
@@ -18,7 +18,7 @@ final class PageMetaDataTest extends TestCase
 
     public function testWithersNormalizeValuesAndCreateNewInstances(): void
     {
-        $pageMetaData = new PageMetaData();
+        $pageMetaData = new PageMetaData;
 
         $result = $pageMetaData
             ->withTitle('  Example Title  ')
@@ -37,7 +37,7 @@ final class PageMetaDataTest extends TestCase
 
     public function testIsEmptyIndicatesWhetherAnyMetadataIsPresent(): void
     {
-        $pageMetaData = new PageMetaData();
+        $pageMetaData = new PageMetaData;
         $this->assertTrue($pageMetaData->isEmpty());
 
         $pageMetaDataWithDescription = $pageMetaData->withDescription('Description');

--- a/tests/Php85IdiomEnumsTest.php
+++ b/tests/Php85IdiomEnumsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/GameTrophySort.php';
+require_once __DIR__ . '/../wwwroot/classes/HttpMethod.php';
+
+final class Php85IdiomEnumsTest extends TestCase
+{
+    public function testGameTrophySortFromMixedNormalizesValues(): void
+    {
+        $this->assertSame(GameTrophySort::Default, GameTrophySort::fromMixed(null));
+        $this->assertSame(GameTrophySort::Default, GameTrophySort::fromMixed('unknown'));
+        $this->assertSame(GameTrophySort::Date, GameTrophySort::fromMixed(' Date '));
+        $this->assertSame(GameTrophySort::Rarity, GameTrophySort::fromMixed('RARITY'));
+    }
+
+    public function testHttpMethodFromServerDefaultsToGet(): void
+    {
+        $this->assertSame(HttpMethod::Get, HttpMethod::fromServer([]));
+        $this->assertSame(HttpMethod::Post, HttpMethod::fromServer(['REQUEST_METHOD' => 'post']));
+        $this->assertTrue(HttpMethod::fromMixed('POST')->isPost());
+        $this->assertTrue(HttpMethod::fromMixed('GET')->isGet());
+    }
+}

--- a/tests/PlatformSqlTest.php
+++ b/tests/PlatformSqlTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Platform.php';
 require_once __DIR__ . '/../wwwroot/classes/PlatformSql.php';
 
 final class PlatformSqlTest extends TestCase
@@ -24,9 +25,8 @@ final class PlatformSqlTest extends TestCase
 
     public function testPsvrPredicateDoesNotSubstringMatchPsvr2(): void
     {
-        $psvr = PlatformSql::conditionFor('psvr');
-        $this->assertTrue($psvr !== null);
-        $this->assertStringContainsString("LIKE '%,PSVR,%'", (string) $psvr);
-        $this->assertFalse(str_contains((string) $psvr, "LIKE '%PSVR%'"));
+        $psvr = PlatformSql::conditionFor(Platform::PsVr);
+        $this->assertStringContainsString("LIKE '%,PSVR,%'", $psvr);
+        $this->assertFalse(str_contains($psvr, "LIKE '%PSVR%'"));
     }
 }

--- a/wwwroot/add_to_queue.php
+++ b/wwwroot/add_to_queue.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 require_once 'init.php';
 require_once 'classes/SessionManager.php';
 require_once 'classes/CsrfTokenManager.php';
+require_once 'classes/HttpMethod.php';
 require_once 'classes/PlayerQueueEndpoint.php';
 require_once 'classes/PlayerQueueResponse.php';
 require_once 'classes/JsonResponseEmitter.php';
 
 $jsonResponder = new JsonResponseEmitter();
 
-if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+if (!HttpMethod::fromServer($_SERVER)->isPost()) {
     $jsonResponder->respond(
         PlayerQueueResponse::error('Queue submissions must use POST.')->toArray(),
         405

--- a/wwwroot/admin/login.php
+++ b/wwwroot/admin/login.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../init.php';
 require_once __DIR__ . '/../classes/IpAddressResolver.php';
 require_once __DIR__ . '/../classes/SessionManager.php';
 require_once __DIR__ . '/../classes/CsrfTokenManager.php';
+require_once __DIR__ . '/../classes/HttpMethod.php';
 require_once __DIR__ . '/../classes/Admin/AdminBootstrap.php';
 require_once __DIR__ . '/../classes/BootstrapAssets.php';
 
@@ -19,7 +20,7 @@ if ($authService->isConfigured() && $authService->isAuthenticated()) {
     exit;
 }
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+if (HttpMethod::fromServer($_SERVER)->isPost()) {
     $submittedToken = $_POST['_csrf_token'] ?? '';
     if (!CsrfTokenManager::validate('admin', $submittedToken)) {
         http_response_code(403);

--- a/wwwroot/admin/logout.php
+++ b/wwwroot/admin/logout.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../init.php';
 require_once __DIR__ . '/../classes/SessionManager.php';
+require_once __DIR__ . '/../classes/HttpMethod.php';
 require_once __DIR__ . '/../classes/Admin/AdminBootstrap.php';
 
 SessionManager::ensureStarted();
 
-if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+if (!HttpMethod::fromServer($_SERVER)->isPost()) {
     http_response_code(405);
     echo 'Method not allowed.';
     exit;

--- a/wwwroot/admin/psnp-plus-refresh.php
+++ b/wwwroot/admin/psnp-plus-refresh.php
@@ -3,9 +3,10 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../classes/HttpMethod.php';
 require_once __DIR__ . '/../classes/PsnpPlusClient.php';
 
-if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+if (!HttpMethod::fromServer($_SERVER)->isPost()) {
     header('Location: /admin/psnp-plus.php');
     exit;
 }

--- a/wwwroot/classes/Admin/AdminBootstrap.php
+++ b/wwwroot/classes/Admin/AdminBootstrap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../CsrfTokenManager.php';
 require_once __DIR__ . '/../SessionManager.php';
 require_once __DIR__ . '/../Html.php';
+require_once __DIR__ . '/../HttpMethod.php';
 require_once __DIR__ . '/AdminAuthService.php';
 require_once __DIR__ . '/AdminLoginThrottleService.php';
 require_once __DIR__ . '/AdminUserRepository.php';
@@ -69,9 +70,7 @@ final class AdminBootstrap
 
     private static function isPostRequest(): bool
     {
-        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
-
-        return is_string($method) && strtoupper($method) === 'POST';
+        return HttpMethod::fromServer($_SERVER)->isPost();
     }
 
     public static function requireValidPostCsrfToken(): void

--- a/wwwroot/classes/Admin/AdminRequest.php
+++ b/wwwroot/classes/Admin/AdminRequest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/HttpMethod.php';
+require_once __DIR__ . '/../HttpMethod.php';
 
 final readonly class AdminRequest
 {

--- a/wwwroot/classes/Admin/AdminRequest.php
+++ b/wwwroot/classes/Admin/AdminRequest.php
@@ -2,19 +2,20 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/HttpMethod.php';
+
 final readonly class AdminRequest
 {
-    private string $method;
+    private HttpMethod $method;
 
     /**
      * @param array<string, mixed> $postData
      */
     public function __construct(
-        string $method,
+        string|HttpMethod $method,
         private array $postData,
     ) {
-        $normalizedMethod = $method |> trim(...) |> strtoupper(...);
-        $this->method = $normalizedMethod === '' ? 'GET' : $normalizedMethod;
+        $this->method = $method instanceof HttpMethod ? $method : HttpMethod::fromMixed($method);
     }
 
     /**
@@ -24,23 +25,17 @@ final readonly class AdminRequest
     #[\NoDiscard]
     public static function fromGlobals(array $serverData, array $postData): self
     {
-        $method = $serverData['REQUEST_METHOD'] ?? 'GET';
-
-        if (!is_string($method)) {
-            $method = 'GET';
-        }
-
-        return new self($method, $postData);
+        return new self(HttpMethod::fromServer($serverData), $postData);
     }
 
-    public function getMethod(): string
+    public function getMethod(): HttpMethod
     {
         return $this->method;
     }
 
     public function isPost(): bool
     {
-        return $this->method === 'POST';
+        return $this->method->isPost();
     }
 
     public function getPostValue(string $key): mixed

--- a/wwwroot/classes/Admin/GameDetailPage.php
+++ b/wwwroot/classes/Admin/GameDetailPage.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../Html.php';
+require_once __DIR__ . '/../HttpMethod.php';
 
 require_once __DIR__ . '/GameDetailFormParser.php';
 require_once __DIR__ . '/GameDetailService.php';
@@ -53,9 +54,9 @@ final readonly class GameDetailPage
         $error = null;
 
         try {
-            $method = ((string) ($serverParameters['REQUEST_METHOD'] ?? 'GET')) |> strtoupper(...);
+            $method = HttpMethod::fromServer($serverParameters);
 
-            if ($method === 'POST') {
+            if ($method->isPost()) {
                 $action = $this->formParser->parseAction($postData['action'] ?? null);
 
                 if ($action === 'update-status') {
@@ -63,7 +64,7 @@ final readonly class GameDetailPage
                 } else {
                     [$gameDetail, $success, $error] = $this->handleDetailUpdate($postData);
                 }
-            } elseif ($method === 'GET') {
+            } elseif ($method->isGet()) {
                 $npCommunicationId = null;
                 $gameId = $this->formParser->parseGameId($queryParameters['game'] ?? null);
 

--- a/wwwroot/classes/Admin/GameRescanRequestHandler.php
+++ b/wwwroot/classes/Admin/GameRescanRequestHandler.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../ExecutionEnvironmentConfigurator.php';
+require_once __DIR__ . '/../HttpMethod.php';
 require_once __DIR__ . '/GameRescanProgressListener.php';
 require_once __DIR__ . '/CallableGameRescanProgressListener.php';
 
@@ -21,8 +22,7 @@ class GameRescanRequestHandler
      */
     public function handleRequest(array $postData, array $serverData): void
     {
-        $method = ((string) ($serverData['REQUEST_METHOD'] ?? '')) |> strtoupper(...);
-        if ($method !== 'POST') {
+        if (!HttpMethod::fromServer($serverData)->isPost()) {
             $this->sendJsonResponse(405, [
                 'success' => false,
                 'error' => 'Method not allowed.',

--- a/wwwroot/classes/Admin/LogPage.php
+++ b/wwwroot/classes/Admin/LogPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/LogService.php';
 require_once __DIR__ . '/LogPageResult.php';
 require_once __DIR__ . '/LogDeletionRequest.php';
+require_once __DIR__ . '/../HttpMethod.php';
 
 final class LogPage
 {
@@ -27,7 +28,7 @@ final class LogPage
         $successMessage = null;
         $errorMessage = null;
 
-        if (strtoupper($method) === 'POST') {
+        if (HttpMethod::fromMixed($method)->isPost()) {
             $deletionRequest = LogDeletionRequest::fromPostData($postData);
 
             if ($deletionRequest->hasError()) {

--- a/wwwroot/classes/Admin/PlayerReportAdminPage.php
+++ b/wwwroot/classes/Admin/PlayerReportAdminPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/PlayerReportAdminService.php';
 require_once __DIR__ . '/PlayerReportAdminPageResult.php';
 require_once __DIR__ . '/PlayerReportDeletionRequest.php';
+require_once __DIR__ . '/../HttpMethod.php';
 
 final readonly class PlayerReportAdminPage
 {
@@ -22,7 +23,7 @@ final readonly class PlayerReportAdminPage
         $successMessage = null;
         $errorMessage = null;
 
-        if (strtoupper($method) === 'POST') {
+        if (HttpMethod::fromMixed($method)->isPost()) {
             $deletionRequest = PlayerReportDeletionRequest::fromPostData($postData);
 
             if ($deletionRequest->hasError()) {

--- a/wwwroot/classes/Admin/TrophyMergeProcessor.php
+++ b/wwwroot/classes/Admin/TrophyMergeProcessor.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../ExecutionEnvironmentConfigurator.php';
+require_once __DIR__ . '/../HttpMethod.php';
 require_once __DIR__ . '/../TrophyMergeMethod.php';
 require_once __DIR__ . '/../TrophyMergeService.php';
 require_once __DIR__ . '/TrophyMergeRequestHandler.php';
@@ -32,8 +33,7 @@ class TrophyMergeProcessor
      */
     public function processRequest(array $postData, array $serverData): void
     {
-        $method = ((string) ($serverData['REQUEST_METHOD'] ?? '')) |> strtoupper(...);
-        if ($method !== 'POST') {
+        if (!HttpMethod::fromServer($serverData)->isPost()) {
             $this->sendJsonResponse(405, [
                 'success' => false,
                 'error' => 'Method not allowed.',

--- a/wwwroot/classes/Admin/TrophyStatusPage.php
+++ b/wwwroot/classes/Admin/TrophyStatusPage.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/TrophyStatusService.php';
 require_once __DIR__ . '/TrophyStatusUpdateResultPresenter.php';
 require_once __DIR__ . '/../TrophyMetaStatus.php';
 require_once __DIR__ . '/../Html.php';
+require_once __DIR__ . '/../HttpMethod.php';
 
 final readonly class TrophyStatusPageResult
 {
@@ -57,11 +58,10 @@ final readonly class TrophyStatusPage
         $statusInput = '1';
         $message = null;
 
-        $normalizedMethod = $requestMethod |> trim(...) |> strtoupper(...);
         $hasTrophyPost = array_key_exists('trophy', $postData);
         $hasGamePost = array_key_exists('game', $postData);
 
-        if ($normalizedMethod === 'POST' && ($hasTrophyPost || $hasGamePost)) {
+        if (HttpMethod::fromMixed($requestMethod)->isPost() && ($hasTrophyPost || $hasGamePost)) {
             $status = TrophyMetaStatus::fromMixed($postData['status'] ?? TrophyMetaStatus::Unobtainable->value);
             $statusInput = (string) $status->value;
 

--- a/wwwroot/classes/Admin/WorkerPage.php
+++ b/wwwroot/classes/Admin/WorkerPage.php
@@ -31,7 +31,7 @@ final class WorkerPage
             ? $this->processAction($request)
             : [null, null];
 
-        $workers = $this->workerService->fetchWorkers($sortField->value, $sortDirection->value);
+        $workers = $this->workerService->fetchWorkers($sortField, $sortDirection);
 
         $sortLinks = [
             'id' => $this->createSortLink(WorkerSortField::Id, $sortField, $sortDirection),

--- a/wwwroot/classes/Admin/WorkerService.php
+++ b/wwwroot/classes/Admin/WorkerService.php
@@ -28,15 +28,14 @@ final class WorkerService
     /**
      * @return list<Worker>
      */
-    public function fetchWorkers(string $orderBy = 'scan_start', string $direction = 'ASC'): array
-    {
-        $sortField = WorkerSortField::fromMixed($orderBy);
-        $sortDirection = WorkerSortDirection::fromMixed($direction);
-
+    public function fetchWorkers(
+        WorkerSortField $orderBy = WorkerSortField::ScanStart,
+        WorkerSortDirection $direction = WorkerSortDirection::Asc,
+    ): array {
         $query = sprintf(
             'SELECT id, refresh_token, npsso, scanning, scan_start, scan_progress FROM setting ORDER BY %s %s',
-            $sortField->toSqlColumn(),
-            $sortDirection->toSqlKeyword()
+            $orderBy->toSqlColumn(),
+            $direction->toSqlKeyword()
         );
 
         $statement = $this->database->query($query);

--- a/wwwroot/classes/GameHistoryChangeFilter.php
+++ b/wwwroot/classes/GameHistoryChangeFilter.php
@@ -89,7 +89,10 @@ final class GameHistoryChangeFilter
                 $titleHighlights['icon_url'] = $this->isNewNonEmptyString($titleChange['icon_url'] ?? null, $previousTitle['icon_url']);
                 $titleHighlights['set_version'] = $this->isNewNonEmptyString($titleChange['set_version'] ?? null, $previousTitle['set_version']);
 
-                $hasTitleChanges = in_array(true, $titleHighlights, true);
+                $hasTitleChanges = array_any(
+                    $titleHighlights,
+                    static fn (bool $changed): bool => $changed
+                );
 
                 foreach (['detail', 'icon_url', 'set_version'] as $field) {
                     if ($titleHighlights[$field]) {
@@ -123,7 +126,10 @@ final class GameHistoryChangeFilter
                     }
                 }
 
-                $hasRowChanges = $isNewRow || in_array(true, $changedFields, true);
+                $hasRowChanges = $isNewRow || array_any(
+                    $changedFields,
+                    static fn (bool $changed): bool => $changed
+                );
 
                 if ($hasRowChanges) {
                     $fieldDiffs = [];
@@ -186,7 +192,10 @@ final class GameHistoryChangeFilter
                     }
                 }
 
-                $hasRowChanges = $isNewRow || in_array(true, $changedFields, true);
+                $hasRowChanges = $isNewRow || array_any(
+                    $changedFields,
+                    static fn (bool $changed): bool => $changed
+                );
 
                 if ($hasRowChanges) {
                     $fieldDiffs = [];

--- a/wwwroot/classes/GameHistoryPage.php
+++ b/wwwroot/classes/GameHistoryPage.php
@@ -123,7 +123,7 @@ final class GameHistoryPage
     #[\NoDiscard]
     public function createMetaData(): PageMetaData
     {
-        return (new PageMetaData())
+        return (new PageMetaData)
             ->withTitle($this->game->getName() . ' Trophy Data History')
             ->withDescription('Version history and trophy data changes for ' . $this->game->getName())
             ->withImage('https://psn100.net/img/title/' . $this->game->getIconUrl())

--- a/wwwroot/classes/GameHistoryRenderer.php
+++ b/wwwroot/classes/GameHistoryRenderer.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Game/GameDetails.php';
+require_once __DIR__ . '/HistoryIconType.php';
+require_once __DIR__ . '/HistoryIconState.php';
 require_once __DIR__ . '/Html.php';
 
 /**
@@ -68,7 +70,7 @@ final class GameHistoryRenderer
     public function renderIconDiff(
         ?array $diff,
         GameDetails $game,
-        string $type,
+        HistoryIconType $type,
         ?string $name,
         bool $hidePrevious = false
     ): string {
@@ -81,20 +83,20 @@ final class GameHistoryRenderer
             $game,
             $type,
             $name,
-            'previous'
+            HistoryIconState::Previous
         );
         $current = $this->formatIcon(
             is_string($diff['current'] ?? null) ? $diff['current'] : null,
             $game,
             $type,
             $name,
-            'current'
+            HistoryIconState::Current
         );
 
         return $this->renderDiffBlocks($previous, $current, $hidePrevious);
     }
 
-    public function renderSingleIcon(?string $iconUrl, GameDetails $game, string $type, ?string $name): string
+    public function renderSingleIcon(?string $iconUrl, GameDetails $game, HistoryIconType $type, ?string $name): string
     {
         $resolvedPath = $this->resolveIconPath($iconUrl, $game, $type);
 
@@ -102,7 +104,7 @@ final class GameHistoryRenderer
             return '<div class="text-center"><span class="history-diff__empty">&mdash;</span></div>';
         }
 
-        ['objectFit' => $objectFit, 'directory' => $directory, 'height' => $height] = $this->resolveIconDisplay($type);
+        ['objectFit' => $objectFit, 'directory' => $directory, 'height' => $height] = $type->display();
 
         return '<div class="text-center">'
             . '<img class="' . $objectFit . ' rounded" style="height: ' . $height . 'rem;" src="/img/' . $directory . '/'
@@ -312,7 +314,7 @@ final class GameHistoryRenderer
         return $html;
     }
 
-    private function resolveIconPath(?string $iconUrl, GameDetails $game, string $type): ?string
+    private function resolveIconPath(?string $iconUrl, GameDetails $game, HistoryIconType $type): ?string
     {
         if ($iconUrl === null || $iconUrl === '') {
             return null;
@@ -321,46 +323,37 @@ final class GameHistoryRenderer
         if ($iconUrl === '.png') {
             $hasPs5Assets = str_contains($game->getPlatform(), 'PS5') || str_contains($game->getPlatform(), 'PSVR2');
 
-            if ($type === 'group' || $type === 'title') {
+            if ($type->usesGameMissingAsset()) {
                 return $hasPs5Assets ? '../missing-ps5-game-and-trophy.png' : '../missing-ps4-game.png';
             }
 
-            if ($type === 'trophy') {
-                return $hasPs5Assets ? '../missing-ps5-game-and-trophy.png' : '../missing-ps4-trophy.png';
-            }
+            return $hasPs5Assets ? '../missing-ps5-game-and-trophy.png' : '../missing-ps4-trophy.png';
         }
 
         return $iconUrl;
     }
 
-    private function formatIcon(?string $iconUrl, GameDetails $game, string $type, ?string $name, string $state): string
-    {
+    private function formatIcon(
+        ?string $iconUrl,
+        GameDetails $game,
+        HistoryIconType $type,
+        ?string $name,
+        HistoryIconState $state
+    ): string {
         $resolvedPath = $this->resolveIconPath($iconUrl, $game, $type);
 
         if ($resolvedPath === null) {
             return '<div class="text-center"><span class="history-diff__empty">&mdash;</span></div>';
         }
 
-        $borderClass = $state === 'previous' ? 'border-danger' : 'border-success';
-        ['objectFit' => $objectFit, 'directory' => $directory, 'height' => $height] = $this->resolveIconDisplay($type);
+        $borderClass = $state->borderClass();
+        ['objectFit' => $objectFit, 'directory' => $directory, 'height' => $height] = $type->display();
 
         return '<div class="text-center">'
             . '<img class="' . $objectFit . ' border border-2 ' . $borderClass . ' rounded" style="height: ' . $height . 'rem;" src="/img/'
             . $directory . '/' . Html::escape($resolvedPath)
             . '" alt="' . Html::escape($name ?? '') . '">'
             . '</div>';
-    }
-
-    /**
-     * @return array{objectFit: string, directory: string, height: float}
-     */
-    private function resolveIconDisplay(string $type): array
-    {
-        return match ($type) {
-            'group' => ['objectFit' => 'object-fit-cover', 'directory' => 'group', 'height' => 3.5],
-            'title' => ['objectFit' => 'object-fit-scale', 'directory' => 'title', 'height' => 5.5],
-            default => ['objectFit' => 'object-fit-scale', 'directory' => 'trophy', 'height' => 3.5],
-        };
     }
 }
 

--- a/wwwroot/classes/GamePage.php
+++ b/wwwroot/classes/GamePage.php
@@ -12,10 +12,11 @@ require_once __DIR__ . '/Game/GameHeaderData.php';
 require_once __DIR__ . '/Game/GameTrophyGroup.php';
 require_once __DIR__ . '/Game/GameTrophyGroupPlayer.php';
 require_once __DIR__ . '/Game/GameTrophyRow.php';
+require_once __DIR__ . '/GameTrophySort.php';
 require_once __DIR__ . '/PageMetaData.php';
 require_once __DIR__ . '/Utility.php';
 
-class GamePage
+final class GamePage
 {
     private GameService $gameService;
 
@@ -27,7 +28,7 @@ class GamePage
 
     private GameHeaderData $headerData;
 
-    private string $sort;
+    private GameTrophySort $sort;
 
     private ?int $playerAccountId;
 
@@ -114,7 +115,7 @@ class GamePage
         return $this->headerData;
     }
 
-    public function getSort(): string
+    public function getSort(): GameTrophySort
     {
         return $this->sort;
     }
@@ -199,7 +200,7 @@ class GamePage
     #[\NoDiscard]
     public function createMetaData(): PageMetaData
     {
-        return (new PageMetaData())
+        return (new PageMetaData)
             ->withTitle($this->game->getName() . ' Trophies')
             ->withDescription(
                 $this->game->getBronze() . ' Bronze ~ '

--- a/wwwroot/classes/GameService.php
+++ b/wwwroot/classes/GameService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/Game/GamePlayerProgress.php';
 require_once __DIR__ . '/Game/GameTrophyGroupPlayer.php';
+require_once __DIR__ . '/GameTrophySort.php';
 require_once __DIR__ . '/TrophyType.php';
 
 class GameService
@@ -61,14 +62,9 @@ class GameService
     /**
      * @param array<string, mixed> $queryParameters
      */
-    public function resolveSort(array $queryParameters): string
+    public function resolveSort(array $queryParameters): GameTrophySort
     {
-        $sort = ((string) ($queryParameters['sort'] ?? 'default')) |> strtolower(...);
-
-        return match ($sort) {
-            'date', 'rarity' => $sort,
-            default => 'default',
-        };
+        return GameTrophySort::fromMixed($queryParameters['sort'] ?? null);
     }
 
     public function getPlayerAccountId(string $onlineId): ?int
@@ -197,7 +193,7 @@ class GameService
     /**
      * @return array<int, array<string, mixed>>
      */
-    public function getTrophies(string $npCommunicationId, string $groupId, ?int $accountId, string $sort): array
+    public function getTrophies(string $npCommunicationId, string $groupId, ?int $accountId, GameTrophySort $sort): array
     {
         if ($accountId !== null) {
             $sql = <<<'SQL'
@@ -282,20 +278,20 @@ class GameService
         return is_array($trophies) ? $trophies : [];
     }
 
-    private function buildAccountSortSql(string $sort): string
+    private function buildAccountSortSql(GameTrophySort $sort): string
     {
         $trophyTypeSort = TrophyType::sqlFieldOrder('t.type');
 
         return match ($sort) {
-            'date' => " ORDER BY te.earned_date IS NULL, te.earned_date, {$trophyTypeSort}, t.order_id",
-            'rarity' => " ORDER BY tm.rarity_percent DESC, {$trophyTypeSort}, t.order_id",
-            default => ' ORDER BY t.order_id',
+            GameTrophySort::Date => " ORDER BY te.earned_date IS NULL, te.earned_date, {$trophyTypeSort}, t.order_id",
+            GameTrophySort::Rarity => " ORDER BY tm.rarity_percent DESC, {$trophyTypeSort}, t.order_id",
+            GameTrophySort::Default => ' ORDER BY t.order_id',
         };
     }
 
-    private function buildPublicSortSql(string $sort): string
+    private function buildPublicSortSql(GameTrophySort $sort): string
     {
-        if ($sort !== 'rarity') {
+        if ($sort !== GameTrophySort::Rarity) {
             return ' ORDER BY t.order_id';
         }
 

--- a/wwwroot/classes/GameTrophySort.php
+++ b/wwwroot/classes/GameTrophySort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+enum GameTrophySort: string
+{
+    case Default = 'default';
+    case Date = 'date';
+    case Rarity = 'rarity';
+
+    #[\NoDiscard]
+    public static function fromMixed(mixed $value): self
+    {
+        if (!is_string($value)) {
+            return self::Default;
+        }
+
+        return self::tryFrom($value |> trim(...) |> strtolower(...)) ?? self::Default;
+    }
+}

--- a/wwwroot/classes/HistoryIconState.php
+++ b/wwwroot/classes/HistoryIconState.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+enum HistoryIconState: string
+{
+    case Previous = 'previous';
+    case Current = 'current';
+
+    public function borderClass(): string
+    {
+        return $this === self::Previous ? 'border-danger' : 'border-success';
+    }
+}

--- a/wwwroot/classes/HistoryIconType.php
+++ b/wwwroot/classes/HistoryIconType.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+enum HistoryIconType: string
+{
+    case Group = 'group';
+    case Title = 'title';
+    case Trophy = 'trophy';
+
+    public function usesGameMissingAsset(): bool
+    {
+        return $this === self::Group || $this === self::Title;
+    }
+
+    /**
+     * @return array{objectFit: string, directory: string, height: float}
+     */
+    public function display(): array
+    {
+        return match ($this) {
+            self::Group => ['objectFit' => 'object-fit-cover', 'directory' => 'group', 'height' => 3.5],
+            self::Title => ['objectFit' => 'object-fit-scale', 'directory' => 'title', 'height' => 5.5],
+            self::Trophy => ['objectFit' => 'object-fit-scale', 'directory' => 'trophy', 'height' => 3.5],
+        };
+    }
+}

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/Homepage/HomepageNewGame.php';
 require_once __DIR__ . '/Homepage/HomepageDlc.php';
 require_once __DIR__ . '/Homepage/HomepagePopularGame.php';
 require_once __DIR__ . '/HomepagePopularGamesFilter.php';
+require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/PlatformSql.php';
 
 class HomepageContentService
@@ -142,9 +143,9 @@ class HomepageContentService
         } elseif ($filter->isExclusiveOnly()) {
             $conditions[] = "tt.platform NOT LIKE '%,%'";
         } elseif ($filter->hasPlatformFilter()) {
-            $platformCondition = PlatformSql::conditionFor($filter->getPlatform());
-            if ($platformCondition !== null) {
-                $conditions[] = $platformCondition;
+            $platform = Platform::tryFrom($filter->getPlatform());
+            if ($platform !== null) {
+                $conditions[] = PlatformSql::conditionFor($platform);
             }
         }
 

--- a/wwwroot/classes/HttpMethod.php
+++ b/wwwroot/classes/HttpMethod.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+enum HttpMethod: string
+{
+    case Get = 'GET';
+    case Post = 'POST';
+    case Put = 'PUT';
+    case Patch = 'PATCH';
+    case Delete = 'DELETE';
+    case Head = 'HEAD';
+    case Options = 'OPTIONS';
+
+    #[\NoDiscard]
+    public static function fromMixed(mixed $value): self
+    {
+        if (!is_string($value)) {
+            return self::Get;
+        }
+
+        $normalized = $value |> trim(...) |> strtoupper(...);
+
+        if ($normalized === '') {
+            return self::Get;
+        }
+
+        return self::tryFrom($normalized) ?? self::Get;
+    }
+
+    #[\NoDiscard]
+    public static function fromServer(array $serverData): self
+    {
+        return self::fromMixed($serverData['REQUEST_METHOD'] ?? self::Get->value);
+    }
+
+    public function isPost(): bool
+    {
+        return $this === self::Post;
+    }
+
+    public function isGet(): bool
+    {
+        return $this === self::Get;
+    }
+}

--- a/wwwroot/classes/PlatformSql.php
+++ b/wwwroot/classes/PlatformSql.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Platform.php';
+
 /**
  * Shared SQL fragments for filtering trophy_title.platform.
  *
@@ -18,13 +20,13 @@ final class PlatformSql
      * @var array<string, string>
      */
     public const array CONDITIONS = [
-        'pc' => "tt.platform LIKE '%PC%'",
-        'ps3' => "tt.platform LIKE '%PS3%'",
-        'ps4' => "tt.platform LIKE '%PS4%'",
-        'ps5' => "tt.platform LIKE '%PS5%'",
-        'psvita' => "tt.platform LIKE '%PSVITA%'",
-        'psvr' => self::PSVR_TOKEN_MATCH,
-        'psvr2' => "tt.platform LIKE '%PSVR2%'",
+        Platform::Pc->value => "tt.platform LIKE '%PC%'",
+        Platform::Ps3->value => "tt.platform LIKE '%PS3%'",
+        Platform::Ps4->value => "tt.platform LIKE '%PS4%'",
+        Platform::Ps5->value => "tt.platform LIKE '%PS5%'",
+        Platform::PsVita->value => "tt.platform LIKE '%PSVITA%'",
+        Platform::PsVr->value => self::PSVR_TOKEN_MATCH,
+        Platform::PsVr2->value => "tt.platform LIKE '%PSVR2%'",
     ];
 
     /**
@@ -59,8 +61,8 @@ final class PlatformSql
         return $expression === null ? '' : ' AND ' . $expression;
     }
 
-    public static function conditionFor(string $platformKey): ?string
+    public static function conditionFor(Platform $platform): string
     {
-        return self::CONDITIONS[$platformKey] ?? null;
+        return self::CONDITIONS[$platform->value];
     }
 }

--- a/wwwroot/classes/PlayerGamesPageContext.php
+++ b/wwwroot/classes/PlayerGamesPageContext.php
@@ -218,7 +218,7 @@ final readonly class PlayerGamesPageContext
      */
     private function buildMetaData(array $playerData, PlayerSummary $playerSummary): PageMetaData
     {
-        $metaData = (new PageMetaData())
+        $metaData = (new PageMetaData)
             ->withTitle($this->buildTitle($playerData))
             ->withImage('https://psn100.net/img/avatar/' . $this->extractString($playerData['avatar_url'] ?? ''))
             ->withUrl('https://psn100.net' . PlayerUrlBuilder::playerPath($this->extractString($playerData['online_id'] ?? '')));

--- a/wwwroot/classes/Router.php
+++ b/wwwroot/classes/Router.php
@@ -46,8 +46,8 @@ class Router
     #[\NoDiscard]
     public function dispatch(string $requestUri): RouteResult
     {
-        $path = Uri\Rfc3986\Uri::parse($requestUri)?->getPath() ?? '';
-        $normalizedPath = trim($path, '/');
+        $normalizedPath = (Uri\Rfc3986\Uri::parse($requestUri)?->getPath() ?? '')
+            |> (fn (string $path): string => trim($path, '/'));
 
         if ($normalizedPath === '') {
             return $this->defaultHandler->handle([]);

--- a/wwwroot/classes/TrophyPage.php
+++ b/wwwroot/classes/TrophyPage.php
@@ -48,7 +48,7 @@ final readonly class TrophyPage
         }
 
         $trophyName = $trophy->getName();
-        $metaData = (new PageMetaData())
+        $metaData = (new PageMetaData)
             ->withTitle($trophyName . ' Trophy')
             ->withDescription(Html::escape($trophy->getDetail()))
             ->withImage('https://psn100.net/img/trophy/' . $trophy->getIconFileName())

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -90,15 +90,15 @@ require_once("header.php");
                         ?>
                         <select class="form-select" name="sort" onChange="this.form.submit()">
                             <option disabled>Sort by...</option>
-                            <option value="default"<?= ($sort == "default" ? " selected" : ""); ?>>Default</option>
+                            <option value="<?= GameTrophySort::Default->value; ?>"<?= ($sort === GameTrophySort::Default ? " selected" : ""); ?>>Default</option>
                             <?php
                             if (isset($player)) {
                                 ?>
-                                <option value="date"<?= ($sort == "date" ? " selected" : ""); ?>>Date</option>
+                                <option value="<?= GameTrophySort::Date->value; ?>"<?= ($sort === GameTrophySort::Date ? " selected" : ""); ?>>Date</option>
                                 <?php
                             }
                             ?>
-                            <option value="rarity"<?= ($sort == "rarity" ? " selected" : ""); ?>>Rarity</option>
+                            <option value="<?= GameTrophySort::Rarity->value; ?>"<?= ($sort === GameTrophySort::Rarity ? " selected" : ""); ?>>Rarity</option>
                         </select>
                     </div>
                 </form>
@@ -281,7 +281,7 @@ require_once("header.php");
                                                 ></span>
                                                 <?php
                                                 if (
-                                                    $sort == "date"
+                                                    $sort === GameTrophySort::Date
                                                     && $previousTimeStamp !== null
                                                     && $trophyRow->hasRecordedEarnedDate()
                                                 ) {
@@ -296,7 +296,7 @@ require_once("header.php");
                                                     } catch (DateMalformedStringException) {
                                                     }
                                                 }
-                                                if ($sort == "date") {
+                                                if ($sort === GameTrophySort::Date) {
                                                     $previousTimeStamp = $trophyRow->hasRecordedEarnedDate()
                                                         ? $trophyRow->getEarnedDate()
                                                         : null;

--- a/wwwroot/game_history.php
+++ b/wwwroot/game_history.php
@@ -141,7 +141,7 @@ require_once 'header.php';
                                 <div class="row g-3 align-items-start mb-3">
                                     <?php if ($titleHighlights['icon_url'] ?? false) { ?>
                                         <div class="col-12 col-md-4 col-lg-3">
-                                            <?= $historyRenderer->renderIconDiff($titleFieldDiffs['icon_url'] ?? null, $game, 'title', $game->getName(), $titleIsNewRow); ?>
+                                            <?= $historyRenderer->renderIconDiff($titleFieldDiffs['icon_url'] ?? null, $game, HistoryIconType::Title, $game->getName(), $titleIsNewRow); ?>
                                         </div>
                                     <?php } ?>
                                     <?php if ($titleHighlights['detail'] ?? false) { ?>
@@ -197,11 +197,11 @@ require_once 'header.php';
                                                         </td>
                                                         <td class="text-center">
                                                             <?php if ($groupIsNewRow) { ?>
-                                                                <?= $historyRenderer->renderSingleIcon($groupChange['icon_url'] ?? null, $game, 'group', $groupChange['name'] ?? ''); ?>
+                                                                <?= $historyRenderer->renderSingleIcon($groupChange['icon_url'] ?? null, $game, HistoryIconType::Group, $groupChange['name'] ?? ''); ?>
                                                             <?php } elseif ($groupChangedFields['icon_url'] ?? false) { ?>
-                                                                <?= $historyRenderer->renderIconDiff($groupFieldDiffs['icon_url'] ?? null, $game, 'group', $groupChange['name'] ?? ''); ?>
+                                                                <?= $historyRenderer->renderIconDiff($groupFieldDiffs['icon_url'] ?? null, $game, HistoryIconType::Group, $groupChange['name'] ?? ''); ?>
                                                             <?php } else { ?>
-                                                                <?= $historyRenderer->renderSingleIcon($groupChange['icon_url'] ?? null, $game, 'group', $groupChange['name'] ?? ''); ?>
+                                                                <?= $historyRenderer->renderSingleIcon($groupChange['icon_url'] ?? null, $game, HistoryIconType::Group, $groupChange['name'] ?? ''); ?>
                                                             <?php } ?>
                                                         </td>
                                                     </tr>
@@ -275,11 +275,11 @@ require_once 'header.php';
                                                         </td>
                                                         <td class="text-center">
                                                             <?php if ($trophyIsNewRow) { ?>
-                                                                <?= $historyRenderer->renderSingleIcon($trophyChange['icon_url'] ?? null, $game, 'trophy', $trophyChange['name'] ?? ''); ?>
+                                                                <?= $historyRenderer->renderSingleIcon($trophyChange['icon_url'] ?? null, $game, HistoryIconType::Trophy, $trophyChange['name'] ?? ''); ?>
                                                             <?php } elseif ($trophyChangedFields['icon_url'] ?? false) { ?>
-                                                                <?= $historyRenderer->renderIconDiff($trophyFieldDiffs['icon_url'] ?? null, $game, 'trophy', $trophyChange['name'] ?? ''); ?>
+                                                                <?= $historyRenderer->renderIconDiff($trophyFieldDiffs['icon_url'] ?? null, $game, HistoryIconType::Trophy, $trophyChange['name'] ?? ''); ?>
                                                             <?php } else { ?>
-                                                                <?= $historyRenderer->renderSingleIcon($trophyChange['icon_url'] ?? null, $game, 'trophy', $trophyChange['name'] ?? ''); ?>
+                                                                <?= $historyRenderer->renderSingleIcon($trophyChange['icon_url'] ?? null, $game, HistoryIconType::Trophy, $trophyChange['name'] ?? ''); ?>
                                                             <?php } ?>
                                                         </td>
                                                     </tr>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the PHP 8.5 modernization pass with typed enums and idioms where stringly-typed code remained.

### Changes
- **`GameTrophySort`** — game trophy sort is now a backed enum end-to-end (`GameService` / `GamePage` / `game.php`)
- **`HttpMethod`** — centralizes request method parsing; adopted by `AdminRequest`, admin pages/handlers, and a few POST-only endpoints
- **`WorkerService::fetchWorkers()`** — takes `WorkerSortField` / `WorkerSortDirection` directly (no string round-trip)
- **`HistoryIconType` / `HistoryIconState`** — typed icon rendering on game history
- **`PlatformSql::conditionFor(Platform)`** — platform-typed SQL fragment lookup
- Prefer **`array_any`**, pipe-friendly path normalization in `Router`, and `new PageMetaData` without empty constructor parentheses where chained

### Tests
- Extended existing tests for workers, history icons, platform SQL, and page metadata
- Added `Php85IdiomEnumsTest` for `GameTrophySort` / `HttpMethod` parsing
- Full suite: **1000 tests passed** (`php tests/run.php`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcf9aef9-927c-419b-a9d3-4ae182075fb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcf9aef9-927c-419b-a9d3-4ae182075fb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

