### PR TITLE
Adopt remaining PHP 8.5 idioms for status enums and rarity names

### DIFF
--- a/tests/AdminWorkerPageTest.php
+++ b/tests/AdminWorkerPageTest.php
@@ -11,6 +11,8 @@ require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerPageSortLink.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerService.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerCredentialField.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/Worker.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerSortField.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerSortDirection.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/CommandExecutionResult.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/CommandExecutorInterface.php';
 
@@ -38,8 +40,8 @@ final class AdminWorkerPageTest extends TestCase
         $workers = $result->getWorkers();
         $this->assertCount(2, $workers);
         $this->assertSame(2, $workers[0]->getId());
-        $this->assertSame('id', $result->getSortField());
-        $this->assertSame('desc', $result->getSortDirection());
+        $this->assertSame(WorkerSortField::Id, $result->getSortField());
+        $this->assertSame(WorkerSortDirection::Desc, $result->getSortDirection());
 
         $idSortLink = $result->getSortLink('id');
         $this->assertTrue($idSortLink instanceof WorkerPageSortLink);

--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -53,7 +53,7 @@ final class DailyCronJobTest extends TestCase
 
     public function testApplyTrophyRarityQueryUsesTempTableOwnerCountsAndTopTenThousandDenominator(): void
     {
-        $source = $this->readPrivateConstant('APPLY_TROPHY_RARITY_QUERY');
+        $source = $this->invokeBuildApplyTrophyRarityQuery();
 
         $this->assertStringContainsString('LEFT JOIN tmp_daily_ranked_trophy_owners owners', $source);
         $this->assertStringContainsString('/ 10000.0) * 100 AS rarity_percent', $source);
@@ -65,7 +65,7 @@ final class DailyCronJobTest extends TestCase
 
     public function testApplyTrophyRarityQueryAssignsRarityNamesFromThresholds(): void
     {
-        $source = $this->readPrivateConstant('APPLY_TROPHY_RARITY_QUERY');
+        $source = $this->invokeBuildApplyTrophyRarityQuery();
 
         $this->assertStringContainsString("WHEN r.rarity_percent > 10 THEN 'COMMON'", $source);
         $this->assertStringContainsString("WHEN r.rarity_percent > 2 THEN 'UNCOMMON'", $source);
@@ -509,6 +509,17 @@ final class DailyCronJobTest extends TestCase
         $constant = $class->getReflectionConstant($name);
         $this->assertTrue($constant instanceof ReflectionClassConstant);
         $value = $constant->getValue();
+        $this->assertTrue(is_string($value));
+
+        return $value;
+    }
+
+    private function invokeBuildApplyTrophyRarityQuery(): string
+    {
+        $class = new ReflectionClass(DailyCronJob::class);
+        $method = $class->getMethod('buildApplyTrophyRarityQuery');
+        $job = $class->newInstanceWithoutConstructor();
+        $value = $method->invoke($job);
         $this->assertTrue(is_string($value));
 
         return $value;

--- a/tests/Php85IdiomEnumsTest.php
+++ b/tests/Php85IdiomEnumsTest.php
@@ -6,6 +6,9 @@ require_once __DIR__ . '/TestCase.php';
 require_once __DIR__ . '/../wwwroot/classes/GameTrophySort.php';
 require_once __DIR__ . '/../wwwroot/classes/HttpMethod.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerAction.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerSortField.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerSortDirection.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyRarityName.php';
 
 final class Php85IdiomEnumsTest extends TestCase
 {
@@ -31,5 +34,23 @@ final class Php85IdiomEnumsTest extends TestCase
         $this->assertSame(WorkerAction::RestartAllWorkers, WorkerAction::tryFromMixed('restart_all_workers'));
         $this->assertSame(null, WorkerAction::tryFromMixed('unknown'));
         $this->assertSame(null, WorkerAction::tryFromMixed(null));
+    }
+
+    public function testTrophyRarityNameFromMixedNormalizesValues(): void
+    {
+        $this->assertSame(TrophyRarityName::None, TrophyRarityName::fromMixed(null));
+        $this->assertSame(TrophyRarityName::None, TrophyRarityName::fromMixed('unknown'));
+        $this->assertSame(TrophyRarityName::Common, TrophyRarityName::fromMixed(' common '));
+        $this->assertSame(TrophyRarityName::Legendary, TrophyRarityName::fromMixed('LEGENDARY'));
+        $this->assertSame("'EPIC'", TrophyRarityName::Epic->toSqlLiteral());
+    }
+
+    public function testWorkerSortFieldAndDirectionFromMixed(): void
+    {
+        $this->assertSame(WorkerSortField::ScanStart, WorkerSortField::fromMixed(null));
+        $this->assertSame(WorkerSortField::Id, WorkerSortField::fromMixed(' ID '));
+        $this->assertSame(WorkerSortDirection::Asc, WorkerSortDirection::fromMixed(null));
+        $this->assertSame(WorkerSortDirection::Desc, WorkerSortDirection::fromMixed(' DESC '));
+        $this->assertSame(WorkerSortDirection::Asc, WorkerSortDirection::Desc->toggled());
     }
 }

--- a/tests/PlayerScanCompletionServiceTest.php
+++ b/tests/PlayerScanCompletionServiceTest.php
@@ -138,7 +138,8 @@ final class PlayerScanCompletionServiceTest extends TestCase
         $source = file_get_contents(__DIR__ . '/../wwwroot/classes/Cron/PlayerScanCompletionService.php');
 
         $this->assertStringContainsString('INTERVAL 1 YEAR', $source);
-        $this->assertStringContainsString('AND p.status != 1', $source);
+        $this->assertStringContainsString('PlayerStatus::FLAGGED->value', $source);
+        $this->assertStringContainsString('AND p.status != {$flaggedStatus}', $source);
     }
 
     public function testRemovePlayerFromScanQueueDeletesOnlyMatchingOnlineId(): void

--- a/wwwroot/classes/Admin/CheaterService.php
+++ b/wwwroot/classes/Admin/CheaterService.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class CheaterService
+require_once __DIR__ . '/../PlayerStatus.php';
+
+final class CheaterService
 {
     public function __construct(
         private readonly PDO $database,
@@ -18,16 +20,18 @@ class CheaterService
         $this->database->beginTransaction();
 
         try {
+            $flaggedStatus = PlayerStatus::FLAGGED->value;
+
             $query = $this->database->prepare(
-                'UPDATE player
-                SET `status` = 1,
+                "UPDATE player
+                SET `status` = {$flaggedStatus},
                     rank_last_week = 0,
                     rarity_rank_last_week = 0,
                     in_game_rarity_rank_last_week = 0,
                     rank_country_last_week = 0,
                     rarity_rank_country_last_week = 0,
                     in_game_rarity_rank_country_last_week = 0
-                WHERE online_id = :online_id'
+                WHERE online_id = :online_id"
             );
             $query->bindValue(':online_id', $onlineId, PDO::PARAM_STR);
             $query->execute();

--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../ChangelogEntry.php';
+require_once __DIR__ . '/../TrophyRarityName.php';
 require_once __DIR__ . '/MergeTrophyCopier.php';
 require_once __DIR__ . '/MergeTrophyGroupCopier.php';
 require_once __DIR__ . '/TrophyGroupConflictResolver.php';
@@ -98,29 +99,6 @@ class GameCopyService
                     AND tm.child_order_id = t.order_id
                     AND tm.parent_np_communication_id = :parent_np_communication_id
             )
-        SQL;
-
-    private const string TROPHY_META_INSERT_QUERY = <<<'SQL'
-        INSERT INTO
-            trophy_meta (
-                trophy_id,
-                status,
-                rarity_name
-            )
-        SELECT
-            parent.id,
-            tm.status,
-            'NONE'
-        FROM
-            trophy parent
-            INNER JOIN trophy t ON t.np_communication_id = :child_np_communication_id
-                AND t.group_id = parent.group_id
-                AND t.order_id = parent.order_id
-            INNER JOIN trophy_meta tm ON tm.trophy_id = t.id
-            LEFT JOIN trophy_meta existing ON existing.trophy_id = parent.id
-        WHERE
-            parent.np_communication_id = :parent_np_communication_id
-            AND existing.trophy_id IS NULL
         SQL;
 
     private readonly PDO $database;
@@ -279,11 +257,39 @@ class GameCopyService
         $query->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
         $query->execute();
 
-        $metaQuery = $this->database->prepare(self::TROPHY_META_INSERT_QUERY);
+        $metaQuery = $this->database->prepare($this->buildTrophyMetaInsertQuery());
         $metaQuery->bindValue(':child_np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
         $metaQuery->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
         $metaQuery->execute();
         $metaQuery->closeCursor();
+    }
+
+    private function buildTrophyMetaInsertQuery(): string
+    {
+        $none = TrophyRarityName::None->toSqlLiteral();
+
+        return <<<SQL
+        INSERT INTO
+            trophy_meta (
+                trophy_id,
+                status,
+                rarity_name
+            )
+        SELECT
+            parent.id,
+            tm.status,
+            {$none}
+        FROM
+            trophy parent
+            INNER JOIN trophy t ON t.np_communication_id = :child_np_communication_id
+                AND t.group_id = parent.group_id
+                AND t.order_id = parent.order_id
+            INNER JOIN trophy_meta tm ON tm.trophy_id = t.id
+            LEFT JOIN trophy_meta existing ON existing.trophy_id = parent.id
+        WHERE
+            parent.np_communication_id = :parent_np_communication_id
+            AND existing.trophy_id IS NULL
+        SQL;
     }
 
     private function updateTrophyTitleCounts(string $npCommunicationId): void

--- a/wwwroot/classes/Admin/LogPage.php
+++ b/wwwroot/classes/Admin/LogPage.php
@@ -9,13 +9,12 @@ require_once __DIR__ . '/../HttpMethod.php';
 
 final class LogPage
 {
-    private LogService $logService;
-
     private int $entriesPerPage;
 
-    public function __construct(LogService $logService, int $entriesPerPage = 50)
-    {
-        $this->logService = $logService;
+    public function __construct(
+        private LogService $logService,
+        int $entriesPerPage = 50,
+    ) {
         $this->entriesPerPage = max(1, $entriesPerPage);
     }
 

--- a/wwwroot/classes/Admin/LogPageResult.php
+++ b/wwwroot/classes/Admin/LogPageResult.php
@@ -15,20 +15,19 @@ final readonly class LogPageResult
 
     private int $totalPages;
 
-    private ?string $successMessage;
-
-    private ?string $errorMessage;
-
     /**
      * @param list<LogEntry> $entries
      */
-    public function __construct(array $entries, int $currentPage, int $totalPages, ?string $successMessage, ?string $errorMessage)
-    {
+    public function __construct(
+        array $entries,
+        int $currentPage,
+        int $totalPages,
+        private ?string $successMessage,
+        private ?string $errorMessage,
+    ) {
         $this->entries = $entries;
         $this->currentPage = max(1, $currentPage);
         $this->totalPages = max(1, $totalPages);
-        $this->successMessage = $successMessage;
-        $this->errorMessage = $errorMessage;
     }
 
     /**

--- a/wwwroot/classes/Admin/PossibleCheaterService.php
+++ b/wwwroot/classes/Admin/PossibleCheaterService.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 require_once __DIR__ . '/PossibleCheaterRuleConditionParser.php';
 require_once __DIR__ . '/PossibleCheaterRulesCatalog.php';
 require_once __DIR__ . '/PossibleCheaterReport.php';
+require_once __DIR__ . '/../PlayerStatus.php';
 
-class PossibleCheaterService
+final class PossibleCheaterService
 {
-    private readonly PDO $database;
     private readonly PossibleCheaterRulesCatalog $rulesCatalog;
     private readonly PossibleCheaterRuleConditionParser $conditionParser;
 
     public function __construct(
-        PDO $database,
+        private readonly PDO $database,
         ?PossibleCheaterRulesCatalog $rulesCatalog = null,
         ?PossibleCheaterRuleConditionParser $conditionParser = null,
     ) {
-        $this->database = $database;
         $this->rulesCatalog = $rulesCatalog ?? new PossibleCheaterRulesCatalog();
         $this->conditionParser = $conditionParser ?? new PossibleCheaterRuleConditionParser();
     }
@@ -86,6 +85,7 @@ class PossibleCheaterService
         $ruleDerivedTable = $this->conditionParser->buildRuleDerivedTableSql(
             $this->rulesCatalog->getGeneralRuleGroups()
         );
+        $flaggedStatus = PlayerStatus::FLAGGED->value;
 
         // Drive from trophy_title_player so trophy_earned is probed by account_id
         // (HASH partition key) instead of scanning all 256 partitions by title.
@@ -119,7 +119,7 @@ class PossibleCheaterService
             JOIN player p ON p.account_id = ttp.account_id
             JOIN trophy_title tt ON tt.np_communication_id = cheat_rules.np_communication_id
             WHERE
-                p.status != 1
+                p.status != {$flaggedStatus}
             GROUP BY
                 p.account_id,
                 p.online_id

--- a/wwwroot/classes/Admin/PsnpPlusService.php
+++ b/wwwroot/classes/Admin/PsnpPlusService.php
@@ -8,8 +8,9 @@ require_once __DIR__ . '/PsnpPlusFixedGame.php';
 require_once __DIR__ . '/PsnpPlusMissingGame.php';
 require_once __DIR__ . '/PsnpPlusGame.php';
 require_once __DIR__ . '/../PsnpPlusClient.php';
+require_once __DIR__ . '/../TrophyMetaStatus.php';
 
-class PsnpPlusService
+final class PsnpPlusService
 {
     /**
      * @var list<int>
@@ -23,13 +24,12 @@ class PsnpPlusService
         35758, 40301,
     ];
 
-    private readonly PDO $database;
-
     private readonly PsnpPlusClient $psnpPlusClient;
 
-    public function __construct(PDO $database, ?PsnpPlusClient $psnpPlusClient = null)
-    {
-        $this->database = $database;
+    public function __construct(
+        private readonly PDO $database,
+        ?PsnpPlusClient $psnpPlusClient = null,
+    ) {
         $this->psnpPlusClient = $psnpPlusClient ?? new PsnpPlusClient();
     }
 
@@ -122,7 +122,8 @@ class PsnpPlusService
     {
         $sql = 'SELECT t.order_id + 1 FROM trophy t';
         if ($obtainableOnly) {
-            $sql .= ' JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = 1';
+            $unobtainableStatus = TrophyMetaStatus::Unobtainable->value;
+            $sql .= " JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = {$unobtainableStatus}";
         }
         $sql .= ' WHERE t.np_communication_id = :np_communication_id ORDER BY t.order_id';
 
@@ -179,10 +180,12 @@ class PsnpPlusService
      */
     private function findGamesWithUnobtainableTrophies(): array
     {
+        $unobtainableStatus = TrophyMetaStatus::Unobtainable->value;
+
         $statement = $this->database->prepare(
             "SELECT DISTINCT t.np_communication_id
             FROM trophy t
-            JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = 1
+            JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = {$unobtainableStatus}
             WHERE t.np_communication_id LIKE 'N%'
             ORDER BY t.np_communication_id"
         );
@@ -264,12 +267,14 @@ class PsnpPlusService
      */
     private function findObtainableTrophyIds(string $npCommunicationId): array
     {
+        $unobtainableStatus = TrophyMetaStatus::Unobtainable->value;
+
         $statement = $this->database->prepare(
-            'SELECT t.id
+            "SELECT t.id
             FROM trophy t
-            JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = 1
+            JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = {$unobtainableStatus}
             WHERE t.np_communication_id = :np_communication_id
-            ORDER BY t.id'
+            ORDER BY t.id"
         );
         $statement->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $statement->execute();

--- a/wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php
+++ b/wwwroot/classes/Admin/TrophyStatusProgressRecalculator.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../TrophyMetaStatus.php';
+require_once __DIR__ . '/../TrophyType.php';
 require_once __DIR__ . '/../ChangelogEntry.php';
 
 /**
@@ -25,17 +26,23 @@ class TrophyStatusProgressRecalculator
     {
         $this->createImpactedAccountsTempTable($npCommunicationId, $groupId, $affectedTrophyIds);
 
+        $bronze = TrophyType::Bronze->value;
+        $silver = TrophyType::Silver->value;
+        $gold = TrophyType::Gold->value;
+        $platinum = TrophyType::Platinum->value;
+        $obtainableStatus = TrophyMetaStatus::Obtainable->value;
+
         $this->executeGroupStatement(
-            <<<'SQL'
+            <<<SQL
 WITH counts AS (
     SELECT
-      COALESCE(SUM(CASE WHEN t.type = 'bronze' THEN 1 ELSE 0 END), 0) AS bronze,
-      COALESCE(SUM(CASE WHEN t.type = 'silver' THEN 1 ELSE 0 END), 0) AS silver,
-      COALESCE(SUM(CASE WHEN t.type = 'gold' THEN 1 ELSE 0 END), 0) AS gold,
-      COALESCE(SUM(CASE WHEN t.type = 'platinum' THEN 1 ELSE 0 END), 0) AS platinum
+      COALESCE(SUM(CASE WHEN t.type = '{$bronze}' THEN 1 ELSE 0 END), 0) AS bronze,
+      COALESCE(SUM(CASE WHEN t.type = '{$silver}' THEN 1 ELSE 0 END), 0) AS silver,
+      COALESCE(SUM(CASE WHEN t.type = '{$gold}' THEN 1 ELSE 0 END), 0) AS gold,
+      COALESCE(SUM(CASE WHEN t.type = '{$platinum}' THEN 1 ELSE 0 END), 0) AS platinum
     FROM
       trophy t
-      JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = 0
+      JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = {$obtainableStatus}
     WHERE
       t.np_communication_id = :np_communication_id
       AND t.group_id = :group_id
@@ -240,16 +247,22 @@ SQL
 
     private function getPlayerTrophyCountSql(): string
     {
-        return <<<'SQL'
+        $bronze = TrophyType::Bronze->value;
+        $silver = TrophyType::Silver->value;
+        $gold = TrophyType::Gold->value;
+        $platinum = TrophyType::Platinum->value;
+        $obtainableStatus = TrophyMetaStatus::Obtainable->value;
+
+        return <<<SQL
 UPDATE
     trophy_group_player tgp
     LEFT JOIN (
         SELECT
             tia.account_id,
-            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'bronze' THEN 1 ELSE 0 END), 0) AS bronze,
-            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'silver' THEN 1 ELSE 0 END), 0) AS silver,
-            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'gold' THEN 1 ELSE 0 END), 0) AS gold,
-            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = 'platinum' THEN 1 ELSE 0 END), 0) AS platinum
+            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = '{$bronze}' THEN 1 ELSE 0 END), 0) AS bronze,
+            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = '{$silver}' THEN 1 ELSE 0 END), 0) AS silver,
+            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = '{$gold}' THEN 1 ELSE 0 END), 0) AS gold,
+            COALESCE(SUM(CASE WHEN tm.trophy_id IS NOT NULL AND t.type = '{$platinum}' THEN 1 ELSE 0 END), 0) AS platinum
         FROM
             temp_impacted_accounts tia
             LEFT JOIN trophy_earned te ON te.account_id = tia.account_id
@@ -260,7 +273,7 @@ UPDATE
             AND t.group_id = te.group_id
             AND t.order_id = te.order_id
             LEFT JOIN trophy_meta tm ON tm.trophy_id = t.id
-            AND tm.status = 0
+            AND tm.status = {$obtainableStatus}
         GROUP BY
             tia.account_id
     ) aggregate ON aggregate.account_id = tgp.account_id

--- a/wwwroot/classes/Admin/WorkerPage.php
+++ b/wwwroot/classes/Admin/WorkerPage.php
@@ -41,8 +41,8 @@ final class WorkerPage
             $successMessage,
             $errorMessage,
             $sortLinks,
-            $sortField->value,
-            $sortDirection->value
+            $sortField,
+            $sortDirection
         );
     }
 

--- a/wwwroot/classes/Admin/WorkerPageResult.php
+++ b/wwwroot/classes/Admin/WorkerPageResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/Worker.php';
 require_once __DIR__ . '/WorkerPageSortLink.php';
+require_once __DIR__ . '/WorkerSortField.php';
+require_once __DIR__ . '/WorkerSortDirection.php';
 
 final readonly class WorkerPageResult
 {
@@ -12,37 +14,19 @@ final readonly class WorkerPageResult
      */
     private readonly array $workers;
 
-    private readonly ?string $successMessage;
-
-    private readonly ?string $errorMessage;
-
-    /**
-     * @var array<string, WorkerPageSortLink>
-     */
-    private readonly array $sortLinks;
-
-    private readonly string $sortField;
-
-    private readonly string $sortDirection;
-
     /**
      * @param list<Worker> $workers
      * @param array<string, WorkerPageSortLink> $sortLinks
      */
     public function __construct(
         array $workers,
-        ?string $successMessage,
-        ?string $errorMessage,
-        array $sortLinks,
-        string $sortField,
-        string $sortDirection
+        private readonly ?string $successMessage,
+        private readonly ?string $errorMessage,
+        private readonly array $sortLinks,
+        private readonly WorkerSortField $sortField,
+        private readonly WorkerSortDirection $sortDirection,
     ) {
         $this->workers = array_values($workers);
-        $this->successMessage = $successMessage;
-        $this->errorMessage = $errorMessage;
-        $this->sortLinks = $sortLinks;
-        $this->sortField = $sortField;
-        $this->sortDirection = $sortDirection;
     }
 
     /**
@@ -76,12 +60,12 @@ final readonly class WorkerPageResult
         return $this->sortLinks[$field] ?? null;
     }
 
-    public function getSortField(): string
+    public function getSortField(): WorkerSortField
     {
         return $this->sortField;
     }
 
-    public function getSortDirection(): string
+    public function getSortDirection(): WorkerSortDirection
     {
         return $this->sortDirection;
     }

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/CronJobInterface.php';
+require_once __DIR__ . '/../TrophyMetaStatus.php';
+require_once __DIR__ . '/../GameAvailabilityStatus.php';
+require_once __DIR__ . '/../TrophyRarityName.php';
 
 final readonly class DailyCronJob implements CronJobInterface
 {
@@ -106,7 +109,18 @@ final readonly class DailyCronJob implements CronJobInterface
      * earned by a top-10k player get zero owners via LEFT JOIN + IFNULL, matching
      * the previous zero-owner fast path (10000 / LEGENDARY when obtainable).
      */
-    private const string APPLY_TROPHY_RARITY_QUERY = <<<'SQL'
+    private function buildApplyTrophyRarityQuery(): string
+    {
+        $obtainableStatus = TrophyMetaStatus::Obtainable->value;
+        $normalTitleStatus = GameAvailabilityStatus::NORMAL->value;
+        $none = TrophyRarityName::None->toSqlLiteral();
+        $common = TrophyRarityName::Common->toSqlLiteral();
+        $uncommon = TrophyRarityName::Uncommon->toSqlLiteral();
+        $rare = TrophyRarityName::Rare->toSqlLiteral();
+        $epic = TrophyRarityName::Epic->toSqlLiteral();
+        $legendary = TrophyRarityName::Legendary->toSqlLiteral();
+
+        return <<<SQL
         WITH rarity AS (
             SELECT
                 t.id AS trophy_id,
@@ -132,33 +146,34 @@ final readonly class DailyCronJob implements CronJobInterface
             tm.rarity_percent = r.rarity_percent,
             tm.owners = r.trophy_owners,
             tm.rarity_point = IF(
-                r.meta_status = 0 AND r.title_status = 0,
+                r.meta_status = {$obtainableStatus} AND r.title_status = {$normalTitleStatus},
                 IF(r.rarity_percent = 0, 10000, FLOOR(1 / (r.rarity_percent / 100) - 1)),
                 0
             ),
             tm.rarity_name = CASE
-                WHEN r.meta_status != 0 OR r.title_status != 0 THEN 'NONE'
-                WHEN r.rarity_percent > 10 THEN 'COMMON'
-                WHEN r.rarity_percent > 2 THEN 'UNCOMMON'
-                WHEN r.rarity_percent > 0.2 THEN 'RARE'
-                WHEN r.rarity_percent > 0.02 THEN 'EPIC'
-                ELSE 'LEGENDARY'
+                WHEN r.meta_status != {$obtainableStatus} OR r.title_status != {$normalTitleStatus} THEN {$none}
+                WHEN r.rarity_percent > 10 THEN {$common}
+                WHEN r.rarity_percent > 2 THEN {$uncommon}
+                WHEN r.rarity_percent > 0.2 THEN {$rare}
+                WHEN r.rarity_percent > 0.02 THEN {$epic}
+                ELSE {$legendary}
             END,
             tm.in_game_rarity_percent = r.in_game_rarity_percent,
             tm.in_game_rarity_point = IF(
-                r.meta_status = 0 AND r.title_status = 0 AND r.title_owners > 0,
+                r.meta_status = {$obtainableStatus} AND r.title_status = {$normalTitleStatus} AND r.title_owners > 0,
                 IF(r.in_game_rarity_percent = 0, 0, FLOOR(1 / (r.in_game_rarity_percent / 100) - 1)),
                 0
             ),
             tm.in_game_rarity_name = CASE
-                WHEN r.meta_status != 0 OR r.title_status != 0 THEN 'NONE'
-                WHEN r.in_game_rarity_percent <= 1 THEN 'LEGENDARY'
-                WHEN r.in_game_rarity_percent <= 5 THEN 'EPIC'
-                WHEN r.in_game_rarity_percent <= 20 THEN 'RARE'
-                WHEN r.in_game_rarity_percent <= 60 THEN 'UNCOMMON'
-                ELSE 'COMMON'
+                WHEN r.meta_status != {$obtainableStatus} OR r.title_status != {$normalTitleStatus} THEN {$none}
+                WHEN r.in_game_rarity_percent <= 1 THEN {$legendary}
+                WHEN r.in_game_rarity_percent <= 5 THEN {$epic}
+                WHEN r.in_game_rarity_percent <= 20 THEN {$rare}
+                WHEN r.in_game_rarity_percent <= 60 THEN {$uncommon}
+                ELSE {$common}
             END
         SQL;
+    }
 
     private const string UPDATE_TITLE_RARITY_POINTS_QUERY = <<<'SQL'
         WITH rarity AS (
@@ -296,7 +311,7 @@ final readonly class DailyCronJob implements CronJobInterface
 
     private function applyTrophyRarityFromTemporaryTable(): void
     {
-        $query = $this->database->prepare(self::APPLY_TROPHY_RARITY_QUERY);
+        $query = $this->database->prepare($this->buildApplyTrophyRarityQuery());
         $query->execute();
     }
 

--- a/wwwroot/classes/Cron/PlayerRankingUpdater.php
+++ b/wwwroot/classes/Cron/PlayerRankingUpdater.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../Psn100Logger.php';
+require_once __DIR__ . '/../PlayerStatus.php';
 
 class PlayerRankingUpdater
 {
@@ -47,8 +48,8 @@ SELECT
         ORDER BY `in_game_rarity_points` DESC
     ) AS in_game_rarity_ranking_country
 FROM player
-WHERE `status` = 0
-SQL;
+WHERE `status` = 
+SQL . PlayerStatus::NORMAL->value;
 
     public function __construct(
         private readonly PDO $database,

--- a/wwwroot/classes/Cron/PlayerScanCompletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionService.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../PlayStationTrophyLevelCalculator.php';
+require_once __DIR__ . '/../PlayerStatus.php';
+require_once __DIR__ . '/../GameAvailabilityStatus.php';
+require_once __DIR__ . '/../TrophyRarityName.php';
 
 /**
  * Recalculates player trophy totals, PSN level/progress, status, and rarity rollups
@@ -21,6 +24,8 @@ final class PlayerScanCompletionService
         int $totalTrophiesSony,
         string $recheck,
     ): PlayerScanCompletionResult {
+        $normalGameStatus = GameAvailabilityStatus::NORMAL->value;
+
         $query = $this->database->prepare("SELECT Ifnull(Sum(ttp.bronze), 0)   AS bronze,
                 Ifnull(Sum(ttp.silver), 0)   AS silver,
                 Ifnull(Sum(ttp.gold), 0)     AS gold,
@@ -28,7 +33,7 @@ final class PlayerScanCompletionService
             FROM   trophy_title_player ttp
                 JOIN trophy_title tt USING (np_communication_id)
                 JOIN trophy_title_meta ttm USING (np_communication_id)
-            WHERE  ttm.status = 0
+            WHERE  ttm.status = {$normalGameStatus}
                 AND ttp.account_id = :account_id ");
         $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
@@ -58,7 +63,7 @@ final class PlayerScanCompletionService
         $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->execute();
 
-        $playerStatus = 0;
+        $playerStatus = PlayerStatus::NORMAL->value;
 
         $query = $this->database->prepare('SELECT trophy_count_npwr FROM player WHERE account_id = :account_id');
         $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
@@ -103,8 +108,10 @@ final class PlayerScanCompletionService
         $query->execute();
         $withinAYear = $query->fetchColumn();
         if ((int) $withinAYear === 0) {
-            $playerStatus = 4;
+            $playerStatus = PlayerStatus::INACTIVE->value;
         }
+
+        $flaggedStatus = PlayerStatus::FLAGGED->value;
 
         $query = $this->database->prepare("UPDATE
                 player p
@@ -113,7 +120,7 @@ final class PlayerScanCompletionService
                 p.trophy_count_sony = :trophy_count_sony
             WHERE
                 p.account_id = :account_id
-                AND p.status != 1
+                AND p.status != {$flaggedStatus}
             ");
         $query->bindValue(':status', $playerStatus, PDO::PARAM_INT);
         $query->bindValue(':trophy_count_sony', $totalTrophiesSony, PDO::PARAM_INT);
@@ -159,27 +166,42 @@ final class PlayerScanCompletionService
         $query->execute();
         $playerStatus = $query->fetchColumn();
 
-        if ((int) $playerStatus !== 0) {
+        if (PlayerStatus::fromValue((int) $playerStatus) !== PlayerStatus::NORMAL) {
             return;
         }
 
-        $this->executeWithDeadlockRetry(function () use ($accountId): void {
+        $common = TrophyRarityName::Common->toSqlLiteral();
+        $uncommon = TrophyRarityName::Uncommon->toSqlLiteral();
+        $rare = TrophyRarityName::Rare->toSqlLiteral();
+        $epic = TrophyRarityName::Epic->toSqlLiteral();
+        $legendary = TrophyRarityName::Legendary->toSqlLiteral();
+        $normalPlayerStatus = PlayerStatus::NORMAL->value;
+
+        $this->executeWithDeadlockRetry(function () use (
+            $accountId,
+            $common,
+            $uncommon,
+            $rare,
+            $epic,
+            $legendary,
+            $normalPlayerStatus,
+        ): void {
             $query = $this->database->prepare("WITH
                     rarity AS(
                     SELECT
                         trophy_earned.np_communication_id,
                         SUM(tm.rarity_point) AS points,
                         SUM(tm.in_game_rarity_point) AS in_game_points,
-                        SUM(tm.rarity_name = 'COMMON') common,
-                        SUM(tm.rarity_name = 'UNCOMMON') uncommon,
-                        SUM(tm.rarity_name = 'RARE') rare,
-                        SUM(tm.rarity_name = 'EPIC') epic,
-                        SUM(tm.rarity_name = 'LEGENDARY') legendary,
-                        SUM(tm.in_game_rarity_name = 'COMMON') in_game_common,
-                        SUM(tm.in_game_rarity_name = 'UNCOMMON') in_game_uncommon,
-                        SUM(tm.in_game_rarity_name = 'RARE') in_game_rare,
-                        SUM(tm.in_game_rarity_name = 'EPIC') in_game_epic,
-                        SUM(tm.in_game_rarity_name = 'LEGENDARY') in_game_legendary
+                        SUM(tm.rarity_name = {$common}) common,
+                        SUM(tm.rarity_name = {$uncommon}) uncommon,
+                        SUM(tm.rarity_name = {$rare}) rare,
+                        SUM(tm.rarity_name = {$epic}) epic,
+                        SUM(tm.rarity_name = {$legendary}) legendary,
+                        SUM(tm.in_game_rarity_name = {$common}) in_game_common,
+                        SUM(tm.in_game_rarity_name = {$uncommon}) in_game_uncommon,
+                        SUM(tm.in_game_rarity_name = {$rare}) in_game_rare,
+                        SUM(tm.in_game_rarity_name = {$epic}) in_game_epic,
+                        SUM(tm.in_game_rarity_name = {$legendary}) in_game_legendary
                     FROM
                         trophy_earned
                     JOIN trophy t ON t.np_communication_id = trophy_earned.np_communication_id
@@ -248,7 +270,7 @@ final class PlayerScanCompletionService
                     p.in_game_epic = rarity.in_game_epic,
                     p.in_game_legendary = rarity.in_game_legendary
                 WHERE
-                    p.account_id = :account_id AND p.status = 0");
+                    p.account_id = :account_id AND p.status = {$normalPlayerStatus}");
             $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
             $query->execute();
         });

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/../ImageHashCalculator.php';
 require_once __DIR__ . '/PlayerCountryResolver.php';
 require_once __DIR__ . '/PlayerScanPrivacyService.php';
 require_once __DIR__ . '/../PlayerRepository.php';
+require_once __DIR__ . '/../PlayerStatus.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\PlayStation\Client;
@@ -341,8 +342,9 @@ final class PlayerScanProfileSynchronizer
                     sprintf('Sony issues with %s (%s).', $player['online_id'], $accountId)
                 );
 
+                $unavailableStatus = PlayerStatus::UNAVAILABLE->value;
                 $query = $this->database->prepare(
-                    'UPDATE player SET `status` = 5, last_updated_date = NOW() WHERE account_id = :account_id'
+                    "UPDATE player SET `status` = {$unavailableStatus}, last_updated_date = NOW() WHERE account_id = :account_id"
                 );
                 $query->bindValue(':account_id', (string) $accountId, PDO::PARAM_STR);
                 $query->execute();

--- a/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/../TrophyImageDirectories.php';
 require_once __DIR__ . '/../TrophyImageDownloader.php';
 require_once __DIR__ . '/../TrophyMetaRepository.php';
 require_once __DIR__ . '/../TrophyTitleNameFormatter.php';
+require_once __DIR__ . '/../GameAvailabilityStatus.php';
 require_once __DIR__ . '/PlayerScanCatalogSideEffects.php';
 require_once __DIR__ . '/PlayerScanTitleCatalogSyncResult.php';
 require_once __DIR__ . '/PlayerScanTitleHeaderSynchronizer.php';
@@ -317,7 +318,7 @@ final class PlayerScanTitleCatalogSynchronizer
                 $query->bindValue(':np_communication_id', $npid, PDO::PARAM_STR);
                 $query->execute();
                 $status = $query->fetchColumn();
-                if ((int) $status === 2) {
+                if (GameAvailabilityStatus::fromInt((int) $status) === GameAvailabilityStatus::MERGED) {
                     $this->logger->log('New trophies added for ' . $trophyTitle->name() . '. ' . $npid . ', ' . $trophyGroupId . ', ' . $trophyGroupName);
                 } else {
                     $this->logger->log('SET VERSION for ' . $trophyTitle->name() . '. ' . $npid . ', ' . $trophyGroupId . ', ' . $trophyGroupName);

--- a/wwwroot/classes/GameHistoryPage.php
+++ b/wwwroot/classes/GameHistoryPage.php
@@ -14,15 +14,7 @@ require_once __DIR__ . '/Utility.php';
 
 final class GameHistoryPage
 {
-    private GameService $gameService;
-
-    private GameHistoryService $historyService;
-
-    private GameHeaderService $gameHeaderService;
-
     private GameHistoryChangeFilter $historyChangeFilter;
-
-    private Utility $utility;
 
     private GameDetails $game;
 
@@ -63,18 +55,14 @@ final class GameHistoryPage
     private ?array $historyEntries = null;
 
     public function __construct(
-        GameService $gameService,
-        GameHistoryService $historyService,
-        GameHeaderService $gameHeaderService,
-        Utility $utility,
+        private GameService $gameService,
+        private GameHistoryService $historyService,
+        private GameHeaderService $gameHeaderService,
+        private Utility $utility,
         int $gameId,
         ?GameHistoryChangeFilter $historyChangeFilter = null
     ) {
-        $this->gameService = $gameService;
-        $this->historyService = $historyService;
-        $this->gameHeaderService = $gameHeaderService;
         $this->historyChangeFilter = $historyChangeFilter ?? new GameHistoryChangeFilter();
-        $this->utility = $utility;
 
         $this->game = $this->loadGame($gameId);
         $this->headerData = $this->gameHeaderService->buildHeaderData($this->game);

--- a/wwwroot/classes/GamePage.php
+++ b/wwwroot/classes/GamePage.php
@@ -18,12 +18,6 @@ require_once __DIR__ . '/Utility.php';
 
 final class GamePage
 {
-    private GameService $gameService;
-
-    private GameHeaderService $gameHeaderService;
-
-    private Utility $utility;
-
     private GameDetails $game;
 
     private GameHeaderData $headerData;
@@ -55,16 +49,13 @@ final class GamePage
      * @param array<string, mixed> $queryParameters
      */
     public function __construct(
-        GameService $gameService,
-        GameHeaderService $gameHeaderService,
-        Utility $utility,
+        private GameService $gameService,
+        private GameHeaderService $gameHeaderService,
+        private Utility $utility,
         int $gameId,
         array $queryParameters = [],
         ?string $playerOnlineId = null
     ) {
-        $this->gameService = $gameService;
-        $this->gameHeaderService = $gameHeaderService;
-        $this->utility = $utility;
         $this->playerOnlineId = $playerOnlineId !== null ? trim($playerOnlineId) : null;
 
         $this->game = $this->loadGame($gameId);

--- a/wwwroot/classes/PlayerHeaderViewModel.php
+++ b/wwwroot/classes/PlayerHeaderViewModel.php
@@ -256,6 +256,6 @@ final readonly class PlayerHeaderViewModel
 
     private function isLeaderboardRankAvailable(): bool
     {
-        return (int) ($this->player['status'] ?? 0) === 0;
+        return $this->getStatus() === PlayerStatus::NORMAL;
     }
 }

--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Random\Randomizer;
 
 require_once __DIR__ . '/PlatformSql.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
 
 class PlayerRandomGamesService
 {
@@ -67,14 +68,16 @@ class PlayerRandomGamesService
 
     private function buildBaseQuery(PlayerRandomGamesFilter $filter): string
     {
-        $sql = <<<'SQL'
+        $normalGameStatus = GameAvailabilityStatus::NORMAL->value;
+
+        $sql = <<<SQL
              FROM trophy_title tt
             JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             LEFT JOIN trophy_title_player ttp ON
                 ttp.np_communication_id = tt.np_communication_id
                 AND ttp.account_id = :account_id
             WHERE
-                ttm.status = 0
+                ttm.status = {$normalGameStatus}
                 AND (ttp.progress IS NULL OR ttp.progress < 100)
         SQL;
 

--- a/wwwroot/classes/PlayerSummaryService.php
+++ b/wwwroot/classes/PlayerSummaryService.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/GameAvailabilityStatus.php';
+
 class PlayerSummaryService
 {
     public function __construct(private readonly PDO $database)
@@ -25,8 +27,10 @@ class PlayerSummaryService
      */
     private function fetchSummaryRow(int $accountId): array
     {
+        $normalGameStatus = GameAvailabilityStatus::NORMAL->value;
+
         $query = $this->database->prepare(
-            <<<'SQL'
+            <<<SQL
             SELECT
                 CAST(COUNT(*) AS UNSIGNED)                                  AS number_of_games,
                 CAST(COALESCE(SUM(ttp.progress = 100), 0) AS UNSIGNED)      AS number_of_completed_games,
@@ -42,7 +46,7 @@ class PlayerSummaryService
                 INNER JOIN trophy_title tt ON tt.np_communication_id = ttp.np_communication_id
                 INNER JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
             WHERE
-                ttm.status = 0
+                ttm.status = {$normalGameStatus}
                 AND ttp.account_id = :account_id
             SQL
         );

--- a/wwwroot/classes/PlayerTimelineService.php
+++ b/wwwroot/classes/PlayerTimelineService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerTimelineData.php';
 require_once __DIR__ . '/PlayerTimelineEntry.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
+
 class PlayerTimelineService
 {
     public function __construct(private readonly PDO $database)
@@ -12,7 +14,9 @@ class PlayerTimelineService
 
     public function getTimelineData(int $accountId): ?PlayerTimelineData
     {
-        $sql = <<<'SQL'
+        $normalGameStatus = GameAvailabilityStatus::NORMAL->value;
+
+        $sql = <<<SQL
             WITH timeline AS (
                 SELECT
                     tt.id AS game_id,
@@ -28,7 +32,7 @@ class PlayerTimelineService
                 JOIN trophy_title tt ON tt.np_communication_id = ttp.np_communication_id
                 JOIN trophy_title_meta ttm ON ttm.np_communication_id = ttp.np_communication_id
                 WHERE ttp.account_id = :account_id
-                    AND ttm.status = 0
+                    AND ttm.status = {$normalGameStatus}
                 GROUP BY ttp.np_communication_id, tt.id, tt.name, ttp.progress
             )
             SELECT

--- a/wwwroot/classes/TrophyCalculator.php
+++ b/wwwroot/classes/TrophyCalculator.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/TrophyMetaStatus.php';
+
 final class TrophyCalculator
 {
     private const int BRONZE_SCORE = 15;
@@ -94,14 +96,16 @@ final class TrophyCalculator
 
     public function recalculateTrophyGroup(string $npCommunicationId, string $groupId, string $accountId): void
     {
+        $obtainableStatus = TrophyMetaStatus::Obtainable->value;
+
         $query = $this->database->prepare(
-            'SELECT t.type, COUNT(*) AS count
+            "SELECT t.type, COUNT(*) AS count
             FROM trophy t
             JOIN trophy_meta tm ON tm.trophy_id = t.id
             WHERE t.np_communication_id = :np_communication_id
                 AND t.group_id = :group_id
-                AND tm.status = 0
-            GROUP BY t.type'
+                AND tm.status = {$obtainableStatus}
+            GROUP BY t.type"
         );
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
@@ -132,7 +136,7 @@ final class TrophyCalculator
         $maxScore = $this->calculateScore($trophyTypes);
 
         $query = $this->database->prepare(
-            'SELECT t.type, COUNT(t.type) AS count
+            "SELECT t.type, COUNT(t.type) AS count
             FROM trophy_earned te
             JOIN trophy t ON t.np_communication_id = te.np_communication_id
                 AND t.order_id = te.order_id
@@ -141,8 +145,8 @@ final class TrophyCalculator
                 AND te.np_communication_id = :np_communication_id
                 AND te.group_id = :group_id
                 AND te.earned = 1
-                AND tm.status = 0
-            GROUP BY t.type'
+                AND tm.status = {$obtainableStatus}
+            GROUP BY t.type"
         );
         $query->bindValue(':account_id', $accountId, PDO::PARAM_STR);
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);

--- a/wwwroot/classes/TrophyListService.php
+++ b/wwwroot/classes/TrophyListService.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/TrophyListItem.php';
+require_once __DIR__ . '/TrophyMetaStatus.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
 
-class TrophyListService
+final class TrophyListService
 {
     public const int PAGE_SIZE = 50;
 
@@ -14,13 +16,16 @@ class TrophyListService
 
     public function countTrophies(): int
     {
+        $obtainableStatus = TrophyMetaStatus::Obtainable->value;
+        $normalGameStatus = GameAvailabilityStatus::NORMAL->value;
+
         $query = $this->database->prepare(
-            'SELECT COUNT(*)
+            "SELECT COUNT(*)
             FROM trophy t
             JOIN trophy_meta tm ON tm.trophy_id = t.id
             JOIN trophy_title tt USING (np_communication_id)
             JOIN trophy_title_meta ttm USING (np_communication_id)
-            WHERE tm.status = 0 AND ttm.status = 0'
+            WHERE tm.status = {$obtainableStatus} AND ttm.status = {$normalGameStatus}"
         );
 
         $query->execute();
@@ -36,9 +41,11 @@ class TrophyListService
     {
         $offset = max($offset, 0);
         $limit = max($limit, 1);
+        $obtainableStatus = TrophyMetaStatus::Obtainable->value;
+        $normalGameStatus = GameAvailabilityStatus::NORMAL->value;
 
         $query = $this->database->prepare(
-            'SELECT
+            "SELECT
                 t.id AS trophy_id,
                 t.type AS trophy_type,
                 t.name AS trophy_name,
@@ -57,9 +64,9 @@ class TrophyListService
             JOIN trophy_meta tm ON tm.trophy_id = t.id
             JOIN trophy_title tt USING(np_communication_id)
             JOIN trophy_title_meta ttm USING (np_communication_id)
-            WHERE tm.status = 0 AND ttm.status = 0
+            WHERE tm.status = {$obtainableStatus} AND ttm.status = {$normalGameStatus}
             ORDER BY tm.rarity_percent DESC
-            LIMIT :offset, :limit'
+            LIMIT :offset, :limit"
         );
 
         $query->bindValue(':offset', $offset, PDO::PARAM_INT);

--- a/wwwroot/classes/TrophyMergeMetadataRepository.php
+++ b/wwwroot/classes/TrophyMergeMetadataRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
 require_once __DIR__ . '/Platform.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
 
 /**
  * Persists trophy-title merge metadata: merged status, parent links, platform union, and changelog rows.
@@ -20,10 +21,12 @@ final class TrophyMergeMetadataRepository
     public function markGameAsMergedByNpId(string $npCommunicationId): void
     {
         $this->transactionRunner->execute(function () use ($npCommunicationId): void {
+            $mergedStatus = GameAvailabilityStatus::MERGED->value;
+
             $query = $this->database->prepare(
-                <<<'SQL'
+                <<<SQL
                 UPDATE trophy_title_meta
-                SET    status = 2
+                SET    status = {$mergedStatus}
                 WHERE  np_communication_id = :child_np_communication_id
                 SQL
             );
@@ -51,10 +54,12 @@ final class TrophyMergeMetadataRepository
                 return;
             }
 
+            $mergedStatus = GameAvailabilityStatus::MERGED->value;
+
             $query = $this->database->prepare(
-                <<<'SQL'
+                <<<SQL
                 UPDATE trophy_title_meta
-                SET    status = 2
+                SET    status = {$mergedStatus}
                 WHERE  np_communication_id = :np_communication_id
                 SQL
             );

--- a/wwwroot/classes/TrophyMergePlayerProgressRecalculator.php
+++ b/wwwroot/classes/TrophyMergePlayerProgressRecalculator.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/TrophyMetaStatus.php';
+require_once __DIR__ . '/TrophyType.php';
+
 /**
  * Recalculates trophy group/title player progress aggregates for merged titles.
  *
@@ -30,6 +33,11 @@ class TrophyMergePlayerProgressRecalculator
             $childPlaceholders[] = ':child_np_' . $index;
         }
         $childListSql = implode(', ', $childPlaceholders);
+        $bronze = TrophyType::Bronze->value;
+        $silver = TrophyType::Silver->value;
+        $gold = TrophyType::Gold->value;
+        $platinum = TrophyType::Platinum->value;
+        $obtainableStatus = TrophyMetaStatus::Obtainable->value;
 
         $groups = $this->database->prepare(
             <<<'SQL'
@@ -48,7 +56,7 @@ SQL
             // Drive trophy_earned from child title accounts so HASH(account_id)
             // partition pruning applies instead of scanning all 256 partitions by title.
             $mergeSql = sprintf(
-                <<<'SQL'
+                <<<SQL
                 INSERT INTO trophy_group_player(
                     np_communication_id,
                     group_id,
@@ -78,11 +86,11 @@ SQL
                 player AS(
                     SELECT
                         te.account_id,
-                        SUM(t.type = 'bronze') AS bronze,
-                        SUM(t.type = 'silver') AS silver,
-                        SUM(t.type = 'gold') AS gold,
-                        SUM(t.type = 'platinum') AS platinum,
-                        SUM(t.type = 'bronze') * 15 + SUM(t.type = 'silver') * 30 + SUM(t.type = 'gold') * 90 AS score
+                        SUM(t.type = '{$bronze}') AS bronze,
+                        SUM(t.type = '{$silver}') AS silver,
+                        SUM(t.type = '{$gold}') AS gold,
+                        SUM(t.type = '{$platinum}') AS platinum,
+                        SUM(t.type = '{$bronze}') * 15 + SUM(t.type = '{$silver}') * 30 + SUM(t.type = '{$gold}') * 90 AS score
                     FROM
                         accounts a
                     JOIN trophy_earned te ON
@@ -92,7 +100,7 @@ SQL
                         AND te.earned = 1
                     JOIN trophy t ON
                         t.np_communication_id = te.np_communication_id AND t.order_id = te.order_id
-                    JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = 0
+                    JOIN trophy_meta tm ON tm.trophy_id = t.id AND tm.status = {$obtainableStatus}
                     GROUP BY
                         te.account_id
                 )

--- a/wwwroot/classes/TrophyMetaRepository.php
+++ b/wwwroot/classes/TrophyMetaRepository.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/TrophyMetaStatus.php';
+require_once __DIR__ . '/TrophyRarityName.php';
+
 final class TrophyMetaRepository
 {
     private const string SELECT_TROPHY_ID_SQL = <<<'SQL'
@@ -10,44 +13,6 @@ final class TrophyMetaRepository
         WHERE np_communication_id = :np_communication_id
           AND group_id = :group_id
           AND order_id = :order_id
-    SQL;
-
-    private const string SQLITE_INSERT_META_SQL = <<<'SQL'
-        INSERT OR IGNORE INTO trophy_meta (
-            trophy_id,
-            rarity_percent,
-            rarity_point,
-            status,
-            owners,
-            rarity_name
-        ) VALUES (
-            :trophy_id,
-            0,
-            0,
-            0,
-            0,
-            'NONE'
-        )
-    SQL;
-
-    private const string MYSQL_INSERT_META_SQL = <<<'SQL'
-        INSERT INTO trophy_meta (
-            trophy_id,
-            rarity_percent,
-            rarity_point,
-            status,
-            owners,
-            rarity_name
-        ) VALUES (
-            :trophy_id,
-            0,
-            0,
-            0,
-            0,
-            'NONE'
-        ) AS new_meta
-        ON DUPLICATE KEY UPDATE
-            trophy_id = new_meta.trophy_id
     SQL;
 
     private ?PDOStatement $selectTrophyIdStatement = null;
@@ -81,9 +46,59 @@ final class TrophyMetaRepository
         $driver = $this->database->getAttribute(PDO::ATTR_DRIVER_NAME);
 
         return match ($driver) {
-            'sqlite' => self::SQLITE_INSERT_META_SQL,
-            'mysql' => self::MYSQL_INSERT_META_SQL,
+            'sqlite' => $this->sqliteInsertMetaSql(),
+            'mysql' => $this->mysqlInsertMetaSql(),
             default => throw new RuntimeException("Unsupported PDO driver: {$driver}"),
         };
+    }
+
+    private function sqliteInsertMetaSql(): string
+    {
+        $obtainableStatus = TrophyMetaStatus::Obtainable->value;
+        $none = TrophyRarityName::None->toSqlLiteral();
+
+        return <<<SQL
+        INSERT OR IGNORE INTO trophy_meta (
+            trophy_id,
+            rarity_percent,
+            rarity_point,
+            status,
+            owners,
+            rarity_name
+        ) VALUES (
+            :trophy_id,
+            0,
+            0,
+            {$obtainableStatus},
+            0,
+            {$none}
+        )
+        SQL;
+    }
+
+    private function mysqlInsertMetaSql(): string
+    {
+        $obtainableStatus = TrophyMetaStatus::Obtainable->value;
+        $none = TrophyRarityName::None->toSqlLiteral();
+
+        return <<<SQL
+        INSERT INTO trophy_meta (
+            trophy_id,
+            rarity_percent,
+            rarity_point,
+            status,
+            owners,
+            rarity_name
+        ) VALUES (
+            :trophy_id,
+            0,
+            0,
+            {$obtainableStatus},
+            0,
+            {$none}
+        ) AS new_meta
+        ON DUPLICATE KEY UPDATE
+            trophy_id = new_meta.trophy_id
+        SQL;
     }
 }

--- a/wwwroot/classes/TrophyRarityFormatter.php
+++ b/wwwroot/classes/TrophyRarityFormatter.php
@@ -30,9 +30,10 @@ final class TrophyRarityFormatter
     /**
      * @param float|int|string|null $rarityPercent
      */
+    #[\NoDiscard]
     public function format(
         float|int|string|null $rarityPercent,
-        int|TrophyMetaStatus $status = 0,
+        int|TrophyMetaStatus $status = TrophyMetaStatus::Obtainable,
     ): TrophyRarity {
         return $this->formatMeta($rarityPercent, $status);
     }
@@ -40,9 +41,10 @@ final class TrophyRarityFormatter
     /**
      * @param float|int|string|null $rarityPercent
      */
+    #[\NoDiscard]
     public function formatMeta(
         float|int|string|null $rarityPercent,
-        int|TrophyMetaStatus $status = 0,
+        int|TrophyMetaStatus $status = TrophyMetaStatus::Obtainable,
     ): TrophyRarity {
         return $this->formatWithThresholds($rarityPercent, $status, self::META_THRESHOLDS);
     }
@@ -50,9 +52,10 @@ final class TrophyRarityFormatter
     /**
      * @param float|int|string|null $rarityPercent
      */
+    #[\NoDiscard]
     public function formatInGame(
         float|int|string|null $rarityPercent,
-        int|TrophyMetaStatus $status = 0,
+        int|TrophyMetaStatus $status = TrophyMetaStatus::Obtainable,
     ): TrophyRarity {
         return $this->formatWithThresholds($rarityPercent, $status, self::IN_GAME_THRESHOLDS);
     }

--- a/wwwroot/classes/TrophyRarityName.php
+++ b/wwwroot/classes/TrophyRarityName.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+enum TrophyRarityName: string
+{
+    case None = 'NONE';
+    case Common = 'COMMON';
+    case Uncommon = 'UNCOMMON';
+    case Rare = 'RARE';
+    case Epic = 'EPIC';
+    case Legendary = 'LEGENDARY';
+
+    #[\NoDiscard]
+    public static function fromMixed(mixed $value): self
+    {
+        if ($value instanceof self) {
+            return $value;
+        }
+
+        if (!is_string($value) && !is_numeric($value)) {
+            return self::None;
+        }
+
+        return self::tryFrom(((string) $value) |> trim(...) |> strtoupper(...)) ?? self::None;
+    }
+
+    /**
+     * Quote the enum value for safe embedding in SQL string literals.
+     */
+    public function toSqlLiteral(): string
+    {
+        return "'" . $this->value . "'";
+    }
+}

--- a/wwwroot/classes/TrophyTitleCloneService.php
+++ b/wwwroot/classes/TrophyTitleCloneService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
 require_once __DIR__ . '/ChangelogEntry.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
 
 /**
  * Clones a trophy title into a new MERGE_* title, including catalog rows and history.
@@ -98,8 +99,11 @@ SQL
 
             $cloneGameId = (int) $insertedGameId;
 
+            $mergedStatus = GameAvailabilityStatus::MERGED->value;
+            $normalStatus = GameAvailabilityStatus::NORMAL->value;
+
             $metaInsert = $this->database->prepare(
-                <<<'SQL'
+                <<<SQL
                 INSERT INTO trophy_title_meta (
                     np_communication_id,
                     owners,
@@ -117,7 +121,7 @@ SQL
                     owners,
                     difficulty,
                     message,
-                    CASE WHEN status = 2 THEN 0 ELSE status END,
+                    CASE WHEN status = {$mergedStatus} THEN {$normalStatus} ELSE status END,
                     recent_players,
                     owners_completed,
                     NULL,

--- a/wwwroot/config/possible-cheater-sections.php
+++ b/wwwroot/config/possible-cheater-sections.php
@@ -2,10 +2,14 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../classes/PlayerStatus.php';
+
+$flaggedStatus = PlayerStatus::FLAGGED->value;
+
 return [
         [
             'title' => 'FUEL',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -24,7 +28,7 @@ return [
                     AND fuel_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR00481_00'
                 HAVING
@@ -36,7 +40,7 @@ return [
         ],
         [
             'title' => 'SOCOM: U.S. NAVY SEALS CONFRONTATION',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -55,7 +59,7 @@ return [
                     AND socom_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR00302_00'
                 HAVING
@@ -67,7 +71,7 @@ return [
         ],
         [
             'title' => 'Resonance of Fate (Lap Two Complete < A New Beginning)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -86,7 +90,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR01103_00'
                 HAVING
@@ -98,7 +102,7 @@ return [
         ],
         [
             'title' => 'End of Eternity (2周目クリア < 2周目突入)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -117,7 +121,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR00987_00'
                 HAVING
@@ -129,7 +133,7 @@ return [
         ],
         [
             'title' => 'Catherine: Full Body',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -148,7 +152,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR17582_00'
                 HAVING
@@ -160,7 +164,7 @@ return [
         ],
         [
             'title' => '凱薩琳FULL BODY',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -179,7 +183,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR17415_00'
                 HAVING
@@ -191,7 +195,7 @@ return [
         ],
         [
             'title' => 'キャサリン・フルボディ',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -210,7 +214,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR14836_00'
                 HAVING
@@ -222,7 +226,7 @@ return [
         ],
         [
             'title' => 'Lost Planet 2 (200-Chapter Playback <-> 300-Chapter Playback)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -241,7 +245,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR00928_00'
                 HAVING
@@ -253,7 +257,7 @@ return [
         ],
         [
             'title' => 'Lost Planet 2 (Snow Pirate Leader <-> Snow Pirate Commander)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -272,7 +276,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR00928_00'
                 HAVING
@@ -284,7 +288,7 @@ return [
         ],
         [
             'title' => 'Resident Evil: Revelations [PS4] (Bonus Legend <-> Bonus Demi-god)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -303,7 +307,7 @@ return [
                     AND rer_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR11777_00'
                 HAVING
@@ -315,7 +319,7 @@ return [
         ],
         [
             'title' => 'Resident Evil: Revelations [PS4] (Meteoric Rise <-> Top of My Game)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -334,7 +338,7 @@ return [
                     AND rer_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR11777_00'
                 HAVING
@@ -346,7 +350,7 @@ return [
         ],
         [
             'title' => 'Resident Evil: Revelations [PS3] (Bonus Legend <-> Bonus Demi-god)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -365,7 +369,7 @@ return [
                     AND rer_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR03903_00'
                 HAVING
@@ -377,7 +381,7 @@ return [
         ],
         [
             'title' => 'Resident Evil: Revelations [PS3] (Meteoric Rise <-> Top of My Game)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -396,7 +400,7 @@ return [
                     AND rer_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR03903_00'
                 HAVING
@@ -408,7 +412,7 @@ return [
         ],
         [
             'title' => 'Angry Birds Trilogy [PS3] (Block Breaker <-> Block Annihilator)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -427,7 +431,7 @@ return [
                     AND abt_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR03771_00'
                 HAVING
@@ -439,7 +443,7 @@ return [
         ],
         [
             'title' => 'Terminator Salvation',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -470,7 +474,7 @@ return [
                 ) trophy_counter
                 INNER JOIN player p ON
                     p.account_id = trophy_counter.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 ORDER BY
                     p.online_id
             SQL,
@@ -478,7 +482,7 @@ return [
         ],
         [
             'title' => 'F1 Race Stars',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -497,7 +501,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR03734_00'
                 HAVING
@@ -509,7 +513,7 @@ return [
         ],
         [
             'title' => 'Mega Man: Legacy Collection',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -528,7 +532,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR09098_00'
                 HAVING
@@ -540,7 +544,7 @@ return [
         ],
         [
             'title' => 'Batman: Arkham Asylum',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -559,7 +563,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR00626_00'
                 HAVING
@@ -571,7 +575,7 @@ return [
         ],
         [
             'title' => 'Batman: Arkham Asylum (JP)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -590,7 +594,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR01012_00'
                 HAVING
@@ -602,7 +606,7 @@ return [
         ],
         [
             'title' => 'Dead Space',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -621,7 +625,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR00464_00'
                 HAVING
@@ -633,7 +637,7 @@ return [
         ],
         [
             'title' => 'Street Fighter X Tekken [PSVITA] (Transcend All You Know <-> Your Legend Will Never Die)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -652,7 +656,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR03139_00'
                 HAVING
@@ -664,7 +668,7 @@ return [
         ],
         [
             'title' => 'Street Fighter X Tekken [PS3] (Transcend All You Know <-> Your Legend Will Never Die)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -683,7 +687,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR01781_00'
                 HAVING
@@ -695,7 +699,7 @@ return [
         ],
         [
             'title' => 'Fat Princess',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -714,7 +718,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR00737_00'
                 HAVING
@@ -726,7 +730,7 @@ return [
         ],
         [
             'title' => 'Code Vein (Determiner of Fate <-> Heirs)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -745,7 +749,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR14318_00'
                 HAVING
@@ -757,7 +761,7 @@ return [
         ],
         [
             'title' => 'Code Vein (Determiner of Fate <-> To Eternity)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -776,7 +780,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR14318_00'
                 HAVING
@@ -788,7 +792,7 @@ return [
         ],
         [
             'title' => 'Code Vein (Determiner of Fate <-> Dweller in the Dark)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -807,7 +811,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR14318_00'
                 HAVING
@@ -819,7 +823,7 @@ return [
         ],
         [
             'title' => 'Final Fantasy X-2 HD Remaster (Giant Tower <-> Almost There)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -838,7 +842,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR05019_00'
                 HAVING
@@ -850,7 +854,7 @@ return [
         ],
         [
             'title' => 'Pic-a-Pix Color 2 [VITA, EU] (Casual Puzzler <-> Casual Completionist)',
-            'query' => <<<'SQL'
+            'query' => <<<SQL
                 SELECT
                     p.account_id,
                     p.online_id,
@@ -869,7 +873,7 @@ return [
                     AND trophy_end.earned = 1
                 JOIN player p ON
                     p.account_id = ttp.account_id
-                    AND p.status != 1
+                    AND p.status != {$flaggedStatus}
                 WHERE
                     ttp.np_communication_id = 'NPWR18592_00'
                 HAVING


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Continues the PHP 8.5 modernization series by clearing leftover magic status/type/rarity literals now that the project no longer needs older PHP compatibility.

### Changes
- Replace remaining player/game/trophy **status integers** in SQL and PHP with `PlayerStatus`, `GameAvailabilityStatus`, and `TrophyMetaStatus`
- Add `TrophyRarityName` and use it in daily rarity SQL, scan completion rollups, trophy meta inserts, and game copy
- Use `TrophyType` values in progress recalculation SQL instead of `'bronze'|'silver'|…` string literals
- Store `WorkerPageResult` sort field/direction as enums rather than strings
- Promote a few simple constructors, mark several leaf services `final`, and add `#[\NoDiscard]` on rarity formatters
- Interpolate `PlayerStatus::FLAGGED` into possible-cheater section SQL config

### Tests
- `php tests/run.php` — all 1004 tests passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64b9f776-88f4-4e33-9703-89ace3d8173b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64b9f776-88f4-4e33-9703-89ace3d8173b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

