### PR TITLE
Adopt remaining PHP 8.5 idioms for enums, secrets, and sealing

### DIFF
--- a/tests/LeaderboardPageContextTest.php
+++ b/tests/LeaderboardPageContextTest.php
@@ -178,7 +178,7 @@ final class FakeLeaderboardPageContext extends AbstractLeaderboardPageContext
     }
 }
 
-final class FakeLeaderboardRow extends AbstractLeaderboardRow
+final readonly class FakeLeaderboardRow extends AbstractLeaderboardRow
 {
     public function __construct(
         array $player,

--- a/tests/Php85IdiomEnumsTest.php
+++ b/tests/Php85IdiomEnumsTest.php
@@ -15,6 +15,10 @@ require_once __DIR__ . '/../wwwroot/classes/TrophyType.php';
 require_once __DIR__ . '/../wwwroot/classes/TrophyMetaStatus.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerTimelineStatus.php';
 require_once __DIR__ . '/../wwwroot/classes/HistoryIconType.php';
+require_once __DIR__ . '/../wwwroot/classes/HistoryDiffTokenState.php';
+require_once __DIR__ . '/../wwwroot/classes/LeaderboardView.php';
+require_once __DIR__ . '/../wwwroot/classes/NpServiceName.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterDateOperator.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerTimelineEntry.php';
 require_once __DIR__ . '/../wwwroot/classes/Platform.php';
 
@@ -133,5 +137,42 @@ final class Php85IdiomEnumsTest extends TestCase
         $this->assertFalse(Platform::usesPlayStation5Assets('PS4, PS3'));
         $this->assertTrue(Platform::anyUsesPlayStation5Assets(['PS4', 'PS5']));
         $this->assertFalse(Platform::anyUsesPlayStation5Assets(['PS4', 'PC']));
+        $this->assertSame(
+            ['PS3', 'PS4', 'PSVR', 'PSVITA'],
+            Platform::legacyTrophyServiceLabels()
+        );
+    }
+
+    public function testHistoryDiffTokenStateHelpers(): void
+    {
+        $this->assertTrue(HistoryDiffTokenState::Equal->isEqual());
+        $this->assertFalse(HistoryDiffTokenState::Removed->isEqual());
+        $this->assertSame('added', HistoryDiffTokenState::Added->value);
+    }
+
+    public function testLeaderboardViewIncludeFiles(): void
+    {
+        $this->assertSame('leaderboard_main.php', LeaderboardView::Main->includeFile());
+        $this->assertSame('leaderboard_main.php', LeaderboardView::Trophy->includeFile());
+        $this->assertSame('leaderboard_rarity.php', LeaderboardView::Rarity->includeFile());
+        $this->assertSame('leaderboard_in_game_rarity.php', LeaderboardView::InGameRarity->includeFile());
+        $this->assertSame(null, LeaderboardView::tryFrom('unknown'));
+    }
+
+    public function testNpServiceNamePreferForPlatformLabels(): void
+    {
+        $this->assertSame(NpServiceName::Trophy, NpServiceName::preferForPlatformLabels(['PS4']));
+        $this->assertSame(NpServiceName::Trophy2, NpServiceName::preferForPlatformLabels(['PS5']));
+        $this->assertSame(NpServiceName::Trophy2, NpServiceName::tryFromMixed(' TROPHY2 '));
+        $this->assertSame(null, NpServiceName::tryFromMixed('unknown'));
+    }
+
+    public function testPossibleCheaterDateOperatorTryFromMixed(): void
+    {
+        $this->assertSame(PossibleCheaterDateOperator::GreaterThanOrEqual, PossibleCheaterDateOperator::tryFromMixed('>='));
+        $this->assertSame(PossibleCheaterDateOperator::LessThanOrEqual, PossibleCheaterDateOperator::tryFromMixed('<='));
+        $this->assertSame(PossibleCheaterDateOperator::LessThan, PossibleCheaterDateOperator::tryFromMixed('<'));
+        $this->assertSame(null, PossibleCheaterDateOperator::tryFromMixed(''));
+        $this->assertSame(null, PossibleCheaterDateOperator::tryFromMixed(null));
     }
 }

--- a/tests/PossibleCheaterRuleConditionParserTest.php
+++ b/tests/PossibleCheaterRuleConditionParserTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterDateOperator.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterRulesCatalog.php';
 
@@ -31,7 +32,7 @@ final class PossibleCheaterRuleConditionParserTest extends TestCase
             "te.np_communication_id = 'NPWR00550_00' AND te.order_id = 4 AND te.earned_date >= '2015-01-01'"
         );
 
-        $this->assertSame('>=', $tuple->getDateOperator());
+        $this->assertSame(PossibleCheaterDateOperator::GreaterThanOrEqual, $tuple->getDateOperator());
         $this->assertSame('2015-01-01', $tuple->getDateValue());
     }
 
@@ -41,7 +42,7 @@ final class PossibleCheaterRuleConditionParserTest extends TestCase
             "te.np_communication_id = 'NPWR14225_00' AND te.order_id = 6 AND te.earned_date <= '2020-04-12'"
         );
 
-        $this->assertSame('<=', $tuple->getDateOperator());
+        $this->assertSame(PossibleCheaterDateOperator::LessThanOrEqual, $tuple->getDateOperator());
         $this->assertSame('2020-04-12', $tuple->getDateValue());
     }
 
@@ -51,7 +52,7 @@ final class PossibleCheaterRuleConditionParserTest extends TestCase
             "te.np_communication_id = 'NPWR18341_00' AND te.order_id = 0 AND te.earned_date < '2020-03-01'"
         );
 
-        $this->assertSame('<', $tuple->getDateOperator());
+        $this->assertSame(PossibleCheaterDateOperator::LessThan, $tuple->getDateOperator());
         $this->assertSame('2020-03-01', $tuple->getDateValue());
     }
 

--- a/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
+++ b/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/GameRescanDifferenceTracker.php';
 require_once __DIR__ . '/GameRescanProgressReporter.php';
 require_once __DIR__ . '/GameRescanGroupDataFetcher.php';
 require_once __DIR__ . '/PsnTrophyLookupGroupDataProvider.php';
+require_once __DIR__ . '/../Platform.php';
 require_once __DIR__ . '/../TrophyMetaRepository.php';
 require_once __DIR__ . '/../TrophyImageDirectories.php';
 require_once __DIR__ . '/../TrophyImageDownloader.php';
@@ -338,31 +339,36 @@ final class GameRescanCatalogUpdater
             |> array_unique(...)
             |> array_values(...);
 
-        if (in_array('PSVR2', $existingPlatforms, true)) {
-            if (!in_array('PSVR2', $platforms, true)) {
-                $platforms[] = 'PSVR2';
+        $psVr2 = Platform::PsVr2->label();
+        $ps5 = Platform::Ps5->label();
+        $psVr = Platform::PsVr->label();
+        $ps4 = Platform::Ps4->label();
+
+        if (in_array($psVr2, $existingPlatforms, true)) {
+            if (!in_array($psVr2, $platforms, true)) {
+                $platforms[] = $psVr2;
             }
 
-            if (!in_array('PS5', $existingPlatforms, true)) {
+            if (!in_array($ps5, $existingPlatforms, true)) {
                 $platforms = $platforms
                     |> (fn(array $items): array => array_filter(
                         $items,
-                        static fn(string $platform): bool => $platform !== 'PS5'
+                        static fn(string $platform): bool => $platform !== $ps5
                     ))
                     |> array_values(...);
             }
         }
 
-        if (in_array('PSVR', $existingPlatforms, true)) {
-            if (!in_array('PSVR', $platforms, true)) {
-                $platforms[] = 'PSVR';
+        if (in_array($psVr, $existingPlatforms, true)) {
+            if (!in_array($psVr, $platforms, true)) {
+                $platforms[] = $psVr;
             }
 
-            if (!in_array('PS4', $existingPlatforms, true)) {
+            if (!in_array($ps4, $existingPlatforms, true)) {
                 $platforms = $platforms
                     |> (fn(array $items): array => array_filter(
                         $items,
-                        static fn(string $platform): bool => $platform !== 'PS4'
+                        static fn(string $platform): bool => $platform !== $ps4
                     ))
                     |> array_values(...);
             }

--- a/wwwroot/classes/Admin/LogEntryFormatter.php
+++ b/wwwroot/classes/Admin/LogEntryFormatter.php
@@ -45,7 +45,7 @@ final class LogEntryFormatter
 
     private function formatTrophyHistoryMessage(string $message): ?string
     {
-        if (!preg_match('/^(Recorded new trophy_title_history entry \d+ for trophy_title\\.id )(\d+)(.*)$/', $message, $matches)) {
+        if (preg_match('/^(Recorded new trophy_title_history entry \d+ for trophy_title\\.id )(\d+)(.*)$/', $message, $matches) !== 1) {
             return null;
         }
 
@@ -67,7 +67,7 @@ final class LogEntryFormatter
 
     private function formatSetVersionMessage(string $message): ?string
     {
-        if (!preg_match('/^SET VERSION for (.+)\s*\.\s*([A-Z0-9_]+),\s*([^,]+),\s*(.+)$/', $message, $matches, PREG_OFFSET_CAPTURE)) {
+        if (preg_match('/^SET VERSION for (.+)\s*\.\s*([A-Z0-9_]+),\s*([^,]+),\s*(.+)$/', $message, $matches, PREG_OFFSET_CAPTURE) !== 1) {
             return null;
         }
 
@@ -94,7 +94,7 @@ final class LogEntryFormatter
 
     private function formatNewTrophiesAddedMessage(string $message): ?string
     {
-        if (!preg_match('/^New trophies added for (.+)\s*\.\s*([A-Z0-9_]+),\s*([^,]+),\s*(.+)$/', $message, $matches, PREG_OFFSET_CAPTURE)) {
+        if (preg_match('/^New trophies added for (.+)\s*\.\s*([A-Z0-9_]+),\s*([^,]+),\s*(.+)$/', $message, $matches, PREG_OFFSET_CAPTURE) !== 1) {
             return null;
         }
 
@@ -121,7 +121,7 @@ final class LogEntryFormatter
 
     private function formatSonyIssuesMessage(string $message): ?string
     {
-        if (!preg_match('/^(Sony issues with )(.+?)(( \(\d+\)\.)$)/', $message, $matches, PREG_OFFSET_CAPTURE)) {
+        if (preg_match('/^(Sony issues with )(.+?)(( \(\d+\)\.)$)/', $message, $matches, PREG_OFFSET_CAPTURE) !== 1) {
             return null;
         }
 

--- a/wwwroot/classes/Admin/PossibleCheaterDateOperator.php
+++ b/wwwroot/classes/Admin/PossibleCheaterDateOperator.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+enum PossibleCheaterDateOperator: string
+{
+    case GreaterThanOrEqual = '>=';
+    case LessThanOrEqual = '<=';
+    case LessThan = '<';
+
+    #[\NoDiscard]
+    public static function tryFromMixed(mixed $value): ?self
+    {
+        if (!is_string($value) || $value === '') {
+            return null;
+        }
+
+        return self::tryFrom($value);
+    }
+}

--- a/wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php
@@ -2,23 +2,24 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PossibleCheaterDateOperator.php';
 require_once __DIR__ . '/PossibleCheaterRuleGroup.php';
 require_once __DIR__ . '/PossibleCheaterRuleTuple.php';
 
-final class PossibleCheaterRuleConditionParser
+final readonly class PossibleCheaterRuleConditionParser
 {
     private const string CONDITION_PATTERN = '/^te\.np_communication_id = \'([^\']+)\' AND te\.order_id = (\d+)(?: AND te\.earned_date (>=|<=|<) \'([^\']+)\')?$/';
 
     public function parse(string $condition): PossibleCheaterRuleTuple
     {
-        if (!preg_match(self::CONDITION_PATTERN, $condition, $matches)) {
+        if (preg_match(self::CONDITION_PATTERN, $condition, $matches) !== 1) {
             throw new InvalidArgumentException('Unsupported possible cheater rule condition: ' . $condition);
         }
 
         return new PossibleCheaterRuleTuple(
             $matches[1],
             (int) $matches[2],
-            isset($matches[3]) && $matches[3] !== '' ? $matches[3] : null,
+            PossibleCheaterDateOperator::tryFromMixed($matches[3] ?? null),
             isset($matches[4]) && $matches[4] !== '' ? $matches[4] : null
         );
     }

--- a/wwwroot/classes/Admin/PossibleCheaterRuleTuple.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleTuple.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PossibleCheaterDateOperator.php';
+
 final readonly class PossibleCheaterRuleTuple
 {
     public function __construct(
         private string $npCommunicationId,
         private int $orderId,
-        private ?string $dateOperator,
+        private ?PossibleCheaterDateOperator $dateOperator,
         private ?string $dateValue,
     ) {
     }
@@ -22,7 +24,7 @@ final readonly class PossibleCheaterRuleTuple
         return $this->orderId;
     }
 
-    public function getDateOperator(): ?string
+    public function getDateOperator(): ?PossibleCheaterDateOperator
     {
         return $this->dateOperator;
     }
@@ -36,7 +38,7 @@ final readonly class PossibleCheaterRuleTuple
     {
         $npCommunicationId = $this->quote($this->npCommunicationId);
         $orderId = $this->orderId;
-        $dateOperator = $this->dateOperator !== null ? $this->quote($this->dateOperator) : 'NULL';
+        $dateOperator = $this->dateOperator !== null ? $this->quote($this->dateOperator->value) : 'NULL';
         $dateValue = $this->dateValue !== null ? $this->quote($this->dateValue) : 'NULL';
 
         return 'SELECT '

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/PsnTrophyApiPayloadInspector.php';
 require_once __DIR__ . '/PsnTrophyGroupAssembler.php';
 require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
 require_once __DIR__ . '/../CommaSeparatedValues.php';
+require_once __DIR__ . '/../NpServiceName.php';
 
 use Tustin\PlayStation\Client;
 
@@ -191,7 +192,7 @@ final class PsnGameLookupService
         return $normalizedResponse;
     }
 
-    private function resolvePreferredNpServiceName(string $npCommunicationId): ?string
+    private function resolvePreferredNpServiceName(string $npCommunicationId): ?NpServiceName
     {
         $query = $this->database->prepare(
             'SELECT platform FROM trophy_title WHERE np_communication_id = :np_communication_id LIMIT 1'
@@ -210,12 +211,7 @@ final class PsnGameLookupService
             return null;
         }
 
-        $legacyPlatforms = ['PS3', 'PS4', 'PSVR', 'PSVITA'];
-
-        return array_any(
-            $platforms,
-            static fn (string $platformValue): bool => in_array($platformValue, $legacyPlatforms, true)
-        ) ? 'trophy' : 'trophy2';
+        return NpServiceName::preferForPlatformLabels($platforms);
     }
 
     /**
@@ -254,7 +250,7 @@ final class PsnGameLookupService
     private function executeLookupRequest(
         object $client,
         string $path,
-        ?string $preferredNpServiceName = null,
+        ?NpServiceName $preferredNpServiceName = null,
         ?array $pinnedQuery = null
     ): array
     {
@@ -293,7 +289,7 @@ final class PsnGameLookupService
     /**
      * @return list<array{npLanguage: string, npServiceName?: string}>
      */
-    private function buildLookupQueryVariants(?string $preferredNpServiceName): array
+    private function buildLookupQueryVariants(?NpServiceName $preferredNpServiceName): array
     {
         $queryVariants = [];
         $addVariant = static function (array $variant) use (&$queryVariants): void {
@@ -302,14 +298,14 @@ final class PsnGameLookupService
             }
         };
 
-        if ($preferredNpServiceName === 'trophy' || $preferredNpServiceName === 'trophy2') {
-            $addVariant(['npLanguage' => 'en-US', 'npServiceName' => $preferredNpServiceName]);
+        if ($preferredNpServiceName instanceof NpServiceName) {
+            $addVariant(['npLanguage' => 'en-US', 'npServiceName' => $preferredNpServiceName->value]);
         } else {
             $addVariant(['npLanguage' => 'en-US']);
         }
 
-        $addVariant(['npLanguage' => 'en-US', 'npServiceName' => 'trophy']);
-        $addVariant(['npLanguage' => 'en-US', 'npServiceName' => 'trophy2']);
+        $addVariant(['npLanguage' => 'en-US', 'npServiceName' => NpServiceName::Trophy->value]);
+        $addVariant(['npLanguage' => 'en-US', 'npServiceName' => NpServiceName::Trophy2->value]);
         $addVariant(['npLanguage' => 'en-US']);
 
         return $queryVariants;

--- a/wwwroot/classes/Admin/WorkerCredentialRevealResult.php
+++ b/wwwroot/classes/Admin/WorkerCredentialRevealResult.php
@@ -8,13 +8,14 @@ final readonly class WorkerCredentialRevealResult
 {
     private function __construct(
         final private bool $success,
+        #[\SensitiveParameter]
         final private ?string $credential,
         final private ?string $errorMessage,
     ) {
     }
 
     #[\NoDiscard]
-    public static function success(string $credential): self
+    public static function success(#[\SensitiveParameter] string $credential): self
     {
         return new self(true, $credential, null);
     }

--- a/wwwroot/classes/CsrfTokenManager.php
+++ b/wwwroot/classes/CsrfTokenManager.php
@@ -26,7 +26,7 @@ final readonly class CsrfTokenManager
     }
 
     #[\NoDiscard]
-    public static function validate(string $scope, mixed $submittedToken): bool
+    public static function validate(string $scope, #[\SensitiveParameter] mixed $submittedToken): bool
     {
         SessionManager::ensureStarted();
 

--- a/wwwroot/classes/GameHistoryRenderer.php
+++ b/wwwroot/classes/GameHistoryRenderer.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Game/GameDetails.php';
+require_once __DIR__ . '/HistoryDiffTokenState.php';
 require_once __DIR__ . '/HistoryIconType.php';
 require_once __DIR__ . '/HistoryIconState.php';
 require_once __DIR__ . '/Html.php';
@@ -159,8 +160,8 @@ final readonly class GameHistoryRenderer
         $diff = $this->buildTokenDiff($previousTokens, $currentTokens);
 
         return [
-            'previous' => $this->renderHighlightedTokens($diff['previous'], $isMultiline, 'previous'),
-            'current' => $this->renderHighlightedTokens($diff['current'], $isMultiline, 'current'),
+            'previous' => $this->renderHighlightedTokens($diff['previous'], $isMultiline),
+            'current' => $this->renderHighlightedTokens($diff['current'], $isMultiline),
         ];
     }
 
@@ -181,7 +182,7 @@ final readonly class GameHistoryRenderer
     /**
      * @param list<string> $previousTokens
      * @param list<string> $currentTokens
-     * @return array{previous: list<array{value: string, state: string}>, current: list<array{value: string, state: string}>}
+     * @return array{previous: list<array{value: string, state: HistoryDiffTokenState}>, current: list<array{value: string, state: HistoryDiffTokenState}>}
      */
     private function buildTokenDiff(array $previousTokens, array $currentTokens): array
     {
@@ -207,30 +208,30 @@ final readonly class GameHistoryRenderer
 
         while ($i < $previousLength && $j < $currentLength) {
             if ($previousTokens[$i] === $currentTokens[$j]) {
-                $previousDiff[] = ['value' => $previousTokens[$i], 'state' => 'equal'];
-                $currentDiff[] = ['value' => $currentTokens[$j], 'state' => 'equal'];
+                $previousDiff[] = ['value' => $previousTokens[$i], 'state' => HistoryDiffTokenState::Equal];
+                $currentDiff[] = ['value' => $currentTokens[$j], 'state' => HistoryDiffTokenState::Equal];
                 $i++;
                 $j++;
                 continue;
             }
 
             if ($lcs[$i + 1][$j] >= $lcs[$i][$j + 1]) {
-                $previousDiff[] = ['value' => $previousTokens[$i], 'state' => 'removed'];
+                $previousDiff[] = ['value' => $previousTokens[$i], 'state' => HistoryDiffTokenState::Removed];
                 $i++;
                 continue;
             }
 
-            $currentDiff[] = ['value' => $currentTokens[$j], 'state' => 'added'];
+            $currentDiff[] = ['value' => $currentTokens[$j], 'state' => HistoryDiffTokenState::Added];
             $j++;
         }
 
         while ($i < $previousLength) {
-            $previousDiff[] = ['value' => $previousTokens[$i], 'state' => 'removed'];
+            $previousDiff[] = ['value' => $previousTokens[$i], 'state' => HistoryDiffTokenState::Removed];
             $i++;
         }
 
         while ($j < $currentLength) {
-            $currentDiff[] = ['value' => $currentTokens[$j], 'state' => 'added'];
+            $currentDiff[] = ['value' => $currentTokens[$j], 'state' => HistoryDiffTokenState::Added];
             $j++;
         }
 
@@ -238,9 +239,9 @@ final readonly class GameHistoryRenderer
     }
 
     /**
-     * @param list<array{value: string, state: string}> $tokens
+     * @param list<array{value: string, state: HistoryDiffTokenState}> $tokens
      */
-    private function renderHighlightedTokens(array $tokens, bool $isMultiline, string $state): string
+    private function renderHighlightedTokens(array $tokens, bool $isMultiline): string
     {
         $html = '';
         $highlightTokens = [];
@@ -269,7 +270,7 @@ final readonly class GameHistoryRenderer
                 $html .= $highlightTokens[$i]['value'];
             }
 
-            $html .= '<mark class="history-highlight history-highlight--' . $highlightState . '">';
+            $html .= '<mark class="history-highlight history-highlight--' . $highlightState->value . '">';
             for ($i = $firstNonWhitespaceIndex; $i <= $lastNonWhitespaceIndex; $i++) {
                 $html .= $highlightTokens[$i]['value'];
             }
@@ -291,7 +292,7 @@ final readonly class GameHistoryRenderer
                 $escaped = str_replace(["\r\n", "\n", "\r"], '<br>', $escaped);
             }
 
-            if ($token['state'] !== 'equal') {
+            if (!$token['state']->isEqual()) {
                 if ($highlightState !== $token['state']) {
                     $flushHighlight();
                 }

--- a/wwwroot/classes/GameRepository.php
+++ b/wwwroot/classes/GameRepository.php
@@ -14,7 +14,9 @@ class GameRepository
             return null;
         }
 
-        $id = (int) (($segment |> explode('-', ...) |> array_first(...)) ?? 0);
+        $id = (int) (($segment
+            |> (fn (string $value): array => explode('-', $value))
+            |> array_first(...)) ?? 0);
 
         if ($id <= 0) {
             return null;

--- a/wwwroot/classes/GameRepository.php
+++ b/wwwroot/classes/GameRepository.php
@@ -14,7 +14,7 @@ class GameRepository
             return null;
         }
 
-        $id = (int) (array_first(explode('-', $segment)) ?? 0);
+        $id = (int) (($segment |> explode('-', ...) |> array_first(...)) ?? 0);
 
         if ($id <= 0) {
             return null;

--- a/wwwroot/classes/HistoryDiffTokenState.php
+++ b/wwwroot/classes/HistoryDiffTokenState.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+enum HistoryDiffTokenState: string
+{
+    case Equal = 'equal';
+    case Removed = 'removed';
+    case Added = 'added';
+
+    public function isEqual(): bool
+    {
+        return $this === self::Equal;
+    }
+}

--- a/wwwroot/classes/JsonResponseEmitter.php
+++ b/wwwroot/classes/JsonResponseEmitter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/JsonResponseStatus.php';
 
-final class JsonResponseEmitter
+final readonly class JsonResponseEmitter
 {
     /**
      * @param array<string, mixed>|\JsonSerializable $payload
@@ -34,7 +34,8 @@ final class JsonResponseEmitter
         $encodedFallback = json_encode($fallbackPayload);
 
         if ($encodedFallback === false) {
-            echo '{"status":"error","message":"An unexpected error occurred while encoding the response.","shouldPoll":false}';
+            echo '{"status":"' . JsonResponseStatus::Error->value
+                . '","message":"An unexpected error occurred while encoding the response.","shouldPoll":false}';
 
             return;
         }

--- a/wwwroot/classes/Leaderboard/AbstractLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/AbstractLeaderboardRow.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 require_once __DIR__ . '/../PlayerLeaderboardFilter.php';
 require_once __DIR__ . '/../Utility.php';
 
-abstract class AbstractLeaderboardRow
+abstract readonly class AbstractLeaderboardRow
 {
     private const int NEW_PLAYER_RANK_VALUE = 16777215;
+
+    private ?string $highlightedPlayerId;
 
     /**
      * @param array<string, mixed> $player
@@ -17,7 +19,7 @@ abstract class AbstractLeaderboardRow
         protected array $player,
         private PlayerLeaderboardFilter $filter,
         private Utility $utility,
-        private ?string $highlightedPlayerId,
+        ?string $highlightedPlayerId,
         /** @var array<string, int|string> */
         private array $filterParameters,
         private string $rankingField,

--- a/wwwroot/classes/Leaderboard/InGameRarityLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/InGameRarityLeaderboardRow.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/AbstractLeaderboardRow.php';
 
-final class InGameRarityLeaderboardRow extends AbstractLeaderboardRow
+final readonly class InGameRarityLeaderboardRow extends AbstractLeaderboardRow
 {
     /**
      * @param array<string, mixed> $player

--- a/wwwroot/classes/Leaderboard/RarityLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/RarityLeaderboardRow.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/AbstractLeaderboardRow.php';
 
-final class RarityLeaderboardRow extends AbstractLeaderboardRow
+final readonly class RarityLeaderboardRow extends AbstractLeaderboardRow
 {
     /**
      * @param array<string, mixed> $player

--- a/wwwroot/classes/Leaderboard/TrophyLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/TrophyLeaderboardRow.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/AbstractLeaderboardRow.php';
 
-final class TrophyLeaderboardRow extends AbstractLeaderboardRow
+final readonly class TrophyLeaderboardRow extends AbstractLeaderboardRow
 {
     /**
      * @param array<string, mixed> $player

--- a/wwwroot/classes/LeaderboardView.php
+++ b/wwwroot/classes/LeaderboardView.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+enum LeaderboardView: string
+{
+    case Main = 'main';
+    case Trophy = 'trophy';
+    case Rarity = 'rarity';
+    case InGameRarity = 'in-game-rarity';
+
+    #[\NoDiscard]
+    public function includeFile(): string
+    {
+        return match ($this) {
+            self::Main, self::Trophy => 'leaderboard_main.php',
+            self::Rarity => 'leaderboard_rarity.php',
+            self::InGameRarity => 'leaderboard_in_game_rarity.php',
+        };
+    }
+}

--- a/wwwroot/classes/NpServiceName.php
+++ b/wwwroot/classes/NpServiceName.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Platform.php';
+
+enum NpServiceName: string
+{
+    case Trophy = 'trophy';
+    case Trophy2 = 'trophy2';
+
+    #[\NoDiscard]
+    public static function tryFromMixed(mixed $value): ?self
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return self::tryFrom($value |> trim(...) |> strtolower(...));
+    }
+
+    /**
+     * Prefer the legacy trophy service when any platform still uses it.
+     *
+     * @param list<string> $platformLabels
+     */
+    #[\NoDiscard]
+    public static function preferForPlatformLabels(array $platformLabels): self
+    {
+        return array_any(
+            $platformLabels,
+            static fn (string $platform): bool => in_array($platform, Platform::legacyTrophyServiceLabels(), true),
+        ) ? self::Trophy : self::Trophy2;
+    }
+}

--- a/wwwroot/classes/PaginationRenderer.php
+++ b/wwwroot/classes/PaginationRenderer.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/Html.php';
  * existing style. The renderer generates the HTML as a string so that templates
  * can decide where and how to output it.
  */
-final class PaginationRenderer
+final readonly class PaginationRenderer
 {
     /**
      * @param \Closure(int):array<string, string> $queryParametersFactory

--- a/wwwroot/classes/Platform.php
+++ b/wwwroot/classes/Platform.php
@@ -34,6 +34,21 @@ enum Platform: string
     }
 
     /**
+     * Platforms that still prefer the legacy PSN trophy service name.
+     *
+     * @return list<string>
+     */
+    public static function legacyTrophyServiceLabels(): array
+    {
+        return [
+            self::Ps3->label(),
+            self::Ps4->label(),
+            self::PsVr->label(),
+            self::PsVita->label(),
+        ];
+    }
+
+    /**
      * Display / merge sort order for platform labels (e.g. "PS5", "PC").
      *
      * @return list<string>

--- a/wwwroot/classes/PlayStationGraphqlPlayerSearch.php
+++ b/wwwroot/classes/PlayStationGraphqlPlayerSearch.php
@@ -137,19 +137,11 @@ final class PlayStationGraphqlPlayerSearch
             return null;
         }
 
-        foreach ($results as $domainResponse) {
-            if (!is_object($domainResponse)) {
-                continue;
-            }
-
-            if ($this->extractStringProperty($domainResponse, 'domain') !== self::GRAPHQL_SEARCH_DOMAIN) {
-                continue;
-            }
-
-            return $domainResponse;
-        }
-
-        return null;
+        return array_find(
+            $results,
+            fn (mixed $domainResponse): bool => is_object($domainResponse)
+                && $this->extractStringProperty($domainResponse, 'domain') === self::GRAPHQL_SEARCH_DOMAIN
+        );
     }
 
     private function performDomainSearch(

--- a/wwwroot/classes/PlayStationTrophyLevelCalculator.php
+++ b/wwwroot/classes/PlayStationTrophyLevelCalculator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * Converts PlayStation Network trophy points into PSN level and progress percentage.
  */
-final class PlayStationTrophyLevelCalculator
+final readonly class PlayStationTrophyLevelCalculator
 {
     /**
      * @return array{level: int, progress: int}

--- a/wwwroot/classes/PlayerQueuePollTokenManager.php
+++ b/wwwroot/classes/PlayerQueuePollTokenManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/SessionManager.php';
 
-final class PlayerQueuePollTokenManager
+final readonly class PlayerQueuePollTokenManager
 {
     private const string SESSION_KEY = 'queue_poll_tokens';
 
@@ -27,7 +27,7 @@ final class PlayerQueuePollTokenManager
         return $token;
     }
 
-    public function validate(string $playerName, string $submittedToken): bool
+    public function validate(string $playerName, #[\SensitiveParameter] string $submittedToken): bool
     {
         if ($playerName === '' || $submittedToken === '') {
             return false;

--- a/wwwroot/classes/PlayerQueueRequest.php
+++ b/wwwroot/classes/PlayerQueueRequest.php
@@ -10,6 +10,7 @@ final readonly class PlayerQueueRequest
     private function __construct(
         final private string $playerName,
         final private string $ipAddress,
+        #[\SensitiveParameter]
         final private string $pollToken,
     ) {}
 

--- a/wwwroot/classes/PlayerQueueResponse.php
+++ b/wwwroot/classes/PlayerQueueResponse.php
@@ -13,6 +13,7 @@ final readonly class PlayerQueueResponse implements \JsonSerializable
         final private PlayerQueueStatus $status,
         final private string $message,
         final private ?array $messageParts = null,
+        #[\SensitiveParameter]
         final private ?string $pollToken = null,
         final private int $httpStatusCode = 200,
     ) {}
@@ -54,7 +55,7 @@ final readonly class PlayerQueueResponse implements \JsonSerializable
     }
 
     #[\NoDiscard]
-    public function withPollToken(string $pollToken): self
+    public function withPollToken(#[\SensitiveParameter] string $pollToken): self
     {
         return clone($this, ['pollToken' => $pollToken]);
     }

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -204,7 +204,7 @@ final class PlayerQueueResponseFactory
         }
 
         if (preg_match('/^(Updating|Fetching)\b/i', $normalizedTitle) === 1) {
-            return $normalizedTitle |> strtolower(...) |> ucfirst(...);
+            return $normalizedTitle |> strtolower(...) |> mb_ucfirst(...);
         }
 
         if ($this->isErrorProgressTitle($normalizedTitle)) {

--- a/wwwroot/classes/PlayerReportRequest.php
+++ b/wwwroot/classes/PlayerReportRequest.php
@@ -11,6 +11,7 @@ final readonly class PlayerReportRequest
         final private string $explanation,
         final private bool $explanationSubmitted,
         final private string $ipAddress,
+        #[\SensitiveParameter]
         final private string $csrfToken,
     ) {}
 

--- a/wwwroot/classes/PsnHttpExceptionClassifier.php
+++ b/wwwroot/classes/PsnHttpExceptionClassifier.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  *
  * Shared by PSN lookup services and player scan profile synchronization.
  */
-final class PsnHttpExceptionClassifier
+final readonly class PsnHttpExceptionClassifier
 {
     public static function determineStatusCode(Throwable $exception): ?int
     {

--- a/wwwroot/classes/Routing/LeaderboardRouteHandler.php
+++ b/wwwroot/classes/Routing/LeaderboardRouteHandler.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/RouteHandlerInterface.php';
+require_once __DIR__ . '/../LeaderboardView.php';
 
 final readonly class LeaderboardRouteHandler implements RouteHandlerInterface
 {
@@ -14,13 +15,10 @@ final readonly class LeaderboardRouteHandler implements RouteHandlerInterface
     #[\Override]
     public function handle(array $segments): RouteResult
     {
-        $view = array_first($segments) ?? '';
+        $view = LeaderboardView::tryFrom(array_first($segments) ?? '');
 
-        return match ($view) {
-            'main', 'trophy' => RouteResult::include('leaderboard_main.php'),
-            'rarity' => RouteResult::include('leaderboard_rarity.php'),
-            'in-game-rarity' => RouteResult::include('leaderboard_in_game_rarity.php'),
-            default => RouteResult::redirect(self::DEFAULT_REDIRECT),
-        };
+        return $view !== null
+            ? RouteResult::include($view->includeFile())
+            : RouteResult::redirect(self::DEFAULT_REDIRECT);
     }
 }

--- a/wwwroot/classes/TrophyRepository.php
+++ b/wwwroot/classes/TrophyRepository.php
@@ -14,7 +14,7 @@ class TrophyRepository
             return null;
         }
 
-        $id = (int) (array_first(explode('-', $segment)) ?? 0);
+        $id = (int) (($segment |> explode('-', ...) |> array_first(...)) ?? 0);
 
         if ($id <= 0) {
             return null;

--- a/wwwroot/classes/TrophyRepository.php
+++ b/wwwroot/classes/TrophyRepository.php
@@ -14,7 +14,9 @@ class TrophyRepository
             return null;
         }
 
-        $id = (int) (($segment |> explode('-', ...) |> array_first(...)) ?? 0);
+        $id = (int) (($segment
+            |> (fn (string $value): array => explode('-', $value))
+            |> array_first(...)) ?? 0);
 
         if ($id <= 0) {
             return null;

--- a/wwwroot/classes/TrophyType.php
+++ b/wwwroot/classes/TrophyType.php
@@ -36,7 +36,7 @@ enum TrophyType: string
 
     public function label(): string
     {
-        return $this->value |> ucfirst(...);
+        return $this->value |> mb_ucfirst(...);
     }
 
     /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the PHP 8.5 modernization series with leftovers that still used string discriminators, untyped first-match loops, and unsealed helpers. No backward compatibility is required.

### Changes
- Add backed enums `HistoryDiffTokenState`, `LeaderboardView`, `NpServiceName`, and `PossibleCheaterDateOperator`, wiring them into game history diffs, leaderboard routing, PSN game lookup, and possible-cheater rule parsing
- Mark CSRF, queue poll, and worker credential token parameters with `#[\SensitiveParameter]`
- Prefer `array_find`, pipes for ID-segment parsing, `Platform` labels, `mb_ucfirst`, `preg_match === 1`, and `readonly` sealing on pure helpers / leaderboard rows
- Extend `Php85IdiomEnumsTest` coverage for the new enums and platform helpers

### Testing
- `php tests/run.php` — all 1023 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-557fad27-1ad6-482f-9ca3-1d7f9ae06867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-557fad27-1ad6-482f-9ca3-1d7f9ae06867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

