### PR TITLE
Remove ugly `\n` escapes from SQL string construction

### DIFF
--- a/tests/PlayerAdvisorServiceTest.php
+++ b/tests/PlayerAdvisorServiceTest.php
@@ -104,43 +104,55 @@ final class PlayerAdvisorServiceTest extends TestCase
     public function testCountAdvisableTrophiesIgnoresEarnedAndUnselectedPlatforms(): void
     {
         $this->database->exec(
-            "INSERT INTO trophy_title (np_communication_id, name, icon_url, platform) VALUES\n" .
-            "('NPWR-PS5-1', 'Game PS5', 'game-ps5.png', 'PS5'),\n" .
-            "('NPWR-PS5-2', 'Game PS5 Earned', 'game-ps5-earned.png', 'PS5'),\n" .
-            "('NPWR-PS4-1', 'Game PS4', 'game-ps4.png', 'PS4')"
+            <<<'SQL'
+            INSERT INTO trophy_title (np_communication_id, name, icon_url, platform) VALUES
+                ('NPWR-PS5-1', 'Game PS5', 'game-ps5.png', 'PS5'),
+                ('NPWR-PS5-2', 'Game PS5 Earned', 'game-ps5-earned.png', 'PS5'),
+                ('NPWR-PS4-1', 'Game PS4', 'game-ps4.png', 'PS4')
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_title_meta (np_communication_id, status) VALUES\n" .
-            "('NPWR-PS5-1', 0),\n" .
-            "('NPWR-PS5-2', 0),\n" .
-            "('NPWR-PS4-1', 0)"
+            <<<'SQL'
+            INSERT INTO trophy_title_meta (np_communication_id, status) VALUES
+                ('NPWR-PS5-1', 0),
+                ('NPWR-PS5-2', 0),
+                ('NPWR-PS4-1', 0)
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy (id, np_communication_id, order_id, type, name, detail, icon_url, progress_target_value, reward_name, reward_image_url) VALUES\n" .
-            "(1, 'NPWR-PS5-1', 1, 'bronze', 'Unearned Trophy', 'Complete a task', 'trophy-1.png', NULL, NULL, NULL),\n" .
-            "(2, 'NPWR-PS5-2', 1, 'bronze', 'Earned Trophy', 'Already done', 'trophy-2.png', NULL, NULL, NULL),\n" .
-            "(3, 'NPWR-PS4-1', 1, 'bronze', 'Different Platform', 'Wrong platform', 'trophy-3.png', NULL, NULL, NULL)"
+            <<<'SQL'
+            INSERT INTO trophy (id, np_communication_id, order_id, type, name, detail, icon_url, progress_target_value, reward_name, reward_image_url) VALUES
+                (1, 'NPWR-PS5-1', 1, 'bronze', 'Unearned Trophy', 'Complete a task', 'trophy-1.png', NULL, NULL, NULL),
+                (2, 'NPWR-PS5-2', 1, 'bronze', 'Earned Trophy', 'Already done', 'trophy-2.png', NULL, NULL, NULL),
+                (3, 'NPWR-PS4-1', 1, 'bronze', 'Different Platform', 'Wrong platform', 'trophy-3.png', NULL, NULL, NULL)
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_meta (trophy_id, rarity_percent, status) VALUES\n" .
-            "(1, 12.5, 0),\n" .
-            "(2, 20.0, 0),\n" .
-            "(3, 30.0, 0)"
+            <<<'SQL'
+            INSERT INTO trophy_meta (trophy_id, rarity_percent, status) VALUES
+                (1, 12.5, 0),
+                (2, 20.0, 0),
+                (3, 30.0, 0)
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_title_player (np_communication_id, account_id, last_updated_date) VALUES\n" .
-            "('NPWR-PS5-1', 42, '2024-01-01 10:00:00'),\n" .
-            "('NPWR-PS5-2', 42, '2024-01-01 11:00:00'),\n" .
-            "('NPWR-PS4-1', 42, '2024-01-01 12:00:00')"
+            <<<'SQL'
+            INSERT INTO trophy_title_player (np_communication_id, account_id, last_updated_date) VALUES
+                ('NPWR-PS5-1', 42, '2024-01-01 10:00:00'),
+                ('NPWR-PS5-2', 42, '2024-01-01 11:00:00'),
+                ('NPWR-PS4-1', 42, '2024-01-01 12:00:00')
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_earned (np_communication_id, order_id, account_id, earned, progress) VALUES\n" .
-            "('NPWR-PS5-2', 1, 42, 1, NULL)"
+            <<<'SQL'
+            INSERT INTO trophy_earned (np_communication_id, order_id, account_id, earned, progress) VALUES
+                ('NPWR-PS5-2', 1, 42, 1, NULL)
+            SQL
         );
 
         $filter = PlayerAdvisorFilter::fromArray(['ps5' => '1']);
@@ -153,43 +165,55 @@ final class PlayerAdvisorServiceTest extends TestCase
     public function testGetAdvisableTrophiesReturnsOrderedTrophyCollection(): void
     {
         $this->database->exec(
-            "INSERT INTO trophy_title (np_communication_id, name, icon_url, platform) VALUES\n" .
-            "('NPWR-1', 'First Game', 'game-1.png', 'PS4'),\n" .
-            "('NPWR-2', 'Second Game', 'game-2.png', 'PS4'),\n" .
-            "('NPWR-3', 'Third Game', 'game-3.png', 'PS4')"
+            <<<'SQL'
+            INSERT INTO trophy_title (np_communication_id, name, icon_url, platform) VALUES
+                ('NPWR-1', 'First Game', 'game-1.png', 'PS4'),
+                ('NPWR-2', 'Second Game', 'game-2.png', 'PS4'),
+                ('NPWR-3', 'Third Game', 'game-3.png', 'PS4')
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_title_meta (np_communication_id, status) VALUES\n" .
-            "('NPWR-1', 0),\n" .
-            "('NPWR-2', 0),\n" .
-            "('NPWR-3', 0)"
+            <<<'SQL'
+            INSERT INTO trophy_title_meta (np_communication_id, status) VALUES
+                ('NPWR-1', 0),
+                ('NPWR-2', 0),
+                ('NPWR-3', 0)
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy (id, np_communication_id, order_id, type, name, detail, icon_url, progress_target_value, reward_name, reward_image_url) VALUES\n" .
-            "(1, 'NPWR-1', 1, 'bronze', 'First Trophy', 'Description 1', 'trophy-1.png', NULL, NULL, NULL),\n" .
-            "(2, 'NPWR-2', 1, 'silver', 'Second Trophy', 'Description 2', 'trophy-2.png', NULL, NULL, NULL),\n" .
-            "(3, 'NPWR-3', 1, 'gold', 'Third Trophy', 'Description 3', 'trophy-3.png', 100, 'Reward', 'reward.png')"
+            <<<'SQL'
+            INSERT INTO trophy (id, np_communication_id, order_id, type, name, detail, icon_url, progress_target_value, reward_name, reward_image_url) VALUES
+                (1, 'NPWR-1', 1, 'bronze', 'First Trophy', 'Description 1', 'trophy-1.png', NULL, NULL, NULL),
+                (2, 'NPWR-2', 1, 'silver', 'Second Trophy', 'Description 2', 'trophy-2.png', NULL, NULL, NULL),
+                (3, 'NPWR-3', 1, 'gold', 'Third Trophy', 'Description 3', 'trophy-3.png', 100, 'Reward', 'reward.png')
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_meta (trophy_id, rarity_percent, status) VALUES\n" .
-            "(1, 15.0, 0),\n" .
-            "(2, 20.0, 0),\n" .
-            "(3, 15.0, 0)"
+            <<<'SQL'
+            INSERT INTO trophy_meta (trophy_id, rarity_percent, status) VALUES
+                (1, 15.0, 0),
+                (2, 20.0, 0),
+                (3, 15.0, 0)
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_title_player (np_communication_id, account_id, last_updated_date) VALUES\n" .
-            "('NPWR-1', 99, '2024-01-02 08:00:00'),\n" .
-            "('NPWR-2', 99, '2024-01-01 09:00:00'),\n" .
-            "('NPWR-3', 99, '2024-01-03 07:00:00')"
+            <<<'SQL'
+            INSERT INTO trophy_title_player (np_communication_id, account_id, last_updated_date) VALUES
+                ('NPWR-1', 99, '2024-01-02 08:00:00'),
+                ('NPWR-2', 99, '2024-01-01 09:00:00'),
+                ('NPWR-3', 99, '2024-01-03 07:00:00')
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_earned (np_communication_id, order_id, account_id, earned, progress) VALUES\n" .
-            "('NPWR-3', 1, 99, 0, 25.0)"
+            <<<'SQL'
+            INSERT INTO trophy_earned (np_communication_id, order_id, account_id, earned, progress) VALUES
+                ('NPWR-3', 1, 99, 0, 25.0)
+            SQL
         );
 
         $filter = PlayerAdvisorFilter::fromArray([]);
@@ -214,38 +238,48 @@ final class PlayerAdvisorServiceTest extends TestCase
     public function testGetAdvisableTrophiesSortsByInGameRarityWhenRequested(): void
     {
         $this->database->exec(
-            "INSERT INTO trophy_title (np_communication_id, name, icon_url, platform) VALUES\n" .
-            "('NPWR-1', 'First Game', 'game-1.png', 'PS4'),\n" .
-            "('NPWR-2', 'Second Game', 'game-2.png', 'PS4'),\n" .
-            "('NPWR-3', 'Third Game', 'game-3.png', 'PS4')"
+            <<<'SQL'
+            INSERT INTO trophy_title (np_communication_id, name, icon_url, platform) VALUES
+                ('NPWR-1', 'First Game', 'game-1.png', 'PS4'),
+                ('NPWR-2', 'Second Game', 'game-2.png', 'PS4'),
+                ('NPWR-3', 'Third Game', 'game-3.png', 'PS4')
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_title_meta (np_communication_id, status) VALUES\n" .
-            "('NPWR-1', 0),\n" .
-            "('NPWR-2', 0),\n" .
-            "('NPWR-3', 0)"
+            <<<'SQL'
+            INSERT INTO trophy_title_meta (np_communication_id, status) VALUES
+                ('NPWR-1', 0),
+                ('NPWR-2', 0),
+                ('NPWR-3', 0)
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy (id, np_communication_id, order_id, type, name, detail, icon_url) VALUES\n" .
-            "(1, 'NPWR-1', 1, 'bronze', 'First Trophy', 'Description 1', 'trophy-1.png'),\n" .
-            "(2, 'NPWR-2', 1, 'bronze', 'Second Trophy', 'Description 2', 'trophy-2.png'),\n" .
-            "(3, 'NPWR-3', 1, 'bronze', 'Third Trophy', 'Description 3', 'trophy-3.png')"
+            <<<'SQL'
+            INSERT INTO trophy (id, np_communication_id, order_id, type, name, detail, icon_url) VALUES
+                (1, 'NPWR-1', 1, 'bronze', 'First Trophy', 'Description 1', 'trophy-1.png'),
+                (2, 'NPWR-2', 1, 'bronze', 'Second Trophy', 'Description 2', 'trophy-2.png'),
+                (3, 'NPWR-3', 1, 'bronze', 'Third Trophy', 'Description 3', 'trophy-3.png')
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_meta (trophy_id, rarity_percent, in_game_rarity_percent, status) VALUES\n" .
-            "(1, 30.0, 5.0, 0),\n" .
-            "(2, 10.0, 25.0, 0),\n" .
-            "(3, 5.0, 15.0, 0)"
+            <<<'SQL'
+            INSERT INTO trophy_meta (trophy_id, rarity_percent, in_game_rarity_percent, status) VALUES
+                (1, 30.0, 5.0, 0),
+                (2, 10.0, 25.0, 0),
+                (3, 5.0, 15.0, 0)
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_title_player (np_communication_id, account_id, last_updated_date) VALUES\n" .
-            "('NPWR-1', 22, '2024-01-01 08:00:00'),\n" .
-            "('NPWR-2', 22, '2024-01-01 09:00:00'),\n" .
-            "('NPWR-3', 22, '2024-01-01 10:00:00')"
+            <<<'SQL'
+            INSERT INTO trophy_title_player (np_communication_id, account_id, last_updated_date) VALUES
+                ('NPWR-1', 22, '2024-01-01 08:00:00'),
+                ('NPWR-2', 22, '2024-01-01 09:00:00'),
+                ('NPWR-3', 22, '2024-01-01 10:00:00')
+            SQL
         );
 
         $filter = PlayerAdvisorFilter::fromArray(['sort' => PlayerAdvisorFilter::SORT_IN_GAME_RARITY]);

--- a/tests/PlayerSummaryServiceTest.php
+++ b/tests/PlayerSummaryServiceTest.php
@@ -65,25 +65,31 @@ final class PlayerSummaryServiceTest extends TestCase
     public function testGetSummaryAggregatesPlayerStatistics(): void
     {
         $this->database->exec(
-            "INSERT INTO trophy_title (np_communication_id, bronze, silver, gold, platinum) VALUES\n" .
-            "('NPWR001', 10, 5, 3, 1),\n" .
-            "('NPWR002', 5, 2, 1, 0),\n" .
-            "('NPWR003', 1, 1, 1, 0)"
+            <<<'SQL'
+            INSERT INTO trophy_title (np_communication_id, bronze, silver, gold, platinum) VALUES
+                ('NPWR001', 10, 5, 3, 1),
+                ('NPWR002', 5, 2, 1, 0),
+                ('NPWR003', 1, 1, 1, 0)
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_title_meta (np_communication_id, status) VALUES\n" .
-            "('NPWR001', 0),\n" .
-            "('NPWR002', 0),\n" .
-            "('NPWR003', 1)"
+            <<<'SQL'
+            INSERT INTO trophy_title_meta (np_communication_id, status) VALUES
+                ('NPWR001', 0),
+                ('NPWR002', 0),
+                ('NPWR003', 1)
+            SQL
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_title_player (np_communication_id, account_id, progress, bronze, silver, gold, platinum) VALUES\n" .
-            "('NPWR001', 42, 75, 8, 4, 2, 1),\n" .
-            "('NPWR002', 42, 100, 1, 1, 0, 0),\n" .
-            "('NPWR003', 42, 100, 1, 1, 1, 0),\n" .
-            "('NPWR001', 7, 50, 0, 0, 0, 0)"
+            <<<'SQL'
+            INSERT INTO trophy_title_player (np_communication_id, account_id, progress, bronze, silver, gold, platinum) VALUES
+                ('NPWR001', 42, 75, 8, 4, 2, 1),
+                ('NPWR002', 42, 100, 1, 1, 0, 0),
+                ('NPWR003', 42, 100, 1, 1, 1, 0),
+                ('NPWR001', 7, 50, 0, 0, 0, 0)
+            SQL
         );
 
         $summary = $this->service->getSummary(42);
@@ -97,8 +103,10 @@ final class PlayerSummaryServiceTest extends TestCase
     public function testGetSummaryReturnsEmptySummaryWhenPlayerHasNoVisibleGames(): void
     {
         $this->database->exec(
-            "INSERT INTO trophy_title (np_communication_id, bronze, silver, gold, platinum) VALUES\n" .
-            "('NPWR010', 2, 2, 1, 0)"
+            <<<'SQL'
+            INSERT INTO trophy_title (np_communication_id, bronze, silver, gold, platinum) VALUES
+                ('NPWR010', 2, 2, 1, 0)
+            SQL
         );
 
         $this->database->exec(
@@ -106,8 +114,10 @@ final class PlayerSummaryServiceTest extends TestCase
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_title_player (np_communication_id, account_id, progress, bronze, silver, gold, platinum) VALUES\n" .
-            "('NPWR010', 42, 12, 1, 0, 0, 0)"
+            <<<'SQL'
+            INSERT INTO trophy_title_player (np_communication_id, account_id, progress, bronze, silver, gold, platinum) VALUES
+                ('NPWR010', 42, 12, 1, 0, 0, 0)
+            SQL
         );
 
         $summary = $this->service->getSummary(99);
@@ -121,8 +131,10 @@ final class PlayerSummaryServiceTest extends TestCase
     public function testGetSummaryDoesNotAllowNegativeUnearnedTrophies(): void
     {
         $this->database->exec(
-            "INSERT INTO trophy_title (np_communication_id, bronze, silver, gold, platinum) VALUES\n" .
-            "('NPWR020', 1, 0, 0, 0)"
+            <<<'SQL'
+            INSERT INTO trophy_title (np_communication_id, bronze, silver, gold, platinum) VALUES
+                ('NPWR020', 1, 0, 0, 0)
+            SQL
         );
 
         $this->database->exec(
@@ -130,8 +142,10 @@ final class PlayerSummaryServiceTest extends TestCase
         );
 
         $this->database->exec(
-            "INSERT INTO trophy_title_player (np_communication_id, account_id, progress, bronze, silver, gold, platinum) VALUES\n" .
-            "('NPWR020', 42, 100, 5, 0, 0, 0)"
+            <<<'SQL'
+            INSERT INTO trophy_title_player (np_communication_id, account_id, progress, bronze, silver, gold, platinum) VALUES
+                ('NPWR020', 42, 100, 5, 0, 0, 0)
+            SQL
         );
 
         $summary = $this->service->getSummary(42);

--- a/wwwroot/classes/AbstractPlayerLeaderboardService.php
+++ b/wwwroot/classes/AbstractPlayerLeaderboardService.php
@@ -77,7 +77,7 @@ abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeader
         bool $includeTotalCount,
     ): array {
         $normalStatus = PlayerStatus::NORMAL->value;
-        $totalCountProjection = $includeTotalCount ? ",\n                COUNT(*) OVER() AS total_rows" : '';
+        $totalCountProjection = $includeTotalCount ? ', COUNT(*) OVER() AS total_rows' : '';
 
         $sql = <<<SQL
             SELECT

--- a/wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php
@@ -40,6 +40,6 @@ final class PossibleCheaterRuleConditionParser
             return 'SELECT NULL AS np_communication_id, NULL AS order_id, NULL AS date_operator, NULL AS date_value WHERE 0';
         }
 
-        return implode("\nUNION ALL\n", $selects);
+        return implode(' UNION ALL ', $selects);
     }
 }

--- a/wwwroot/classes/Cron/PlayerScanQueueSelector.php
+++ b/wwwroot/classes/Cron/PlayerScanQueueSelector.php
@@ -263,6 +263,6 @@ final class PlayerScanQueueSelector
                 SQL;
         }
 
-        return implode("\n\n                UNION ALL\n\n", $branches);
+        return implode(' UNION ALL ', $branches);
     }
 }

--- a/wwwroot/classes/TrophyMergeEarnedCopier.php
+++ b/wwwroot/classes/TrophyMergeEarnedCopier.php
@@ -160,7 +160,7 @@ SQL
                 earned
             )
         SQL
-            . "\n" . $mergeSourceCte . "\n"
+            . $mergeSourceCte
             . <<<'SQL'
             SELECT
                 source.parent_np_communication_id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Drop `\n` escape sequences from SQL builders in leaderboard, scan-queue, possible-cheater, and trophy-merge code; MySQL ignores the extra whitespace either way.
- Convert test seed `INSERT` statements that concatenated `"...\n"` fragments to heredocs for the same readability win.

## Test plan
- [x] `php tests/run.php` — all 1019 tests passed
- [x] Spot-check that generated SQL still contains `UNION ALL` / `COUNT(*) OVER()` where expected
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-637c84bc-cc14-4a99-972f-64e1eea52e60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-637c84bc-cc14-4a99-972f-64e1eea52e60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

