### PR TITLE
Stop hourly tmp_hourly_stats INSERT from restarting per batch

### DIFF
--- a/tests/HourlyCronJobTest.php
+++ b/tests/HourlyCronJobTest.php
@@ -7,24 +7,24 @@ require_once __DIR__ . '/../wwwroot/classes/Cron/HourlyCronJob.php';
 
 final class HourlyCronJobTest extends TestCase
 {
-    public function testUsesBatchAndStatsTemporaryTablesForNonEmptyBatchUpdates(): void
+    public function testPrecomputesAllStatisticsOnceBeforeBatchUpdates(): void
     {
         $class = new ReflectionClass(HourlyCronJob::class);
         $createBatchTableQuery = $this->readPrivateConstantValue($class, 'CREATE_BATCH_TEMP_TABLE_QUERY');
         $createStatsTableQuery = $this->readPrivateConstantValue($class, 'CREATE_STATS_TEMP_TABLE_QUERY');
-        $populateBatchStatsQuery = $this->readPrivateConstantValue($class, 'POPULATE_BATCH_STATS_QUERY');
+        $populateAllStatsQuery = $this->readPrivateConstantValue($class, 'POPULATE_ALL_STATS_QUERY');
         $updateMetaQuery = $this->readPrivateConstantValue($class, 'UPDATE_META_QUERY');
 
         $this->assertStringContainsString('COLLATE utf8mb4_0900_ai_ci', $createBatchTableQuery);
         $this->assertStringContainsString('COLLATE utf8mb4_0900_ai_ci', $createStatsTableQuery);
-        $this->assertStringContainsString('INSERT INTO tmp_hourly_stats', $populateBatchStatsQuery);
-        $this->assertStringContainsString('FROM trophy_title_player ttp', $populateBatchStatsQuery);
-        $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id', $populateBatchStatsQuery);
-        $this->assertStringContainsString('JOIN tmp_hourly_ranked_players rp ON rp.account_id = ttp.account_id', $populateBatchStatsQuery);
-        $this->assertFalse(str_contains($populateBatchStatsQuery, 'player_ranking'));
-        $this->assertStringContainsString('COUNT(*) AS owners', $populateBatchStatsQuery);
-        $this->assertStringContainsString('SUM(ttp.progress = 100) AS owners_completed', $populateBatchStatsQuery);
-        $this->assertStringContainsString('SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players', $populateBatchStatsQuery);
+        $this->assertStringContainsString('INSERT INTO tmp_hourly_stats', $populateAllStatsQuery);
+        $this->assertStringContainsString('FROM trophy_title_player ttp', $populateAllStatsQuery);
+        $this->assertStringContainsString('JOIN tmp_hourly_ranked_players rp ON rp.account_id = ttp.account_id', $populateAllStatsQuery);
+        $this->assertFalse(str_contains($populateAllStatsQuery, 'tmp_hourly_batch'));
+        $this->assertFalse(str_contains($populateAllStatsQuery, 'player_ranking'));
+        $this->assertStringContainsString('COUNT(*) AS owners', $populateAllStatsQuery);
+        $this->assertStringContainsString('SUM(ttp.progress = 100) AS owners_completed', $populateAllStatsQuery);
+        $this->assertStringContainsString('SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players', $populateAllStatsQuery);
 
         $this->assertStringContainsString('UPDATE trophy_title_meta ttm', $updateMetaQuery);
         $this->assertStringContainsString('JOIN tmp_hourly_batch b ON b.np_communication_id = ttm.np_communication_id', $updateMetaQuery);
@@ -80,23 +80,79 @@ final class HourlyCronJobTest extends TestCase
         $this->assertTrue(is_string($source));
 
         $this->assertStringContainsString('DELETE FROM tmp_hourly_batch', $source);
-        $this->assertStringContainsString('DELETE FROM tmp_hourly_stats', $source);
+        $this->assertFalse(str_contains($source, 'DELETE FROM tmp_hourly_stats'));
         $this->assertFalse(str_contains($source, 'TRUNCATE TABLE tmp_hourly_batch'));
         $this->assertFalse(str_contains($source, 'TRUNCATE TABLE tmp_hourly_stats'));
     }
 
-    public function testPopulatesStatisticsPerBatch(): void
+    public function testPopulatesAllStatisticsOnceBeforeBatchUpdates(): void
     {
         $class = new ReflectionClass(HourlyCronJob::class);
 
-        $this->assertFalse($class->hasMethod('populateAllStatistics'));
+        $this->assertTrue($class->hasMethod('populateAllStatistics'));
+        $this->assertFalse($class->hasConstant('POPULATE_BATCH_STATS_QUERY'));
 
         $batchSource = $this->readMethodSource($class, 'updateStatisticsForBatch');
-        $this->assertStringContainsString('POPULATE_BATCH_STATS_QUERY', $batchSource);
-        $this->assertStringContainsString('DELETE FROM tmp_hourly_stats', $batchSource);
+        $this->assertFalse(str_contains($batchSource, 'POPULATE_ALL_STATS_QUERY'));
+        $this->assertFalse(str_contains($batchSource, 'DELETE FROM tmp_hourly_stats'));
 
-        $updateSource = $this->readMethodSource($class, 'updateTrophyTitleStatistics');
-        $this->assertFalse(str_contains($updateSource, 'populateAllStatistics'));
+        $runSource = $this->readMethodSource($class, 'run');
+        $this->assertStringContainsString('prepareAndPopulateStatistics', $runSource);
+        $this->assertStringContainsString('applyStatisticsInBatchesWithRecovery', $runSource);
+
+        $prepareSource = $this->readMethodSource($class, 'prepareAndPopulateStatistics');
+        $this->assertStringContainsString('populateAllStatistics', $prepareSource);
+
+        $applySource = $this->readMethodSource($class, 'applyStatisticsInBatches');
+        $this->assertStringContainsString('while (true)', $applySource);
+        $this->assertFalse(str_contains($applySource, 'populateAllStatistics'));
+    }
+
+    public function testPopulateAndApplyRetryIndependently(): void
+    {
+        $class = new ReflectionClass(HourlyCronJob::class);
+        $runSource = $this->readMethodSource($class, 'run');
+
+        $this->assertStringContainsString(
+            '$this->executeWithRetry($this->prepareAndPopulateStatistics(...));',
+            $runSource,
+        );
+        $this->assertStringContainsString(
+            '$this->executeWithRetry($this->applyStatisticsInBatchesWithRecovery(...));',
+            $runSource,
+        );
+
+        $recoverySource = $this->readMethodSource($class, 'applyStatisticsInBatchesWithRecovery');
+        $this->assertStringContainsString('isMissingTempTableError', $recoverySource);
+        $this->assertStringContainsString('preparePopulateAndApplyStatistics', $recoverySource);
+    }
+
+    public function testIsMissingTempTableErrorDetectsHourlyTempTables(): void
+    {
+        $class = new ReflectionClass(HourlyCronJob::class);
+        $method = $class->getMethod('isMissingTempTableError');
+        $job = $class->newInstanceWithoutConstructor();
+
+        $this->assertTrue($method->invoke(
+            $job,
+            new RuntimeException("Table 'psn100.tmp_hourly_stats' doesn't exist")
+        ));
+        $this->assertTrue($method->invoke(
+            $job,
+            new RuntimeException('Base table or view not found: tmp_hourly_batch')
+        ));
+        $this->assertTrue($method->invoke(
+            $job,
+            new RuntimeException("Temporary table tmp_hourly_ranked_players does not exist")
+        ));
+        $this->assertFalse($method->invoke(
+            $job,
+            new RuntimeException('Lock wait timeout exceeded; try restarting transaction')
+        ));
+        $this->assertFalse($method->invoke(
+            $job,
+            new RuntimeException("Table 'psn100.trophy_title_meta' doesn't exist")
+        ));
     }
 
     public function testNoDynamicUnionAllSelectBatchPathExists(): void
@@ -118,6 +174,15 @@ final class HourlyCronJobTest extends TestCase
 
         $this->assertFalse($class->hasConstant('UPDATE_ALL_META_QUERY'));
         $this->assertStringContainsString('BATCH_SIZE', $source);
+    }
+
+    public function testFailedPopulateDropsTempTablesBeforeRethrow(): void
+    {
+        $class = new ReflectionClass(HourlyCronJob::class);
+        $prepareSource = $this->readMethodSource($class, 'prepareAndPopulateStatistics');
+
+        $this->assertStringContainsString('dropTemporaryTables', $prepareSource);
+        $this->assertStringContainsString('throw $exception', $prepareSource);
     }
 
     private function readPrivateConstantValue(ReflectionClass $class, string $name): string

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -51,7 +51,13 @@ final readonly class HourlyCronJob implements CronJobInterface
         WHERE pr.ranking <= 10000
         SQL;
 
-    private const string POPULATE_BATCH_STATS_QUERY = <<<'SQL'
+    /**
+     * Aggregate all top-10k title stats once. Re-running this per 500-title
+     * batch previously stretched hourly runtime from ~1 minute to 10+ minutes
+     * and made PROCESSLIST look like INSERT INTO tmp_hourly_stats was
+     * "restarting" on every batch.
+     */
+    private const string POPULATE_ALL_STATS_QUERY = <<<'SQL'
         INSERT INTO tmp_hourly_stats (np_communication_id, owners, owners_completed, recent_players)
         SELECT
             ttp.np_communication_id,
@@ -59,7 +65,6 @@ final readonly class HourlyCronJob implements CronJobInterface
             SUM(ttp.progress = 100) AS owners_completed,
             SUM(ttp.last_updated_date >= (UTC_TIMESTAMP() - INTERVAL 7 DAY)) AS recent_players
         FROM trophy_title_player ttp
-        JOIN tmp_hourly_batch b ON b.np_communication_id = ttp.np_communication_id
         JOIN tmp_hourly_ranked_players rp ON rp.account_id = ttp.account_id
         GROUP BY ttp.np_communication_id
         SQL;
@@ -82,44 +87,98 @@ final readonly class HourlyCronJob implements CronJobInterface
     public function __construct(
         final private PDO $database,
         final private int $retryDelaySeconds = 3,
+        final private \Closure $sleeper = sleep(...),
     ) {
     }
 
     #[\Override]
     public function run(): void
     {
-        $this->executeWithRetry($this->updateTrophyTitleStatistics(...));
+        try {
+            // Populate and apply retry independently so a trophy_title_meta
+            // lock/timeout does not force another full trophy_title_player scan.
+            $this->executeWithRetry($this->prepareAndPopulateStatistics(...));
+            $this->executeWithRetry($this->applyStatisticsInBatchesWithRecovery(...));
+        } finally {
+            // Best-effort: a transient DROP failure must not abort run().
+            // The tables are TEMPORARY/session-scoped anyway.
+            try {
+                $this->dropTemporaryTables();
+            } catch (Throwable) {
+            }
+        }
     }
 
-    private function updateTrophyTitleStatistics(): void
+    private function prepareAndPopulateStatistics(): void
+    {
+        try {
+            $this->initializeTemporaryTables();
+            $this->populateAllStatistics();
+        } catch (Throwable $exception) {
+            // Do not leave a partial stats table behind. A later apply retry
+            // would otherwise see the table exist and write zero/stale values.
+            try {
+                $this->dropTemporaryTables();
+            } catch (Throwable) {
+            }
+
+            throw $exception;
+        }
+    }
+
+    private function populateAllStatistics(): void
+    {
+        $query = $this->database->prepare(self::POPULATE_ALL_STATS_QUERY);
+        $query->execute();
+    }
+
+    /**
+     * Apply precomputed stats in short batched UPDATE transactions. If the
+     * session-scoped temp tables disappeared (e.g. MySQL session reset after
+     * populate succeeded), rebuild populate+apply as one retry unit.
+     */
+    private function applyStatisticsInBatchesWithRecovery(): void
+    {
+        try {
+            $this->applyStatisticsInBatches();
+        } catch (Throwable $exception) {
+            if (!$this->isMissingTempTableError($exception)) {
+                throw $exception;
+            }
+
+            $this->executeWithRetry($this->preparePopulateAndApplyStatistics(...));
+        }
+    }
+
+    private function preparePopulateAndApplyStatistics(): void
+    {
+        $this->prepareAndPopulateStatistics();
+        $this->applyStatisticsInBatches();
+    }
+
+    private function applyStatisticsInBatches(): void
     {
         $lastId = null;
 
-        $this->initializeTemporaryTables();
+        while (true) {
+            $batchIds = $this->getBatchNpCommunicationIds($lastId, self::BATCH_SIZE);
 
-        try {
-            while (true) {
-                $batchIds = $this->getBatchNpCommunicationIds($lastId, self::BATCH_SIZE);
-
-                if ($batchIds === []) {
-                    break;
-                }
-
-                $this->database->beginTransaction();
-
-                try {
-                    $this->updateStatisticsForBatch($batchIds);
-                    $this->database->commit();
-                } catch (Exception $exception) {
-                    $this->database->rollBack();
-
-                    throw $exception;
-                }
-
-                $lastId = array_last($batchIds);
+            if ($batchIds === []) {
+                break;
             }
-        } finally {
-            $this->dropTemporaryTables();
+
+            $this->database->beginTransaction();
+
+            try {
+                $this->updateStatisticsForBatch($batchIds);
+                $this->database->commit();
+            } catch (Exception $exception) {
+                $this->database->rollBack();
+
+                throw $exception;
+            }
+
+            $lastId = array_last($batchIds);
         }
     }
 
@@ -143,11 +202,7 @@ final readonly class HourlyCronJob implements CronJobInterface
     private function updateStatisticsForBatch(array $batchIds): void
     {
         $this->database->exec('DELETE FROM tmp_hourly_batch');
-        $this->database->exec('DELETE FROM tmp_hourly_stats');
         $this->insertBatchIdsIntoTemporaryTable($batchIds);
-
-        $populateStatsQuery = $this->database->prepare(self::POPULATE_BATCH_STATS_QUERY);
-        $populateStatsQuery->execute();
 
         $updateMetaQuery = $this->database->prepare(self::UPDATE_META_QUERY);
         $updateMetaQuery->execute();
@@ -155,6 +210,7 @@ final readonly class HourlyCronJob implements CronJobInterface
 
     private function initializeTemporaryTables(): void
     {
+        $this->dropTemporaryTables();
         $this->database->exec(self::CREATE_BATCH_TEMP_TABLE_QUERY);
         $this->database->exec(self::CREATE_STATS_TEMP_TABLE_QUERY);
         $this->prepareRankedPlayerSnapshot();
@@ -191,6 +247,21 @@ final readonly class HourlyCronJob implements CronJobInterface
         $query->execute(array_values($batchIds));
     }
 
+    private function isMissingTempTableError(Throwable $exception): bool
+    {
+        $message = $exception->getMessage();
+        $mentionsTempTable = str_contains($message, 'tmp_hourly_stats')
+            || str_contains($message, 'tmp_hourly_batch')
+            || str_contains($message, 'tmp_hourly_ranked_players');
+
+        return $mentionsTempTable
+            && (
+                str_contains($message, "doesn't exist")
+                || str_contains($message, 'does not exist')
+                || str_contains($message, 'Base table or view not found')
+            );
+    }
+
     private function executeWithRetry(\Closure $operation): void
     {
         while (true) {
@@ -199,7 +270,7 @@ final readonly class HourlyCronJob implements CronJobInterface
 
                 return;
             } catch (Throwable $exception) {
-                sleep($this->retryDelaySeconds);
+                ($this->sleeper)($this->retryDelaySeconds);
             }
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Watching `SHOW FULL PROCESSLIST` during `hourly.php`, `INSERT INTO tmp_hourly_stats` appeared to restart several times (`Time` dropped back toward 0) before the job finished.

That was mostly expected under the current per-batch design: every 500 titles ran a fresh `INSERT INTO tmp_hourly_stats ... SELECT ... FROM trophy_title_player`. PROCESSLIST shows the same statement text each batch, so `Time` resets whenever the next batch starts. On top of that, `executeWithRetry()` wrapped the **entire** job — so a later `trophy_title_meta` lock wait/timeout restarted the expensive aggregation from scratch.

This per-batch aggregation was reintroduced by #16142 after #16113 had already shown it stretches production runtime from ~1 minute to 10+ minutes.

## Fix

1. **Precompute once** — one `INSERT INTO tmp_hourly_stats` aggregates all top-10k title stats (joining the frozen `tmp_hourly_ranked_players` snapshot from #16205).
2. **Keep short batched UPDATEs** — still update `trophy_title_meta` in 500-title transactions so Cloudflare 525 lock windows stay short (#16103).
3. **Retry populate and apply independently** — same pattern as `DailyCronJob`: a meta lock timeout no longer forces another full `trophy_title_player` scan. If session temp tables disappear after populate, rebuild populate+apply as one recovery unit.

## Test plan

- [x] Update `HourlyCronJobTest` for one-shot populate, independent retries, and missing-temp-table recovery
- [x] `php tests/run.php` — 1012 tests passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9498c206-221f-4cf6-88a9-3a4c90918af8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9498c206-221f-4cf6-88a9-3a4c90918af8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

