### PR TITLE
Adopt remaining PHP 8.5 idioms for status enums and routes

### DIFF
--- a/tests/GameListFilterTest.php
+++ b/tests/GameListFilterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/GameListFilter.php';
 require_once __DIR__ . '/../wwwroot/classes/GameListSort.php';
+require_once __DIR__ . '/../wwwroot/classes/Platform.php';
 
 final class GameListFilterTest extends TestCase
 {
@@ -33,10 +34,10 @@ final class GameListFilterTest extends TestCase
         $this->assertTrue($filter->shouldFilterUncompleted());
         $this->assertTrue($filter->shouldShowUncompletedOption());
         $this->assertTrue($filter->hasPlatformFilters());
-        $this->assertTrue($filter->isPlatformSelected(GameListFilter::PLATFORM_PS4));
-        $this->assertFalse($filter->isPlatformSelected(GameListFilter::PLATFORM_PS5));
-        $this->assertFalse($filter->isPlatformSelected(GameListFilter::PLATFORM_PC));
-        $this->assertSame([GameListFilter::PLATFORM_PS4], $filter->getSelectedPlatforms());
+        $this->assertTrue($filter->isPlatformSelected(Platform::Ps4->value));
+        $this->assertFalse($filter->isPlatformSelected(Platform::Ps5->value));
+        $this->assertFalse($filter->isPlatformSelected(Platform::Pc->value));
+        $this->assertSame([Platform::Ps4->value], $filter->getSelectedPlatforms());
     }
 
     public function testFromArrayDefaultsSearchSortAndNormalizesPage(): void

--- a/tests/HomepagePopularGamesFilterTest.php
+++ b/tests/HomepagePopularGamesFilterTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/HomepagePopularGamesFilter.php';
+require_once __DIR__ . '/../wwwroot/classes/Platform.php';
 
 final class HomepagePopularGamesFilterTest extends TestCase
 {
@@ -23,7 +24,7 @@ final class HomepagePopularGamesFilterTest extends TestCase
             'exclusive' => 'true',
         ]);
 
-        $this->assertTrue($filter->isPlatformSelected(HomepagePopularGamesFilter::PLATFORM_PS5));
+        $this->assertTrue($filter->isPlatformSelected(Platform::Ps5->value));
         $this->assertTrue($filter->isExclusiveOnly());
         $this->assertSame(
             [
@@ -54,7 +55,7 @@ final class HomepagePopularGamesFilterTest extends TestCase
             'exclusive' => 'false',
         ]);
 
-        $this->assertTrue($filter->isPlatformSelected(HomepagePopularGamesFilter::PLATFORM_PS4));
+        $this->assertTrue($filter->isPlatformSelected(Platform::Ps4->value));
         $this->assertFalse($filter->isExclusiveOnly());
         $this->assertSame(['platform' => 'ps4'], $filter->getQueryParameters());
     }

--- a/tests/PlayerGamesServiceTest.php
+++ b/tests/PlayerGamesServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/PlayerGamesService.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerGamesFilter.php';
+require_once __DIR__ . '/../wwwroot/classes/Platform.php';
 require_once __DIR__ . '/../wwwroot/classes/SearchQueryHelper.php';
 
 final class PlayerGamesServiceTest extends TestCase
@@ -127,7 +128,7 @@ final class PlayerGamesServiceTest extends TestCase
         $filter = PlayerGamesFilter::fromArray([
             'completed' => '1',
             'base' => '1',
-            PlayerGamesFilter::PLATFORM_PS4 => '1',
+            Platform::Ps4->value => '1',
         ]);
 
         $count = $this->service->countPlayerGames(42, $filter);

--- a/tests/PlayerRandomGamesFilterTest.php
+++ b/tests/PlayerRandomGamesFilterTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../wwwroot/classes/Platform.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerRandomGamesFilter.php';
 
 final class PlayerRandomGamesFilterTest extends TestCase
@@ -19,13 +20,13 @@ final class PlayerRandomGamesFilterTest extends TestCase
             'extra' => true,
         ]);
 
-        $this->assertTrue($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PC));
-        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS3));
-        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS4));
-        $this->assertTrue($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS5));
-        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVITA));
-        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVR));
-        $this->assertTrue($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVR2));
+        $this->assertTrue($filter->isPlatformSelected(Platform::Pc->value));
+        $this->assertFalse($filter->isPlatformSelected(Platform::Ps3->value));
+        $this->assertFalse($filter->isPlatformSelected(Platform::Ps4->value));
+        $this->assertTrue($filter->isPlatformSelected(Platform::Ps5->value));
+        $this->assertFalse($filter->isPlatformSelected(Platform::PsVita->value));
+        $this->assertFalse($filter->isPlatformSelected(Platform::PsVr->value));
+        $this->assertTrue($filter->isPlatformSelected(Platform::PsVr2->value));
         $this->assertFalse($filter->isPlatformSelected('extra'));
     }
 
@@ -33,12 +34,12 @@ final class PlayerRandomGamesFilterTest extends TestCase
     {
         $filter = PlayerRandomGamesFilter::fromArray([]);
 
-        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PC));
-        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS3));
-        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS4));
-        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PS5));
-        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVITA));
-        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVR));
-        $this->assertFalse($filter->isPlatformSelected(PlayerRandomGamesFilter::PLATFORM_PSVR2));
+        $this->assertFalse($filter->isPlatformSelected(Platform::Pc->value));
+        $this->assertFalse($filter->isPlatformSelected(Platform::Ps3->value));
+        $this->assertFalse($filter->isPlatformSelected(Platform::Ps4->value));
+        $this->assertFalse($filter->isPlatformSelected(Platform::Ps5->value));
+        $this->assertFalse($filter->isPlatformSelected(Platform::PsVita->value));
+        $this->assertFalse($filter->isPlatformSelected(Platform::PsVr->value));
+        $this->assertFalse($filter->isPlatformSelected(Platform::PsVr2->value));
     }
 }

--- a/tests/PlayerRandomGamesServiceTest.php
+++ b/tests/PlayerRandomGamesServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../wwwroot/classes/Utility.php';
+require_once __DIR__ . '/../wwwroot/classes/Platform.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerRandomGame.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerRandomGamesFilter.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerRandomGamesService.php';
@@ -114,7 +115,7 @@ final class PlayerRandomGamesServiceTest extends TestCase
 
         $rows = $this->invokeFetchFallbackGames(
             accountId: 77,
-            filter: PlayerRandomGamesFilter::fromArray([PlayerRandomGamesFilter::PLATFORM_PS3 => '1']),
+            filter: PlayerRandomGamesFilter::fromArray([Platform::Ps3->value => '1']),
             limit: 30,
             seenIds: [1, 2]
         );
@@ -133,7 +134,7 @@ final class PlayerRandomGamesServiceTest extends TestCase
 
         $games = $this->service->getRandomGames(
             accountId: 222,
-            filter: PlayerRandomGamesFilter::fromArray([PlayerRandomGamesFilter::PLATFORM_PS3 => '1']),
+            filter: PlayerRandomGamesFilter::fromArray([Platform::Ps3->value => '1']),
             limit: 5
         );
 
@@ -150,7 +151,7 @@ final class PlayerRandomGamesServiceTest extends TestCase
 
         $games = $this->service->getRandomGames(
             accountId: 333,
-            filter: PlayerRandomGamesFilter::fromArray([PlayerRandomGamesFilter::PLATFORM_PSVR => '1']),
+            filter: PlayerRandomGamesFilter::fromArray([Platform::PsVr->value => '1']),
             limit: 6
         );
 

--- a/wwwroot/classes/AboutPageService.php
+++ b/wwwroot/classes/AboutPageService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/AboutPageDataProviderInterface.php';
 require_once __DIR__ . '/AboutPagePlayer.php';
 require_once __DIR__ . '/AboutPageScanSummary.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
 final readonly class AboutPageService implements AboutPageDataProviderInterface
 {
@@ -19,8 +20,10 @@ final readonly class AboutPageService implements AboutPageDataProviderInterface
     #[\Override]
     public function getScanSummary(): AboutPageScanSummary
     {
+        $normalStatus = PlayerStatus::NORMAL->value;
+
         $summaryQuery = $this->database->prepare(
-            <<<'SQL'
+            <<<SQL
             SELECT
                 (
                     SELECT COUNT(*)
@@ -30,7 +33,7 @@ final readonly class AboutPageService implements AboutPageDataProviderInterface
                 (
                     SELECT COUNT(*)
                     FROM player
-                    WHERE status = 0 AND rank_last_week = 0
+                    WHERE status = {$normalStatus} AND rank_last_week = 0
                 ) AS new_players
             SQL
         );

--- a/wwwroot/classes/AbstractPlayerLeaderboardService.php
+++ b/wwwroot/classes/AbstractPlayerLeaderboardService.php
@@ -4,20 +4,22 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerLeaderboardDataProvider.php';
 require_once __DIR__ . '/PlayerLeaderboardQueryResult.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
 abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeaderboardDataProvider
 {
     public const int PAGE_SIZE = 50;
 
-    private const string COUNT_SQL = <<<'SQL'
+    private const string COUNT_SQL =
+        <<<'SQL'
         SELECT
             COUNT(*)
         FROM
             player_ranking r
         JOIN player p ON p.account_id = r.account_id
         WHERE
-            p.status = 0
-    SQL;
+            p.status = 
+        SQL . PlayerStatus::NORMAL->value;
 
     public function __construct(protected \PDO $database)
     {
@@ -74,6 +76,7 @@ abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeader
         int $limit,
         bool $includeTotalCount,
     ): array {
+        $normalStatus = PlayerStatus::NORMAL->value;
         $totalCountProjection = $includeTotalCount ? ",\n                COUNT(*) OVER() AS total_rows" : '';
 
         $sql = <<<SQL
@@ -84,7 +87,7 @@ abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeader
                 player_ranking r
             JOIN player p ON p.account_id = r.account_id
             WHERE
-                p.status = 0
+                p.status = {$normalStatus}
         SQL;
 
         $sql .= $this->buildFilterSql($filter);

--- a/wwwroot/classes/Admin/SystemCommandExecutor.php
+++ b/wwwroot/classes/Admin/SystemCommandExecutor.php
@@ -44,7 +44,7 @@ final class SystemCommandExecutor implements CommandExecutorInterface
     private function buildCommandString(array $command): string
     {
         $escapedParts = array_map(
-            static fn(string $part): string => escapeshellarg($part),
+            escapeshellarg(...),
             $command
         );
 

--- a/wwwroot/classes/AvatarService.php
+++ b/wwwroot/classes/AvatarService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Avatar.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
 class AvatarService
 {
@@ -12,14 +13,16 @@ class AvatarService
 
     public function getTotalUniqueAvatarCount(): int
     {
+        $normalStatus = PlayerStatus::NORMAL->value;
+
         $query = $this->database->prepare(
-            <<<'SQL'
+            <<<SQL
             SELECT
                 COUNT(DISTINCT avatar_url)
             FROM
                 player p
             WHERE
-                p.status = 0
+                p.status = {$normalStatus}
             SQL
         );
         $query->execute();
@@ -35,16 +38,17 @@ class AvatarService
         $limit = max($limit, 1);
         $page = max($page, 1);
         $offset = ($page - 1) * $limit;
+        $normalStatus = PlayerStatus::NORMAL->value;
 
         $query = $this->database->prepare(
-            <<<'SQL'
+            <<<SQL
             SELECT
                 COUNT(*) AS count,
                 avatar_url
             FROM
                 player p
             WHERE
-                p.status = 0
+                p.status = {$normalStatus}
             GROUP BY
                 avatar_url
             ORDER BY

--- a/wwwroot/classes/Cron/PlayerScanQueueSelector.php
+++ b/wwwroot/classes/Cron/PlayerScanQueueSelector.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../PlayerStatus.php';
+
 /**
  * Selects the next player for a worker scan from the tiered priority queue.
  *
@@ -115,6 +117,12 @@ final class PlayerScanQueueSelector
             ],
         );
 
+        $unavailableStatus = PlayerStatus::UNAVAILABLE->value;
+        $normalStatus = PlayerStatus::NORMAL->value;
+        $newPlayerStatus = PlayerStatus::NEW_PLAYER->value;
+        $privateStatus = PlayerStatus::PRIVATE_PROFILE->value;
+        $inactiveStatus = PlayerStatus::INACTIVE->value;
+
         return <<<SQL
             WITH
                 now_values AS (
@@ -156,7 +164,7 @@ final class PlayerScanQueueSelector
                     player p
                     JOIN now_values nv
                 WHERE
-                    p.status = 5
+                    p.status = {$unavailableStatus}
                     AND p.last_updated_date < nv.cutoff_1d
 
                 UNION ALL
@@ -171,7 +179,7 @@ final class PlayerScanQueueSelector
                     LEFT JOIN player_ranking pr ON pr.account_id = p.account_id
                     JOIN now_values nv
                 WHERE
-                    p.status IN (0, 99)
+                    p.status IN ({$normalStatus}, {$newPlayerStatus})
                     AND p.last_updated_date < nv.cutoff_1w
                     AND (
                         pr.account_id IS NULL
@@ -191,7 +199,7 @@ final class PlayerScanQueueSelector
                     player p
                     JOIN now_values nv
                 WHERE
-                    p.status = 3
+                    p.status = {$privateStatus}
                     AND p.last_updated_date < nv.cutoff_1m
 
                 UNION ALL
@@ -205,7 +213,7 @@ final class PlayerScanQueueSelector
                     player p
                     JOIN now_values nv
                 WHERE
-                    p.status = 4
+                    p.status = {$inactiveStatus}
                     AND p.last_updated_date < nv.cutoff_3m
 
                 UNION ALL

--- a/wwwroot/classes/Cron/WeeklyCronJob.php
+++ b/wwwroot/classes/Cron/WeeklyCronJob.php
@@ -3,12 +3,14 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/CronJobInterface.php';
+require_once __DIR__ . '/../PlayerStatus.php';
 
 final readonly class WeeklyCronJob implements CronJobInterface
 {
     private const \Closure DEFAULT_SLEEPER = sleep(...);
 
-    private const string UPDATE_PLAYER_RANKINGS_QUERY = <<<'SQL'
+    private const string UPDATE_PLAYER_RANKINGS_QUERY =
+        <<<'SQL'
         UPDATE player p
         JOIN player_ranking r ON p.account_id = r.account_id
         SET
@@ -18,10 +20,11 @@ final readonly class WeeklyCronJob implements CronJobInterface
             p.rank_country_last_week = r.ranking_country,
             p.rarity_rank_country_last_week = r.rarity_ranking_country,
             p.in_game_rarity_rank_country_last_week = r.in_game_rarity_ranking_country
-        WHERE p.status = 0
-        SQL;
+        WHERE p.status = 
+        SQL . PlayerStatus::NORMAL->value;
 
-    private const string RESET_INACTIVE_RANKINGS_QUERY = <<<'SQL'
+    private const string RESET_INACTIVE_RANKINGS_QUERY =
+        <<<'SQL'
         UPDATE
             player p
         SET
@@ -32,8 +35,8 @@ final readonly class WeeklyCronJob implements CronJobInterface
             p.in_game_rarity_rank_last_week = 0,
             p.in_game_rarity_rank_country_last_week = 0
         WHERE
-            p.status != 0
-        SQL;
+            p.status != 
+        SQL . PlayerStatus::NORMAL->value;
 
     public function __construct(
         final private PDO $database,

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/Game/GameHeaderStack.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/PsnpPlusClient.php';
 require_once __DIR__ . '/Html.php';
+require_once __DIR__ . '/TrophyMetaStatus.php';
 
 class GameHeaderService
 {
@@ -112,15 +113,17 @@ class GameHeaderService
 
     private function countUnobtainableTrophies(string $npCommunicationId): int
     {
+        $unobtainableStatus = TrophyMetaStatus::Unobtainable->value;
+
         $query = $this->database->prepare(
-            <<<'SQL'
+            <<<SQL
             SELECT
                 COUNT(*)
             FROM
                 trophy t
                 JOIN trophy_meta tm ON tm.trophy_id = t.id
             WHERE
-                tm.status = 1
+                tm.status = {$unobtainableStatus}
                 AND t.np_communication_id = :np_communication_id
             SQL
         );

--- a/wwwroot/classes/GameLeaderboardService.php
+++ b/wwwroot/classes/GameLeaderboardService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/GameLeaderboardRow.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
 class GameLeaderboardService
 {
@@ -92,7 +93,9 @@ class GameLeaderboardService
 
     public function getLeaderboardPlayerCount(string $npCommunicationId, GamePlayerFilter $filter): int
     {
-        $sql = <<<'SQL'
+        $normalStatus = PlayerStatus::NORMAL->value;
+
+        $sql = <<<SQL
             SELECT
                 COUNT(*)
             FROM
@@ -101,7 +104,7 @@ class GameLeaderboardService
             JOIN player_ranking r ON r.account_id = p.account_id
             WHERE
                 ttp.np_communication_id = :np_communication_id
-                AND p.status = 0
+                AND p.status = {$normalStatus}
                 AND r.ranking <= 10000
         SQL;
 
@@ -120,7 +123,9 @@ class GameLeaderboardService
      */
     public function getLeaderboardRows(string $npCommunicationId, GameLeaderboardFilter $filter, int $limit): array
     {
-        $sql = <<<'SQL'
+        $normalStatus = PlayerStatus::NORMAL->value;
+
+        $sql = <<<SQL
             SELECT
                 p.account_id,
                 p.avatar_url,
@@ -139,7 +144,7 @@ class GameLeaderboardService
             JOIN player p ON ttp.account_id = p.account_id
             JOIN player_ranking r ON p.account_id = r.account_id
             WHERE
-                p.status = 0
+                p.status = {$normalStatus}
                 AND r.ranking <= 10000
                 AND ttp.np_communication_id = :np_communication_id
         SQL;

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -15,14 +15,6 @@ final readonly class GameListFilter
     public const string SORT_IN_GAME_RARITY = GameListSort::InGameRarity->value;
     public const string SORT_SEARCH = GameListSort::Search->value;
 
-    public const string PLATFORM_PC = Platform::Pc->value;
-    public const string PLATFORM_PS3 = Platform::Ps3->value;
-    public const string PLATFORM_PS4 = Platform::Ps4->value;
-    public const string PLATFORM_PS5 = Platform::Ps5->value;
-    public const string PLATFORM_PSVITA = Platform::PsVita->value;
-    public const string PLATFORM_PSVR = Platform::PsVr->value;
-    public const string PLATFORM_PSVR2 = Platform::PsVr2->value;
-
     private function __construct(
         final private ?string $player,
         final private GameListSort $sort,
@@ -172,15 +164,18 @@ final readonly class GameListFilter
      */
     public function getSelectedPlatforms(): array
     {
-        return array_keys(array_filter(
-            $this->platformFilters,
-            static fn (bool $selected): bool => $selected,
-        ));
+        return $this->platformFilters
+            |> (fn (array $filters): array => array_filter(
+                $filters,
+                static fn (bool $selected): bool => $selected,
+            ))
+            |> array_keys(...);
     }
 
     /**
      * @return array<string, string>
      */
+    #[\NoDiscard]
     public function getQueryParametersForPagination(): array
     {
         $parameters = $this->originalParameters;

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/GameListItem.php';
 require_once __DIR__ . '/GameListPageResult.php';
 require_once __DIR__ . '/GameListSort.php';
@@ -199,11 +200,14 @@ class GameListService
 
     private function buildConditions(GameListFilter $filter): string
     {
+        $normalStatus = GameAvailabilityStatus::NORMAL->value;
+        $mergedStatus = GameAvailabilityStatus::MERGED->value;
+
         $conditions = [
             match ($filter->getSort()) {
-                GameListSort::Completion => "ttm.status = 0 AND (tt.bronze + tt.silver + tt.gold + tt.platinum) != 0",
-                GameListSort::Rarity, GameListSort::InGameRarity => 'ttm.status = 0',
-                default => 'ttm.status != 2',
+                GameListSort::Completion => "ttm.status = {$normalStatus} AND (tt.bronze + tt.silver + tt.gold + tt.platinum) != 0",
+                GameListSort::Rarity, GameListSort::InGameRarity => "ttm.status = {$normalStatus}",
+                default => "ttm.status != {$mergedStatus}",
             },
         ];
 

--- a/wwwroot/classes/GameRecentPlayersQueryBuilder.php
+++ b/wwwroot/classes/GameRecentPlayersQueryBuilder.php
@@ -3,10 +3,11 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/GamePlayerFilter.php';
+require_once __DIR__ . '/PlayerStatus.php';
 
-final class GameRecentPlayersQueryBuilder
+final readonly class GameRecentPlayersQueryBuilder
 {
-    private const string BASE_QUERY = <<<'SQL'
+    private const string BASE_QUERY_PREFIX = <<<'SQL'
         WITH eligible_players AS (
             SELECT
                 p.account_id,
@@ -17,7 +18,10 @@ final class GameRecentPlayersQueryBuilder
                 p.trophy_count_sony
             FROM player p
             JOIN player_ranking r ON r.account_id = p.account_id
-            WHERE p.status = 0
+            WHERE p.status = 
+        SQL;
+
+    private const string BASE_QUERY_SUFFIX = <<<'SQL'
               AND r.ranking <= 10000
         )
         SELECT
@@ -44,14 +48,14 @@ final class GameRecentPlayersQueryBuilder
         LIMIT :limit
     SQL;
 
+    private int $limit;
+
     public function __construct(
-        private readonly GamePlayerFilter $filter,
+        private GamePlayerFilter $filter,
         int $limit,
     ) {
         $this->limit = max(1, $limit);
     }
-
-    private readonly int $limit;
 
     public function prepare(\PDO $database, string $npCommunicationId): \PDOStatement
     {
@@ -65,7 +69,9 @@ final class GameRecentPlayersQueryBuilder
 
     private function buildSql(): string
     {
-        return self::BASE_QUERY
+        return self::BASE_QUERY_PREFIX
+            . PlayerStatus::NORMAL->value
+            . self::BASE_QUERY_SUFFIX
             . $this->buildFilterSql()
             . self::ORDER_BY_QUERY;
     }

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/Homepage/HomepageNewGame.php';
 require_once __DIR__ . '/Homepage/HomepageDlc.php';
 require_once __DIR__ . '/Homepage/HomepagePopularGame.php';
 require_once __DIR__ . '/HomepagePopularGamesFilter.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/PlatformSql.php';
 
@@ -26,8 +27,10 @@ class HomepageContentService
      */
     public function getNewGames(int $limit = self::DEFAULT_NEW_GAME_LIMIT): array
     {
+        $mergedStatus = GameAvailabilityStatus::MERGED->value;
+
         $query = $this->database->prepare(
-            <<<'SQL'
+            <<<SQL
             SELECT
                 tt.id,
                 tt.name,
@@ -41,7 +44,7 @@ class HomepageContentService
                 trophy_title tt
                 JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             WHERE
-                ttm.status <> 2
+                ttm.status <> {$mergedStatus}
             ORDER BY
                 tt.id DESC
             LIMIT
@@ -61,8 +64,10 @@ class HomepageContentService
      */
     public function getNewDlcs(int $limit = self::DEFAULT_NEW_DLCS_LIMIT): array
     {
+        $mergedStatus = GameAvailabilityStatus::MERGED->value;
+
         $query = $this->database->prepare(
-            <<<'SQL'
+            <<<SQL
             SELECT
                 tt.id,
                 tt.name AS game_name,
@@ -78,7 +83,7 @@ class HomepageContentService
                 JOIN trophy_title tt USING (np_communication_id)
                 JOIN trophy_title_meta ttm USING (np_communication_id)
             WHERE
-                ttm.status <> 2
+                ttm.status <> {$mergedStatus}
                 AND tg.group_id <> 'default'
             ORDER BY
                 tg.id DESC
@@ -136,7 +141,8 @@ class HomepageContentService
      */
     private function buildPopularGamesWhereClauses(HomepagePopularGamesFilter $filter): array
     {
-        $conditions = ['ttm.status <> 2'];
+        $mergedStatus = GameAvailabilityStatus::MERGED->value;
+        $conditions = ["ttm.status <> {$mergedStatus}"];
 
         if ($filter->isExclusiveOnly() && $filter->hasPlatformFilter()) {
             $conditions[] = 'tt.platform = ' . $this->database->quote($filter->getPlatformDatabaseValue());

--- a/wwwroot/classes/HomepagePopularGamesFilter.php
+++ b/wwwroot/classes/HomepagePopularGamesFilter.php
@@ -8,13 +8,6 @@ require_once __DIR__ . '/RequestParameter.php';
 final readonly class HomepagePopularGamesFilter
 {
     public const string PLATFORM_ALL = '';
-    public const string PLATFORM_PC = Platform::Pc->value;
-    public const string PLATFORM_PS3 = Platform::Ps3->value;
-    public const string PLATFORM_PS4 = Platform::Ps4->value;
-    public const string PLATFORM_PS5 = Platform::Ps5->value;
-    public const string PLATFORM_PSVITA = Platform::PsVita->value;
-    public const string PLATFORM_PSVR = Platform::PsVr->value;
-    public const string PLATFORM_PSVR2 = Platform::PsVr2->value;
 
     private function __construct(
         final private string $platform,
@@ -62,6 +55,7 @@ final readonly class HomepagePopularGamesFilter
     /**
      * @return array<string, string>
      */
+    #[\NoDiscard]
     public function getQueryParameters(): array
     {
         $parameters = [];

--- a/wwwroot/classes/Leaderboard/InGameRarityLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/InGameRarityLeaderboardPageContext.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/AbstractLeaderboardPageContext.php';
 require_once __DIR__ . '/../PlayerInGameRarityLeaderboardService.php';
 require_once __DIR__ . '/InGameRarityLeaderboardRow.php';
 
-class InGameRarityLeaderboardPageContext extends AbstractLeaderboardPageContext
+final class InGameRarityLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
     private const string TITLE = 'PSN Rarity (Game) Leaderboard ~ PSN 100%';
 

--- a/wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/RarityLeaderboardPageContext.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/AbstractLeaderboardPageContext.php';
 require_once __DIR__ . '/../PlayerRarityLeaderboardService.php';
 require_once __DIR__ . '/RarityLeaderboardRow.php';
 
-class RarityLeaderboardPageContext extends AbstractLeaderboardPageContext
+final class RarityLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
     private const string TITLE = 'PSN Rarity Leaderboard ~ PSN 100%';
 

--- a/wwwroot/classes/Leaderboard/TrophyLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/TrophyLeaderboardPageContext.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/AbstractLeaderboardPageContext.php';
 require_once __DIR__ . '/../PlayerLeaderboardService.php';
 require_once __DIR__ . '/TrophyLeaderboardRow.php';
 
-class TrophyLeaderboardPageContext extends AbstractLeaderboardPageContext
+final class TrophyLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
     private const string TITLE = 'PSN Trophy Leaderboard ~ PSN 100%';
 

--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 require_once __DIR__ . '/PlayerAdvisableTrophy.php';
 require_once __DIR__ . '/PlayerAdvisorSort.php';
 require_once __DIR__ . '/PlatformSql.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
+require_once __DIR__ . '/TrophyMetaStatus.php';
 require_once __DIR__ . '/Utility.php';
 
 class PlayerAdvisorService
@@ -19,7 +21,10 @@ class PlayerAdvisorService
 
     public function countAdvisableTrophies(int $accountId, PlayerAdvisorFilter $filter): int
     {
-        $sql = <<<'SQL'
+        $normalGameStatus = GameAvailabilityStatus::NORMAL->value;
+        $obtainableStatus = TrophyMetaStatus::Obtainable->value;
+
+        $sql = <<<SQL
             SELECT COUNT(*)
             FROM trophy_title_player ttp
             JOIN trophy t ON t.np_communication_id = ttp.np_communication_id
@@ -31,8 +36,8 @@ class PlayerAdvisorService
                 AND te.np_communication_id = t.np_communication_id
                 AND te.order_id = t.order_id
             WHERE ttp.account_id = :account_id
-                AND ttm.status = 0
-                AND tm.status = 0
+                AND ttm.status = {$normalGameStatus}
+                AND tm.status = {$obtainableStatus}
                 AND (te.account_id IS NULL OR te.earned = 0)
         SQL;
 
@@ -50,7 +55,10 @@ class PlayerAdvisorService
      */
     public function getAdvisableTrophies(int $accountId, PlayerAdvisorFilter $filter, int $offset, int $limit = self::PAGE_SIZE): array
     {
-        $sql = <<<'SQL'
+        $normalGameStatus = GameAvailabilityStatus::NORMAL->value;
+        $obtainableStatus = TrophyMetaStatus::Obtainable->value;
+
+        $sql = <<<SQL
             SELECT
                 t.id AS trophy_id,
                 t.type AS trophy_type,
@@ -77,8 +85,8 @@ class PlayerAdvisorService
                 AND te.np_communication_id = t.np_communication_id
                 AND te.order_id = t.order_id
             WHERE ttp.account_id = :account_id
-                AND ttm.status = 0
-                AND tm.status = 0
+                AND ttm.status = {$normalGameStatus}
+                AND tm.status = {$obtainableStatus}
                 AND (te.account_id IS NULL OR te.earned = 0)
         SQL;
 

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -16,14 +16,6 @@ final readonly class PlayerGamesFilter
     public const string SORT_RARITY = PlayerGamesSort::Rarity->value;
     public const string SORT_SEARCH = PlayerGamesSort::Search->value;
 
-    public const string PLATFORM_PC = Platform::Pc->value;
-    public const string PLATFORM_PS3 = Platform::Ps3->value;
-    public const string PLATFORM_PS4 = Platform::Ps4->value;
-    public const string PLATFORM_PS5 = Platform::Ps5->value;
-    public const string PLATFORM_PSVITA = Platform::PsVita->value;
-    public const string PLATFORM_PSVR = Platform::PsVr->value;
-    public const string PLATFORM_PSVR2 = Platform::PsVr2->value;
-
     private const int DEFAULT_LIMIT = 50;
 
     /**

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/PlayerGame.php';
 require_once __DIR__ . '/PlayerGamesFilter.php';
 require_once __DIR__ . '/PlayerGamesSort.php';
 require_once __DIR__ . '/PlatformSql.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/SearchQueryHelper.php';
 require_once __DIR__ . '/DateDurationSummary.php';
 
@@ -121,8 +122,9 @@ final class PlayerGamesService
 
     private function buildWhereClause(PlayerGamesFilter $filter): string
     {
+        $mergedStatus = GameAvailabilityStatus::MERGED->value;
         $conditions = [
-            'ttm.status != 2',
+            "ttm.status != {$mergedStatus}",
             'ttp.account_id = :account_id',
         ];
 

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 require_once __DIR__ . '/PlayerLogEntry.php';
 require_once __DIR__ . '/PlayerLogSort.php';
 require_once __DIR__ . '/PlatformSql.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
+require_once __DIR__ . '/TrophyMetaStatus.php';
 
 class PlayerLogService
 {
@@ -16,17 +18,20 @@ class PlayerLogService
 
     public function countTrophies(int $accountId, PlayerLogFilter $filter): int
     {
-        $sql = <<<'SQL'
+        $mergedStatus = GameAvailabilityStatus::MERGED->value;
+        $unobtainableStatus = TrophyMetaStatus::Unobtainable->value;
+
+        $sql = <<<SQL
             SELECT COUNT(*)
             FROM trophy_earned te
             LEFT JOIN trophy t USING (np_communication_id, group_id, order_id)
             LEFT JOIN trophy_meta tm ON tm.trophy_id = t.id
             JOIN trophy_title tt USING (np_communication_id)
             JOIN trophy_title_meta ttm USING (np_communication_id)
-            WHERE ttm.status != 2
+            WHERE ttm.status != {$mergedStatus}
                 AND te.account_id = :account_id
                 AND te.earned = 1
-                AND (tm.status IS NULL OR tm.status != 1)
+                AND (tm.status IS NULL OR tm.status != {$unobtainableStatus})
         SQL;
 
         $sql .= $this->buildPlatformClause($filter);
@@ -43,7 +48,10 @@ class PlayerLogService
      */
     public function getTrophies(int $accountId, PlayerLogFilter $filter, int $offset, int $limit = self::PAGE_SIZE): array
     {
-        $sql = <<<'SQL'
+        $mergedStatus = GameAvailabilityStatus::MERGED->value;
+        $unobtainableStatus = TrophyMetaStatus::Unobtainable->value;
+
+        $sql = <<<SQL
             SELECT
                 te.earned,
                 te.progress,
@@ -69,10 +77,10 @@ class PlayerLogService
             LEFT JOIN trophy_meta tm ON tm.trophy_id = t.id
             JOIN trophy_title tt USING (np_communication_id)
             JOIN trophy_title_meta ttm USING (np_communication_id)
-            WHERE ttm.status != 2
+            WHERE ttm.status != {$mergedStatus}
                 AND te.account_id = :account_id
                 AND te.earned = 1
-                AND (tm.status IS NULL OR tm.status != 1)
+                AND (tm.status IS NULL OR tm.status != {$unobtainableStatus})
         SQL;
 
         $sql .= $this->buildPlatformClause($filter);

--- a/wwwroot/classes/PlayerNavigationRenderer.php
+++ b/wwwroot/classes/PlayerNavigationRenderer.php
@@ -10,7 +10,7 @@ final class PlayerNavigationRenderer
     public function render(PlayerNavigation $navigation): string
     {
         $links = array_map(
-            fn (PlayerNavigationLink $link): string => $this->renderLink($link),
+            $this->renderLink(...),
             $navigation->getLinks()
         );
 

--- a/wwwroot/classes/PlayerPlatformFilterRenderer.php
+++ b/wwwroot/classes/PlayerPlatformFilterRenderer.php
@@ -53,7 +53,7 @@ HTML;
     public function renderOptionItems(PlayerPlatformFilterOptions $options): string
     {
         $optionItems = array_map(
-            fn (PlayerPlatformFilterOption $option): string => $this->renderOption($option),
+            $this->renderOption(...),
             $options->getOptions()
         );
 

--- a/wwwroot/classes/PlayerRandomGamesFilter.php
+++ b/wwwroot/classes/PlayerRandomGamesFilter.php
@@ -7,14 +7,6 @@ require_once __DIR__ . '/RequestParameter.php';
 
 final readonly class PlayerRandomGamesFilter
 {
-    public const string PLATFORM_PC = Platform::Pc->value;
-    public const string PLATFORM_PS3 = Platform::Ps3->value;
-    public const string PLATFORM_PS4 = Platform::Ps4->value;
-    public const string PLATFORM_PS5 = Platform::Ps5->value;
-    public const string PLATFORM_PSVITA = Platform::PsVita->value;
-    public const string PLATFORM_PSVR = Platform::PsVr->value;
-    public const string PLATFORM_PSVR2 = Platform::PsVr2->value;
-
     /**
      * @var array<string, bool>
      */

--- a/wwwroot/classes/PlayerTimelineService.php
+++ b/wwwroot/classes/PlayerTimelineService.php
@@ -61,7 +61,7 @@ class PlayerTimelineService
         $endDate = $timelineEnd->modify('first day of next month');
 
         $entries = array_map(
-            fn(array $row): PlayerTimelineEntry => PlayerTimelineEntry::fromRow($row),
+            PlayerTimelineEntry::fromRow(...),
             $rows
         );
 

--- a/wwwroot/classes/Routing/GameRouteHandler.php
+++ b/wwwroot/classes/Routing/GameRouteHandler.php
@@ -30,8 +30,9 @@ final readonly class GameRouteHandler implements RouteHandlerInterface
             return RouteResult::redirect($this->redirectPath);
         }
 
-        $gameSegment = array_shift($segments);
+        $gameSegment = array_first($segments);
         $gameId = $this->gameRepository->findIdFromSegment($gameSegment);
+        $segments = array_slice($segments, 1);
 
         if ($gameId === null) {
             return RouteResult::redirect($this->redirectPath);

--- a/wwwroot/classes/Routing/PlayerRouteHandler.php
+++ b/wwwroot/classes/Routing/PlayerRouteHandler.php
@@ -22,8 +22,9 @@ final readonly class PlayerRouteHandler implements RouteHandlerInterface
             return RouteResult::redirect('/leaderboard/trophy');
         }
 
-        $onlineIdSegment = array_shift($segments) ?? '';
+        $onlineIdSegment = array_first($segments) ?? '';
         $onlineId = rawurldecode($onlineIdSegment);
+        $segments = array_slice($segments, 1);
 
         $accountId = $this->playerRepository->findAccountIdByOnlineId($onlineId);
 

--- a/wwwroot/classes/Routing/TrophyRouteHandler.php
+++ b/wwwroot/classes/Routing/TrophyRouteHandler.php
@@ -23,8 +23,9 @@ final readonly class TrophyRouteHandler implements RouteHandlerInterface
             return RouteResult::include('trophies.php');
         }
 
-        $trophySegment = array_shift($segments);
+        $trophySegment = array_first($segments);
         $trophyId = $this->trophyRepository->findIdFromSegment($trophySegment);
+        $segments = array_slice($segments, 1);
 
         if ($trophyId === null) {
             return RouteResult::redirect('/trophy/');

--- a/wwwroot/games.php
+++ b/wwwroot/games.php
@@ -8,6 +8,8 @@ require_once __DIR__ . '/classes/GameListFilter.php';
 require_once __DIR__ . '/classes/GameListSort.php';
 require_once __DIR__ . '/classes/GameListService.php';
 require_once __DIR__ . '/classes/GameListPage.php';
+require_once __DIR__ . '/classes/PlayerPlatformFilterOptions.php';
+require_once __DIR__ . '/classes/PlayerPlatformFilterRenderer.php';
 require_once __DIR__ . '/classes/SearchQueryHelper.php';
 
 $title = "Games ~ PSN 100%";
@@ -23,6 +25,10 @@ $playerName = $gameListPage->getPlayerName();
 $totalGames = $gameListPage->getTotalGames();
 $startIndex = $gameListPage->getRangeStart();
 $endIndex = $gameListPage->getRangeEnd();
+$platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(
+    $filter->isPlatformSelected(...)
+);
+$platformFilterRenderer = PlayerPlatformFilterRenderer::createDefault();
 
 require_once("header.php");
 ?>
@@ -42,62 +48,7 @@ require_once("header.php");
 
                     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Filter</button>
                     <ul class="dropdown-menu p-2">
-                        <li>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox"<?= ($filter->isPlatformSelected(GameListFilter::PLATFORM_PC) ? ' checked' : ''); ?> value="true" onChange="this.form.submit()" id="filterPC" name="pc">
-                                <label class="form-check-label" for="filterPC">
-                                    PC
-                                </label>
-                            </div>
-                        </li>
-                        <li>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox"<?= ($filter->isPlatformSelected(GameListFilter::PLATFORM_PS3) ? ' checked' : ''); ?> value="true" onChange="this.form.submit()" id="filterPS3" name="ps3">
-                                <label class="form-check-label" for="filterPS3">
-                                    PS3
-                                </label>
-                            </div>
-                        </li>
-                        <li>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox"<?= ($filter->isPlatformSelected(GameListFilter::PLATFORM_PS4) ? ' checked' : ''); ?> value="true" onChange="this.form.submit()" id="filterPS4" name="ps4">
-                                <label class="form-check-label" for="filterPS4">
-                                    PS4
-                                </label>
-                            </div>
-                        </li>
-                        <li>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox"<?= ($filter->isPlatformSelected(GameListFilter::PLATFORM_PS5) ? ' checked' : ''); ?> value="true" onChange="this.form.submit()" id="filterPS5" name="ps5">
-                                <label class="form-check-label" for="filterPS5">
-                                    PS5
-                                </label>
-                            </div>
-                        </li>
-                        <li>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox"<?= ($filter->isPlatformSelected(GameListFilter::PLATFORM_PSVITA) ? ' checked' : ''); ?> value="true" onChange="this.form.submit()" id="filterPSVITA" name="psvita">
-                                <label class="form-check-label" for="filterPSVITA">
-                                    PSVITA
-                                </label>
-                            </div>
-                        </li>
-                        <li>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox"<?= ($filter->isPlatformSelected(GameListFilter::PLATFORM_PSVR) ? ' checked' : ''); ?> value="true" onChange="this.form.submit()" id="filterPSVR" name="psvr">
-                                <label class="form-check-label" for="filterPSVR">
-                                    PSVR
-                                </label>
-                            </div>
-                        </li>
-                        <li>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox"<?= ($filter->isPlatformSelected(GameListFilter::PLATFORM_PSVR2) ? ' checked' : ''); ?> value="true" onChange="this.form.submit()" id="filterPSVR2" name="psvr2">
-                                <label class="form-check-label" for="filterPSVR2">
-                                    PSVR2
-                                </label>
-                            </div>
-                        </li>
+                        <?= $platformFilterRenderer->renderOptionItems($platformFilterOptions); ?>
                         <?php
                         if ($filter->shouldShowUncompletedOption()) {
                             ?>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the PHP 8.5 modernization work by replacing remaining magic status integers and route mutation patterns with existing 8.5-friendly idioms.

### Changes
- Use `PlayerStatus`, `GameAvailabilityStatus`, and `TrophyMetaStatus` values in SQL across homepage, game list, leaderboards, advisor/log/games services, scan queue selection, and related cron/avatar paths
- Replace `array_shift()` in game/player/trophy route handlers with `array_first()` + `array_slice()` so route segment parsing no longer mutates input
- Drop redundant `PLATFORM_*` aliases from filters in favor of `Platform`, and render games-page platform checkboxes via `PlayerPlatformFilterOptions` / `PlayerPlatformFilterRenderer`
- Mark leaf leaderboard page contexts `final`, make `GameRecentPlayersQueryBuilder` `readonly`, and prefer first-class callables / pipe where they already fit local style

### Testing
- `php tests/run.php` — all 1001 tests passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a07389e0-0b58-4f57-ad48-736a1e03034d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a07389e0-0b58-4f57-ad48-736a1e03034d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

