### PR TITLE
Adopt remaining PHP 8.5 sort enums and admin action types

### DIFF
--- a/tests/GameDetailFormParserTest.php
+++ b/tests/GameDetailFormParserTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/GameDetail.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameDetailAction.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/GameDetailFormParser.php';
 require_once __DIR__ . '/../wwwroot/classes/GameAvailabilityStatus.php';
+require_once __DIR__ . '/../wwwroot/classes/Platform.php';
 
 final class GameDetailFormParserTest extends TestCase
 {
@@ -45,10 +47,11 @@ final class GameDetailFormParserTest extends TestCase
 
     public function testParseActionNormalizesCaseAndWhitespace(): void
     {
-        $this->assertSame('update-status', $this->parser->parseAction('Update-Status'));
-        $this->assertSame('update-detail', $this->parser->parseAction(' update-detail '));
-        $this->assertSame('', $this->parser->parseAction(''));
-        $this->assertSame('', $this->parser->parseAction(null));
+        $this->assertSame(GameDetailAction::UpdateStatus, $this->parser->parseAction('Update-Status'));
+        $this->assertSame(GameDetailAction::UpdateDetail, $this->parser->parseAction(' update-detail '));
+        $this->assertSame(null, $this->parser->parseAction(''));
+        $this->assertSame(null, $this->parser->parseAction(null));
+        $this->assertSame(null, $this->parser->parseAction('unknown'));
     }
 
     public function testParseStatusAcceptsValidEnumValues(): void
@@ -109,5 +112,10 @@ final class GameDetailFormParserTest extends TestCase
         $this->assertSame('999', $detail->getPsnprofilesId());
         $this->assertSame(GameAvailabilityStatus::OBSOLETE, $detail->getStatus());
         $this->assertSame('42,84', $detail->getObsoleteIds());
+    }
+
+    public function testGetPlatformOptionsUsesPlatformLabelOrder(): void
+    {
+        $this->assertSame(Platform::labelOrder(), $this->parser->getPlatformOptions());
     }
 }

--- a/tests/GameListFilterTest.php
+++ b/tests/GameListFilterTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/GameListFilter.php';
+require_once __DIR__ . '/../wwwroot/classes/GameListSort.php';
 
 final class GameListFilterTest extends TestCase
 {
@@ -20,7 +21,8 @@ final class GameListFilterTest extends TestCase
 
         $this->assertSame('Alice', $filter->getPlayer());
         $this->assertTrue($filter->hasPlayer());
-        $this->assertSame(GameListFilter::SORT_OWNERS, $filter->getSort());
+        $this->assertSame(GameListSort::Owners, $filter->getSort());
+        $this->assertTrue($filter->isSort(GameListSort::Owners));
         $this->assertTrue($filter->isSort(GameListFilter::SORT_OWNERS));
         $this->assertTrue($filter->hasExplicitSort());
         $this->assertSame('God of War', $filter->getSearch());
@@ -45,7 +47,7 @@ final class GameListFilterTest extends TestCase
             'filter' => 'false',
         ]);
 
-        $this->assertSame(GameListFilter::SORT_SEARCH, $filter->getSort());
+        $this->assertSame(GameListSort::Search, $filter->getSort());
         $this->assertFalse($filter->hasExplicitSort());
         $this->assertSame('Kratos', $filter->getSearch());
         $this->assertTrue($filter->hasSearch());
@@ -67,7 +69,7 @@ final class GameListFilterTest extends TestCase
         ]);
 
         $this->assertTrue($filter->hasPlatformFilters());
-        $this->assertTrue($filter->isSort(GameListFilter::SORT_SEARCH));
+        $this->assertTrue($filter->isSort(GameListSort::Search));
         $this->assertTrue($filter->shouldApplySearch());
 
         $this->assertSame(

--- a/tests/PlayerAdvisorFilterTest.php
+++ b/tests/PlayerAdvisorFilterTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/PlayerAdvisorFilter.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerAdvisorSort.php';
 require_once __DIR__ . '/TestCase.php';
 
 final class PlayerAdvisorFilterTest extends TestCase
@@ -12,7 +13,7 @@ final class PlayerAdvisorFilterTest extends TestCase
         $filter = PlayerAdvisorFilter::fromArray([]);
 
         $this->assertSame(1, $filter->getPage());
-        $this->assertSame(PlayerAdvisorFilter::SORT_RARITY, $filter->getSort());
+        $this->assertSame(PlayerAdvisorSort::Rarity, $filter->getSort());
         $this->assertFalse($filter->hasPlatformFilters());
         $this->assertSame([], $filter->getPlatforms());
     }
@@ -44,14 +45,15 @@ final class PlayerAdvisorFilterTest extends TestCase
     {
         $filter = PlayerAdvisorFilter::fromArray(['sort' => PlayerAdvisorFilter::SORT_IN_GAME_RARITY]);
 
-        $this->assertSame(PlayerAdvisorFilter::SORT_IN_GAME_RARITY, $filter->getSort());
+        $this->assertSame(PlayerAdvisorSort::InGameRarity, $filter->getSort());
+        $this->assertTrue($filter->isSort(PlayerAdvisorSort::InGameRarity));
     }
 
     public function testFromArrayFallsBackToDefaultSortWhenUnknown(): void
     {
         $filter = PlayerAdvisorFilter::fromArray(['sort' => 'unknown']);
 
-        $this->assertSame(PlayerAdvisorFilter::SORT_RARITY, $filter->getSort());
+        $this->assertSame(PlayerAdvisorSort::Rarity, $filter->getSort());
     }
 
     public function testPageIsNeverBelowOne(): void

--- a/wwwroot/classes/Admin/AdminStreamEventType.php
+++ b/wwwroot/classes/Admin/AdminStreamEventType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+enum AdminStreamEventType: string
+{
+    case Progress = 'progress';
+    case Log = 'log';
+    case Complete = 'complete';
+    case Error = 'error';
+}

--- a/wwwroot/classes/Admin/GameDetailAction.php
+++ b/wwwroot/classes/Admin/GameDetailAction.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+enum GameDetailAction: string
+{
+    case UpdateStatus = 'update-status';
+    case UpdateDetail = 'update-detail';
+
+    #[\NoDiscard]
+    public static function tryFromMixed(mixed $value): ?self
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return self::tryFrom($value |> trim(...) |> strtolower(...));
+    }
+}

--- a/wwwroot/classes/Admin/GameDetailFormParser.php
+++ b/wwwroot/classes/Admin/GameDetailFormParser.php
@@ -2,31 +2,20 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../Platform.php';
 require_once __DIR__ . '/GameDetail.php';
+require_once __DIR__ . '/GameDetailAction.php';
 require_once __DIR__ . '/../CommaSeparatedValues.php';
 require_once __DIR__ . '/../GameAvailabilityStatus.php';
 
 final class GameDetailFormParser
 {
     /**
-     * @var list<string>
-     */
-    public const array PLATFORM_OPTIONS = [
-        'PS3',
-        'PSVITA',
-        'PS4',
-        'PSVR',
-        'PS5',
-        'PSVR2',
-        'PC',
-    ];
-
-    /**
      * @return list<string>
      */
     public function getPlatformOptions(): array
     {
-        return self::PLATFORM_OPTIONS;
+        return Platform::labelOrder();
     }
 
     public function parseNpCommunicationId(mixed $value): ?string
@@ -66,13 +55,9 @@ final class GameDetailFormParser
         return (int) $trimmed;
     }
 
-    public function parseAction(mixed $value): string
+    public function parseAction(mixed $value): ?GameDetailAction
     {
-        if (!is_string($value)) {
-            return '';
-        }
-
-        return $value |> trim(...) |> strtolower(...);
+        return GameDetailAction::tryFromMixed($value);
     }
 
     public function parseStatus(mixed $value): ?GameAvailabilityStatus
@@ -146,7 +131,7 @@ final class GameDetailFormParser
             $selected[$platform] = true;
         }
 
-        return self::PLATFORM_OPTIONS
+        return Platform::labelOrder()
             |> (fn(array $platforms): array => array_filter(
                 $platforms,
                 static fn (string $platform): bool => isset($selected[$platform])

--- a/wwwroot/classes/Admin/GameDetailPage.php
+++ b/wwwroot/classes/Admin/GameDetailPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../Html.php';
 require_once __DIR__ . '/../HttpMethod.php';
 
+require_once __DIR__ . '/GameDetailAction.php';
 require_once __DIR__ . '/GameDetailFormParser.php';
 require_once __DIR__ . '/GameDetailService.php';
 require_once __DIR__ . '/GameDetailPageResult.php';
@@ -59,7 +60,7 @@ final readonly class GameDetailPage
             if ($method->isPost()) {
                 $action = $this->formParser->parseAction($postData['action'] ?? null);
 
-                if ($action === 'update-status') {
+                if ($action === GameDetailAction::UpdateStatus) {
                     [$gameDetail, $success, $error] = $this->handleStatusUpdate($postData);
                 } else {
                     [$gameDetail, $success, $error] = $this->handleDetailUpdate($postData);

--- a/wwwroot/classes/Admin/GameRescanRequestHandler.php
+++ b/wwwroot/classes/Admin/GameRescanRequestHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../ExecutionEnvironmentConfigurator.php';
 require_once __DIR__ . '/../HttpMethod.php';
+require_once __DIR__ . '/AdminStreamEventType.php';
 require_once __DIR__ . '/GameRescanProgressListener.php';
 require_once __DIR__ . '/CallableGameRescanProgressListener.php';
 
@@ -45,7 +46,7 @@ class GameRescanRequestHandler
         $this->prepareStreamResponse();
 
         $this->sendEvent([
-            'type' => 'progress',
+            'type' => AdminStreamEventType::Progress->value,
             'progress' => 0,
             'message' => 'Preparing rescan…',
         ]);
@@ -53,14 +54,14 @@ class GameRescanRequestHandler
         try {
             $logListener = function (string $message): void {
                 $this->sendEvent([
-                    'type' => 'log',
+                    'type' => AdminStreamEventType::Log->value,
                     'message' => $message,
                 ]);
             };
 
             $progressListener = new CallableGameRescanProgressListener(function (int $percent, string $message): void {
                 $this->sendEvent([
-                    'type' => 'progress',
+                    'type' => AdminStreamEventType::Progress->value,
                     'progress' => $percent,
                     'message' => $message,
                 ]);
@@ -69,7 +70,7 @@ class GameRescanRequestHandler
             $result = $this->gameRescanService->rescan($gameId, $progressListener, $logListener);
 
             $this->sendEvent([
-                'type' => 'complete',
+                'type' => AdminStreamEventType::Complete->value,
                 'success' => true,
                 'progress' => 100,
                 'message' => $result->getMessage(),
@@ -79,7 +80,7 @@ class GameRescanRequestHandler
             http_response_code(200);
 
             $this->sendEvent([
-                'type' => 'error',
+                'type' => AdminStreamEventType::Error->value,
                 'success' => false,
                 'progress' => 100,
                 'error' => $exception->getMessage(),
@@ -89,7 +90,7 @@ class GameRescanRequestHandler
             error_log($exception->getMessage());
 
             $this->sendEvent([
-                'type' => 'error',
+                'type' => AdminStreamEventType::Error->value,
                 'success' => false,
                 'progress' => 100,
                 'error' => 'An unexpected error occurred while rescanning the game.',

--- a/wwwroot/classes/Admin/LogDeletionAction.php
+++ b/wwwroot/classes/Admin/LogDeletionAction.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+enum LogDeletionAction
+{
+    case Single;
+    case Bulk;
+}

--- a/wwwroot/classes/Admin/LogDeletionRequest.php
+++ b/wwwroot/classes/Admin/LogDeletionRequest.php
@@ -2,16 +2,15 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/LogDeletionAction.php';
+
 final readonly class LogDeletionRequest
 {
-    private const string ACTION_SINGLE = 'single';
-    private const string ACTION_BULK = 'bulk';
-
     /**
      * @param list<int> $bulkDeletionIds
      */
     private function __construct(
-        final private ?string $action,
+        final private ?LogDeletionAction $action,
         final private ?int $singleDeletionId,
         /** @var list<int> */
         final private array $bulkDeletionIds,
@@ -31,14 +30,14 @@ final readonly class LogDeletionRequest
         $errorMessage = null;
 
         if (array_key_exists('delete_id', $postData)) {
-            $action = self::ACTION_SINGLE;
+            $action = LogDeletionAction::Single;
             $singleDeletionId = self::parsePositiveInt($postData['delete_id'] ?? null);
 
             if ($singleDeletionId === null) {
                 $errorMessage = 'Please provide a valid log entry ID to delete.';
             }
         } elseif (array_key_exists('delete_selected', $postData) || array_key_exists('delete_ids', $postData)) {
-            $action = self::ACTION_BULK;
+            $action = LogDeletionAction::Bulk;
             $bulkDeletionIds = self::parsePositiveIntList($postData['delete_ids'] ?? []);
 
             if ($bulkDeletionIds === []) {
@@ -66,12 +65,12 @@ final readonly class LogDeletionRequest
 
     public function isSingleDeletion(): bool
     {
-        return $this->action === self::ACTION_SINGLE && !$this->hasError();
+        return $this->action === LogDeletionAction::Single && !$this->hasError();
     }
 
     public function isBulkDeletion(): bool
     {
-        return $this->action === self::ACTION_BULK && !$this->hasError();
+        return $this->action === LogDeletionAction::Bulk && !$this->hasError();
     }
 
     public function getSingleDeletionId(): ?int

--- a/wwwroot/classes/Admin/TrophyMergeProcessor.php
+++ b/wwwroot/classes/Admin/TrophyMergeProcessor.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../ExecutionEnvironmentConfigurator.php';
 require_once __DIR__ . '/../HttpMethod.php';
 require_once __DIR__ . '/../TrophyMergeMethod.php';
 require_once __DIR__ . '/../TrophyMergeService.php';
+require_once __DIR__ . '/AdminStreamEventType.php';
 require_once __DIR__ . '/TrophyMergeRequestHandler.php';
 require_once __DIR__ . '/CallableTrophyMergeProgressListener.php';
 
@@ -69,14 +70,14 @@ class TrophyMergeProcessor
         $this->prepareStreamResponse();
 
         $this->sendEvent([
-            'type' => 'progress',
+            'type' => AdminStreamEventType::Progress->value,
             'progress' => 0,
             'message' => 'Preparing game merge…',
         ]);
 
         $progressListener = new CallableTrophyMergeProgressListener(function (int $percent, string $message): void {
             $this->sendEvent([
-                'type' => 'progress',
+                'type' => AdminStreamEventType::Progress->value,
                 'progress' => $percent,
                 'message' => $message,
             ]);
@@ -93,14 +94,14 @@ class TrophyMergeProcessor
             );
 
             $this->sendEvent([
-                'type' => 'complete',
+                'type' => AdminStreamEventType::Complete->value,
                 'success' => true,
                 'progress' => 100,
                 'message' => $resultMessage,
             ]);
         } catch (\InvalidArgumentException | \RuntimeException $exception) {
             $this->sendEvent([
-                'type' => 'error',
+                'type' => AdminStreamEventType::Error->value,
                 'success' => false,
                 'progress' => 100,
                 'error' => $exception->getMessage(),
@@ -109,7 +110,7 @@ class TrophyMergeProcessor
             error_log($exception->getMessage());
 
             $this->sendEvent([
-                'type' => 'error',
+                'type' => AdminStreamEventType::Error->value,
                 'success' => false,
                 'progress' => 100,
                 'error' => 'An unexpected error occurred while merging the games.',

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -100,13 +100,17 @@ final readonly class GameListFilter
         return clone($this, ['page' => max($page, 1)]);
     }
 
-    public function getSort(): string
+    public function getSort(): GameListSort
     {
-        return $this->sort->value;
+        return $this->sort;
     }
 
-    public function isSort(string $sort): bool
+    public function isSort(GameListSort|string $sort): bool
     {
+        if ($sort instanceof GameListSort) {
+            return $this->sort === $sort;
+        }
+
         return $this->sort->value === $sort;
     }
 

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -200,7 +200,7 @@ class GameListService
     private function buildConditions(GameListFilter $filter): string
     {
         $conditions = [
-            match (GameListSort::from($filter->getSort())) {
+            match ($filter->getSort()) {
                 GameListSort::Completion => "ttm.status = 0 AND (tt.bronze + tt.silver + tt.gold + tt.platinum) != 0",
                 GameListSort::Rarity, GameListSort::InGameRarity => 'ttm.status = 0',
                 default => 'ttm.status != 2',
@@ -240,7 +240,7 @@ class GameListService
 
     private function buildOrderByClause(GameListFilter $filter): string
     {
-        return match (GameListSort::from($filter->getSort())) {
+        return match ($filter->getSort()) {
             GameListSort::Completion => 'ORDER BY difficulty DESC, owners DESC, `name`',
             GameListSort::Owners => 'ORDER BY owners DESC, `name`',
             GameListSort::Rarity => 'ORDER BY rarity_points DESC, owners DESC, `name`',

--- a/wwwroot/classes/PlayerAdvisorFilter.php
+++ b/wwwroot/classes/PlayerAdvisorFilter.php
@@ -78,9 +78,18 @@ final readonly class PlayerAdvisorFilter
         return in_array($platform, $this->platforms, true);
     }
 
-    public function getSort(): string
+    public function getSort(): PlayerAdvisorSort
     {
-        return $this->sort->value;
+        return $this->sort;
+    }
+
+    public function isSort(PlayerAdvisorSort|string $sort): bool
+    {
+        if ($sort instanceof PlayerAdvisorSort) {
+            return $this->sort === $sort;
+        }
+
+        return $this->sort->value === $sort;
     }
 
     /**

--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -116,7 +116,7 @@ class PlayerAdvisorService
 
     private function buildOrderByClause(PlayerAdvisorFilter $filter): string
     {
-        return match (PlayerAdvisorSort::from($filter->getSort())) {
+        return match ($filter->getSort()) {
             PlayerAdvisorSort::InGameRarity => ' ORDER BY tm.in_game_rarity_percent DESC, ttp.last_updated_date DESC',
             PlayerAdvisorSort::Rarity => ' ORDER BY tm.rarity_percent DESC, ttp.last_updated_date DESC',
         };

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -108,13 +108,17 @@ final readonly class PlayerGamesFilter
         return $this->shouldApplyFulltextCondition();
     }
 
-    public function getSort(): string
+    public function getSort(): PlayerGamesSort
     {
-        return $this->sort->value;
+        return $this->sort;
     }
 
-    public function isSort(string $sort): bool
+    public function isSort(PlayerGamesSort|string $sort): bool
     {
+        if ($sort instanceof PlayerGamesSort) {
+            return $this->sort === $sort;
+        }
+
         return $this->sort->value === $sort;
     }
 

--- a/wwwroot/classes/PlayerGamesPageContext.php
+++ b/wwwroot/classes/PlayerGamesPageContext.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/PageMetaData.php';
 require_once __DIR__ . '/PlayerGamesFilter.php';
 require_once __DIR__ . '/PlayerGamesPage.php';
 require_once __DIR__ . '/PlayerGamesService.php';
+require_once __DIR__ . '/PlayerGamesSort.php';
 require_once __DIR__ . '/PlayerNavigation.php';
 require_once __DIR__ . '/PlayerNavigationSection.php';
 require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
@@ -29,7 +30,7 @@ final readonly class PlayerGamesPageContext
 
     private string $playerSearch;
 
-    private string $sort;
+    private PlayerGamesSort $sort;
 
     private PlayerNavigation $playerNavigation;
 
@@ -173,7 +174,7 @@ final readonly class PlayerGamesPageContext
         return $this->playerSearch;
     }
 
-    public function getSort(): string
+    public function getSort(): PlayerGamesSort
     {
         return $this->sort;
     }

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -157,7 +157,7 @@ final class PlayerGamesService
 
     private function buildOrderByClause(PlayerGamesFilter $filter): string
     {
-        return match (PlayerGamesSort::from($filter->getSort())) {
+        return match ($filter->getSort()) {
             PlayerGamesSort::InGameMaxRarity => 'ORDER BY max_in_game_rarity_points DESC, `name`',
             PlayerGamesSort::InGameRarity => 'ORDER BY in_game_rarity_points DESC, `name`',
             PlayerGamesSort::MaxRarity => 'ORDER BY max_rarity_points DESC, `name`',

--- a/wwwroot/classes/PlayerLogFilter.php
+++ b/wwwroot/classes/PlayerLogFilter.php
@@ -42,13 +42,17 @@ final readonly class PlayerLogFilter
         );
     }
 
-    public function getSort(): string
+    public function getSort(): PlayerLogSort
     {
-        return $this->sort->value;
+        return $this->sort;
     }
 
-    public function isSort(string $sort): bool
+    public function isSort(PlayerLogSort|string $sort): bool
     {
+        if ($sort instanceof PlayerLogSort) {
+            return $this->sort === $sort;
+        }
+
         return $this->sort === PlayerLogSort::fromMixed($sort);
     }
 

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -104,7 +104,7 @@ class PlayerLogService
 
     private function buildOrderByClause(PlayerLogFilter $filter): string
     {
-        return match (PlayerLogSort::from($filter->getSort())) {
+        return match ($filter->getSort()) {
             PlayerLogSort::Rarity => PHP_EOL . '            ORDER BY tm.rarity_percent, te.earned_date',
             PlayerLogSort::InGameRarity => PHP_EOL . '            ORDER BY tm.in_game_rarity_percent, te.earned_date',
             default => PHP_EOL . '            ORDER BY te.earned_date DESC',

--- a/wwwroot/games.php
+++ b/wwwroot/games.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/classes/Html.php';
 require_once __DIR__ . '/classes/PsnOnlineIdValidator.php';
 
 require_once __DIR__ . '/classes/GameListFilter.php';
+require_once __DIR__ . '/classes/GameListSort.php';
 require_once __DIR__ . '/classes/GameListService.php';
 require_once __DIR__ . '/classes/GameListPage.php';
 require_once __DIR__ . '/classes/SearchQueryHelper.php';
@@ -115,18 +116,18 @@ require_once("header.php");
 
                     <select class="form-select" name="sort" onChange="this.form.submit()">
                         <option disabled>Sort by...</option>
-                        <option value="added"<?= ($filter->isSort(GameListFilter::SORT_ADDED) ? ' selected' : ''); ?>>Added to Site</option>
+                        <option value="<?= GameListSort::Added->value; ?>"<?= ($filter->isSort(GameListSort::Added) ? ' selected' : ''); ?>>Added to Site</option>
                         <?php
-                        if ($filter->hasSearch() || $filter->isSort(GameListFilter::SORT_SEARCH)) {
+                        if ($filter->hasSearch() || $filter->isSort(GameListSort::Search)) {
                             ?>
-                            <option value="search"<?= ($filter->isSort(GameListFilter::SORT_SEARCH) ? ' selected' : ''); ?>>Best Match</option>
+                            <option value="<?= GameListSort::Search->value; ?>"<?= ($filter->isSort(GameListSort::Search) ? ' selected' : ''); ?>>Best Match</option>
                             <?php
                         }
                         ?>
-                        <option value="completion"<?= ($filter->isSort(GameListFilter::SORT_COMPLETION) ? ' selected' : ''); ?>>Completion Rate</option>
-                        <option value="owners"<?= ($filter->isSort(GameListFilter::SORT_OWNERS) ? ' selected' : ''); ?>>Owners</option>
-                        <option value="rarity"<?= ($filter->isSort(GameListFilter::SORT_RARITY) ? ' selected' : ''); ?>>Rarity Points</option>
-                        <option value="in-game-rarity"<?= ($filter->isSort(GameListFilter::SORT_IN_GAME_RARITY) ? ' selected' : ''); ?>>Rarity (Game) Points</option>
+                        <option value="<?= GameListSort::Completion->value; ?>"<?= ($filter->isSort(GameListSort::Completion) ? ' selected' : ''); ?>>Completion Rate</option>
+                        <option value="<?= GameListSort::Owners->value; ?>"<?= ($filter->isSort(GameListSort::Owners) ? ' selected' : ''); ?>>Owners</option>
+                        <option value="<?= GameListSort::Rarity->value; ?>"<?= ($filter->isSort(GameListSort::Rarity) ? ' selected' : ''); ?>>Rarity Points</option>
+                        <option value="<?= GameListSort::InGameRarity->value; ?>"<?= ($filter->isSort(GameListSort::InGameRarity) ? ' selected' : ''); ?>>Rarity (Game) Points</option>
                     </select>
                 </div>
             </form>
@@ -192,9 +193,9 @@ require_once("header.php");
                         <!-- rarity points / status -->
                         <div>
                             <?php
-                            if ($game->shouldShowRarityPoints() && $filter->isSort(GameListFilter::SORT_RARITY)) {
+                            if ($game->shouldShowRarityPoints() && $filter->isSort(GameListSort::Rarity)) {
                                 echo number_format($rarityPoints) . ' Rarity Points';
-                            } elseif ($game->shouldShowRarityPoints() && $filter->isSort(GameListFilter::SORT_IN_GAME_RARITY)) {
+                            } elseif ($game->shouldShowRarityPoints() && $filter->isSort(GameListSort::InGameRarity)) {
                                 echo number_format($inGameRarityPoints) . ' Rarity (Game) Points';
                             } elseif ($statusBadge !== null) {
                                 ?>

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/classes/Html.php';
 
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerGamesPageContext.php';
+require_once __DIR__ . '/classes/PlayerGamesSort.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
 require_once __DIR__ . '/classes/PlayerStatusNotice.php';
 require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
@@ -92,13 +93,13 @@ require_once("header.php");
 
                         <select class="form-select" name="sort" onChange="this.form.submit()">
                             <option disabled>Sort by...</option>
-                            <option value="search"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_SEARCH) ? ' selected' : ''); ?>>Best Match</option>
-                            <option value="date"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_DATE) ? ' selected' : ''); ?>>Date</option>
-                            <option value="max-rarity"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_MAX_RARITY) ? ' selected' : ''); ?>>Max Rarity</option>
-                            <option value="max-in-game-rarity"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_IN_GAME_MAX_RARITY) ? ' selected' : ''); ?>>Max Rarity (Game)</option>
-                            <option value="name"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_NAME) ? ' selected' : ''); ?>>Name</option>
-                            <option value="rarity"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_RARITY) ? ' selected' : ''); ?>>Rarity</option>
-                            <option value="in-game-rarity"<?= ($playerGamesFilter->isSort(PlayerGamesFilter::SORT_IN_GAME_RARITY) ? ' selected' : ''); ?>>Rarity (Game)</option>
+                            <option value="<?= PlayerGamesSort::Search->value; ?>"<?= ($playerGamesFilter->isSort(PlayerGamesSort::Search) ? ' selected' : ''); ?>>Best Match</option>
+                            <option value="<?= PlayerGamesSort::Date->value; ?>"<?= ($playerGamesFilter->isSort(PlayerGamesSort::Date) ? ' selected' : ''); ?>>Date</option>
+                            <option value="<?= PlayerGamesSort::MaxRarity->value; ?>"<?= ($playerGamesFilter->isSort(PlayerGamesSort::MaxRarity) ? ' selected' : ''); ?>>Max Rarity</option>
+                            <option value="<?= PlayerGamesSort::InGameMaxRarity->value; ?>"<?= ($playerGamesFilter->isSort(PlayerGamesSort::InGameMaxRarity) ? ' selected' : ''); ?>>Max Rarity (Game)</option>
+                            <option value="<?= PlayerGamesSort::Name->value; ?>"<?= ($playerGamesFilter->isSort(PlayerGamesSort::Name) ? ' selected' : ''); ?>>Name</option>
+                            <option value="<?= PlayerGamesSort::Rarity->value; ?>"<?= ($playerGamesFilter->isSort(PlayerGamesSort::Rarity) ? ' selected' : ''); ?>>Rarity</option>
+                            <option value="<?= PlayerGamesSort::InGameRarity->value; ?>"<?= ($playerGamesFilter->isSort(PlayerGamesSort::InGameRarity) ? ' selected' : ''); ?>>Rarity (Game)</option>
                         </select>
                     </div>
                 </form>

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/classes/Html.php';
 
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerAdvisorPageContext.php';
+require_once __DIR__ . '/classes/PlayerAdvisorSort.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
 require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
@@ -35,7 +36,7 @@ $platformFilterOptions = $playerAdvisorPageContext->getPlatformFilterOptions();
 $platformFilterRenderer = PlayerPlatformFilterRenderer::createDefault();
 $playerStatusNotice = $playerAdvisorPageContext->getPlayerStatusNotice();
 $playerOnlineId = $playerAdvisorPageContext->getPlayerOnlineId();
-$rarityColumnLabel = $playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_IN_GAME_RARITY
+$rarityColumnLabel = $playerAdvisorFilter->isSort(PlayerAdvisorSort::InGameRarity)
     ? 'Rarity (Game)'
     : 'Rarity';
 
@@ -65,8 +66,8 @@ require_once("header.php");
 
                         <select class="form-select" name="sort" onChange="this.form.submit()">
                             <option disabled>Sort by...</option>
-                            <option value="<?= PlayerAdvisorFilter::SORT_RARITY; ?>"<?php if ($playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_RARITY) { echo ' selected'; } ?>>Rarity</option>
-                            <option value="<?= PlayerAdvisorFilter::SORT_IN_GAME_RARITY; ?>"<?php if ($playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_IN_GAME_RARITY) { echo ' selected'; } ?>>Rarity (Game)</option>
+                            <option value="<?= PlayerAdvisorSort::Rarity->value; ?>"<?php if ($playerAdvisorFilter->isSort(PlayerAdvisorSort::Rarity)) { echo ' selected'; } ?>>Rarity</option>
+                            <option value="<?= PlayerAdvisorSort::InGameRarity->value; ?>"<?php if ($playerAdvisorFilter->isSort(PlayerAdvisorSort::InGameRarity)) { echo ' selected'; } ?>>Rarity (Game)</option>
                         </select>
                     </div>
                 </form>
@@ -153,7 +154,7 @@ require_once("header.php");
                                         </td>
                                         <td class="text-center align-middle">
                                         <?php
-                                        $rarityPercent = $playerAdvisorFilter->getSort() === PlayerAdvisorFilter::SORT_IN_GAME_RARITY
+                                        $rarityPercent = $playerAdvisorFilter->isSort(PlayerAdvisorSort::InGameRarity)
                                             ? $trophy->getInGameRarityPercent()
                                             : $trophy->getRarityPercent();
                                         $trophyRarity = $trophyRarityFormatter->format($rarityPercent);

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/classes/Html.php';
 
 require_once __DIR__ . '/classes/PlayerPageAccessGuard.php';
 require_once __DIR__ . '/classes/PlayerLogPageContext.php';
+require_once __DIR__ . '/classes/PlayerLogSort.php';
 require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
 require_once __DIR__ . '/classes/PlayerStatusNotice.php';
 require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
@@ -64,9 +65,9 @@ require_once("header.php");
 
                         <select class="form-select" name="sort" onChange="this.form.submit()">
                             <option disabled>Sort by...</option>
-                            <option value="date"<?= $playerLogFilter->isSort(PlayerLogFilter::SORT_DATE) ? ' selected' : ''; ?>>Date</option>
-                            <option value="rarity"<?= $playerLogFilter->isSort(PlayerLogFilter::SORT_RARITY) ? ' selected' : ''; ?>>Rarity</option>
-                            <option value="in-game-rarity"<?= $playerLogFilter->isSort(PlayerLogFilter::SORT_IN_GAME_RARITY) ? ' selected' : ''; ?>>Rarity (Game)</option>
+                            <option value="<?= PlayerLogSort::Date->value; ?>"<?= $playerLogFilter->isSort(PlayerLogSort::Date) ? ' selected' : ''; ?>>Date</option>
+                            <option value="<?= PlayerLogSort::Rarity->value; ?>"<?= $playerLogFilter->isSort(PlayerLogSort::Rarity) ? ' selected' : ''; ?>>Rarity</option>
+                            <option value="<?= PlayerLogSort::InGameRarity->value; ?>"<?= $playerLogFilter->isSort(PlayerLogSort::InGameRarity) ? ' selected' : ''; ?>>Rarity (Game)</option>
                         </select>
                     </div>
                 </form>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Finishes a few leftover PHP 8.5 modernization spots after the earlier enum/pipe/clone work.

### Changes
- Filters now expose sort enums directly (`getSort(): GameListSort|PlayerGamesSort|…`) so list/player services can `match` without `Enum::from($filter->getSort())` string round-trips.
- Templates compare against enum cases (same pattern as `GameTrophySort` on the game page).
- New admin enums: `GameDetailAction`, `LogDeletionAction`, `AdminStreamEventType`.
- Admin game detail platform options come from `Platform::labelOrder()` instead of a duplicated constant list.

### Testing
- `php tests/run.php` — all 1001 tests passed.

### Notes
Property hooks were considered for `clone()` withers (e.g. `PageMetaData`), but hooked properties cannot be `readonly`, so that was left alone to preserve the existing DTO style.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c7bfd0b-241c-43d4-b610-ecb02889d94f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c7bfd0b-241c-43d4-b610-ecb02889d94f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

