### PR TITLE
Adopt remaining PHP 8.5 idioms for queue parts and closures

### DIFF
--- a/tests/DailyCronJobTest.php
+++ b/tests/DailyCronJobTest.php
@@ -1433,8 +1433,7 @@ final class DailyCronJobFinalDropFailureTestDatabase extends PDO
 
 final class DailyCronJobTestStatement extends PDOStatement
 {
-    /** @var callable */
-    private $callback;
+    private \Closure $callback;
 
     private bool $isSelect;
 
@@ -1443,10 +1442,7 @@ final class DailyCronJobTestStatement extends PDOStatement
     /** @var array<string|int, mixed> */
     private array $boundValues = [];
 
-    /**
-     * @param callable $callback
-     */
-    public function __construct(callable $callback, bool $isSelect = false, mixed $fetchColumnValue = null)
+    public function __construct(\Closure $callback, bool $isSelect = false, mixed $fetchColumnValue = null)
     {
         $this->callback = $callback;
         $this->isSelect = $isSelect;

--- a/tests/Php85IdiomEnumsTest.php
+++ b/tests/Php85IdiomEnumsTest.php
@@ -9,6 +9,10 @@ require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerAction.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerSortField.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/WorkerSortDirection.php';
 require_once __DIR__ . '/../wwwroot/classes/TrophyRarityName.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerQueueMessagePartType.php';
+require_once __DIR__ . '/../wwwroot/classes/JsonResponseStatus.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyType.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMetaStatus.php';
 
 final class Php85IdiomEnumsTest extends TestCase
 {
@@ -52,5 +56,34 @@ final class Php85IdiomEnumsTest extends TestCase
         $this->assertSame(WorkerSortDirection::Asc, WorkerSortDirection::fromMixed(null));
         $this->assertSame(WorkerSortDirection::Desc, WorkerSortDirection::fromMixed(' DESC '));
         $this->assertSame(WorkerSortDirection::Asc, WorkerSortDirection::Desc->toggled());
+    }
+
+    public function testPlayerQueueMessagePartTypeTryFromMixed(): void
+    {
+        $this->assertSame(PlayerQueueMessagePartType::Text, PlayerQueueMessagePartType::tryFromMixed(' TEXT '));
+        $this->assertSame(PlayerQueueMessagePartType::Progress, PlayerQueueMessagePartType::tryFromMixed('progress'));
+        $this->assertSame(null, PlayerQueueMessagePartType::tryFromMixed('unknown'));
+        $this->assertSame(null, PlayerQueueMessagePartType::tryFromMixed(null));
+    }
+
+    public function testJsonResponseStatusValues(): void
+    {
+        $this->assertSame('ok', JsonResponseStatus::Ok->value);
+        $this->assertSame('error', JsonResponseStatus::Error->value);
+    }
+
+    public function testTrophyTypeFromMixedDefaultsToBronze(): void
+    {
+        $this->assertSame(TrophyType::Bronze, TrophyType::fromMixed(null));
+        $this->assertSame(TrophyType::Bronze, TrophyType::fromMixed(''));
+        $this->assertSame(TrophyType::Gold, TrophyType::fromMixed(' GOLD '));
+        $this->assertSame(TrophyType::Platinum, TrophyType::fromMixed('platinum'));
+    }
+
+    public function testTrophyMetaStatusFromMixed(): void
+    {
+        $this->assertSame(TrophyMetaStatus::Unobtainable, TrophyMetaStatus::fromMixed('1'));
+        $this->assertSame(TrophyMetaStatus::Obtainable, TrophyMetaStatus::fromMixed('0'));
+        $this->assertSame(TrophyMetaStatus::Obtainable, TrophyMetaStatus::fromMixed('unknown'));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -50,10 +50,12 @@ abstract class TestCase
     {
         $methods = get_class_methods($this);
 
-        return array_values(array_filter(
-            $methods,
-            static fn (string $method): bool => str_starts_with($method, 'test')
-        ));
+        return $methods
+            |> (fn (array $methods): array => array_filter(
+                $methods,
+                static fn (string $method): bool => str_starts_with($method, 'test')
+            ))
+            |> array_values(...);
     }
 
     protected function setUp(): void

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -46,10 +46,12 @@ final readonly class TestSuite implements TestSuiteInterface
         $afterClasses = get_declared_classes();
         $newClasses = array_diff($afterClasses, $beforeClasses);
 
-        $testClasses = array_values(array_filter(
-            $newClasses,
-            static fn (string $className): bool => is_subclass_of($className, TestCase::class)
-        ));
+        $testClasses = $newClasses
+            |> (fn (array $classes): array => array_filter(
+                $classes,
+                static fn (string $className): bool => is_subclass_of($className, TestCase::class)
+            ))
+            |> array_values(...);
 
         sort($testClasses);
 

--- a/tests/WeeklyCronJobTest.php
+++ b/tests/WeeklyCronJobTest.php
@@ -183,10 +183,10 @@ final class WeeklyCronJobActiveRetryTestDatabase extends PDO
 
 final class WeeklyCronJobTestStatement extends PDOStatement
 {
-    /** @var callable(): void */
-    private $callback;
+    /** @var \Closure(): void */
+    private \Closure $callback;
 
-    public function __construct(callable $callback)
+    public function __construct(\Closure $callback)
     {
         $this->callback = $callback;
     }

--- a/wwwroot/admin/unobtainable.php
+++ b/wwwroot/admin/unobtainable.php
@@ -1,3 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
 require_once __DIR__ . '/../classes/ExecutionEnvironmentConfigurator.php';
 
 ExecutionEnvironmentConfigurator::create()

--- a/wwwroot/admin/unobtainable.php
+++ b/wwwroot/admin/unobtainable.php
@@ -1,6 +1,3 @@
-<?php
-declare(strict_types=1);
-
 require_once __DIR__ . '/../classes/ExecutionEnvironmentConfigurator.php';
 
 ExecutionEnvironmentConfigurator::create()
@@ -14,6 +11,7 @@ require_once __DIR__ . '/bootstrap.php';
 require_once("../classes/Admin/TrophyStatusInputParser.php");
 require_once("../classes/Admin/TrophyStatusService.php");
 require_once("../classes/Admin/TrophyStatusPage.php");
+require_once("../classes/TrophyMetaStatus.php");
 
 $trophyStatusInputParser = new TrophyStatusInputParser($database);
 $trophyStatusService = new TrophyStatusService($database);
@@ -26,6 +24,7 @@ $queryData = $_GET ?? [];
 $pageResult = $trophyStatusPage->handleRequest($requestMethod, $postData, $queryData);
 $trophyInput = $pageResult->getTrophyInput();
 $statusInput = $pageResult->getStatusInput();
+$status = TrophyMetaStatus::fromMixed($statusInput);
 
 ?>
 <!doctype html>
@@ -49,8 +48,8 @@ $statusInput = $pageResult->getStatusInput();
                 <br>
                 Status:<br>
                 <select name="status">
-                    <option value="1" <?= ($statusInput == "1" ? "selected" : ""); ?>>Unobtainable</option>
-                    <option value="0" <?= ($statusInput == "0" ? "selected" : ""); ?>>Obtainable</option>
+                    <option value="<?= TrophyMetaStatus::Unobtainable->value ?>" <?= ($status === TrophyMetaStatus::Unobtainable ? "selected" : ""); ?>>Unobtainable</option>
+                    <option value="<?= TrophyMetaStatus::Obtainable->value ?>" <?= ($status === TrophyMetaStatus::Obtainable ? "selected" : ""); ?>>Obtainable</option>
                 </select><br><br>
                 <input type="submit" value="Submit">
             </form>

--- a/wwwroot/classes/AboutPageScanLogController.php
+++ b/wwwroot/classes/AboutPageScanLogController.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/AboutPageDataProviderInterface.php';
 require_once __DIR__ . '/AboutPageScanSummary.php';
 require_once __DIR__ . '/AboutPagePlayerArraySerializer.php';
 require_once __DIR__ . '/JsonResponseEmitter.php';
+require_once __DIR__ . '/JsonResponseStatus.php';
 require_once __DIR__ . '/IpRateLimitService.php';
 require_once __DIR__ . '/IpRateLimitBucket.php';
 require_once __DIR__ . '/IpAddressResolver.php';
@@ -50,7 +51,7 @@ final class AboutPageScanLogController
                 )
             ) {
                 $this->jsonResponder->respond([
-                    'status' => 'error',
+                    'status' => JsonResponseStatus::Error->value,
                     'message' => 'Too many scan log requests. Please wait a moment and try again.',
                 ], 429);
 
@@ -65,7 +66,7 @@ final class AboutPageScanLogController
             $scanLogPlayers = $this->aboutPageService->getScanLogPlayers($limit);
 
             $this->jsonResponder->respond([
-                'status' => 'ok',
+                'status' => JsonResponseStatus::Ok->value,
                 'summary' => [
                     'scannedPlayers' => $scanSummary->getScannedPlayers(),
                     'newPlayers' => $scanSummary->getNewPlayers(),
@@ -74,7 +75,7 @@ final class AboutPageScanLogController
             ]);
         } catch (\Throwable) {
             $this->jsonResponder->respond([
-                'status' => 'error',
+                'status' => JsonResponseStatus::Error->value,
                 'message' => 'Unable to load scan log data at this time.',
             ], 500);
         }

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/WorkerService.php';
 
 use Tustin\PlayStation\Client;
 
-class GameRescanService
+final class GameRescanService
 {
     private readonly PDO $database;
     private readonly TrophyCalculator $trophyCalculator;

--- a/wwwroot/classes/Admin/LogEntryFormatter.php
+++ b/wwwroot/classes/Admin/LogEntryFormatter.php
@@ -26,18 +26,21 @@ final class LogEntryFormatter
 
     public function format(string $message): string
     {
-        return array_find(
-            array_map(
-                static fn (callable $formatter): ?string => $formatter($message),
-                [
-                    $this->formatTrophyHistoryMessage(...),
-                    $this->formatSetVersionMessage(...),
-                    $this->formatNewTrophiesAddedMessage(...),
-                    $this->formatSonyIssuesMessage(...),
-                ]
-            ),
-            static fn (?string $formatted): bool => $formatted !== null
-        ) ?? $this->escape($message);
+        return [
+            $this->formatTrophyHistoryMessage(...),
+            $this->formatSetVersionMessage(...),
+            $this->formatNewTrophiesAddedMessage(...),
+            $this->formatSonyIssuesMessage(...),
+        ]
+            |> (fn (array $formatters): array => array_map(
+                static fn (\Closure $formatter): ?string => $formatter($message),
+                $formatters
+            ))
+            |> (fn (array $results): ?string => array_find(
+                $results,
+                static fn (?string $formatted): bool => $formatted !== null
+            ))
+            ?? $this->escape($message);
     }
 
     private function formatTrophyHistoryMessage(string $message): ?string

--- a/wwwroot/classes/Admin/WorkerCredentialRevealResult.php
+++ b/wwwroot/classes/Admin/WorkerCredentialRevealResult.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../JsonResponseStatus.php';
+
 final readonly class WorkerCredentialRevealResult
 {
     private function __construct(
@@ -45,13 +47,13 @@ final readonly class WorkerCredentialRevealResult
     {
         if ($this->success) {
             return [
-                'status' => 'ok',
+                'status' => JsonResponseStatus::Ok->value,
                 'credential' => $this->credential ?? '',
             ];
         }
 
         return [
-            'status' => 'error',
+            'status' => JsonResponseStatus::Error->value,
             'message' => $this->errorMessage ?? 'Unable to reveal credential.',
         ];
     }

--- a/wwwroot/classes/BootstrapAssets.php
+++ b/wwwroot/classes/BootstrapAssets.php
@@ -9,16 +9,19 @@ final class BootstrapAssets
     public const string VERSION = '5.3.8';
     public const string POPPER_VERSION = '2.11.8';
 
+    #[\NoDiscard]
     public static function stylesheetUrl(): string
     {
         return StaticAsset::url('/lib/bootstrap/' . self::VERSION . '/css/bootstrap.min.css');
     }
 
+    #[\NoDiscard]
     public static function scriptUrl(): string
     {
         return StaticAsset::url('/lib/bootstrap/' . self::VERSION . '/js/bootstrap.min.js');
     }
 
+    #[\NoDiscard]
     public static function popperScriptUrl(): string
     {
         return StaticAsset::url('/lib/popper/' . self::POPPER_VERSION . '/popper.min.js');

--- a/wwwroot/classes/Cron/DailyCronJob.php
+++ b/wwwroot/classes/Cron/DailyCronJob.php
@@ -346,7 +346,7 @@ final readonly class DailyCronJob implements CronJobInterface
         $query->execute();
     }
 
-    private function executeWithRetry(callable $operation, mixed ...$arguments): mixed
+    private function executeWithRetry(\Closure $operation, mixed ...$arguments): mixed
     {
         while (true) {
             try {

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -149,7 +149,7 @@ final readonly class HourlyCronJob implements CronJobInterface
         $query->execute(array_values($batchIds));
     }
 
-    private function executeWithRetry(callable $operation): void
+    private function executeWithRetry(\Closure $operation): void
     {
         while (true) {
             try {

--- a/wwwroot/classes/Cron/PlayerRankingUpdater.php
+++ b/wwwroot/classes/Cron/PlayerRankingUpdater.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../Psn100Logger.php';
 require_once __DIR__ . '/../PlayerStatus.php';
 
-class PlayerRankingUpdater
+final class PlayerRankingUpdater
 {
     private const string TEMPORARY_TABLE = 'player_ranking_new';
     private const string PRIMARY_TABLE = 'player_ranking';
@@ -97,7 +97,7 @@ SQL . PlayerStatus::NORMAL->value;
         }
     }
 
-    private function executeWithRetry(callable $operation, string $phase): void
+    private function executeWithRetry(\Closure $operation, string $phase): void
     {
         $attempt = 0;
 

--- a/wwwroot/classes/Cron/PlayerScanCompletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionService.php
@@ -277,9 +277,9 @@ final class PlayerScanCompletionService
     }
 
     /**
-     * @param callable(): void $operation
+     * @param \Closure(): void $operation
      */
-    private function executeWithDeadlockRetry(callable $operation, int $maxAttempts = 3): void
+    private function executeWithDeadlockRetry(\Closure $operation, int $maxAttempts = 3): void
     {
         $attempt = 0;
 

--- a/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/../TrophyImageDownloader.php';
 require_once __DIR__ . '/../TrophyMetaRepository.php';
 require_once __DIR__ . '/../TrophyTitleNameFormatter.php';
 require_once __DIR__ . '/../GameAvailabilityStatus.php';
+require_once __DIR__ . '/../TrophyType.php';
 require_once __DIR__ . '/PlayerScanCatalogSideEffects.php';
 require_once __DIR__ . '/PlayerScanTitleCatalogSyncResult.php';
 require_once __DIR__ . '/PlayerScanTitleHeaderSynchronizer.php';
@@ -25,7 +26,7 @@ require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
 final class PlayerScanTitleCatalogSynchronizer
 {
     /**
-     * @param null|callable(string, object): array<string, mixed> $trophyDataFetcher
+     * @param null|\Closure(string, object): array<string, mixed> $trophyDataFetcher
      */
     public function __construct(
         private readonly PDO $database,
@@ -38,7 +39,7 @@ final class PlayerScanTitleCatalogSynchronizer
         private readonly ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
         private readonly ?TrophyMetaRepository $trophyMetaRepository = null,
         private readonly ?PlayerScanCatalogSideEffects $catalogSideEffects = null,
-        private readonly mixed $trophyDataFetcher = null,
+        private readonly ?\Closure $trophyDataFetcher = null,
         private readonly ?PlayerScanTitleHeaderSynchronizer $titleHeaderSynchronizer = null,
     ) {
     }
@@ -211,18 +212,20 @@ final class PlayerScanTitleCatalogSynchronizer
                 $rewardImageUrl = $trophy['trophyRewardImageUrl'] ?? null;
                 $rewardImageShouldBeNull = $rewardImageUrl === null || $rewardImageUrl === '';
 
-                $trophyTypeEnumValue = strtolower((string) ($trophy['trophyType'] ?? ''));
-                if ($trophyTypeEnumValue === '') {
-                    $trophyTypeEnumValue = 'bronze';
-                }
+                $trophyType = TrophyType::fromMixed($trophy['trophyType'] ?? null);
+                $trophyTypeEnumValue = $trophyType->value;
 
                 $trophyName = (string) ($trophy['trophyName'] ?? '');
                 $trophyDetail = (string) ($trophy['trophyDetail'] ?? '');
                 $trophyIconUrl = (string) ($trophy['trophyIconUrl'] ?? '');
 
+                $existingTrophyType = $existingTrophy === null
+                    ? null
+                    : TrophyType::fromMixed($existingTrophy['type'] ?? null);
+
                 $trophyNeedsUpdate = $existingTrophy === null
                     || (int) ($existingTrophy['hidden'] ?? -1) !== $trophyHidden
-                    || ($existingTrophy['type'] ?? '') !== $trophyTypeEnumValue
+                    || $existingTrophyType !== $trophyType
                     || ($existingTrophy['name'] ?? '') !== $trophyName
                     || ($existingTrophy['detail'] ?? '') !== $trophyDetail
                     || $existingProgressTargetValue !== $progressTargetValue

--- a/wwwroot/classes/Cron/PlayerScanTitleMetadataHelper.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleMetadataHelper.php
@@ -25,7 +25,8 @@ final class PlayerScanTitleMetadataHelper
             return false;
         }
 
-        return $sonyLastUpdatedDate == $dbLastUpdatedDate;
+        return $sonyLastUpdatedDate->getTimestamp() === $dbLastUpdatedDate->getTimestamp()
+            && $sonyLastUpdatedDate->format('u') === $dbLastUpdatedDate->format('u');
     }
 
     public function isValidSonyLastUpdatedDateTime(string $value): bool

--- a/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
@@ -111,10 +111,10 @@ final class PlayerScanTrophyProgressSynchronizer
 
     /**
      * @template T
-     * @param callable():T $operation
+     * @param \Closure():T $operation
      * @return T
      */
-    private function retryNotFound(callable $operation, string $description): mixed
+    private function retryNotFound(\Closure $operation, string $description): mixed
     {
         $attempt = 0;
         $delay = 2;

--- a/wwwroot/classes/Cron/WeeklyCronJob.php
+++ b/wwwroot/classes/Cron/WeeklyCronJob.php
@@ -64,7 +64,7 @@ final readonly class WeeklyCronJob implements CronJobInterface
         $query->execute();
     }
 
-    private function executeWithRetry(callable $operation): void
+    private function executeWithRetry(\Closure $operation): void
     {
         while (true) {
             try {

--- a/wwwroot/classes/GameResetService.php
+++ b/wwwroot/classes/GameResetService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/GameResetAction.php';
 
-class GameResetService
+final class GameResetService
 {
     public function __construct(private readonly PDO $database)
     {
@@ -172,7 +172,7 @@ class GameResetService
         $query->execute();
     }
 
-    private function executeWithinTransaction(callable $callback): void
+    private function executeWithinTransaction(\Closure $callback): void
     {
         $this->database->beginTransaction();
 

--- a/wwwroot/classes/JsonResponseEmitter.php
+++ b/wwwroot/classes/JsonResponseEmitter.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/JsonResponseStatus.php';
+
 final class JsonResponseEmitter
 {
     /**
@@ -24,7 +26,7 @@ final class JsonResponseEmitter
         http_response_code(500);
 
         $fallbackPayload = [
-            'status' => 'error',
+            'status' => JsonResponseStatus::Error->value,
             'message' => 'An unexpected error occurred while encoding the response.',
             'shouldPoll' => false,
         ];

--- a/wwwroot/classes/JsonResponseStatus.php
+++ b/wwwroot/classes/JsonResponseStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+enum JsonResponseStatus: string
+{
+    case Ok = 'ok';
+    case Error = 'error';
+}

--- a/wwwroot/classes/PaginationRenderer.php
+++ b/wwwroot/classes/PaginationRenderer.php
@@ -10,15 +10,15 @@ require_once __DIR__ . '/Html.php';
  * existing style. The renderer generates the HTML as a string so that templates
  * can decide where and how to output it.
  */
-class PaginationRenderer
+final class PaginationRenderer
 {
     /**
-     * @param callable(int):array<string, string> $queryParametersFactory
+     * @param \Closure(int):array<string, string> $queryParametersFactory
      */
     public function render(
         int $currentPage,
         int $totalPages,
-        callable $queryParametersFactory,
+        \Closure $queryParametersFactory,
         ?string $ariaLabel = null
     ): string {
         $pagination = Pagination::create($currentPage, $totalPages);

--- a/wwwroot/classes/PlayerQueueMessageBuilder.php
+++ b/wwwroot/classes/PlayerQueueMessageBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerUrlBuilder.php';
 require_once __DIR__ . '/PlayerStatusNotice.php';
+require_once __DIR__ . '/PlayerQueueMessagePartType.php';
 
 final class PlayerQueueMessageBuilder
 {
@@ -20,7 +21,7 @@ final class PlayerQueueMessageBuilder
     {
         if ($value !== '') {
             $this->parts[] = [
-                'type' => 'text',
+                'type' => PlayerQueueMessagePartType::Text->value,
                 'value' => $value,
             ];
         }
@@ -31,7 +32,7 @@ final class PlayerQueueMessageBuilder
     public function playerLink(string $playerName): self
     {
         $this->parts[] = [
-            'type' => 'link',
+            'type' => PlayerQueueMessagePartType::Link->value,
             'href' => PlayerUrlBuilder::playerPath($playerName),
             'label' => $playerName,
         ];
@@ -42,7 +43,7 @@ final class PlayerQueueMessageBuilder
     public function link(string $href, string $label): self
     {
         $this->parts[] = [
-            'type' => 'link',
+            'type' => PlayerQueueMessagePartType::Link->value,
             'href' => $href,
             'label' => $label,
         ];
@@ -54,7 +55,7 @@ final class PlayerQueueMessageBuilder
     {
         if ($value !== '') {
             $this->parts[] = [
-                'type' => 'emphasis',
+                'type' => PlayerQueueMessagePartType::Emphasis->value,
                 'value' => $value,
             ];
         }
@@ -64,7 +65,7 @@ final class PlayerQueueMessageBuilder
 
     public function spinner(): self
     {
-        $this->parts[] = ['type' => 'spinner'];
+        $this->parts[] = ['type' => PlayerQueueMessagePartType::Spinner->value];
 
         return $this;
     }
@@ -72,7 +73,7 @@ final class PlayerQueueMessageBuilder
     public function progress(int $percentage, ?string $title = null, ?string $summary = null): self
     {
         $part = [
-            'type' => 'progress',
+            'type' => PlayerQueueMessagePartType::Progress->value,
             'percentage' => $percentage,
         ];
 
@@ -102,14 +103,13 @@ final class PlayerQueueMessageBuilder
         $text = '';
 
         foreach ($this->parts as $part) {
-            $type = $part['type'] ?? '';
+            $type = PlayerQueueMessagePartType::tryFromMixed($part['type'] ?? null);
 
             $text .= match ($type) {
-                'text', 'emphasis' => (string) ($part['value'] ?? ''),
-                'link' => (string) ($part['label'] ?? ''),
+                PlayerQueueMessagePartType::Text, PlayerQueueMessagePartType::Emphasis => (string) ($part['value'] ?? ''),
+                PlayerQueueMessagePartType::Link => (string) ($part['label'] ?? ''),
                 // Progress bars are rendered separately in the client.
-                'progress' => '',
-                default => '',
+                PlayerQueueMessagePartType::Progress, PlayerQueueMessagePartType::Spinner, null => '',
             };
         }
 

--- a/wwwroot/classes/PlayerQueueMessagePartType.php
+++ b/wwwroot/classes/PlayerQueueMessagePartType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerQueueMessagePartType: string
+{
+    case Text = 'text';
+    case Link = 'link';
+    case Emphasis = 'emphasis';
+    case Spinner = 'spinner';
+    case Progress = 'progress';
+
+    #[\NoDiscard]
+    public static function tryFromMixed(mixed $value): ?self
+    {
+        if (!is_string($value) && !is_numeric($value)) {
+            return null;
+        }
+
+        return self::tryFrom(((string) $value) |> trim(...) |> strtolower(...));
+    }
+}

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/PlayerQueueResponse.php';
 require_once __DIR__ . '/PlayerStatusNotice.php';
 require_once __DIR__ . '/PlayerScanProgress.php';
 require_once __DIR__ . '/PlayerQueueMessageBuilder.php';
+require_once __DIR__ . '/PlayerQueueMessagePartType.php';
 require_once __DIR__ . '/PlayerUrlBuilder.php';
 
 final class PlayerQueueResponseFactory
@@ -129,21 +130,21 @@ final class PlayerQueueResponseFactory
         $builder = PlayerQueueMessageBuilder::create();
 
         foreach ($messageParts as $part) {
-            $type = $part['type'] ?? '';
+            $type = PlayerQueueMessagePartType::tryFromMixed($part['type'] ?? null);
 
             match ($type) {
-                'text' => $builder->text((string) ($part['value'] ?? '')),
-                'link' => $builder->link(
+                PlayerQueueMessagePartType::Text => $builder->text((string) ($part['value'] ?? '')),
+                PlayerQueueMessagePartType::Link => $builder->link(
                     (string) ($part['href'] ?? ''),
                     (string) ($part['label'] ?? '')
                 ),
-                'emphasis' => $builder->emphasis((string) ($part['value'] ?? '')),
-                'progress' => $builder->progress(
+                PlayerQueueMessagePartType::Emphasis => $builder->emphasis((string) ($part['value'] ?? '')),
+                PlayerQueueMessagePartType::Progress => $builder->progress(
                     (int) ($part['percentage'] ?? 0),
                     isset($part['title']) ? (string) $part['title'] : null,
                     isset($part['summary']) ? (string) $part['summary'] : null,
                 ),
-                default => null,
+                PlayerQueueMessagePartType::Spinner, null => null,
             };
         }
 

--- a/wwwroot/classes/PlayerUrlBuilder.php
+++ b/wwwroot/classes/PlayerUrlBuilder.php
@@ -4,21 +4,25 @@ declare(strict_types=1);
 
 final class PlayerUrlBuilder
 {
+    #[\NoDiscard]
     public static function playerPath(string $onlineId): string
     {
         return '/player/' . rawurlencode($onlineId);
     }
 
+    #[\NoDiscard]
     public static function playerReportPath(string $onlineId): string
     {
         return self::playerPath($onlineId) . '/report';
     }
 
+    #[\NoDiscard]
     public static function gamePlayerPath(string $gameSlug, string $onlineId): string
     {
         return '/game/' . $gameSlug . '/' . rawurlencode($onlineId);
     }
 
+    #[\NoDiscard]
     public static function gamePath(string $gameSlug, ?string $onlineId = null): string
     {
         if ($onlineId === null || $onlineId === '') {

--- a/wwwroot/game_leaderboard.php
+++ b/wwwroot/game_leaderboard.php
@@ -146,7 +146,7 @@ require_once("header.php");
     <div class="row">
         <div class="col-12">
             <p class="text-center">
-                <?= ($totalPlayers == 0 ? "0" : $offset + 1); ?>-<?= min($offset + $limit, $totalPlayers); ?> of <?= number_format($totalPlayers) ?>
+                <?= ($totalPlayers === 0 ? "0" : $offset + 1); ?>-<?= min($offset + $limit, $totalPlayers); ?> of <?= number_format($totalPlayers) ?>
             </p>
         </div>
         <div class="col-12">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Continues the PHP 8.5 modernization series with leftovers that were still using string discriminators, loose comparisons, and untyped callables.

### Changes
- Add `PlayerQueueMessagePartType` and `JsonResponseStatus` backed enums; wire them into queue message builders/factories and JSON response payloads
- Use `TrophyType` in player-scan catalog sync and `TrophyMetaStatus` in the admin unobtainable form
- Tighten private retry/transaction helpers and related APIs from `callable`/`mixed` to `\Closure`
- Mark safe service/renderer classes `final`, add `#[\NoDiscard]` on pure URL builders, and adopt pipes/`===` where they clarify intent
- Extend `Php85IdiomEnumsTest` coverage for the new enums

### Follow-up
- Restored the accidentally dropped `<?php` / `declare(strict_types=1)` header in `wwwroot/admin/unobtainable.php` (Codex P1 review)

### Testing
- `php tests/run.php` — all 1008 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbef7a10-afa1-4d28-9ff4-040b1b5632fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbef7a10-afa1-4d28-9ff4-040b1b5632fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

