### PR TITLE
Freeze player_ranking snapshot for hourly cron updates

### DIFF
--- a/tests/HourlyCronJobTest.php
+++ b/tests/HourlyCronJobTest.php
@@ -20,13 +20,44 @@ final class HourlyCronJobTest extends TestCase
         $this->assertStringContainsString('INSERT INTO tmp_hourly_stats', $populateBatchStatsQuery);
         $this->assertStringContainsString('FROM trophy_title_player ttp', $populateBatchStatsQuery);
         $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id', $populateBatchStatsQuery);
-        $this->assertStringContainsString('JOIN player_ranking pr ON pr.account_id = ttp.account_id AND pr.ranking <= 10000', $populateBatchStatsQuery);
+        $this->assertStringContainsString('JOIN tmp_hourly_ranked_players rp ON rp.account_id = ttp.account_id', $populateBatchStatsQuery);
+        $this->assertFalse(str_contains($populateBatchStatsQuery, 'player_ranking'));
         $this->assertStringContainsString('COUNT(*) AS owners', $populateBatchStatsQuery);
         $this->assertStringContainsString('SUM(ttp.progress = 100) AS owners_completed', $populateBatchStatsQuery);
         $this->assertStringContainsString('SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players', $populateBatchStatsQuery);
 
         $this->assertStringContainsString('UPDATE trophy_title_meta ttm', $updateMetaQuery);
         $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttm.np_communication_id', $updateMetaQuery);
+    }
+
+    public function testRankedPlayerSnapshotFreezesTopTenThousandFromPlayerRanking(): void
+    {
+        $class = new ReflectionClass(HourlyCronJob::class);
+        $create = $this->readPrivateConstantValue($class, 'CREATE_RANKED_PLAYER_SNAPSHOT_QUERY');
+        $populate = $this->readPrivateConstantValue($class, 'POPULATE_RANKED_PLAYER_SNAPSHOT_QUERY');
+        $source = file_get_contents((string) $class->getFileName());
+        $this->assertTrue(is_string($source));
+
+        $this->assertStringContainsString('CREATE TEMPORARY TABLE tmp_hourly_ranked_players', $create);
+        $this->assertStringContainsString('PRIMARY KEY (account_id)', $create);
+        $this->assertStringContainsString('KEY idx_tmp_hourly_ranked_players_ranking (ranking, account_id)', $create);
+        $this->assertStringContainsString(
+            'INSERT INTO tmp_hourly_ranked_players (account_id, ranking)',
+            $populate,
+        );
+        $this->assertStringContainsString('FROM player_ranking pr FORCE INDEX (idx_pr_ranking_account)', $populate);
+        $this->assertStringContainsString('WHERE pr.ranking <= 10000', $populate);
+        $this->assertSame(10000, $this->readPrivateConstantInt($class, 'TOP_RANKED_PLAYERS'));
+
+        $initSource = $this->readMethodSource($class, 'initializeTemporaryTables');
+        $this->assertStringContainsString('prepareRankedPlayerSnapshot', $initSource);
+
+        $prepareSource = $this->readMethodSource($class, 'prepareRankedPlayerSnapshot');
+        $this->assertStringContainsString('DROP TEMPORARY TABLE IF EXISTS tmp_hourly_ranked_players', $prepareSource);
+        $this->assertStringContainsString('CREATE_RANKED_PLAYER_SNAPSHOT_QUERY', $prepareSource);
+        $this->assertStringContainsString('POPULATE_RANKED_PLAYER_SNAPSHOT_QUERY', $prepareSource);
+
+        $this->assertStringContainsString('DROP TEMPORARY TABLE IF EXISTS tmp_hourly_ranked_players', $source);
     }
 
     public function testResetsBatchTitlesWithoutQualifyingPlayersToZeroValues(): void
@@ -95,6 +126,16 @@ final class HourlyCronJobTest extends TestCase
         $this->assertTrue($constant instanceof ReflectionClassConstant);
         $value = $constant->getValue();
         $this->assertTrue(is_string($value));
+
+        return $value;
+    }
+
+    private function readPrivateConstantInt(ReflectionClass $class, string $name): int
+    {
+        $constant = $class->getReflectionConstant($name);
+        $this->assertTrue($constant instanceof ReflectionClassConstant);
+        $value = $constant->getValue();
+        $this->assertTrue(is_int($value));
 
         return $value;
     }

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -8,6 +8,8 @@ final readonly class HourlyCronJob implements CronJobInterface
 {
     private const int BATCH_SIZE = 500;
 
+    private const int TOP_RANKED_PLAYERS = 10000;
+
     private const string CREATE_BATCH_TEMP_TABLE_QUERY = <<<'SQL'
         CREATE TEMPORARY TABLE IF NOT EXISTS tmp_hourly_batch (
             np_communication_id VARCHAR(12) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci PRIMARY KEY
@@ -23,6 +25,32 @@ final readonly class HourlyCronJob implements CronJobInterface
         )
         SQL;
 
+    /**
+     * Freeze the top-10k account set once so later player_ranking swaps (every
+     * 5th minute) cannot change which players qualify while title batches run.
+     *
+     * account_id is unique in player_ranking; RANK() ties may share the same
+     * ranking value, so membership is defined by ranking <= 10000 at snapshot
+     * time rather than by a dense top-N cut.
+     */
+    private const string CREATE_RANKED_PLAYER_SNAPSHOT_QUERY = <<<'SQL'
+        CREATE TEMPORARY TABLE tmp_hourly_ranked_players (
+            account_id BIGINT UNSIGNED NOT NULL,
+            ranking MEDIUMINT UNSIGNED NOT NULL,
+            PRIMARY KEY (account_id),
+            KEY idx_tmp_hourly_ranked_players_ranking (ranking, account_id)
+        )
+        SQL;
+
+    private const string POPULATE_RANKED_PLAYER_SNAPSHOT_QUERY = <<<'SQL'
+        INSERT INTO tmp_hourly_ranked_players (account_id, ranking)
+        SELECT
+            pr.account_id,
+            pr.ranking
+        FROM player_ranking pr FORCE INDEX (idx_pr_ranking_account)
+        WHERE pr.ranking <= 10000
+        SQL;
+
     private const string POPULATE_BATCH_STATS_QUERY = <<<'SQL'
         INSERT INTO tmp_hourly_stats (np_communication_id, owners, owners_completed, recent_players)
         SELECT
@@ -32,7 +60,7 @@ final readonly class HourlyCronJob implements CronJobInterface
             SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players
         FROM trophy_title_player ttp
         JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id
-        JOIN player_ranking pr ON pr.account_id = ttp.account_id AND pr.ranking <= 10000
+        JOIN tmp_hourly_ranked_players rp ON rp.account_id = ttp.account_id
         GROUP BY ttp.np_communication_id
         SQL;
 
@@ -129,12 +157,26 @@ final readonly class HourlyCronJob implements CronJobInterface
     {
         $this->database->exec(self::CREATE_BATCH_TEMP_TABLE_QUERY);
         $this->database->exec(self::CREATE_STATS_TEMP_TABLE_QUERY);
+        $this->prepareRankedPlayerSnapshot();
+    }
+
+    /**
+     * Capture the current top-10k ranking set before any title batches run.
+     */
+    private function prepareRankedPlayerSnapshot(): void
+    {
+        $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_hourly_ranked_players');
+        $this->database->exec(self::CREATE_RANKED_PLAYER_SNAPSHOT_QUERY);
+
+        $snapshot = $this->database->prepare(self::POPULATE_RANKED_PLAYER_SNAPSHOT_QUERY);
+        $snapshot->execute();
     }
 
     private function dropTemporaryTables(): void
     {
         $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_hourly_stats');
         $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_hourly_batch');
+        $this->database->exec('DROP TEMPORARY TABLE IF EXISTS tmp_hourly_ranked_players');
     }
 
     private function insertBatchIdsIntoTemporaryTable(array $batchIds): void


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Hourly title-statistics updates now freeze the top-10k (`ranking <= 10000`) account set from `player_ranking` into a session temporary table once before batching.
- Per-batch owner/completion/recent-player counts join that snapshot instead of the live `player_ranking` table, so 5-minute ranking swaps cannot change membership mid-run.
- Mirrors the existing daily cron snapshot approach (`tmp_daily_ranked_players`).

## Test plan
- [x] Update `HourlyCronJobTest` to assert snapshot create/populate and that batch stats join `tmp_hourly_ranked_players` (not live `player_ranking`)
- [x] Run `php tests/run.php` (1009 tests passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83bff05c-ad39-4ad1-952b-1a5fa9438711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83bff05c-ad39-4ad1-952b-1a5fa9438711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

