### PR TITLE
Adopt remaining PHP 8.5 idioms for worker actions and callables

### DIFF
--- a/tests/AdminWorkerPageTest.php
+++ b/tests/AdminWorkerPageTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/AdminRequest.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerAction.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerPage.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerPageResult.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerPageSortLink.php';
@@ -58,7 +59,7 @@ final class AdminWorkerPageTest extends TestCase
         $service = new WorkerService($this->database, new FakeCommandExecutor(new CommandExecutionResult(0, '')));
         $page = new WorkerPage($service);
 
-        $request = new AdminRequest('POST', ['action' => 'update_npsso', 'worker_id' => '5', 'npsso' => 'updated']);
+        $request = new AdminRequest('POST', ['action' => WorkerAction::UpdateNpsso->value, 'worker_id' => '5', 'npsso' => 'updated']);
         $result = $page->handle([], $request);
 
         $this->assertSame('Worker NPSSO updated successfully.', $result->getSuccessMessage());
@@ -76,7 +77,7 @@ final class AdminWorkerPageTest extends TestCase
         $service = new WorkerService($this->database, new FakeCommandExecutor(new CommandExecutionResult(0, 'Done')));
         $page = new WorkerPage($service);
 
-        $request = new AdminRequest('POST', ['action' => 'restart_worker', 'worker_id' => '3']);
+        $request = new AdminRequest('POST', ['action' => WorkerAction::RestartWorker->value, 'worker_id' => '3']);
         $result = $page->handle([], $request);
 
         $this->assertSame('Worker #3 restart signal sent successfully. Done', $result->getSuccessMessage());
@@ -90,7 +91,7 @@ final class AdminWorkerPageTest extends TestCase
         $service = new WorkerService($this->database, new FakeCommandExecutor(new CommandExecutionResult(0, '')));
         $page = new WorkerPage($service);
 
-        $request = new AdminRequest('POST', ['action' => 'update_refresh_token', 'worker_id' => '7', 'refresh_token' => 'new-refresh-token-value']);
+        $request = new AdminRequest('POST', ['action' => WorkerAction::UpdateRefreshToken->value, 'worker_id' => '7', 'refresh_token' => 'new-refresh-token-value']);
         $result = $page->handle([], $request);
 
         $this->assertSame('Worker refresh token updated successfully.', $result->getSuccessMessage());
@@ -105,7 +106,7 @@ final class AdminWorkerPageTest extends TestCase
         $service = new WorkerService($this->database, new FakeCommandExecutor(new CommandExecutionResult(2, 'error')));
         $page = new WorkerPage($service);
 
-        $request = new AdminRequest('POST', ['action' => 'restart_all_workers']);
+        $request = new AdminRequest('POST', ['action' => WorkerAction::RestartAllWorkers->value]);
         $result = $page->handle([], $request);
 
         $this->assertSame(null, $result->getSuccessMessage());
@@ -117,6 +118,8 @@ final class AdminWorkerPageTest extends TestCase
         $source = file_get_contents(__DIR__ . '/../wwwroot/admin/workers.php');
 
         $this->assertTrue(is_string($source));
+        $this->assertTrue(str_contains($source, 'WorkerAction::UpdateNpsso'));
+        $this->assertTrue(str_contains($source, 'WorkerAction::RestartWorker'));
         $this->assertTrue(str_contains($source, 'WorkerCredentialMasker::mask'));
         $this->assertTrue(str_contains($source, 'admin-worker-credentials.js'));
         $this->assertFalse(str_contains($source, 'getRefreshToken(), ENT_QUOTES'));
@@ -143,11 +146,8 @@ final class AdminWorkerPageTest extends TestCase
 
 final class FakeCommandExecutor implements CommandExecutorInterface
 {
-    private CommandExecutionResult $result;
-
-    public function __construct(CommandExecutionResult $result)
+    public function __construct(private readonly CommandExecutionResult $result)
     {
-        $this->result = $result;
     }
 
     #[\Override]

--- a/tests/Php85IdiomEnumsTest.php
+++ b/tests/Php85IdiomEnumsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/GameTrophySort.php';
 require_once __DIR__ . '/../wwwroot/classes/HttpMethod.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerAction.php';
 
 final class Php85IdiomEnumsTest extends TestCase
 {
@@ -22,5 +23,13 @@ final class Php85IdiomEnumsTest extends TestCase
         $this->assertSame(HttpMethod::Post, HttpMethod::fromServer(['REQUEST_METHOD' => 'post']));
         $this->assertTrue(HttpMethod::fromMixed('POST')->isPost());
         $this->assertTrue(HttpMethod::fromMixed('GET')->isGet());
+    }
+
+    public function testWorkerActionTryFromMixedNormalizesValues(): void
+    {
+        $this->assertSame(WorkerAction::UpdateNpsso, WorkerAction::tryFromMixed(' UPDATE_NPSSO '));
+        $this->assertSame(WorkerAction::RestartAllWorkers, WorkerAction::tryFromMixed('restart_all_workers'));
+        $this->assertSame(null, WorkerAction::tryFromMixed('unknown'));
+        $this->assertSame(null, WorkerAction::tryFromMixed(null));
     }
 }

--- a/tests/PlayerAdvisorServiceTest.php
+++ b/tests/PlayerAdvisorServiceTest.php
@@ -197,7 +197,7 @@ final class PlayerAdvisorServiceTest extends TestCase
         $trophies = $this->service->getAdvisableTrophies(99, $filter, 0, 50);
 
         $this->assertCount(3, $trophies);
-        $this->assertSame(PlayerAdvisableTrophy::class, get_class($trophies[0]));
+        $this->assertSame(PlayerAdvisableTrophy::class, $trophies[0]::class);
 
         $this->assertSame(
             [2, 3, 1],

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,7 +13,7 @@ abstract class TestCase
     public final function runTests(): array
     {
         $results = [];
-        $className = get_class($this);
+        $className = $this::class;
 
         foreach ($this->getTestMethods() as $method) {
             $this->setUp();

--- a/tests/TestRunReporter.php
+++ b/tests/TestRunReporter.php
@@ -17,7 +17,7 @@ final readonly class TestRunReporter
             ? static function (string $line): void {
                 echo $line . PHP_EOL;
             }
-            : \Closure::fromCallable($outputWriter);
+            : $outputWriter(...);
     }
 
     public function report(TestSuiteResult $result): int

--- a/wwwroot/admin/detail.php
+++ b/wwwroot/admin/detail.php
@@ -21,8 +21,8 @@ $gameDetail = $pageResult->getGameDetail();
 $success = $pageResult->getSuccessMessage();
 $error = $pageResult->getErrorMessage();
 
-$requestedGameId = isset($_GET['game']) ? (string) $_GET['game'] : '';
-$requestedNpCommunicationId = isset($_GET['np_communication_id']) ? (string) $_GET['np_communication_id'] : '';
+$requestedGameId = (string) ($_GET['game'] ?? '');
+$requestedNpCommunicationId = (string) ($_GET['np_communication_id'] ?? '');
 
 ?>
 <!doctype html>

--- a/wwwroot/admin/psn-game-lookup.php
+++ b/wwwroot/admin/psn-game-lookup.php
@@ -7,7 +7,7 @@ require_once '../vendor/autoload.php';
 require_once '../classes/Admin/PsnGameLookupService.php';
 require_once '../classes/Admin/PsnGameLookupRequestHandler.php';
 
-$gameId = isset($_GET['gameId']) ? (string) $_GET['gameId'] : '';
+$gameId = (string) ($_GET['gameId'] ?? '');
 $lookupService = PsnGameLookupService::fromDatabase($database);
 $handledRequest = PsnGameLookupRequestHandler::handle($lookupService, $gameId);
 

--- a/wwwroot/admin/psn-player-lookup.php
+++ b/wwwroot/admin/psn-player-lookup.php
@@ -6,7 +6,7 @@ require_once '../vendor/autoload.php';
 require_once '../classes/Admin/PsnPlayerLookupService.php';
 require_once '../classes/Admin/PsnPlayerLookupRequestHandler.php';
 
-$onlineId = isset($_GET['onlineId']) ? (string) $_GET['onlineId'] : '';
+$onlineId = (string) ($_GET['onlineId'] ?? '');
 $lookupService = PsnPlayerLookupService::fromDatabase($database);
 $handledRequest = PsnPlayerLookupRequestHandler::handle($lookupService, $onlineId);
 

--- a/wwwroot/admin/psn-trophy-title-compare.php
+++ b/wwwroot/admin/psn-trophy-title-compare.php
@@ -10,8 +10,8 @@ require_once '../classes/Admin/PsnTrophyTitleComparisonRequestResult.php';
 require_once '../classes/Admin/PsnTrophyTitleComparisonService.php';
 require_once '../classes/Admin/PsnTrophyTitleComparisonSource.php';
 
-$accountId = isset($_GET['accountId']) ? (string) $_GET['accountId'] : '';
-$source = isset($_GET['source']) ? (string) $_GET['source'] : PsnTrophyTitleComparisonSource::Direct->value;
+$accountId = (string) ($_GET['accountId'] ?? '');
+$source = (string) ($_GET['source'] ?? PsnTrophyTitleComparisonSource::Direct->value);
 $service = PsnTrophyTitleComparisonService::fromDatabase($database);
 $handledRequest = PsnTrophyTitleComparisonRequestHandler::handle($service, $accountId, $source);
 

--- a/wwwroot/admin/workers.php
+++ b/wwwroot/admin/workers.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/bootstrap.php';
 require_once '../classes/StaticAsset.php';
 require_once '../classes/Admin/AdminRequest.php';
+require_once '../classes/Admin/WorkerAction.php';
 require_once '../classes/Admin/WorkerCredentialMasker.php';
 require_once '../classes/Admin/WorkerService.php';
 require_once '../classes/Admin/WorkerPage.php';
@@ -48,7 +49,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
             <div class="mb-4 d-flex justify-content-end">
                 <form method="post" onsubmit="return confirm('Restart all workers?');">
                     <?php AdminBootstrap::renderCsrfField(); ?>
-                    <input type="hidden" name="action" value="restart_all_workers">
+                    <input type="hidden" name="action" value="<?= Html::escape(WorkerAction::RestartAllWorkers->value); ?>">
                     <button type="submit" class="btn btn-sm btn-outline-danger">
                         Restart All Workers
                     </button>
@@ -111,7 +112,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                         <div class="vstack gap-2">
                                             <form method="post" class="d-flex gap-2 align-items-center" autocomplete="off">
                                                 <?php AdminBootstrap::renderCsrfField(); ?>
-                                                <input type="hidden" name="action" value="update_refresh_token">
+                                                <input type="hidden" name="action" value="<?= Html::escape(WorkerAction::UpdateRefreshToken->value); ?>">
                                                 <input type="hidden" name="worker_id" value="<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
                                                 <label class="form-label small text-body-secondary mb-0 text-nowrap" for="refresh-token-<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
                                                     Refresh Token
@@ -142,7 +143,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                             </form>
                                             <form method="post" class="d-flex gap-2 align-items-center" autocomplete="off">
                                                 <?php AdminBootstrap::renderCsrfField(); ?>
-                                                <input type="hidden" name="action" value="update_npsso">
+                                                <input type="hidden" name="action" value="<?= Html::escape(WorkerAction::UpdateNpsso->value); ?>">
                                                 <input type="hidden" name="worker_id" value="<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
                                                 <label class="form-label small text-body-secondary mb-0 text-nowrap" for="npsso-<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
                                                     NPSSO
@@ -233,7 +234,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                             onsubmit="return confirm('Restart worker #<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>?');"
                                         >
                                             <?php AdminBootstrap::renderCsrfField(); ?>
-                                            <input type="hidden" name="action" value="restart_worker">
+                                            <input type="hidden" name="action" value="<?= Html::escape(WorkerAction::RestartWorker->value); ?>">
                                             <input type="hidden" name="worker_id" value="<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
                                             <button type="submit" class="btn btn-sm btn-outline-warning">
                                                 Restart

--- a/wwwroot/classes/AboutPageScanLogController.php
+++ b/wwwroot/classes/AboutPageScanLogController.php
@@ -16,27 +16,14 @@ final class AboutPageScanLogController
     private const int MIN_LIMIT = 1;
     private const int MAX_LIMIT = 100;
 
-    private AboutPageDataProviderInterface $aboutPageService;
-    private JsonResponseEmitter $jsonResponder;
-    private ?IpRateLimitService $rateLimitService;
-    private int $defaultLimit;
-    private int $minLimit;
-    private int $maxLimit;
-
     public function __construct(
-        AboutPageDataProviderInterface $aboutPageService,
-        JsonResponseEmitter $jsonResponder,
-        ?IpRateLimitService $rateLimitService = null,
-        int $defaultLimit = self::DEFAULT_LIMIT,
-        int $minLimit = self::MIN_LIMIT,
-        int $maxLimit = self::MAX_LIMIT
+        private readonly AboutPageDataProviderInterface $aboutPageService,
+        private readonly JsonResponseEmitter $jsonResponder,
+        private readonly ?IpRateLimitService $rateLimitService = null,
+        private readonly int $defaultLimit = self::DEFAULT_LIMIT,
+        private readonly int $minLimit = self::MIN_LIMIT,
+        private readonly int $maxLimit = self::MAX_LIMIT,
     ) {
-        $this->aboutPageService = $aboutPageService;
-        $this->jsonResponder = $jsonResponder;
-        $this->rateLimitService = $rateLimitService;
-        $this->defaultLimit = $defaultLimit;
-        $this->minLimit = $minLimit;
-        $this->maxLimit = $maxLimit;
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
+++ b/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
@@ -16,7 +16,7 @@ final class CallableGameRescanProgressListener implements GameRescanProgressList
      */
     public function __construct(callable $callback)
     {
-        $this->callback = \Closure::fromCallable($callback);
+        $this->callback = $callback(...);
     }
 
     #[\Override]

--- a/wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
+++ b/wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
@@ -16,7 +16,7 @@ final class CallableTrophyMergeProgressListener implements TrophyMergeProgressLi
      */
     public function __construct(callable $callback)
     {
-        $this->callback = \Closure::fromCallable($callback);
+        $this->callback = $callback(...);
     }
 
     #[\Override]

--- a/wwwroot/classes/Admin/CheaterRequestHandler.php
+++ b/wwwroot/classes/Admin/CheaterRequestHandler.php
@@ -8,13 +8,10 @@ require_once __DIR__ . '/AdminRequest.php';
 require_once __DIR__ . '/CheaterRequestResult.php';
 require_once __DIR__ . '/CheaterService.php';
 
-class CheaterRequestHandler
+final class CheaterRequestHandler
 {
-    private CheaterService $cheaterService;
-
-    public function __construct(CheaterService $cheaterService)
+    public function __construct(private readonly CheaterService $cheaterService)
     {
-        $this->cheaterService = $cheaterService;
     }
 
     public function handle(AdminRequest $request): CheaterRequestResult

--- a/wwwroot/classes/Admin/DeletePlayerRequestHandler.php
+++ b/wwwroot/classes/Admin/DeletePlayerRequestHandler.php
@@ -9,11 +9,8 @@ require_once __DIR__ . '/../Html.php';
 
 final class DeletePlayerRequestHandler
 {
-    private DeletePlayerService $service;
-
-    public function __construct(DeletePlayerService $service)
+    public function __construct(private readonly DeletePlayerService $service)
     {
-        $this->service = $service;
     }
 
     public function handleRequest(AdminRequest $request): DeletePlayerRequestResult

--- a/wwwroot/classes/Admin/GameRescanProcessor.php
+++ b/wwwroot/classes/Admin/GameRescanProcessor.php
@@ -9,11 +9,8 @@ require_once __DIR__ . '/GameRescanRequestHandler.php';
 
 final class GameRescanProcessor
 {
-    private GameRescanRequestHandler $requestHandler;
-
-    public function __construct(GameRescanRequestHandler $requestHandler)
+    public function __construct(private readonly GameRescanRequestHandler $requestHandler)
     {
-        $this->requestHandler = $requestHandler;
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/Admin/GameRescanRequestHandler.php
+++ b/wwwroot/classes/Admin/GameRescanRequestHandler.php
@@ -8,13 +8,10 @@ require_once __DIR__ . '/AdminStreamEventType.php';
 require_once __DIR__ . '/GameRescanProgressListener.php';
 require_once __DIR__ . '/CallableGameRescanProgressListener.php';
 
-class GameRescanRequestHandler
+final class GameRescanRequestHandler
 {
-    private GameRescanService $gameRescanService;
-
-    public function __construct(GameRescanService $gameRescanService)
+    public function __construct(private readonly GameRescanService $gameRescanService)
     {
-        $this->gameRescanService = $gameRescanService;
     }
 
     /**

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -92,7 +92,7 @@ class GameRescanService
     ): GameRescanResult {
         $previousLogListener = $this->logListener;
         $this->logListener = $logListener !== null
-            ? \Closure::fromCallable($logListener)
+            ? $logListener(...)
             : null;
         $previousImageDownloader = $this->imageDownloader;
         $this->imageDownloader = $this->imageDownloader->withLogger(

--- a/wwwroot/classes/Admin/LogEntryFormatter.php
+++ b/wwwroot/classes/Admin/LogEntryFormatter.php
@@ -8,10 +8,6 @@ require_once __DIR__ . '/../Html.php';
 
 final class LogEntryFormatter
 {
-    private readonly PDO $database;
-
-    private readonly Utility $utility;
-
     /**
      * @var array<int, array{id: int, name: string}|null>
      */
@@ -22,10 +18,10 @@ final class LogEntryFormatter
      */
     private array $gameCacheByNpId = [];
 
-    public function __construct(PDO $database, Utility $utility)
-    {
-        $this->database = $database;
-        $this->utility = $utility;
+    public function __construct(
+        private readonly PDO $database,
+        private readonly Utility $utility,
+    ) {
     }
 
     public function format(string $message): string

--- a/wwwroot/classes/Admin/MergeTrophyCopier.php
+++ b/wwwroot/classes/Admin/MergeTrophyCopier.php
@@ -46,7 +46,7 @@ final class MergeTrophyCopier
              ORDER BY t.group_id, t.order_id'
         );
 
-        $parameters = array_merge([$childNpCommunicationId], array_keys($groupIdMapping));
+        $parameters = [$childNpCommunicationId, ...array_keys($groupIdMapping)];
         $query->execute($parameters);
 
         $trophies = $query->fetchAll(PDO::FETCH_ASSOC);

--- a/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
+++ b/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
@@ -59,12 +59,12 @@ final class PlayStationWorkerAuthenticator
         ?callable $sleeper = null,
         ?callable $refreshTokenPersistenceFailureHandler = null,
     ) {
-        $this->workerFetcher = \Closure::fromCallable($workerFetcher);
-        $this->clientFactory = \Closure::fromCallable($clientFactory ?? self::DEFAULT_CLIENT_FACTORY);
-        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? self::DEFAULT_REFRESH_TOKEN_SAVER);
-        $this->sleeper = \Closure::fromCallable($sleeper ?? self::DEFAULT_SLEEPER);
+        $this->workerFetcher = $workerFetcher(...);
+        $this->clientFactory = ($clientFactory ?? self::DEFAULT_CLIENT_FACTORY)(...);
+        $this->refreshTokenSaver = ($refreshTokenSaver ?? self::DEFAULT_REFRESH_TOKEN_SAVER)(...);
+        $this->sleeper = ($sleeper ?? self::DEFAULT_SLEEPER)(...);
         $this->refreshTokenPersistenceFailureHandler = $refreshTokenPersistenceFailureHandler !== null
-            ? \Closure::fromCallable($refreshTokenPersistenceFailureHandler)
+            ? $refreshTokenPersistenceFailureHandler(...)
             : null;
     }
 
@@ -129,7 +129,7 @@ final class PlayStationWorkerAuthenticator
         ?callable $onLoginFailure = null,
     ): object {
         $onLoginFailureClosure = $onLoginFailure !== null
-            ? \Closure::fromCallable($onLoginFailure)
+            ? $onLoginFailure(...)
             : null;
 
         while (true) {

--- a/wwwroot/classes/Admin/PsnPlayerLookupRequestHandler.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupRequestHandler.php
@@ -73,7 +73,7 @@ final class PsnPlayerLookupRequestHandler
         $country = null;
 
         if (strlen($trimmed) >= 2) {
-            $country = strtoupper(substr($trimmed, -2));
+            $country = substr($trimmed, -2) |> strtoupper(...);
         }
 
         return [$trimmed, $country];

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -41,9 +41,9 @@ final class PsnPlayerLookupService
      */
     public function __construct(callable $workerFetcher, ?callable $clientFactory = null, ?callable $refreshTokenSaver = null)
     {
-        $this->workerFetcher = \Closure::fromCallable($workerFetcher);
-        $this->clientFactory = \Closure::fromCallable($clientFactory ?? self::DEFAULT_CLIENT_FACTORY);
-        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? self::DEFAULT_REFRESH_TOKEN_SAVER);
+        $this->workerFetcher = $workerFetcher(...);
+        $this->clientFactory = ($clientFactory ?? self::DEFAULT_CLIENT_FACTORY)(...);
+        $this->refreshTokenSaver = ($refreshTokenSaver ?? self::DEFAULT_REFRESH_TOKEN_SAVER)(...);
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -59,10 +59,10 @@ final class PsnTrophyTitleComparisonService
         ?callable $timeProvider = null,
         ?callable $refreshTokenSaver = null,
     ) {
-        $this->workerFetcher = \Closure::fromCallable($workerFetcher);
-        $this->clientFactory = \Closure::fromCallable($clientFactory ?? self::DEFAULT_CLIENT_FACTORY);
-        $this->timeProvider = \Closure::fromCallable($timeProvider ?? self::DEFAULT_TIME_PROVIDER);
-        $this->refreshTokenSaver = \Closure::fromCallable($refreshTokenSaver ?? self::DEFAULT_REFRESH_TOKEN_SAVER);
+        $this->workerFetcher = $workerFetcher(...);
+        $this->clientFactory = ($clientFactory ?? self::DEFAULT_CLIENT_FACTORY)(...);
+        $this->timeProvider = ($timeProvider ?? self::DEFAULT_TIME_PROVIDER)(...);
+        $this->refreshTokenSaver = ($refreshTokenSaver ?? self::DEFAULT_REFRESH_TOKEN_SAVER)(...);
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/Admin/TrophyMergeProcessor.php
+++ b/wwwroot/classes/Admin/TrophyMergeProcessor.php
@@ -12,11 +12,8 @@ require_once __DIR__ . '/CallableTrophyMergeProgressListener.php';
 
 class TrophyMergeProcessor
 {
-    private TrophyMergeRequestHandler $requestHandler;
-
-    public function __construct(TrophyMergeRequestHandler $requestHandler)
+    public function __construct(private readonly TrophyMergeRequestHandler $requestHandler)
     {
-        $this->requestHandler = $requestHandler;
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
+++ b/wwwroot/classes/Admin/TrophyMergeRequestHandler.php
@@ -10,11 +10,8 @@ require_once __DIR__ . '/TrophyMergeProgressListener.php';
 
 class TrophyMergeRequestHandler
 {
-    private TrophyMergeService $trophyMergeService;
-
-    public function __construct(TrophyMergeService $trophyMergeService)
+    public function __construct(private readonly TrophyMergeService $trophyMergeService)
     {
-        $this->trophyMergeService = $trophyMergeService;
     }
 
     public function handle(array $postData): string

--- a/wwwroot/classes/Admin/WorkerAction.php
+++ b/wwwroot/classes/Admin/WorkerAction.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+enum WorkerAction: string
+{
+    case UpdateNpsso = 'update_npsso';
+    case UpdateRefreshToken = 'update_refresh_token';
+    case RestartWorker = 'restart_worker';
+    case RestartAllWorkers = 'restart_all_workers';
+
+    #[\NoDiscard]
+    public static function tryFromMixed(mixed $value): ?self
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return self::tryFrom($value |> trim(...) |> strtolower(...));
+    }
+}

--- a/wwwroot/classes/Admin/WorkerPage.php
+++ b/wwwroot/classes/Admin/WorkerPage.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/AdminRequest.php';
+require_once __DIR__ . '/WorkerAction.php';
 require_once __DIR__ . '/WorkerService.php';
 require_once __DIR__ . '/CommandExecutionResult.php';
 require_once __DIR__ . '/WorkerPageSortLink.php';
@@ -12,11 +13,8 @@ require_once __DIR__ . '/WorkerSortDirection.php';
 
 final class WorkerPage
 {
-    private WorkerService $workerService;
-
-    public function __construct(WorkerService $workerService)
+    public function __construct(private readonly WorkerService $workerService)
     {
-        $this->workerService = $workerService;
     }
 
     /**
@@ -53,14 +51,14 @@ final class WorkerPage
      */
     private function processAction(AdminRequest $request): array
     {
-        $action = $request->getPostString('action');
+        $action = WorkerAction::tryFromMixed($request->getPostString('action'));
 
         return match ($action) {
-            'update_npsso' => $this->processUpdateNpsso($request),
-            'update_refresh_token' => $this->processUpdateRefreshToken($request),
-            'restart_worker' => $this->processRestartWorker($request),
-            'restart_all_workers' => $this->processRestartAllWorkers(),
-            default => [null, 'Unsupported action requested.'],
+            WorkerAction::UpdateNpsso => $this->processUpdateNpsso($request),
+            WorkerAction::UpdateRefreshToken => $this->processUpdateRefreshToken($request),
+            WorkerAction::RestartWorker => $this->processRestartWorker($request),
+            WorkerAction::RestartAllWorkers => $this->processRestartAllWorkers(),
+            null => [null, 'Unsupported action requested.'],
         };
     }
 

--- a/wwwroot/classes/Cron/CronJobApplication.php
+++ b/wwwroot/classes/Cron/CronJobApplication.php
@@ -13,11 +13,8 @@ require_once __DIR__ . '/CronJobRunner.php';
  */
 final class CronJobApplication
 {
-    private CronJobRunner $runner;
-
-    private function __construct(CronJobRunner $runner)
+    private function __construct(private readonly CronJobRunner $runner)
     {
-        $this->runner = $runner;
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/Cron/CronJobBootstrapper.php
+++ b/wwwroot/classes/Cron/CronJobBootstrapper.php
@@ -7,16 +7,15 @@ require_once __DIR__ . '/CronJobApplication.php';
 
 final class CronJobBootstrapper
 {
-    private CronJobApplication $application;
-
     private string $projectRoot;
 
     private ?\PDO $database = null;
 
-    private function __construct(string $projectRoot, CronJobApplication $application)
-    {
+    private function __construct(
+        string $projectRoot,
+        private readonly CronJobApplication $application,
+    ) {
         $this->projectRoot = rtrim($projectRoot, '/\\');
-        $this->application = $application;
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/Cron/CronJobEntryPoint.php
+++ b/wwwroot/classes/Cron/CronJobEntryPoint.php
@@ -14,11 +14,8 @@ require_once __DIR__ . '/CronJobInterface.php';
  */
 final class CronJobEntryPoint
 {
-    private CronJobBootstrapper $bootstrapper;
-
-    private function __construct(CronJobBootstrapper $bootstrapper)
+    private function __construct(private readonly CronJobBootstrapper $bootstrapper)
     {
-        $this->bootstrapper = $bootstrapper;
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
@@ -11,14 +11,10 @@ require_once __DIR__ . '/ThirtyMinuteCronJob.php';
 
 final class ThirtyMinuteCronJobApplication
 {
-    private CronJobEntryPoint $entryPoint;
-
-    private CronJobCliArguments $cliArguments;
-
-    private function __construct(CronJobEntryPoint $entryPoint, CronJobCliArguments $cliArguments)
-    {
-        $this->entryPoint = $entryPoint;
-        $this->cliArguments = $cliArguments;
+    private function __construct(
+        private readonly CronJobEntryPoint $entryPoint,
+        private readonly CronJobCliArguments $cliArguments,
+    ) {
     }
 
     /**

--- a/wwwroot/classes/MaintenanceResponder.php
+++ b/wwwroot/classes/MaintenanceResponder.php
@@ -59,8 +59,6 @@ final readonly class MaintenanceResponder
 
     private function toClosure(?callable $callable, callable $fallback): \Closure
     {
-        return $callable instanceof \Closure
-            ? $callable
-            : \Closure::fromCallable($callable ?? $fallback);
+        return ($callable ?? $fallback)(...);
     }
 }

--- a/wwwroot/classes/NavigationBarRenderer.php
+++ b/wwwroot/classes/NavigationBarRenderer.php
@@ -8,14 +8,10 @@ require_once __DIR__ . '/Html.php';
 
 final class NavigationBarRenderer
 {
-    private NavigationState $state;
-
-    private NavigationMenu $menu;
-
-    private function __construct(NavigationState $state, NavigationMenu $menu)
-    {
-        $this->state = $state;
-        $this->menu = $menu;
+    private function __construct(
+        private readonly NavigationState $state,
+        private readonly NavigationMenu $menu,
+    ) {
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/PlayerLeaderboardRank.php
+++ b/wwwroot/classes/PlayerLeaderboardRank.php
@@ -89,13 +89,11 @@ final readonly class PlayerLeaderboardRank
         $page = max(1, (int) ceil($this->rank / self::PAGE_SIZE));
 
         $query = http_build_query(
-            array_merge(
-                $this->additionalQueryParameters,
-                [
-                    'page' => (string) $page,
-                    'player' => $this->onlineId,
-                ]
-            ),
+            [
+                ...$this->additionalQueryParameters,
+                'page' => (string) $page,
+                'player' => $this->onlineId,
+            ],
             '',
             '&',
             PHP_QUERY_RFC3986

--- a/wwwroot/classes/PlayerQueueEndpoint.php
+++ b/wwwroot/classes/PlayerQueueEndpoint.php
@@ -7,16 +7,12 @@ require_once __DIR__ . '/PlayerQueueController.php';
 require_once __DIR__ . '/PlayerQueueResponse.php';
 require_once __DIR__ . '/JsonResponseEmitter.php';
 
-class PlayerQueueEndpoint
+final class PlayerQueueEndpoint
 {
-    private PlayerQueueController $controller;
-
-    private JsonResponseEmitter $jsonResponder;
-
-    private function __construct(PlayerQueueController $controller, JsonResponseEmitter $jsonResponder)
-    {
-        $this->controller = $controller;
-        $this->jsonResponder = $jsonResponder;
+    private function __construct(
+        private readonly PlayerQueueController $controller,
+        private readonly JsonResponseEmitter $jsonResponder,
+    ) {
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -8,16 +8,13 @@ require_once __DIR__ . '/PlatformSql.php';
 
 class PlayerRandomGamesService
 {
-    private readonly PDO $database;
-
-    private readonly Utility $utility;
-
     private readonly Randomizer $randomizer;
 
-    public function __construct(PDO $database, Utility $utility, ?Randomizer $randomizer = null)
-    {
-        $this->database = $database;
-        $this->utility = $utility;
+    public function __construct(
+        private readonly PDO $database,
+        private readonly Utility $utility,
+        ?Randomizer $randomizer = null,
+    ) {
         $this->randomizer = $randomizer ?? new Randomizer();
     }
 

--- a/wwwroot/classes/PlayerTimelineService.php
+++ b/wwwroot/classes/PlayerTimelineService.php
@@ -6,11 +6,8 @@ require_once __DIR__ . '/PlayerTimelineData.php';
 require_once __DIR__ . '/PlayerTimelineEntry.php';
 class PlayerTimelineService
 {
-    private readonly PDO $database;
-
-    public function __construct(PDO $database)
+    public function __construct(private readonly PDO $database)
     {
-        $this->database = $database;
     }
 
     public function getTimelineData(int $accountId): ?PlayerTimelineData

--- a/wwwroot/classes/SessionManager.php
+++ b/wwwroot/classes/SessionManager.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/RequestParameter.php';
+
 final class SessionManager
 {
     public static function ensureStarted(): void
@@ -14,8 +16,7 @@ final class SessionManager
             return;
         }
 
-        $https = (string) ($_SERVER['HTTPS'] ?? '');
-        $isSecure = ($https !== '' && $https !== 'off')
+        $isSecure = RequestParameter::toBool($_SERVER['HTTPS'] ?? null)
             || (($_SERVER['SERVER_PORT'] ?? '') === '443');
 
         session_set_cookie_params([

--- a/wwwroot/classes/SessionManager.php
+++ b/wwwroot/classes/SessionManager.php
@@ -14,7 +14,8 @@ final class SessionManager
             return;
         }
 
-        $isSecure = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+        $https = (string) ($_SERVER['HTTPS'] ?? '');
+        $isSecure = ($https !== '' && $https !== 'off')
             || (($_SERVER['SERVER_PORT'] ?? '') === '443');
 
         session_set_cookie_params([

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -14,8 +14,6 @@ require_once __DIR__ . '/TrophyTitleCloneService.php';
 
 class TrophyMergeService
 {
-    private readonly PDO $database;
-
     private readonly NestedDatabaseTransactionRunner $transactionRunner;
 
     private ?TrophyMergeEarnedCopier $earnedCopier = null;
@@ -29,11 +27,10 @@ class TrophyMergeService
     private ?TrophyTitleCloneService $cloneService = null;
 
     public function __construct(
-        PDO $database,
+        private readonly PDO $database,
         ?NestedDatabaseTransactionRunner $transactionRunner = null,
         ?TrophyMergeEarnedCopier $earnedCopier = null,
     ) {
-        $this->database = $database;
         $this->transactionRunner = $transactionRunner ?? new NestedDatabaseTransactionRunner($database);
         $this->earnedCopier = $earnedCopier;
     }

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -186,10 +186,10 @@ require_once("header.php");
             <?= $paginationRenderer->render(
                 $page,
                 $totalPages,
-                static fn (int $pageNumber): array => array_merge(
-                    $filterParameters,
-                    ['page' => (string) $pageNumber]
-                ),
+                static fn (int $pageNumber): array => [
+                    ...$filterParameters,
+                    'page' => (string) $pageNumber,
+                ],
                 'Player log navigation'
             ); ?>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the PHP 8.5 modernization pass with no backward-compat constraints.

- Add `WorkerAction` backed enum (with pipe-normalized `tryFromMixed`) and wire admin worker forms/`WorkerPage` through it
- Promote leftover simple constructors and seal a few leaf handlers as `final`/`readonly` where safe
- Prefer first-class callables (`$callable(...)`) over `Closure::fromCallable`
- Replace a few `array_merge` call sites with unpacking, `isset($_GET[…])` with `??`, and use the pipe operator for country extraction
- Fix `SessionManager` HTTPS detection so values like `'0'` / `'off'` stay non-secure (`RequestParameter::toBool`)

## Test plan

- [x] `php tests/run.php` — all 1002 tests passed
- [x] `Php85IdiomEnumsTest` covers `WorkerAction::tryFromMixed`
- [x] `AdminWorkerPageTest` uses enum action values and asserts template wiring
- [x] `RequestParameterTest` covers falsy HTTPS-like values (`'0'`, `'off'`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61423ffb-d283-4311-8a06-165d48550a7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61423ffb-d283-4311-8a06-165d48550a7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

