### PR TITLE
Adopt remaining PHP 8.5 idioms for filters, merges, and escaping

### DIFF
--- a/tests/MergeNpCommunicationIdTest.php
+++ b/tests/MergeNpCommunicationIdTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/../wwwroot/classes/MergeNpCommunicationId.php';
+
+final class MergeNpCommunicationIdTest extends TestCase
+{
+    public function testMatchesRecognizesMergePrefix(): void
+    {
+        $this->assertTrue(MergeNpCommunicationId::matches('MERGE_000001'));
+        $this->assertTrue(MergeNpCommunicationId::matches('MERGE'));
+        $this->assertFalse(MergeNpCommunicationId::matches('NPWR10853_00'));
+        $this->assertFalse(MergeNpCommunicationId::matches('merge_000001'));
+    }
+
+    public function testForGameIdBuildsZeroPaddedIdentifier(): void
+    {
+        $this->assertSame('MERGE_000001', MergeNpCommunicationId::forGameId(1));
+        $this->assertSame('MERGE_048500', MergeNpCommunicationId::forGameId(48500));
+        $this->assertSame('MERGE_123456', MergeNpCommunicationId::forGameId(123456));
+    }
+}

--- a/tests/Php85IdiomEnumsTest.php
+++ b/tests/Php85IdiomEnumsTest.php
@@ -141,6 +141,26 @@ final class Php85IdiomEnumsTest extends TestCase
             ['PS3', 'PS4', 'PSVR', 'PSVITA'],
             Platform::legacyTrophyServiceLabels()
         );
+        $this->assertSame(
+            [
+                'pc' => 'PC',
+                'ps3' => 'PS3',
+                'ps4' => 'PS4',
+                'ps5' => 'PS5',
+                'psvita' => 'PSVITA',
+                'psvr' => 'PSVR',
+                'psvr2' => 'PSVR2',
+            ],
+            Platform::labelsByValue()
+        );
+    }
+
+    public function testTrophyTypeSqlFieldOrderUsesPipeFriendlyCases(): void
+    {
+        $this->assertSame(
+            "FIELD(t.type, 'bronze', 'silver', 'gold', 'platinum')",
+            TrophyType::sqlFieldOrder('t.type')
+        );
     }
 
     public function testHistoryDiffTokenStateHelpers(): void

--- a/tests/PlayerLeaderboardFilterTest.php
+++ b/tests/PlayerLeaderboardFilterTest.php
@@ -69,4 +69,17 @@ final class PlayerLeaderboardFilterTest extends TestCase
             $filter->withPage(0)
         );
     }
+
+    public function testWithPageNumberReturnsNewFilterInstance(): void
+    {
+        $filter = PlayerLeaderboardFilter::fromArray(['page' => '2', 'country' => 'us']);
+
+        $updated = $filter->withPageNumber(4);
+
+        $this->assertSame(2, $filter->getPage());
+        $this->assertSame(4, $updated->getPage());
+        $this->assertSame('us', $updated->getCountry());
+        $this->assertSame(150, $updated->getOffset(50));
+        $this->assertSame(1, $filter->withPageNumber(0)->getPage());
+    }
 }

--- a/wwwroot/404.php
+++ b/wwwroot/404.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/NotFoundPage.php';
 
 $notFoundPage = NotFoundPage::createDefault();
@@ -13,11 +15,11 @@ require_once __DIR__ . '/header.php';
 <main class="container">
     <div class="row">
         <div class="col-12">
-            <h1><?= htmlspecialchars($notFoundPage->getHeading(), ENT_QUOTES, 'UTF-8'); ?></h1>
+            <h1><?= Html::escape($notFoundPage->getHeading()); ?></h1>
         </div>
 
         <div class="col-12">
-            <p><?= htmlspecialchars($notFoundPage->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+            <p><?= Html::escape($notFoundPage->getMessage()); ?></p>
         </div>
     </div>
 </main>

--- a/wwwroot/about.php
+++ b/wwwroot/about.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/init.php';
 require_once __DIR__ . '/classes/AboutPageService.php';
 require_once __DIR__ . '/classes/AboutPageContext.php';
@@ -105,8 +107,8 @@ require_once("header.php");
                                         $progress = $player->getProgress();
                                         $level = $player->getLevel();
                                         $encodedOnlineId = rawurlencode($onlineId);
-                                        $escapedOnlineId = htmlspecialchars($onlineId, ENT_QUOTES, 'UTF-8');
-                                        $escapedAvatarUrl = htmlspecialchars($player->getAvatarUrl(), ENT_QUOTES, 'UTF-8');
+                                        $escapedOnlineId = Html::escape($onlineId);
+                                        $escapedAvatarUrl = Html::escape($player->getAvatarUrl());
                                         $lastUpdateElementId = 'lastUpdate' . preg_replace('/[^a-zA-Z0-9_-]/', '', $onlineId);
                                         ?>
                                         <tr>
@@ -126,7 +128,7 @@ require_once("header.php");
                                                 <?php
                                                 if ($statusLabel !== null) {
                                                     echo '<span style="color: #9d9d9d;">('
-                                                        . htmlspecialchars($statusLabel, ENT_QUOTES, 'UTF-8')
+                                                        . Html::escape($statusLabel)
                                                         . ')</span>';
                                                 } elseif ($player->isNew()) {
                                                     echo '(New!)';
@@ -138,7 +140,7 @@ require_once("header.php");
                                             <td
                                                 class="align-middle text-center js-localized-date"
                                                 <?php if ($lastUpdatedDate !== null) { ?>
-                                                data-timestamp="<?= htmlspecialchars($lastUpdatedDate, ENT_QUOTES, 'UTF-8'); ?>"
+                                                data-timestamp="<?= Html::escape($lastUpdatedDate); ?>"
                                                 data-time-style="medium"
                                                 <?php } ?>
                                             ></td>
@@ -155,7 +157,7 @@ require_once("header.php");
                                                     </div>
 
                                                     <div class="ms-auto">
-                                                        <img src="/img/country/<?= htmlspecialchars($countryCode, ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
+                                                        <img src="/img/country/<?= Html::escape($countryCode); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
                                                     </div>
                                                 </div>
                                             </td>
@@ -183,7 +185,7 @@ require_once("header.php");
                     </div>
                 </div>
                 <?php if ($scanLogPlayersData !== []) { ?>
-                    <link rel="stylesheet" href="<?= htmlspecialchars(StaticAsset::url('/css/scan-log-renderer.css'), ENT_QUOTES, 'UTF-8'); ?>">
+                    <link rel="stylesheet" href="<?= Html::escape(StaticAsset::url('/css/scan-log-renderer.css')); ?>">
                     <?php
                     $scanLogConfig = [
                         'scanLogData' => $scanLogPlayersData,
@@ -195,7 +197,7 @@ require_once("header.php");
                     ];
                     ?>
                     <script type="application/json" id="scan-log-config"><?= json_encode($scanLogConfig, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT); ?></script>
-                    <script src="<?= htmlspecialchars(StaticAsset::url('/js/scan-log-renderer.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
+                    <script src="<?= Html::escape(StaticAsset::url('/js/scan-log-renderer.js')); ?>" defer></script>
                 <?php } ?>
             </div>
         </div>

--- a/wwwroot/admin/cheater.php
+++ b/wwwroot/admin/cheater.php
@@ -20,7 +20,7 @@ $errorMessage = $result->getErrorMessage();
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ Cheater</title>
     </head>
     <body>

--- a/wwwroot/admin/copy.php
+++ b/wwwroot/admin/copy.php
@@ -16,7 +16,7 @@ $message = $gameCopyHandler->handle($_POST);
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ Copy</title>
     </head>
     <body>

--- a/wwwroot/admin/delete-player.php
+++ b/wwwroot/admin/delete-player.php
@@ -33,8 +33,8 @@ if ($confirmation !== null) {
     $onlineIdValue = $confirmation->getOnlineId() ?? '';
 }
 
-$encodedAccountIdValue = htmlspecialchars($accountIdValue, ENT_QUOTES, 'UTF-8');
-$encodedOnlineIdValue = htmlspecialchars($onlineIdValue, ENT_QUOTES, 'UTF-8');
+$encodedAccountIdValue = Html::escape($accountIdValue);
+$encodedOnlineIdValue = Html::escape($onlineIdValue);
 
 $confirmationOnlineId = $confirmation?->getOnlineId();
 $confirmationDisplayName = $confirmationOnlineId ?? $accountIdValue;
@@ -42,10 +42,10 @@ $confirmationUrl = $confirmationOnlineId !== null
     ? PlayerUrlBuilder::playerPath($confirmationOnlineId)
     : null;
 $confirmationAccountId = $confirmation?->getAccountId();
-$encodedConfirmationAccountId = $confirmationAccountId === null ? '' : htmlspecialchars($confirmationAccountId, ENT_QUOTES, 'UTF-8');
-$encodedConfirmationOnlineId = $confirmationOnlineId === null ? '' : htmlspecialchars($confirmationOnlineId, ENT_QUOTES, 'UTF-8');
-$encodedConfirmationUrl = $confirmationUrl === null ? null : htmlspecialchars($confirmationUrl, ENT_QUOTES, 'UTF-8');
-$encodedConfirmationDisplayName = htmlspecialchars($confirmationDisplayName, ENT_QUOTES, 'UTF-8');
+$encodedConfirmationAccountId = $confirmationAccountId === null ? '' : Html::escape($confirmationAccountId);
+$encodedConfirmationOnlineId = $confirmationOnlineId === null ? '' : Html::escape($confirmationOnlineId);
+$encodedConfirmationUrl = $confirmationUrl === null ? null : Html::escape($confirmationUrl);
+$encodedConfirmationDisplayName = Html::escape($confirmationDisplayName);
 
 ?>
 <!doctype html>
@@ -54,7 +54,7 @@ $encodedConfirmationDisplayName = htmlspecialchars($confirmationDisplayName, ENT
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ Delete Player</title>
     </head>
     <body>

--- a/wwwroot/admin/detail.php
+++ b/wwwroot/admin/detail.php
@@ -31,7 +31,7 @@ $requestedNpCommunicationId = (string) ($_GET['np_communication_id'] ?? '');
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ Game Details</title>
     </head>
     <body>

--- a/wwwroot/admin/index.php
+++ b/wwwroot/admin/index.php
@@ -14,7 +14,7 @@ $navigationItems = $navigation->getItems();
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin</title>
     </head>
     <body>
@@ -27,15 +27,15 @@ $navigationItems = $navigation->getItems();
                 <?php
                 $authenticatedUsername = AdminBootstrap::createAuthService()->getAuthenticatedUsername();
                 if ($authenticatedUsername !== null) {
-                    echo ' (' . htmlspecialchars($authenticatedUsername, ENT_QUOTES, 'UTF-8') . ')';
+                    echo ' (' . Html::escape($authenticatedUsername) . ')';
                 }
                 ?>
             </p>
             <ul>
                 <?php foreach ($navigationItems as $item) { ?>
                     <li>
-                        <a href="<?= htmlspecialchars($item->getHref(), ENT_QUOTES, 'UTF-8'); ?>">
-                            <?= htmlspecialchars($item->getLabel(), ENT_QUOTES, 'UTF-8'); ?>
+                        <a href="<?= Html::escape($item->getHref()); ?>">
+                            <?= Html::escape($item->getLabel()); ?>
                         </a>
                     </li>
                 <?php } ?>

--- a/wwwroot/admin/log.php
+++ b/wwwroot/admin/log.php
@@ -32,10 +32,10 @@ if ($pageResult->getTotalPages() > 1) {
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ Logs</title>
-        <script src="<?= htmlspecialchars(StaticAsset::url('/js/localized-date-formatter.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
-        <script src="<?= htmlspecialchars(StaticAsset::url('/js/admin-log-bulk-actions.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
+        <script src="<?= Html::escape(StaticAsset::url('/js/localized-date-formatter.js')); ?>" defer></script>
+        <script src="<?= Html::escape(StaticAsset::url('/js/admin-log-bulk-actions.js')); ?>" defer></script>
     </head>
     <body>
         <div class="container py-4">
@@ -45,13 +45,13 @@ if ($pageResult->getTotalPages() > 1) {
 
             <?php if ($pageResult->getSuccessMessage() !== null) { ?>
                 <div class="alert alert-success" role="alert">
-                    <?= htmlspecialchars($pageResult->getSuccessMessage(), ENT_QUOTES, 'UTF-8'); ?>
+                    <?= Html::escape($pageResult->getSuccessMessage()); ?>
                 </div>
             <?php } ?>
 
             <?php if ($pageResult->getErrorMessage() !== null) { ?>
                 <div class="alert alert-danger" role="alert">
-                    <?= htmlspecialchars($pageResult->getErrorMessage(), ENT_QUOTES, 'UTF-8'); ?>
+                    <?= Html::escape($pageResult->getErrorMessage()); ?>
                 </div>
             <?php } ?>
 
@@ -91,15 +91,15 @@ if ($pageResult->getTotalPages() > 1) {
                                                 type="checkbox"
                                                 class="form-check-input js-log-checkbox"
                                                 name="delete_ids[]"
-                                                value="<?= htmlspecialchars((string) $entry->getId(), ENT_QUOTES, 'UTF-8'); ?>"
-                                                aria-label="Select log entry #<?= htmlspecialchars((string) $entry->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                value="<?= Html::escape((string) $entry->getId()); ?>"
+                                                aria-label="Select log entry #<?= Html::escape((string) $entry->getId()); ?>"
                                             >
                                         </td>
-                                        <td class="text-nowrap">#<?= htmlspecialchars((string) $entry->getId(), ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td class="text-nowrap">#<?= Html::escape((string) $entry->getId()); ?></td>
                                         <td>
                                             <?php $time = $entry->getTime(); ?>
-                                            <time class="small text-body-secondary js-localized-datetime" datetime="<?= htmlspecialchars($time->format(DATE_ATOM), ENT_QUOTES, 'UTF-8'); ?>">
-                                                <?= htmlspecialchars($time->format('Y-m-d H:i:s'), ENT_QUOTES, 'UTF-8'); ?>
+                                            <time class="small text-body-secondary js-localized-datetime" datetime="<?= Html::escape($time->format(DATE_ATOM)); ?>">
+                                                <?= Html::escape($time->format('Y-m-d H:i:s')); ?>
                                             </time>
                                         </td>
                                         <td><?= $entry->getFormattedMessage(); ?></td>
@@ -107,7 +107,7 @@ if ($pageResult->getTotalPages() > 1) {
                                             <button
                                                 type="submit"
                                                 name="delete_id"
-                                                value="<?= htmlspecialchars((string) $entry->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                value="<?= Html::escape((string) $entry->getId()); ?>"
                                                 class="btn btn-sm btn-danger js-log-delete-button"
                                             >
                                                 Delete

--- a/wwwroot/admin/login.php
+++ b/wwwroot/admin/login.php
@@ -50,14 +50,14 @@ if (HttpMethod::fromServer($_SERVER)->isPost()) {
 }
 
 $isConfigured = $authService->isConfigured();
-$encodedErrorMessage = $errorMessage === null ? null : htmlspecialchars($errorMessage, ENT_QUOTES, 'UTF-8');
+$encodedErrorMessage = $errorMessage === null ? null : Html::escape($errorMessage);
 ?>
 <!doctype html>
 <html lang="en" data-bs-theme="dark">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin Login</title>
     </head>
     <body>

--- a/wwwroot/admin/merge.php
+++ b/wwwroot/admin/merge.php
@@ -25,10 +25,10 @@ $message = $requestHandler->handle($_POST ?? []);
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <?php AdminBootstrap::renderCsrfMetaTag(); ?>
         <title>Admin ~ Merge Games</title>
-        <script src="<?= htmlspecialchars(StaticAsset::url('/js/admin-merge-form.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
+        <script src="<?= Html::escape(StaticAsset::url('/js/admin-merge-form.js')); ?>" defer></script>
     </head>
     <body>
         <div class="p-4">

--- a/wwwroot/admin/possible.php
+++ b/wwwroot/admin/possible.php
@@ -15,24 +15,24 @@ $possibleCheaterReport = $possibleCheaterPage->getReport();
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ Possible Cheaters</title>
     </head>
     <body>
         <div class="p-4">
             <a href="/admin/">Back</a><br><br>
             <?php foreach ($possibleCheaterReport->getGeneralCheaters() as $possibleCheater): ?>
-                <a href="<?= htmlspecialchars($possibleCheater->getProfileUrl($utility), ENT_QUOTES, 'UTF-8'); ?>">
-                    <?= htmlspecialchars($possibleCheater->getPlayerName(), ENT_QUOTES, 'UTF-8'); ?> (<?= $possibleCheater->getAccountId(); ?>)
+                <a href="<?= Html::escape($possibleCheater->getProfileUrl($utility)); ?>">
+                    <?= Html::escape($possibleCheater->getPlayerName()); ?> (<?= $possibleCheater->getAccountId(); ?>)
                 </a><br>
             <?php endforeach; ?>
 
             <?php foreach ($possibleCheaterReport->getSections() as $section): ?>
                 <br>
-                <?= htmlspecialchars($section->getTitle(), ENT_QUOTES, 'UTF-8'); ?><br>
+                <?= Html::escape($section->getTitle()); ?><br>
                 <?php foreach ($section->getEntries() as $entry): ?>
-                    <a href="<?= htmlspecialchars($entry->getUrl(), ENT_QUOTES, 'UTF-8'); ?>">
-                        <?= htmlspecialchars($entry->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?> (<?= $entry->getAccountId(); ?>)
+                    <a href="<?= Html::escape($entry->getUrl()); ?>">
+                        <?= Html::escape($entry->getOnlineId()); ?> (<?= $entry->getAccountId(); ?>)
                     </a><br>
                 <?php endforeach; ?>
             <?php endforeach; ?>

--- a/wwwroot/admin/psn-game-lookup.php
+++ b/wwwroot/admin/psn-game-lookup.php
@@ -20,7 +20,7 @@ $errorMessage = $handledRequest->getErrorMessage();
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ PSN Game Lookup</title>
     </head>
     <body>

--- a/wwwroot/admin/psn-player-lookup.php
+++ b/wwwroot/admin/psn-player-lookup.php
@@ -37,7 +37,7 @@ if (is_array($earnedTrophies)) {
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ PSN Player Lookup</title>
     </head>
     <body>

--- a/wwwroot/admin/psn-trophy-title-compare.php
+++ b/wwwroot/admin/psn-trophy-title-compare.php
@@ -25,7 +25,7 @@ $errorMessage = $handledRequest->getErrorMessage();
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ Trophy Title Compare</title>
     </head>
     <body>

--- a/wwwroot/admin/psnp-plus.php
+++ b/wwwroot/admin/psnp-plus.php
@@ -38,7 +38,7 @@ try {
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ PSNP+</title>
     </head>
     <body>

--- a/wwwroot/admin/report.php
+++ b/wwwroot/admin/report.php
@@ -20,9 +20,9 @@ $errorMessage = $pageResult->getErrorMessage();
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ Reported Players</title>
-        <script src="<?= htmlspecialchars(StaticAsset::url('/js/admin-report-delete.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
+        <script src="<?= Html::escape(StaticAsset::url('/js/admin-report-delete.js')); ?>" defer></script>
     </head>
     <body>
         <div class="p-4">

--- a/wwwroot/admin/rescan.php
+++ b/wwwroot/admin/rescan.php
@@ -12,11 +12,11 @@ require_once '../classes/StaticAsset.php';
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <?php AdminBootstrap::renderCsrfMetaTag(); ?>
         <title>Admin ~ Rescan Game</title>
-        <link rel="stylesheet" href="<?= htmlspecialchars(StaticAsset::url('/css/admin-rescan.css'), ENT_QUOTES, 'UTF-8'); ?>">
-        <script src="<?= htmlspecialchars(StaticAsset::url('/js/admin-rescan-form.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
+        <link rel="stylesheet" href="<?= Html::escape(StaticAsset::url('/css/admin-rescan.css')); ?>">
+        <script src="<?= Html::escape(StaticAsset::url('/js/admin-rescan-form.js')); ?>" defer></script>
     </head>
     <body>
         <div class="container py-4">

--- a/wwwroot/admin/reset.php
+++ b/wwwroot/admin/reset.php
@@ -21,7 +21,7 @@ $error = $result->getErrorMessage();
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ Reset / Delete</title>
     </head>
     <body>

--- a/wwwroot/admin/unobtainable.php
+++ b/wwwroot/admin/unobtainable.php
@@ -37,7 +37,7 @@ $status = TrophyMetaStatus::fromMixed($statusInput);
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ Unobtainable Trophy</title>
     </head>
     <body>
@@ -48,7 +48,7 @@ $status = TrophyMetaStatus::fromMixed($statusInput);
                 Game ID:<br>
                 <input type="text" name="game" /><br>
                 Trophy ID:<br>
-                <textarea name="trophy" rows="10" cols="30"><?= htmlspecialchars(str_replace(",", PHP_EOL, $trophyInput), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></textarea>
+                <textarea name="trophy" rows="10" cols="30"><?= Html::escape(str_replace(",", PHP_EOL, $trophyInput)); ?></textarea>
                 <br>
                 Status:<br>
                 <select name="status">

--- a/wwwroot/admin/workers.php
+++ b/wwwroot/admin/workers.php
@@ -35,10 +35,10 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta name="csrf-token" content="<?= Html::escape(AdminBootstrap::getCsrfToken()); ?>">
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
         <title>Admin ~ Workers</title>
-        <script src="<?= htmlspecialchars(StaticAsset::url('/js/localized-date-formatter.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
-        <script src="<?= htmlspecialchars(StaticAsset::url('/js/admin-worker-credentials.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
+        <script src="<?= Html::escape(StaticAsset::url('/js/localized-date-formatter.js')); ?>" defer></script>
+        <script src="<?= Html::escape(StaticAsset::url('/js/admin-worker-credentials.js')); ?>" defer></script>
     </head>
     <body>
         <div class="container py-4">
@@ -58,13 +58,13 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
 
             <?php if ($successMessage !== null) { ?>
                 <div class="alert alert-success" role="alert">
-                    <?= htmlspecialchars($successMessage, ENT_QUOTES, 'UTF-8'); ?>
+                    <?= Html::escape($successMessage); ?>
                 </div>
             <?php } ?>
 
             <?php if ($errorMessage !== null) { ?>
                 <div class="alert alert-danger" role="alert">
-                    <?= htmlspecialchars($errorMessage, ENT_QUOTES, 'UTF-8'); ?>
+                    <?= Html::escape($errorMessage); ?>
                 </div>
             <?php } ?>
 
@@ -76,7 +76,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                         <thead>
                             <tr>
                                 <th scope="col" style="width: 4rem;">
-                                    <a class="text-decoration-none text-reset" href="<?= htmlspecialchars($idSortUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                                    <a class="text-decoration-none text-reset" href="<?= Html::escape($idSortUrl); ?>">
                                         ID
                                         <?php if ($idSortIndicator !== '') { ?>
                                             <span class="ms-1"><?= $idSortIndicator |> trim(...) |> Html::escape(...); ?></span>
@@ -86,7 +86,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                 <th scope="col" style="width: 24rem;">Credentials</th>
                                 <th scope="col" style="width: 16rem;">Scanning</th>
                                 <th scope="col" style="width: 16rem;">
-                                    <a class="text-decoration-none text-reset" href="<?= htmlspecialchars($scanStartSortUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                                    <a class="text-decoration-none text-reset" href="<?= Html::escape($scanStartSortUrl); ?>">
                                         Scan Start
                                         <?php if ($scanStartSortIndicator !== '') { ?>
                                             <span class="ms-1"><?= $scanStartSortIndicator |> trim(...) |> Html::escape(...); ?></span>
@@ -102,24 +102,24 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                 <?php
                                 $scanStart = $worker->getScanStart();
                                 $scanning = $worker->getScanning();
-                                $scanningDisplay = htmlspecialchars($scanning, ENT_QUOTES, 'UTF-8');
+                                $scanningDisplay = Html::escape($scanning);
                                 $scanningLink = $scanning !== '' ? '/player/' . rawurlencode($scanning) : null;
                                 $scanProgress = $worker->getScanProgress();
                                 ?>
                                 <tr>
-                                    <td class="text-nowrap">#<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?></td>
+                                    <td class="text-nowrap">#<?= Html::escape((string) $worker->getId()); ?></td>
                                     <td>
                                         <div class="vstack gap-2">
                                             <form method="post" class="d-flex gap-2 align-items-center" autocomplete="off">
                                                 <?php AdminBootstrap::renderCsrfField(); ?>
                                                 <input type="hidden" name="action" value="<?= Html::escape(WorkerAction::UpdateRefreshToken->value); ?>">
-                                                <input type="hidden" name="worker_id" value="<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
-                                                <label class="form-label small text-body-secondary mb-0 text-nowrap" for="refresh-token-<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
+                                                <input type="hidden" name="worker_id" value="<?= Html::escape((string) $worker->getId()); ?>">
+                                                <label class="form-label small text-body-secondary mb-0 text-nowrap" for="refresh-token-<?= Html::escape((string) $worker->getId()); ?>">
                                                     Refresh Token
                                                 </label>
                                                 <div class="d-flex gap-2 flex-grow-1" data-worker-credential-field>
                                                     <input
-                                                        id="refresh-token-<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                        id="refresh-token-<?= Html::escape((string) $worker->getId()); ?>"
                                                         type="password"
                                                         name="refresh_token"
                                                         class="form-control form-control-sm"
@@ -128,7 +128,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                                         autocomplete="off"
                                                         data-worker-credential-input
                                                         data-worker-credential="refresh_token"
-                                                        data-worker-id="<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                        data-worker-id="<?= Html::escape((string) $worker->getId()); ?>"
                                                     >
                                                     <button
                                                         type="button"
@@ -144,13 +144,13 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                             <form method="post" class="d-flex gap-2 align-items-center" autocomplete="off">
                                                 <?php AdminBootstrap::renderCsrfField(); ?>
                                                 <input type="hidden" name="action" value="<?= Html::escape(WorkerAction::UpdateNpsso->value); ?>">
-                                                <input type="hidden" name="worker_id" value="<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
-                                                <label class="form-label small text-body-secondary mb-0 text-nowrap" for="npsso-<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
+                                                <input type="hidden" name="worker_id" value="<?= Html::escape((string) $worker->getId()); ?>">
+                                                <label class="form-label small text-body-secondary mb-0 text-nowrap" for="npsso-<?= Html::escape((string) $worker->getId()); ?>">
                                                     NPSSO
                                                 </label>
                                                 <div class="d-flex gap-2 flex-grow-1" data-worker-credential-field>
                                                     <input
-                                                        id="npsso-<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                        id="npsso-<?= Html::escape((string) $worker->getId()); ?>"
                                                         type="password"
                                                         name="npsso"
                                                         class="form-control form-control-sm"
@@ -159,7 +159,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                                         autocomplete="off"
                                                         data-worker-credential-input
                                                         data-worker-credential="npsso"
-                                                        data-worker-id="<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                        data-worker-id="<?= Html::escape((string) $worker->getId()); ?>"
                                                     >
                                                     <button
                                                         type="button"
@@ -176,7 +176,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                     </td>
                                     <td class="text-nowrap">
                                         <?php if ($scanningLink !== null) { ?>
-                                            <a href="<?= htmlspecialchars($scanningLink, ENT_QUOTES, 'UTF-8'); ?>">
+                                            <a href="<?= Html::escape($scanningLink); ?>">
                                                 <?= $scanningDisplay; ?>
                                             </a>
                                         <?php } else { ?>
@@ -186,9 +186,9 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                     <td class="text-nowrap">
                                         <time
                                             class="js-localized-datetime"
-                                            datetime="<?= htmlspecialchars($scanStart->format(DATE_ATOM), ENT_QUOTES, 'UTF-8'); ?>"
+                                            datetime="<?= Html::escape($scanStart->format(DATE_ATOM)); ?>"
                                         >
-                                            <?= htmlspecialchars($scanStart->format('Y-m-d H:i:s'), ENT_QUOTES, 'UTF-8'); ?>
+                                            <?= Html::escape($scanStart->format('Y-m-d H:i:s')); ?>
                                         </time>
                                     </td>
                                     <td>
@@ -202,7 +202,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                                 <?php if ($title !== null) { ?>
                                                     <div>
                                                         <strong>Title:</strong>
-                                                        <?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?>
+                                                        <?= Html::escape($title); ?>
                                                     </div>
                                                 <?php } ?>
                                                 <?php
@@ -212,9 +212,9 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                                 <?php if ($progressSummary !== null) { ?>
                                                     <div>
                                                         <strong>Progress:</strong>
-                                                        <?= htmlspecialchars($progressSummary, ENT_QUOTES, 'UTF-8'); ?>
+                                                        <?= Html::escape($progressSummary); ?>
                                                         <?php if ($percentage !== null) { ?>
-                                                            (<?= htmlspecialchars(number_format($percentage, 1), ENT_QUOTES, 'UTF-8'); ?>%)
+                                                            (<?= Html::escape(number_format($percentage, 1)); ?>%)
                                                         <?php } ?>
                                                     </div>
                                                 <?php } ?>
@@ -222,7 +222,7 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                                 <?php if ($npCommunicationId !== null) { ?>
                                                     <div>
                                                         <strong>NP Communication ID:</strong>
-                                                        <?= htmlspecialchars($npCommunicationId, ENT_QUOTES, 'UTF-8'); ?>
+                                                        <?= Html::escape($npCommunicationId); ?>
                                                     </div>
                                                 <?php } ?>
                                             </div>
@@ -231,11 +231,11 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                     <td>
                                         <form
                                             method="post"
-                                            onsubmit="return confirm('Restart worker #<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>?');"
+                                            onsubmit="return confirm('Restart worker #<?= Html::escape((string) $worker->getId()); ?>?');"
                                         >
                                             <?php AdminBootstrap::renderCsrfField(); ?>
                                             <input type="hidden" name="action" value="<?= Html::escape(WorkerAction::RestartWorker->value); ?>">
-                                            <input type="hidden" name="worker_id" value="<?= htmlspecialchars((string) $worker->getId(), ENT_QUOTES, 'UTF-8'); ?>">
+                                            <input type="hidden" name="worker_id" value="<?= Html::escape((string) $worker->getId()); ?>">
                                             <button type="submit" class="btn btn-sm btn-outline-warning">
                                                 Restart
                                             </button>

--- a/wwwroot/avatars.php
+++ b/wwwroot/avatars.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once 'classes/AvatarService.php';
 require_once 'classes/AvatarPage.php';
 
@@ -25,8 +27,8 @@ require_once("header.php");
             ?>
             <div class="col">
                 <div class="bg-body-tertiary p-3 rounded mb-3 text-center vstack gap-1">
-                    <a href="/leaderboard/trophy?avatar=<?= htmlspecialchars($avatar->getUrl(), ENT_QUOTES, 'UTF-8'); ?>">
-                        <img src="/img/avatar/<?= htmlspecialchars($avatar->getUrl(), ENT_QUOTES, 'UTF-8'); ?>" class="mx-auto" alt="" width="100" />
+                    <a href="/leaderboard/trophy?avatar=<?= Html::escape($avatar->getUrl()); ?>">
+                        <img src="/img/avatar/<?= Html::escape($avatar->getUrl()); ?>" class="mx-auto" alt="" width="100" />
                     </a>
                     <?= $avatar->getCount(); ?> <?= $avatar->getPlayerLabel(); ?>
                 </div>

--- a/wwwroot/changelog.php
+++ b/wwwroot/changelog.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once 'classes/ChangelogPage.php';
 
 $changelogPage = ChangelogPage::create($database, $utility, $_GET ?? []);
@@ -28,7 +30,7 @@ require_once("header.php");
                             <?php $firstEntry = array_first($entries); ?>
                             <time
                                 class="js-localized-changelog-date"
-                                datetime="<?= htmlspecialchars($firstEntry->getIsoTimestamp(), ENT_QUOTES, 'UTF-8'); ?>"
+                                datetime="<?= Html::escape($firstEntry->getIsoTimestamp()); ?>"
                             >
                                 <?= $dateGroup->getDateLabel(); ?>
                             </time>
@@ -42,7 +44,7 @@ require_once("header.php");
                     <div class="col-4 col-sm-2 col-md-1 text-nowrap small text-body-secondary">
                         <time
                             class="js-localized-changelog-time"
-                            datetime="<?= htmlspecialchars($presenter->getIsoTimestamp(), ENT_QUOTES, 'UTF-8'); ?>"
+                            datetime="<?= Html::escape($presenter->getIsoTimestamp()); ?>"
                         >
                             <?= $presenter->getTimeLabel(); ?>
                         </time>

--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../ChangelogEntry.php';
 require_once __DIR__ . '/../TrophyRarityName.php';
+require_once __DIR__ . '/../MergeNpCommunicationId.php';
 require_once __DIR__ . '/MergeTrophyCopier.php';
 require_once __DIR__ . '/MergeTrophyGroupCopier.php';
 require_once __DIR__ . '/TrophyGroupConflictResolver.php';
@@ -198,14 +199,14 @@ class GameCopyService
 
     private function ensureChildIsNotMergeTitle(string $childNpCommunicationId): void
     {
-        if (str_starts_with($childNpCommunicationId, 'MERGE')) {
+        if (MergeNpCommunicationId::matches($childNpCommunicationId)) {
             throw new RuntimeException("Child can't be a merge title.");
         }
     }
 
     private function ensureParentIsMergeTitle(string $parentNpCommunicationId): void
     {
-        if (!str_starts_with($parentNpCommunicationId, 'MERGE')) {
+        if (!MergeNpCommunicationId::matches($parentNpCommunicationId)) {
             throw new RuntimeException('Parent must be a merge title.');
         }
     }

--- a/wwwroot/classes/Admin/LogEntryFormatter.php
+++ b/wwwroot/classes/Admin/LogEntryFormatter.php
@@ -24,6 +24,7 @@ final class LogEntryFormatter
     ) {
     }
 
+    #[\NoDiscard]
     public function format(string $message): string
     {
         return [

--- a/wwwroot/classes/AutomaticTrophyTitleMergeService.php
+++ b/wwwroot/classes/AutomaticTrophyTitleMergeService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
+require_once __DIR__ . '/MergeNpCommunicationId.php';
 require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/TrophyMergeMethod.php';
 require_once __DIR__ . '/TrophyMergeService.php';
@@ -12,23 +13,14 @@ require_once __DIR__ . '/Cron/PlayerScanNewTitleMergeHandler.php';
 
 final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeHandler
 {
-    private readonly PDO $database;
-
-    private readonly TrophyMergeService $trophyMergeService;
-
-    private readonly TrophySetComparator $trophySetComparator;
-
     /** @var array<string, list<array{group_id:string, order_id:int, name:string, detail:string}>> */
     private array $trophyCache = [];
 
     public function __construct(
-        PDO $database,
-        TrophyMergeService $trophyMergeService,
-        ?TrophySetComparator $trophySetComparator = null,
+        private readonly PDO $database,
+        private readonly TrophyMergeService $trophyMergeService,
+        private readonly TrophySetComparator $trophySetComparator = new TrophySetComparator(),
     ) {
-        $this->database = $database;
-        $this->trophyMergeService = $trophyMergeService;
-        $this->trophySetComparator = $trophySetComparator ?? new TrophySetComparator();
     }
 
     /**
@@ -229,7 +221,7 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
                 'np_communication_id' => $npCommunicationId,
                 'platform' => $platform,
                 'platforms' => $this->parsePlatforms($platform),
-                'is_clone' => str_starts_with($npCommunicationId, 'MERGE'),
+                'is_clone' => MergeNpCommunicationId::matches($npCommunicationId),
                 'matches_by_order' => $comparison['orderMatches'],
                 'status' => (int) ($row['status'] ?? 0),
             ];
@@ -265,7 +257,7 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
         ];
 
         foreach ($matches as $match) {
-            if (str_starts_with($match['np_communication_id'], 'MERGE')) {
+            if (MergeNpCommunicationId::matches($match['np_communication_id'])) {
                 continue;
             }
 
@@ -292,7 +284,7 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
      */
     private function selectGameToClone(array $games): ?array
     {
-        $isEligible = static fn (array $game): bool => !str_starts_with($game['np_communication_id'], 'MERGE')
+        $isEligible = static fn (array $game): bool => !MergeNpCommunicationId::matches($game['np_communication_id'])
             && $game['status'] !== GameAvailabilityStatus::MERGED->value;
 
         return array_find(

--- a/wwwroot/classes/Cron/CronJobCliArguments.php
+++ b/wwwroot/classes/Cron/CronJobCliArguments.php
@@ -20,7 +20,10 @@ final readonly class CronJobCliArguments
         $arguments = [];
 
         if (count($argv) > 1) {
-            parse_str(implode('&', array_slice($argv, 1)), $arguments);
+            parse_str(
+                array_slice($argv, 1) |> (fn (array $args): string => implode('&', $args)),
+                $arguments
+            );
 
             if (!is_array($arguments)) {
                 $arguments = [];

--- a/wwwroot/classes/FooterRenderer.php
+++ b/wwwroot/classes/FooterRenderer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/FooterViewModel.php';
 require_once __DIR__ . '/Html.php';
 
-final class FooterRenderer
+final readonly class FooterRenderer
 {
     public function render(FooterViewModel $viewModel): string
     {

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/Game/GameHeaderData.php';
 require_once __DIR__ . '/Game/GameHeaderParent.php';
 require_once __DIR__ . '/Game/GameHeaderStack.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
+require_once __DIR__ . '/MergeNpCommunicationId.php';
 require_once __DIR__ . '/PsnpPlusClient.php';
 require_once __DIR__ . '/Html.php';
 require_once __DIR__ . '/TrophyMetaStatus.php';
@@ -32,7 +33,7 @@ class GameHeaderService
         }
 
         $stacks = [];
-        if ($npCommunicationId !== '' && str_starts_with($npCommunicationId, 'MERGE')) {
+        if ($npCommunicationId !== '' && MergeNpCommunicationId::matches($npCommunicationId)) {
             $stacks = $this->fetchStacks($npCommunicationId);
         }
 
@@ -200,7 +201,7 @@ class GameHeaderService
         }
 
         $npCommunicationId = $game->getNpCommunicationId();
-        if ($npCommunicationId !== '' && str_starts_with($npCommunicationId, 'MERGE')) {
+        if ($npCommunicationId !== '' && MergeNpCommunicationId::matches($npCommunicationId)) {
             $childPsnprofilesIds = $this->findChildPsnprofilesIds($npCommunicationId);
             foreach ($childPsnprofilesIds as $childPsnprofilesId) {
                 $note = $this->getPsnpPlusNote($childPsnprofilesId);

--- a/wwwroot/classes/GameResetService.php
+++ b/wwwroot/classes/GameResetService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/GameResetAction.php';
+require_once __DIR__ . '/MergeNpCommunicationId.php';
 
 final readonly class GameResetService
 {
@@ -18,7 +19,7 @@ final readonly class GameResetService
             throw new InvalidArgumentException('Can only reset/delete merged game entries.');
         }
 
-        if (!str_starts_with($npCommunicationId, 'MERGE')) {
+        if (!MergeNpCommunicationId::matches($npCommunicationId)) {
             throw new InvalidArgumentException('Can only reset/delete merged game entries.');
         }
 

--- a/wwwroot/classes/ImageHashCalculator.php
+++ b/wwwroot/classes/ImageHashCalculator.php
@@ -9,11 +9,9 @@ final class ImageHashCalculator
     private const int GD_ALPHA_MAX = 127;
     private const int RGBA_CHANNEL_MAX = 255;
 
-    private ImageProcessorInterface $imageProcessor;
-
-    public function __construct(?ImageProcessorInterface $imageProcessor = null)
-    {
-        $this->imageProcessor = $imageProcessor ?? new GdImageProcessor();
+    public function __construct(
+        private ImageProcessorInterface $imageProcessor = new GdImageProcessor(),
+    ) {
     }
 
     /**

--- a/wwwroot/classes/MergeNpCommunicationId.php
+++ b/wwwroot/classes/MergeNpCommunicationId.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Helpers for synthetic MERGE_* NP communication IDs used by cloned/merged titles.
+ */
+final readonly class MergeNpCommunicationId
+{
+    public const string PREFIX = 'MERGE';
+
+    #[\NoDiscard]
+    public static function matches(string $npCommunicationId): bool
+    {
+        return str_starts_with($npCommunicationId, self::PREFIX);
+    }
+
+    #[\NoDiscard]
+    public static function forGameId(int $gameId): string
+    {
+        return self::PREFIX . '_' . str_pad((string) $gameId, 6, '0', STR_PAD_LEFT);
+    }
+}

--- a/wwwroot/classes/Platform.php
+++ b/wwwroot/classes/Platform.php
@@ -71,13 +71,10 @@ enum Platform: string
      */
     public static function labelsByValue(): array
     {
-        $labels = [];
-
-        foreach (self::cases() as $platform) {
-            $labels[$platform->value] = $platform->label();
-        }
-
-        return $labels;
+        return array_combine(
+            array_column(self::cases(), 'value'),
+            array_map(static fn (self $platform): string => $platform->label(), self::cases()),
+        );
     }
 
     /**

--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -70,6 +70,12 @@ final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
         return $parameters;
     }
 
+    #[\NoDiscard]
+    public function withPageNumber(int $page): self
+    {
+        return clone($this, ['page' => max($page, 1)]);
+    }
+
     private static function normalizePage(mixed $value): int
     {
         if ($value === null || is_array($value) || !is_numeric($value)) {

--- a/wwwroot/classes/PlayerLeaderboardPage.php
+++ b/wwwroot/classes/PlayerLeaderboardPage.php
@@ -189,10 +189,6 @@ final readonly class PlayerLeaderboardPage
             return $this->requestedFilter;
         }
 
-        return new PlayerLeaderboardFilter(
-            $this->requestedFilter->getCountry(),
-            $this->requestedFilter->getAvatar(),
-            $page
-        );
+        return $this->requestedFilter->withPageNumber($page);
     }
 }

--- a/wwwroot/classes/TrophyMergePlayerProgressUpdater.php
+++ b/wwwroot/classes/TrophyMergePlayerProgressUpdater.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/TrophyMergeRelationshipResolver.php';
 require_once __DIR__ . '/TrophyMergePlayerProgressRecalculator.php';
+require_once __DIR__ . '/MergeNpCommunicationId.php';
 
 /**
  * Orchestrates player progress updates for merged trophy titles.
@@ -49,7 +50,7 @@ final class TrophyMergePlayerProgressUpdater
 
     public function recomputeByParent(string $parentNpCommunicationId): void
     {
-        if (!str_starts_with($parentNpCommunicationId, 'MERGE')) {
+        if (!MergeNpCommunicationId::matches($parentNpCommunicationId)) {
             throw new InvalidArgumentException('Parent must be a merge title.');
         }
 

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/Admin/GameCopyService.php';
 require_once __DIR__ . '/Admin/TrophyMergeProgressListener.php';
+require_once __DIR__ . '/MergeNpCommunicationId.php';
 require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
 require_once __DIR__ . '/TrophyMergeEarnedCopier.php';
 require_once __DIR__ . '/TrophyMergeMappingService.php';
@@ -43,7 +44,7 @@ class TrophyMergeService
 
         $parentTrophy = $this->getTrophyById($parentTrophyId);
 
-        if (!str_starts_with($parentTrophy['np_communication_id'], 'MERGE')) {
+        if (!MergeNpCommunicationId::matches($parentTrophy['np_communication_id'])) {
             throw new InvalidArgumentException('Parent must be a merge title.');
         }
 
@@ -53,7 +54,7 @@ class TrophyMergeService
             $childTrophyId = (int) $childTrophyId;
             $childTrophy = $this->getTrophyById($childTrophyId);
 
-            if (str_starts_with($childTrophy['np_communication_id'], 'MERGE')) {
+            if (MergeNpCommunicationId::matches($childTrophy['np_communication_id'])) {
                 throw new InvalidArgumentException("Child can't be a merge title.");
             }
 
@@ -100,13 +101,13 @@ class TrophyMergeService
         $method = TrophyMergeMethod::fromMixed($method);
         $childNpCommunicationId = $this->getGameNpCommunicationId($childGameId);
 
-        if (str_starts_with($childNpCommunicationId, 'MERGE')) {
+        if (MergeNpCommunicationId::matches($childNpCommunicationId)) {
             throw new InvalidArgumentException("Child can't be a merge title.");
         }
 
         $parentNpCommunicationId = $this->getGameNpCommunicationId($parentGameId);
 
-        if (!str_starts_with($parentNpCommunicationId, 'MERGE')) {
+        if (!MergeNpCommunicationId::matches($parentNpCommunicationId)) {
             throw new InvalidArgumentException('Parent must be a merge title.');
         }
 

--- a/wwwroot/classes/TrophyTitleCloneService.php
+++ b/wwwroot/classes/TrophyTitleCloneService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/NestedDatabaseTransactionRunner.php';
 require_once __DIR__ . '/ChangelogEntry.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
+require_once __DIR__ . '/MergeNpCommunicationId.php';
 
 /**
  * Clones a trophy title into a new MERGE_* title, including catalog rows and history.
@@ -26,7 +27,7 @@ final class TrophyTitleCloneService
     {
         $childNpCommunicationId = $this->getGameNpCommunicationId($childGameId);
 
-        if (str_starts_with($childNpCommunicationId, 'MERGE')) {
+        if (MergeNpCommunicationId::matches($childNpCommunicationId)) {
             throw new InvalidArgumentException("Can't clone an already cloned game.");
         }
 
@@ -50,7 +51,7 @@ SQL
 
         $gameId = (int) $gameId;
 
-        $cloneNpCommunicationId = 'MERGE_' . str_pad((string) $gameId, 6, '0', STR_PAD_LEFT);
+        $cloneNpCommunicationId = MergeNpCommunicationId::forGameId($gameId);
 
         $cloneGameId = null;
 

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  */
 final readonly class TrophyTitleNameFormatter
 {
+    #[\NoDiscard]
     public function format(string $name): string
     {
         return $name
@@ -16,6 +17,7 @@ final readonly class TrophyTitleNameFormatter
             |> $this->toApaTitleCase(...);
     }
 
+    #[\NoDiscard]
     public function sanitize(string $name): string
     {
         $name = trim($name);

--- a/wwwroot/classes/TrophyType.php
+++ b/wwwroot/classes/TrophyType.php
@@ -44,11 +44,11 @@ enum TrophyType: string
      */
     public static function sqlFieldOrder(string $columnExpression): string
     {
-        $quotedValues = array_map(
-            static fn (self $type): string => "'" . $type->value . "'",
-            self::cases()
-        );
-
-        return 'FIELD(' . $columnExpression . ', ' . implode(', ', $quotedValues) . ')';
+        return self::cases()
+            |> (fn (array $types): array => array_map(
+                static fn (self $type): string => "'" . $type->value . "'",
+                $types,
+            ))
+            |> (fn (array $quotedValues): string => 'FIELD(' . $columnExpression . ', ' . implode(', ', $quotedValues) . ')');
     }
 }

--- a/wwwroot/footer.php
+++ b/wwwroot/footer.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/FooterViewModel.php';
 require_once __DIR__ . '/classes/FooterRenderer.php';
 require_once __DIR__ . '/classes/BootstrapAssets.php';
@@ -13,7 +15,7 @@ echo $footerRenderer->render($footerViewModel);
 ?>
         
         <!-- Popper.js, then Bootstrap JS -->
-        <script src="<?= htmlspecialchars(BootstrapAssets::popperScriptUrl(), ENT_QUOTES, 'UTF-8'); ?>"></script>
-        <script src="<?= htmlspecialchars(BootstrapAssets::scriptUrl(), ENT_QUOTES, 'UTF-8'); ?>"></script>
+        <script src="<?= Html::escape(BootstrapAssets::popperScriptUrl()); ?>"></script>
+        <script src="<?= Html::escape(BootstrapAssets::scriptUrl()); ?>"></script>
     </body>
 </html>

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -61,10 +61,10 @@ require_once("header.php");
 
             <div class="col-12 col-lg-6 mb-3 text-center">
                 <div class="btn-group">
-                    <a class="btn btn-primary active" href="/game/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Trophies</a>
-                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Leaderboard</a>
-                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Recent Players</a>
-                    <a class="btn btn-outline-primary" href="/game-history/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">History</a>
+                    <a class="btn btn-primary active" href="/game/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">Trophies</a>
+                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">Leaderboard</a>
+                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">Recent Players</a>
+                    <a class="btn btn-outline-primary" href="/game-history/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">History</a>
                 </div>
             </div>
 
@@ -122,13 +122,13 @@ require_once("header.php");
                     }
                     ?>
                     <div class="table-responsive-xxl">
-                        <table class="table" id="<?= htmlspecialchars($trophyGroupId, ENT_QUOTES, 'UTF-8'); ?>">
+                        <table class="table" id="<?= Html::escape($trophyGroupId); ?>">
                             <thead>
                                 <tr>
                                     <th scope="col" colspan="5" class="bg-dark-subtle">
                                         <div class="hstack gap-3">
                                             <div>
-                                                <img class="card-img object-fit-cover" style="height: 7rem;" src="/img/group/<?= htmlspecialchars($trophyGroup->getIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($trophyGroup->getName()); ?>">
+                                                <img class="card-img object-fit-cover" style="height: 7rem;" src="/img/group/<?= Html::escape($trophyGroup->getIconPath()); ?>" alt="<?= Html::escape($trophyGroup->getName()); ?>">
                                             </div>
                                             
                                             <div>
@@ -230,7 +230,7 @@ require_once("header.php");
                                                 <img
                                                     class="card-img object-fit-scale"
                                                     style="height: 5rem;"
-                                                    src="/img/trophy/<?= htmlspecialchars($trophyRow->getIconPath(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                    src="/img/trophy/<?= Html::escape($trophyRow->getIconPath()); ?>"
                                                     alt="<?= Html::escape($trophyRow->getName()); ?>"
                                                 >
                                             </div>
@@ -241,7 +241,7 @@ require_once("header.php");
                                                 <span>
                                                     <a
                                                         class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover"
-                                                        href="<?= htmlspecialchars($trophyLink, ENT_QUOTES, 'UTF-8'); ?>"
+                                                        href="<?= Html::escape($trophyLink); ?>"
                                                     >
                                                         <b><?= Html::escape($trophyRow->getName()); ?></b>
                                                     </a>
@@ -250,12 +250,12 @@ require_once("header.php");
                                                 <?php
                                                 $progressDisplay = $trophyRow->getProgressDisplay();
                                                 if ($progressDisplay !== null) {
-                                                    echo '<span>' . htmlspecialchars($progressDisplay, ENT_QUOTES, 'UTF-8') . '</span>';
+                                                    echo '<span>' . Html::escape($progressDisplay) . '</span>';
                                                 }
 
                                                 if ($trophyRow->hasReward()) {
-                                                    $rewardName = htmlspecialchars((string) $trophyRow->getRewardName(), ENT_QUOTES, 'UTF-8');
-                                                    $rewardImageUrl = htmlspecialchars((string) $trophyRow->getRewardImageUrl(), ENT_QUOTES, 'UTF-8');
+                                                    $rewardName = Html::escape((string) $trophyRow->getRewardName());
+                                                    $rewardImageUrl = Html::escape((string) $trophyRow->getRewardImageUrl());
                                                     echo "<span>Reward: <a class='link-underline link-underline-opacity-0 link-underline-opacity-100-hover' href='/img/reward/{$rewardImageUrl}'>"
                                                         . $rewardName
                                                         . '</a></span>';
@@ -264,7 +264,7 @@ require_once("header.php");
                                             </div>
                                         </td>
 
-                                        <td class="w-auto text-center align-middle<?= $earnedCellClass !== '' ? ' ' . $earnedCellClass : ''; ?>"<?= $earnedCellStyle !== '' ? ' style="' . htmlspecialchars($earnedCellStyle, ENT_QUOTES, 'UTF-8') . '"' : ''; ?>>
+                                        <td class="w-auto text-center align-middle<?= $earnedCellClass !== '' ? ' ' . $earnedCellClass : ''; ?>"<?= $earnedCellStyle !== '' ? ' style="' . Html::escape($earnedCellStyle) . '"' : ''; ?>>
                                             <?php
                                             if ($accountId !== null && $trophyRow->isEarned()) {
                                                 $earnedElementId = $trophyRow->getEarnedElementId();
@@ -273,7 +273,7 @@ require_once("header.php");
                                                     class="js-localized-date"
                                                     style="text-wrap: nowrap;"
                                                     <?php if ($trophyRow->hasRecordedEarnedDate()) { ?>
-                                                    data-timestamp="<?= htmlspecialchars($trophyRow->getEarnedDate(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                    data-timestamp="<?= Html::escape($trophyRow->getEarnedDate()); ?>"
                                                     data-line-break="1"
                                                     <?php } elseif ($trophyRow->shouldDisplayNoTimestampMessage()) { ?>
                                                     data-fallback="No Timestamp"

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/classes/GameMessageSanitizer.php';
 /** @var GamePlayerProgress|null $gamePlayer */
 
 $encodedPlayer = isset($player) ? rawurlencode((string) $player) : null;
-$escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES, 'UTF-8') : null;
+$escapedPlayer = isset($player) ? Html::escape((string) $player) : null;
 ?>
 <div class="row">
     <?php
@@ -141,7 +141,7 @@ $escapedPlayer = isset($player) ? htmlspecialchars((string) $player, ENT_QUOTES,
                     : '../missing-ps4-game.png')
                 : $gameIconUrl;
             ?>
-            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= htmlspecialchars($iconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($game->getName()); ?>">
+            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= Html::escape($iconPath); ?>" alt="<?= Html::escape($game->getName()); ?>">
         </div>
 
         <div class="col-12 col-lg-6">

--- a/wwwroot/game_history.php
+++ b/wwwroot/game_history.php
@@ -95,10 +95,10 @@ require_once 'header.php';
 
             <div class="col-12 col-lg-6 mb-3 text-center">
                 <div class="btn-group">
-                    <a class="btn btn-outline-primary" href="/game/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Trophies</a>
-                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Leaderboard</a>
-                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Recent Players</a>
-                    <a class="btn btn-primary active" href="/game-history/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">History</a>
+                    <a class="btn btn-outline-primary" href="/game/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">Trophies</a>
+                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">Leaderboard</a>
+                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">Recent Players</a>
+                    <a class="btn btn-primary active" href="/game-history/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">History</a>
                 </div>
             </div>
 
@@ -132,7 +132,7 @@ require_once 'header.php';
                                 </span>
                             </div>
                             <?php $discoveredAt = $entry['discoveredAt']; ?>
-                            <time class="text-body-secondary small js-localized-datetime" datetime="<?= htmlspecialchars($discoveredAt->format(DATE_ATOM), ENT_QUOTES, 'UTF-8'); ?>" data-show-timezone="1">
+                            <time class="text-body-secondary small js-localized-datetime" datetime="<?= Html::escape($discoveredAt->format(DATE_ATOM)); ?>" data-show-timezone="1">
                                 <?= Html::escape($discoveredAt->format('Y-m-d H:i:s')); ?> UTC
                             </time>
                         </div>

--- a/wwwroot/game_leaderboard.php
+++ b/wwwroot/game_leaderboard.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/GameLeaderboardPageContext.php';
 
 $pageContext = GameLeaderboardPageContext::fromGlobals(
@@ -45,10 +47,10 @@ require_once("header.php");
 
             <div class="col-6 text-center">
                 <div class="btn-group">
-                    <a class="btn btn-outline-primary" href="/game/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Trophies</a>
-                    <a class="btn btn-primary active" href="/game-leaderboard/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Leaderboard</a>
-                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Recent Players</a>
-                    <a class="btn btn-outline-primary" href="/game-history/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">History</a>
+                    <a class="btn btn-outline-primary" href="/game/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">Trophies</a>
+                    <a class="btn btn-primary active" href="/game-leaderboard/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">Leaderboard</a>
+                    <a class="btn btn-outline-primary" href="/game-recent-players/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">Recent Players</a>
+                    <a class="btn btn-outline-primary" href="/game-history/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">History</a>
                 </div>
             </div>
 
@@ -88,13 +90,13 @@ require_once("header.php");
                                         <div class="hstack gap-3">
                                             <div>
                                                 <a href="?<?= http_build_query($paramsAvatar); ?>">
-                                                    <img src="/img/avatar/<?= htmlspecialchars($row->getAvatarUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="" height="50" width="50" />
+                                                    <img src="/img/avatar/<?= Html::escape($row->getAvatarUrl()); ?>" alt="" height="50" width="50" />
                                                 </a>
                                             </div>
 
                                             <div>
                                                 <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= $playerUrl; ?>">
-                                                    <?= htmlspecialchars($playerName, ENT_QUOTES, 'UTF-8'); ?>
+                                                    <?= Html::escape($playerName); ?>
                                                 </a>
                                                 <?php if ($row->hasHiddenTrophies()) { ?>
                                                     <span style='color: #9d9d9d; font-weight: bold;'>(H)</span>
@@ -103,7 +105,7 @@ require_once("header.php");
 
                                             <div class="ms-auto">
                                                 <a href="?<?= http_build_query($paramsCountry); ?>">
-                                                    <img src="/img/country/<?= htmlspecialchars($row->getCountryCode(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
+                                                    <img src="/img/country/<?= Html::escape($row->getCountryCode()); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
                                                 </a>
                                             </div>
                                         </div>
@@ -112,7 +114,7 @@ require_once("header.php");
                                     <td class="align-middle text-center" style="white-space: nowrap; width: 5rem;">
                                         <span
                                             class="js-leaderboard-date"
-                                            data-timestamp="<?= htmlspecialchars($row->getLastKnownDate(), ENT_QUOTES, 'UTF-8'); ?>"
+                                            data-timestamp="<?= Html::escape($row->getLastKnownDate()); ?>"
                                             data-line-break="1"
                                         ></span>
                                     </td>

--- a/wwwroot/game_recent_players.php
+++ b/wwwroot/game_recent_players.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once __DIR__ . '/classes/GameRecentPlayersPageContext.php';
 
 $pageContext = GameRecentPlayersPageContext::fromGlobals(
@@ -42,10 +44,10 @@ require_once("header.php");
 
             <div class="col-6 text-center">
                 <div class="btn-group">
-                    <a class="btn btn-outline-primary" href="/game/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Trophies</a>
-                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Leaderboard</a>
-                    <a class="btn btn-primary active" href="/game-recent-players/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">Recent Players</a>
-                    <a class="btn btn-outline-primary" href="/game-history/<?= htmlspecialchars($gameSlug . $encodedGamePlayer, ENT_QUOTES, 'UTF-8'); ?>">History</a>
+                    <a class="btn btn-outline-primary" href="/game/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">Trophies</a>
+                    <a class="btn btn-outline-primary" href="/game-leaderboard/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">Leaderboard</a>
+                    <a class="btn btn-primary active" href="/game-recent-players/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">Recent Players</a>
+                    <a class="btn btn-outline-primary" href="/game-history/<?= Html::escape($gameSlug . $encodedGamePlayer); ?>">History</a>
                 </div>
             </div>
 
@@ -83,12 +85,12 @@ require_once("header.php");
                                         <div class="hstack gap-3">
                                             <div>
                                                 <a href="?<?= http_build_query($paramsAvatar); ?>">
-                                                    <img src="/img/avatar/<?= htmlspecialchars($recentPlayer->getAvatarUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="" height="50" width="50" />
+                                                    <img src="/img/avatar/<?= Html::escape($recentPlayer->getAvatarUrl()); ?>" alt="" height="50" width="50" />
                                                 </a>
                                             </div>
 
                                             <div>
-                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= $gameSlug; ?>/<?= rawurlencode($recentPlayer->getOnlineId()); ?>"><?= htmlspecialchars($recentPlayer->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
+                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= $gameSlug; ?>/<?= rawurlencode($recentPlayer->getOnlineId()); ?>"><?= Html::escape($recentPlayer->getOnlineId()); ?></a>
                                                 <?php if ($recentPlayer->hasHiddenTrophies()) { ?>
                                                     <span style='color: #9d9d9d; font-weight: bold;'>(H)</span>
                                                 <?php } ?>
@@ -96,7 +98,7 @@ require_once("header.php");
 
                                             <div class="ms-auto">
                                                 <a href="?<?= http_build_query($paramsCountry); ?>">
-                                                    <img src="/img/country/<?= htmlspecialchars($recentPlayer->getCountryCode(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
+                                                    <img src="/img/country/<?= Html::escape($recentPlayer->getCountryCode()); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
                                                 </a>
                                             </div>
                                         </div>
@@ -105,7 +107,7 @@ require_once("header.php");
                                     <td class="align-middle text-center" style="white-space: nowrap; width: 5rem;">
                                         <span
                                             class="js-recent-player-date"
-                                            data-timestamp="<?= htmlspecialchars($recentPlayer->getLastKnownDate(), ENT_QUOTES, 'UTF-8'); ?>"
+                                            data-timestamp="<?= Html::escape($recentPlayer->getLastKnownDate()); ?>"
                                             data-line-break="1"
                                         ></span>
                                     </td>

--- a/wwwroot/games.php
+++ b/wwwroot/games.php
@@ -107,7 +107,7 @@ require_once("header.php");
                             <div class="card">
                                 <div class="d-flex justify-content-center align-items-center" style="min-height: 11.5rem;">
                                     <a href="/game/<?= $gameLink; ?>">
-                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= htmlspecialchars($iconPath, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($game->getName()); ?>">
+                                        <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= Html::escape($iconPath); ?>" alt="<?= Html::escape($game->getName()); ?>">
                                         <div class="card-img-overlay d-flex align-items-end p-2">
                                             <?php
                                             foreach ($platforms as $platform) {

--- a/wwwroot/header.php
+++ b/wwwroot/header.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
 require_once __DIR__ . '/classes/PageMetaData.php';
 require_once __DIR__ . '/classes/PageMetaDataRenderer.php';
 require_once __DIR__ . '/classes/SessionManager.php';
@@ -10,7 +11,7 @@ require_once __DIR__ . '/classes/StaticAsset.php';
 require_once __DIR__ . '/classes/BootstrapAssets.php';
 
 SessionManager::ensureStarted();
-$publicCsrfToken = htmlspecialchars(CsrfTokenManager::getToken('public'), ENT_QUOTES, 'UTF-8');
+$publicCsrfToken = Html::escape(CsrfTokenManager::getToken('public'));
 
 $metaTagHtml = '';
 if (isset($metaData) && $metaData instanceof PageMetaData) {
@@ -38,7 +39,7 @@ if (isset($metaData) && $metaData instanceof PageMetaData) {
         <link rel="manifest" href="/site.webmanifest">
         <link rel="icon" href="/img/favicon.ico">
         <!-- Bootstrap CSS -->
-        <link href="<?= htmlspecialchars(BootstrapAssets::stylesheetUrl(), ENT_QUOTES, 'UTF-8'); ?>" rel="stylesheet">
+        <link href="<?= Html::escape(BootstrapAssets::stylesheetUrl()); ?>" rel="stylesheet">
 
         <style>
             .trophy-bronze {
@@ -163,9 +164,9 @@ if (isset($metaData) && $metaData instanceof PageMetaData) {
             }
         </style>
 
-        <script src="<?= htmlspecialchars(StaticAsset::url('/js/localized-date-formatter.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
+        <script src="<?= Html::escape(StaticAsset::url('/js/localized-date-formatter.js')); ?>" defer></script>
 
-        <title><?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?></title>
+        <title><?= Html::escape($title); ?></title>
     </head>
     <body>
         <?php require_once("nav.php"); ?>

--- a/wwwroot/home.php
+++ b/wwwroot/home.php
@@ -227,7 +227,7 @@ require_once("header.php");
     </div>
 </main>
 
-<script src="<?= htmlspecialchars(StaticAsset::url('/js/player-queue-manager.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
+<script src="<?= Html::escape(StaticAsset::url('/js/player-queue-manager.js')); ?>" defer></script>
 
 <?php
 require_once("footer.php");

--- a/wwwroot/leaderboard_in_game_rarity.php
+++ b/wwwroot/leaderboard_in_game_rarity.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once 'classes/Leaderboard/InGameRarityLeaderboardPageContext.php';
 require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
@@ -56,7 +58,7 @@ $shouldShowCountryRank = $leaderboardPageContext->shouldShowCountryRank();
 
                         <tbody>
                             <?php foreach ($rows as $row) { ?>
-                                <tr id="<?= htmlspecialchars($row->getRowId(), ENT_QUOTES, 'UTF-8'); ?>"<?= $row->getRowCssClass() !== '' ? ' class="' . $row->getRowCssClass() . '"' : ''; ?>>
+                                <tr id="<?= Html::escape($row->getRowId()); ?>"<?= $row->getRowCssClass() !== '' ? ' class="' . $row->getRowCssClass() . '"' : ''; ?>>
                                     <th scope="row" class="text-center align-middle">
                                         <?= $row->getRankCellHtml(); ?>
                                     </th>
@@ -64,18 +66,18 @@ $shouldShowCountryRank = $leaderboardPageContext->shouldShowCountryRank();
                                         <div class="hstack gap-3">
                                             <div>
                                                 <a href="?<?= http_build_query($row->getAvatarQueryParameters()); ?>">
-                                                    <img src="/img/avatar/<?= htmlspecialchars($row->getAvatarUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="" height="50" width="50" />
+                                                    <img src="/img/avatar/<?= Html::escape($row->getAvatarUrl()); ?>" alt="" height="50" width="50" />
                                                 </a>
                                             </div>
 
                                             <div>
-                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars(PlayerUrlBuilder::playerPath($row->getOnlineId()), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
+                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= Html::escape(PlayerUrlBuilder::playerPath($row->getOnlineId())); ?>"><?= Html::escape($row->getOnlineId()); ?></a>
                                             </div>
 
                                             <div class="ms-auto">
                                                 <a href="?<?= http_build_query($row->getCountryQueryParameters()); ?>">
-                                                    <?php $countryName = htmlspecialchars($row->getCountryName(), ENT_QUOTES, 'UTF-8'); ?>
-                                                    <img src="/img/country/<?= htmlspecialchars($row->getCountryCode(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
+                                                    <?php $countryName = Html::escape($row->getCountryName()); ?>
+                                                    <img src="/img/country/<?= Html::escape($row->getCountryCode()); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
                                                 </a>
                                             </div>
                                         </div>

--- a/wwwroot/leaderboard_main.php
+++ b/wwwroot/leaderboard_main.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once 'classes/Leaderboard/TrophyLeaderboardPageContext.php';
 require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
@@ -61,7 +63,7 @@ $filterParameters = $trophyLeaderboardPageContext->getFilterQueryParameters();
 
                         <tbody>
                             <?php foreach ($rows as $row) { ?>
-                                <tr id="<?= htmlspecialchars($row->getRowId(), ENT_QUOTES, 'UTF-8'); ?>"<?= $row->getRowCssClass() !== '' ? ' class="' . $row->getRowCssClass() . '"' : ''; ?>>
+                                <tr id="<?= Html::escape($row->getRowId()); ?>"<?= $row->getRowCssClass() !== '' ? ' class="' . $row->getRowCssClass() . '"' : ''; ?>>
                                     <th scope="row" class="text-center align-middle">
                                         <?= $row->getRankCellHtml(); ?>
                                     </th>
@@ -69,18 +71,18 @@ $filterParameters = $trophyLeaderboardPageContext->getFilterQueryParameters();
                                         <div class="hstack gap-3">
                                             <div>
                                                 <a href="?<?= http_build_query($row->getAvatarQueryParameters()); ?>">
-                                                    <img src="/img/avatar/<?= htmlspecialchars($row->getAvatarUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="" height="50" width="50" />
+                                                    <img src="/img/avatar/<?= Html::escape($row->getAvatarUrl()); ?>" alt="" height="50" width="50" />
                                                 </a>
                                             </div>
 
                                             <div>
-                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars(PlayerUrlBuilder::playerPath($row->getOnlineId()), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
+                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= Html::escape(PlayerUrlBuilder::playerPath($row->getOnlineId())); ?>"><?= Html::escape($row->getOnlineId()); ?></a>
                                             </div>
 
                                             <div class="ms-auto">
                                                 <a href="?<?= http_build_query($row->getCountryQueryParameters()); ?>">
-                                                    <?php $countryName = htmlspecialchars($row->getCountryName(), ENT_QUOTES, 'UTF-8'); ?>
-                                                    <img src="/img/country/<?= htmlspecialchars($row->getCountryCode(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
+                                                    <?php $countryName = Html::escape($row->getCountryName()); ?>
+                                                    <img src="/img/country/<?= Html::escape($row->getCountryCode()); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
                                                 </a>
                                             </div>
                                         </div>

--- a/wwwroot/leaderboard_rarity.php
+++ b/wwwroot/leaderboard_rarity.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/classes/Html.php';
+
 require_once 'classes/Leaderboard/RarityLeaderboardPageContext.php';
 require_once __DIR__ . '/classes/PlayerUrlBuilder.php';
 
@@ -56,7 +58,7 @@ $shouldShowCountryRank = $rarityLeaderboardPageContext->shouldShowCountryRank();
 
                         <tbody>
                             <?php foreach ($rows as $row) { ?>
-                                <tr id="<?= htmlspecialchars($row->getRowId(), ENT_QUOTES, 'UTF-8'); ?>"<?= $row->getRowCssClass() !== '' ? ' class="' . $row->getRowCssClass() . '"' : ''; ?>>
+                                <tr id="<?= Html::escape($row->getRowId()); ?>"<?= $row->getRowCssClass() !== '' ? ' class="' . $row->getRowCssClass() . '"' : ''; ?>>
                                     <th scope="row" class="text-center align-middle">
                                         <?= $row->getRankCellHtml(); ?>
                                     </th>
@@ -64,18 +66,18 @@ $shouldShowCountryRank = $rarityLeaderboardPageContext->shouldShowCountryRank();
                                         <div class="hstack gap-3">
                                             <div>
                                                 <a href="?<?= http_build_query($row->getAvatarQueryParameters()); ?>">
-                                                    <img src="/img/avatar/<?= htmlspecialchars($row->getAvatarUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="" height="50" width="50" />
+                                                    <img src="/img/avatar/<?= Html::escape($row->getAvatarUrl()); ?>" alt="" height="50" width="50" />
                                                 </a>
                                             </div>
 
                                             <div>
-                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars(PlayerUrlBuilder::playerPath($row->getOnlineId()), ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($row->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
+                                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= Html::escape(PlayerUrlBuilder::playerPath($row->getOnlineId())); ?>"><?= Html::escape($row->getOnlineId()); ?></a>
                                             </div>
 
                                             <div class="ms-auto">
                                                 <a href="?<?= http_build_query($row->getCountryQueryParameters()); ?>">
-                                                    <?php $countryName = htmlspecialchars($row->getCountryName(), ENT_QUOTES, 'UTF-8'); ?>
-                                                    <img src="/img/country/<?= htmlspecialchars($row->getCountryCode(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
+                                                    <?php $countryName = Html::escape($row->getCountryName()); ?>
+                                                    <img src="/img/country/<?= Html::escape($row->getCountryCode()); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
                                                 </a>
                                             </div>
                                         </div>

--- a/wwwroot/player.php
+++ b/wwwroot/player.php
@@ -50,7 +50,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= htmlspecialchars(PlayerUrlBuilder::playerReportPath($playerOnlineId), ENT_QUOTES, 'UTF-8'); ?>">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= Html::escape(PlayerUrlBuilder::playerReportPath($playerOnlineId)); ?>">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">
@@ -146,18 +146,18 @@ require_once("header.php");
                                     <tr<?= $rowAttributes; ?>>
                                         <td scope="row">
                                             <div class="hstack gap-3">
-                                                <img src="/img/title/<?= htmlspecialchars($playerGame->getIconFileName(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($playerGame->getName()); ?>" width="100" />
+                                                <img src="/img/title/<?= Html::escape($playerGame->getIconFileName()); ?>" alt="<?= Html::escape($playerGame->getName()); ?>" width="100" />
 
                                                 <div class="vstack">
                                                     <span>
-                                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars(PlayerUrlBuilder::gamePlayerPath($playerGame->getId() . '-' . $utility->slugify($playerGame->getName()), $playerOnlineId), ENT_QUOTES, 'UTF-8'); ?>">
+                                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= Html::escape(PlayerUrlBuilder::gamePlayerPath($playerGame->getId() . '-' . $utility->slugify($playerGame->getName()), $playerOnlineId)); ?>">
                                                             <?= Html::escape($playerGame->getName()); ?>
                                                         </a>
                                                     </span>
 
                                                     <span
                                                         class="js-localized-date"
-                                                        data-timestamp="<?= htmlspecialchars($playerGame->getLastUpdatedDate(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                        data-timestamp="<?= Html::escape($playerGame->getLastUpdatedDate()); ?>"
                                                     ></span>
 
                                                     <?php

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -52,7 +52,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= htmlspecialchars(PlayerUrlBuilder::playerReportPath($playerOnlineId), ENT_QUOTES, 'UTF-8'); ?>">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= Html::escape(PlayerUrlBuilder::playerReportPath($playerOnlineId)); ?>">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">
@@ -85,7 +85,7 @@ require_once("header.php");
                                 <th scope="col" class="text-center">Game</th>
                                 <th scope="col">Trophy</th>
                                 <th scope="col" class="text-center">Platform</th>
-                                <th scope="col" class="text-center"><?= htmlspecialchars($rarityColumnLabel, ENT_QUOTES, 'UTF-8'); ?></th>
+                                <th scope="col" class="text-center"><?= Html::escape($rarityColumnLabel); ?></th>
                                 <th scope="col" class="text-center">Type</th>
                             </tr>
                         </thead>
@@ -106,36 +106,36 @@ require_once("header.php");
                                     ?>
                                     <tr>
                                         <td scope="row" class="text-center align-middle">
-                                            <a href="/game/<?= htmlspecialchars($gameLink, ENT_QUOTES, 'UTF-8'); ?>">
+                                            <a href="/game/<?= Html::escape($gameLink); ?>">
                                                 <?php $gameName = Html::escape($trophy->getGameName()); ?>
-                                                <img src="/img/title/<?= htmlspecialchars($trophy->getGameIconUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= $gameName; ?>" title="<?= $gameName; ?>" style="width: 10rem;" />
+                                                <img src="/img/title/<?= Html::escape($trophy->getGameIconUrl()); ?>" alt="<?= $gameName; ?>" title="<?= $gameName; ?>" style="width: 10rem;" />
                                             </a>
                                         </td>
                                         <td class="align-middle">
                                             <div class="hstack gap-3">
                                                 <div class="d-flex align-items-center justify-content-center">
-                                                    <a href="/trophy/<?= htmlspecialchars($trophyLink, ENT_QUOTES, 'UTF-8'); ?>">
+                                                    <a href="/trophy/<?= Html::escape($trophyLink); ?>">
                                                         <?php $trophyName = Html::escape($trophy->getTrophyName()); ?>
-                                                        <img src="/img/trophy/<?= htmlspecialchars($trophy->getTrophyIconUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= $trophyName; ?>" title="<?= $trophyName; ?>" style="width: 5rem;" />
+                                                        <img src="/img/trophy/<?= Html::escape($trophy->getTrophyIconUrl()); ?>" alt="<?= $trophyName; ?>" title="<?= $trophyName; ?>" style="width: 5rem;" />
                                                     </a>
                                                 </div>
 
                                                 <div>
                                                     <div class="vstack">
                                                         <span>
-                                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/trophy/<?= htmlspecialchars($trophyLink, ENT_QUOTES, 'UTF-8'); ?>">
+                                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/trophy/<?= Html::escape($trophyLink); ?>">
                                                                 <b><?= $trophyName; ?></b>
                                                             </a>
                                                         </span>
                                                         <?= nl2br(Html::escape($trophy->getTrophyDetail())); ?>
                                                         <?php
                                                         if ($progressLabel !== null) {
-                                                            echo '<br><b>' . htmlspecialchars($progressLabel, ENT_QUOTES, 'UTF-8') . '</b>';
+                                                            echo '<br><b>' . Html::escape($progressLabel) . '</b>';
                                                         }
 
                                                         if ($trophy->hasReward()) {
                                                             $rewardName = Html::escape((string) $trophy->getRewardName());
-                                                            $rewardImage = htmlspecialchars((string) $trophy->getRewardImageUrl(), ENT_QUOTES, 'UTF-8');
+                                                            $rewardImage = Html::escape((string) $trophy->getRewardImageUrl());
                                                             echo "<br>Reward: <a href='/img/reward/{$rewardImage}'>{$rewardName}</a>";
                                                         }
                                                         ?>

--- a/wwwroot/player_header.php
+++ b/wwwroot/player_header.php
@@ -28,14 +28,14 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
         <div class="hstack gap-3 bg-body-tertiary p-3 rounded">
             <!-- Avatar -->
             <div>
-                <img src="/img/avatar/<?= htmlspecialchars((string) $player['avatar_url'], ENT_QUOTES, 'UTF-8'); ?>" alt="" height="100" width="100" />
+                <img src="/img/avatar/<?= Html::escape((string) $player['avatar_url']); ?>" alt="" height="100" width="100" />
             </div>
 
             <!-- Online ID and About Me -->
             <div>
                 <figure>
                     <blockquote class="blockquote">
-                        <h1><?= htmlspecialchars((string) $player['online_id'], ENT_QUOTES, 'UTF-8'); ?></h1>
+                        <h1><?= Html::escape((string) $player['online_id']); ?></h1>
                     </blockquote>
                     <?php
                     $aboutMe = $playerHeaderViewModel->getAboutMe();
@@ -53,7 +53,7 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
             <!-- Country -->
             <div class="ms-auto">
                 <?php $countryName = Html::escape($playerHeaderViewModel->getCountryName()); ?>
-                <img src="/img/country/<?= htmlspecialchars($playerHeaderViewModel->getCountryCode(), ENT_QUOTES, 'UTF-8'); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
+                <img src="/img/country/<?= Html::escape($playerHeaderViewModel->getCountryCode()); ?>.svg" alt="<?= $countryName; ?>" title="<?= $countryName; ?>" height="50" width="50" style="border-radius: 50%;" />
             </div>
         </div>
     </div>
@@ -94,7 +94,7 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
                 <small>Last Updated: <span
                     class="js-localized-date"
                     <?php if ($playerHeaderViewModel->hasLastUpdatedDate()) { ?>
-                    data-timestamp="<?= htmlspecialchars($playerHeaderViewModel->getLastUpdatedDate(), ENT_QUOTES, 'UTF-8'); ?>"
+                    data-timestamp="<?= Html::escape($playerHeaderViewModel->getLastUpdatedDate()); ?>"
                     <?php } ?>
                 ></span></small>
             </div>
@@ -199,12 +199,12 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
                             <?php } ?>
 
                             <div class="w-50">
-                                <?= htmlspecialchars($rank->getLabel(), ENT_QUOTES, 'UTF-8'); ?><br>
+                                <?= Html::escape($rank->getLabel()); ?><br>
                                 <?php if ($rank->isAvailable()) { ?>
                                     <h3>
                                         <?php $rankUrl = $rank->getUrl(); ?>
                                         <?php if ($rankUrl !== null) { ?>
-                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($rankUrl, ENT_QUOTES, 'UTF-8'); ?>"><?= $rank->getRank(); ?></a>
+                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= Html::escape($rankUrl); ?>"><?= $rank->getRank(); ?></a>
                                         <?php } else { ?>
                                             <?= $rank->getRank(); ?>
                                         <?php } ?>
@@ -212,11 +212,11 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
                                         <?php if ($change !== null && $change->shouldDisplay()) { ?>
                                             <?php $displayText = $change->getDisplayText(); ?>
                                             <?php if ($change->isNew()) { ?>
-                                                <span class="fs-6"><?= htmlspecialchars($displayText, ENT_QUOTES, 'UTF-8'); ?></span>
+                                                <span class="fs-6"><?= Html::escape($displayText); ?></span>
                                             <?php } else { ?>
                                                 <?php $color = $change->getColor(); ?>
-                                                <span class="fs-6"<?php if ($color !== null) { ?> style="color: <?= htmlspecialchars($color, ENT_QUOTES, 'UTF-8'); ?>;"<?php } ?>>
-                                                    <?= htmlspecialchars($displayText, ENT_QUOTES, 'UTF-8'); ?>
+                                                <span class="fs-6"<?php if ($color !== null) { ?> style="color: <?= Html::escape($color); ?>;"<?php } ?>>
+                                                    <?= Html::escape($displayText); ?>
                                                 </span>
                                             <?php } ?>
                                         <?php } ?>
@@ -264,12 +264,12 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
                             <?php } ?>
 
                             <div class="w-50">
-                                <?= htmlspecialchars($rank->getLabel(), ENT_QUOTES, 'UTF-8'); ?><br>
+                                <?= Html::escape($rank->getLabel()); ?><br>
                                 <?php if ($rank->isAvailable()) { ?>
                                     <h3>
                                         <?php $rankUrl = $rank->getUrl(); ?>
                                         <?php if ($rankUrl !== null) { ?>
-                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($rankUrl, ENT_QUOTES, 'UTF-8'); ?>"><?= $rank->getRank(); ?></a>
+                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= Html::escape($rankUrl); ?>"><?= $rank->getRank(); ?></a>
                                         <?php } else { ?>
                                             <?= $rank->getRank(); ?>
                                         <?php } ?>
@@ -277,11 +277,11 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
                                         <?php if ($change !== null && $change->shouldDisplay()) { ?>
                                             <?php $displayText = $change->getDisplayText(); ?>
                                             <?php if ($change->isNew()) { ?>
-                                                <span class="fs-6"><?= htmlspecialchars($displayText, ENT_QUOTES, 'UTF-8'); ?></span>
+                                                <span class="fs-6"><?= Html::escape($displayText); ?></span>
                                             <?php } else { ?>
                                                 <?php $color = $change->getColor(); ?>
-                                                <span class="fs-6"<?php if ($color !== null) { ?> style="color: <?= htmlspecialchars($color, ENT_QUOTES, 'UTF-8'); ?>;"<?php } ?>>
-                                                    <?= htmlspecialchars($displayText, ENT_QUOTES, 'UTF-8'); ?>
+                                                <span class="fs-6"<?php if ($color !== null) { ?> style="color: <?= Html::escape($color); ?>;"<?php } ?>>
+                                                    <?= Html::escape($displayText); ?>
                                                 </span>
                                             <?php } ?>
                                         <?php } ?>
@@ -329,12 +329,12 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
                             <?php } ?>
 
                             <div class="w-50">
-                                <?= htmlspecialchars($rank->getLabel(), ENT_QUOTES, 'UTF-8'); ?><br>
+                                <?= Html::escape($rank->getLabel()); ?><br>
                                 <?php if ($rank->isAvailable()) { ?>
                                     <h3>
                                         <?php $rankUrl = $rank->getUrl(); ?>
                                         <?php if ($rankUrl !== null) { ?>
-                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($rankUrl, ENT_QUOTES, 'UTF-8'); ?>"><?= $rank->getRank(); ?></a>
+                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= Html::escape($rankUrl); ?>"><?= $rank->getRank(); ?></a>
                                         <?php } else { ?>
                                             <?= $rank->getRank(); ?>
                                         <?php } ?>
@@ -342,11 +342,11 @@ $inGameRarityLeaderboardRanks = $playerHeaderViewModel->getInGameRarityLeaderboa
                                         <?php if ($change !== null && $change->shouldDisplay()) { ?>
                                             <?php $displayText = $change->getDisplayText(); ?>
                                             <?php if ($change->isNew()) { ?>
-                                                <span class="fs-6"><?= htmlspecialchars($displayText, ENT_QUOTES, 'UTF-8'); ?></span>
+                                                <span class="fs-6"><?= Html::escape($displayText); ?></span>
                                             <?php } else { ?>
                                                 <?php $color = $change->getColor(); ?>
-                                                <span class="fs-6"<?php if ($color !== null) { ?> style="color: <?= htmlspecialchars($color, ENT_QUOTES, 'UTF-8'); ?>;"<?php } ?>>
-                                                    <?= htmlspecialchars($displayText, ENT_QUOTES, 'UTF-8'); ?>
+                                                <span class="fs-6"<?php if ($color !== null) { ?> style="color: <?= Html::escape($color); ?>;"<?php } ?>>
+                                                    <?= Html::escape($displayText); ?>
                                                 </span>
                                             <?php } ?>
                                         <?php } ?>

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -51,7 +51,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= htmlspecialchars(PlayerUrlBuilder::playerReportPath($player['online_id']), ENT_QUOTES, 'UTF-8'); ?>">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= Html::escape(PlayerUrlBuilder::playerReportPath($player['online_id'])); ?>">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">
@@ -113,22 +113,22 @@ require_once("header.php");
                                     ?>
                                     <tr<?= $rowClassAttribute; ?>>
                                         <td scope="row" class="text-center align-middle">
-                                            <a href="<?= htmlspecialchars($gameUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                                                <img src="/img/title/<?= htmlspecialchars($trophy->getGameIconRelativePath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($trophy->getGameName()); ?>" title="<?= Html::escape($trophy->getGameName()); ?>" style="width: 10rem;" />
+                                            <a href="<?= Html::escape($gameUrl); ?>">
+                                                <img src="/img/title/<?= Html::escape($trophy->getGameIconRelativePath()); ?>" alt="<?= Html::escape($trophy->getGameName()); ?>" title="<?= Html::escape($trophy->getGameName()); ?>" style="width: 10rem;" />
                                             </a>
                                         </td>
                                         <td class="align-middle">
                                             <div class="hstack gap-3">
                                                 <div class="d-flex align-items-center justify-content-center">
-                                                    <a href="<?= htmlspecialchars($trophyUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                                                        <img src="/img/trophy/<?= htmlspecialchars($trophy->getTrophyIconRelativePath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($trophy->getTrophyName()); ?>" title="<?= Html::escape($trophy->getTrophyName()); ?>" style="width: 5rem;" />
+                                                    <a href="<?= Html::escape($trophyUrl); ?>">
+                                                        <img src="/img/trophy/<?= Html::escape($trophy->getTrophyIconRelativePath()); ?>" alt="<?= Html::escape($trophy->getTrophyName()); ?>" title="<?= Html::escape($trophy->getTrophyName()); ?>" style="width: 5rem;" />
                                                     </a>
                                                 </div>
 
                                                 <div>
                                                     <div class="vstack">
                                                         <span>
-                                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($trophyUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                                                            <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= Html::escape($trophyUrl); ?>">
                                                                 <b><?= Html::escape($trophy->getTrophyName()); ?></b>
                                                             </a>
                                                         </span>
@@ -139,8 +139,8 @@ require_once("header.php");
                                                         }
 
                                                         if ($rewardName !== null && $rewardImageUrl !== null) {
-                                                            echo "<br>Reward: <a href='/img/reward/" . htmlspecialchars($rewardImageUrl, ENT_QUOTES, 'UTF-8') . "'>"
-                                                                . htmlspecialchars($rewardName, ENT_QUOTES, 'UTF-8')
+                                                            echo "<br>Reward: <a href='/img/reward/" . Html::escape($rewardImageUrl) . "'>"
+                                                                . Html::escape($rewardName)
                                                                 . '</a>';
                                                         }
                                                         ?>
@@ -148,7 +148,7 @@ require_once("header.php");
                                                             <span
                                                                 class="badge rounded-pill text-bg-success js-localized-date"
                                                                 data-prefix="Earned "
-                                                                data-timestamp="<?= htmlspecialchars($trophy->getEarnedDate(), ENT_QUOTES, 'UTF-8'); ?>"
+                                                                data-timestamp="<?= Html::escape($trophy->getEarnedDate()); ?>"
                                                             ></span>
                                                         </div>
                                                     </div>
@@ -159,7 +159,7 @@ require_once("header.php");
                                             <div class="vstack gap-1">
                                                 <?php
                                                 foreach ($trophy->getPlatforms() as $platform) {
-                                                    echo "<span class=\"badge rounded-pill text-bg-primary p-2\">" . htmlspecialchars($platform, ENT_QUOTES, 'UTF-8') . '</span> ';
+                                                    echo "<span class=\"badge rounded-pill text-bg-primary p-2\">" . Html::escape($platform) . '</span> ';
                                                 }
                                                 ?>
                                             </div>

--- a/wwwroot/player_random.php
+++ b/wwwroot/player_random.php
@@ -49,7 +49,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= htmlspecialchars(PlayerUrlBuilder::playerReportPath($player['online_id']), ENT_QUOTES, 'UTF-8'); ?>">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= Html::escape(PlayerUrlBuilder::playerReportPath($player['online_id'])); ?>">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">
@@ -81,8 +81,8 @@ require_once("header.php");
                             <div>
                                 <div class="card">
                                     <div class="d-flex justify-content-center align-items-center" style="min-height: 11.5rem;">
-                                        <a href="/game/<?= htmlspecialchars($gameLink, ENT_QUOTES, 'UTF-8'); ?>">
-                                            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= htmlspecialchars($game->getIconUrl(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($game->getName()); ?>">
+                                        <a href="/game/<?= Html::escape($gameLink); ?>">
+                                            <img class="card-img object-fit-scale" style="height: 11.5rem;" src="/img/title/<?= Html::escape($game->getIconUrl()); ?>" alt="<?= Html::escape($game->getName()); ?>">
                                             <div class="card-img-overlay d-flex align-items-end p-2">
                                                 <?php
                                                 foreach ($game->getPlatforms() as $platform) {
@@ -102,7 +102,7 @@ require_once("header.php");
 
                             <!-- name -->
                             <div class="text-center">
-                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= htmlspecialchars($gameLink, ENT_QUOTES, 'UTF-8'); ?>">
+                                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= Html::escape($gameLink); ?>">
                                     <?= Html::escape($game->getName()); ?>
                                 </a>
                             </div>

--- a/wwwroot/player_report.php
+++ b/wwwroot/player_report.php
@@ -34,7 +34,7 @@ $reportResult = $playerReportPage->getReportResult();
 $playerNavigation = PlayerNavigation::forSection((string) $player['online_id']);
 $playerOnlineId = (string) $player['online_id'];
 
-$title = htmlspecialchars($playerOnlineId, ENT_QUOTES, 'UTF-8') . "'s Report ~ PSN 100%";
+$title = Html::escape($playerOnlineId) . "'s Report ~ PSN 100%";
 require_once("header.php");
 ?>
 
@@ -46,7 +46,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= htmlspecialchars(PlayerUrlBuilder::playerReportPath($playerOnlineId), ENT_QUOTES, 'UTF-8'); ?>">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= Html::escape(PlayerUrlBuilder::playerReportPath($playerOnlineId)); ?>">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">

--- a/wwwroot/player_timeline.php
+++ b/wwwroot/player_timeline.php
@@ -44,7 +44,7 @@ require_once("header.php");
     <div class="p-3">
         <div class="row">
             <div class="col-12 col-lg-3">
-                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= htmlspecialchars(PlayerUrlBuilder::playerReportPath($player['online_id']), ENT_QUOTES, 'UTF-8'); ?>">Report Player</a>
+                <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-danger" href="<?= Html::escape(PlayerUrlBuilder::playerReportPath($player['online_id'])); ?>">Report Player</a>
             </div>
 
             <div class="col-12 col-lg-6 mb-3 text-center">

--- a/wwwroot/trophies.php
+++ b/wwwroot/trophies.php
@@ -50,14 +50,14 @@ require_once('header.php');
                                 <tr>
                                     <td scope="row" class="text-center align-middle">
                                         <a href="<?= $gameUrl; ?>">
-                                            <img src="/img/title/<?= htmlspecialchars($trophy->getGameIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($trophy->getGameName()); ?>" title="<?= Html::escape($trophy->getGameName()); ?>" style="width: 10rem;" />
+                                            <img src="/img/title/<?= Html::escape($trophy->getGameIconPath()); ?>" alt="<?= Html::escape($trophy->getGameName()); ?>" title="<?= Html::escape($trophy->getGameName()); ?>" style="width: 10rem;" />
                                         </a>
                                     </td>
                                     <td class="align-middle">
                                         <div class="hstack gap-3">
                                             <div class="d-flex align-items-center justify-content-center">
                                                 <a href="<?= $trophyUrl; ?>">
-                                                    <img src="/img/trophy/<?= htmlspecialchars($trophy->getTrophyIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= Html::escape($trophy->getTrophyName()); ?>" title="<?= Html::escape($trophy->getTrophyName()); ?>" style="width: 5rem;" />
+                                                    <img src="/img/trophy/<?= Html::escape($trophy->getTrophyIconPath()); ?>" alt="<?= Html::escape($trophy->getTrophyName()); ?>" title="<?= Html::escape($trophy->getTrophyName()); ?>" style="width: 5rem;" />
                                                 </a>
                                             </div>
 
@@ -72,15 +72,15 @@ require_once('header.php');
                                                     <?php
                                                     $progressTargetValue = $trophy->getProgressTargetValue();
                                                     if ($progressTargetValue !== null) {
-                                                        echo '<br><b>0/' . htmlspecialchars((string) $progressTargetValue, ENT_QUOTES, 'UTF-8') . '</b>';
+                                                        echo '<br><b>0/' . Html::escape((string) $progressTargetValue) . '</b>';
                                                     }
 
                                                     $rewardName = $trophy->getRewardName();
                                                     $rewardImageUrl = $trophy->getRewardImageUrl();
                                                     if ($rewardName !== null && $rewardImageUrl !== null) {
                                                         echo '<br>Reward: <a href="/img/reward/'
-                                                            . htmlspecialchars($rewardImageUrl, ENT_QUOTES, 'UTF-8') . '">'
-                                                            . htmlspecialchars($rewardName, ENT_QUOTES, 'UTF-8') . '</a>';
+                                                            . Html::escape($rewardImageUrl) . '">'
+                                                            . Html::escape($rewardName) . '</a>';
                                                     }
                                                     ?>
                                                 </div>

--- a/wwwroot/trophy.php
+++ b/wwwroot/trophy.php
@@ -64,14 +64,14 @@ require_once("header.php");
         <div class="col-12">
             <div class="card rounded-4">
                 <div class="d-flex justify-content-center align-items-center">
-                    <img fetchpriority="high" class="card-img object-fit-cover rounded-4" style="height: 25rem;" src="/img/title/<?= htmlspecialchars($trophy->getGameIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlspecialchars($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlspecialchars($trophy->getGameName(), ENT_QUOTES, 'UTF-8'); ?>" />
+                    <img fetchpriority="high" class="card-img object-fit-cover rounded-4" style="height: 25rem;" src="/img/title/<?= Html::escape($trophy->getGameIconPath()); ?>" alt="<?= Html::escape($trophy->getGameName()); ?>" title="<?= Html::escape($trophy->getGameName()); ?>" />
                     <div class="card-img-overlay d-flex align-items-end">
                         <div class="bg-body-tertiary p-3 rounded w-100">
                             <div class="row">
                                 <div class="col-7">
                                     <div class="hstack gap-3">
                                         <div>
-                                            <img fetchpriority="high" src="/img/trophy/<?= htmlspecialchars($trophy->getTrophyIconPath(), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlspecialchars($trophy->getName(), ENT_QUOTES, 'UTF-8'); ?>" title="<?= htmlspecialchars($trophy->getName(), ENT_QUOTES, 'UTF-8'); ?>" style="width: 5rem;" />
+                                            <img fetchpriority="high" src="/img/trophy/<?= Html::escape($trophy->getTrophyIconPath()); ?>" alt="<?= Html::escape($trophy->getName()); ?>" title="<?= Html::escape($trophy->getName()); ?>" style="width: 5rem;" />
                                         </div>
 
                                         <div>
@@ -90,7 +90,7 @@ require_once("header.php");
                                                                 class="badge rounded-pill text-bg-success js-localized-date"
                                                                 <?php if ($earnedDate !== null) { ?>
                                                                 data-prefix="Earned "
-                                                                data-timestamp="<?= htmlspecialchars($earnedDate, ENT_QUOTES, 'UTF-8'); ?>"
+                                                                data-timestamp="<?= Html::escape($earnedDate); ?>"
                                                                 <?php } else { ?>
                                                                 data-fallback="Earned"
                                                                 <?php } ?>
@@ -108,7 +108,7 @@ require_once("header.php");
                                                     if ($progressTargetValue !== null) {
                                                         $progress = $playerTrophy?->getProgress();
                                                         ?>
-                                                        <br><b><?= htmlspecialchars($progress ?? '0', ENT_QUOTES, 'UTF-8'); ?>/<?= htmlspecialchars($progressTargetValue, ENT_QUOTES, 'UTF-8'); ?></b>
+                                                        <br><b><?= Html::escape($progress ?? '0'); ?>/<?= Html::escape($progressTargetValue); ?></b>
                                                         <?php
                                                     }
 
@@ -116,7 +116,7 @@ require_once("header.php");
                                                     $rewardImageUrl = $trophy->getRewardImageUrl();
                                                     if ($rewardName !== null && $rewardImageUrl !== null) {
                                                         ?>
-                                                        <br>Reward: <a href="/img/reward/<?= htmlspecialchars($rewardImageUrl, ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($rewardName, ENT_QUOTES, 'UTF-8'); ?></a>
+                                                        <br>Reward: <a href="/img/reward/<?= Html::escape($rewardImageUrl); ?>"><?= Html::escape($rewardName); ?></a>
                                                         <?php
                                                     }
                                                     ?>
@@ -130,7 +130,7 @@ require_once("header.php");
                                                         }
                                                         ?>
 
-                                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= htmlspecialchars($trophy->getGameLink($utility, $playerOnlineId), ENT_QUOTES, 'UTF-8'); ?>"><?= Html::escape($trophy->getGameName()); ?></a>
+                                                        <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="<?= Html::escape($trophy->getGameLink($utility, $playerOnlineId)); ?>"><?= Html::escape($trophy->getGameName()); ?></a>
                                                     </div>
                                                 </div>
                                             </div>
@@ -204,8 +204,8 @@ require_once("header.php");
                                             </th>
                                             <td class="w-100">
                                                 <div class="hstack gap-3">
-                                                    <img src="/img/avatar/<?= htmlspecialchars($result->getAvatarUrl(), ENT_QUOTES, 'UTF-8'); ?>" loading="lazy" alt="<?= htmlspecialchars($result->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>" height="60" />
-                                                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= htmlspecialchars($trophy->getGameSlug($utility), ENT_QUOTES, 'UTF-8'); ?>/<?= rawurlencode($result->getOnlineId()); ?>"><?= htmlspecialchars($result->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
+                                                    <img src="/img/avatar/<?= Html::escape($result->getAvatarUrl()); ?>" loading="lazy" alt="<?= Html::escape($result->getOnlineId()); ?>" height="60" />
+                                                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= Html::escape($trophy->getGameSlug($utility)); ?>/<?= rawurlencode($result->getOnlineId()); ?>"><?= Html::escape($result->getOnlineId()); ?></a>
                                                     <?php
                                                     if ($result->hasHiddenTrophies()) {
                                                         echo " <span style='color: #9d9d9d; font-weight: bold;'>(H)</span>";
@@ -213,7 +213,7 @@ require_once("header.php");
                                                     ?>
                                                 </div>
                                             </td>
-                                            <td class="align-middle text-center js-localized-date" style="white-space: nowrap;" data-timestamp="<?= htmlspecialchars($result->getEarnedDate(), ENT_QUOTES, 'UTF-8'); ?>" data-line-break="1">
+                                            <td class="align-middle text-center js-localized-date" style="white-space: nowrap;" data-timestamp="<?= Html::escape($result->getEarnedDate()); ?>" data-line-break="1">
                                             </td>
                                         </tr>
                                         <?php
@@ -257,8 +257,8 @@ require_once("header.php");
                                             </th>
                                             <td class="w-100">
                                                 <div class="hstack gap-3">
-                                                    <img src="/img/avatar/<?= htmlspecialchars($result->getAvatarUrl(), ENT_QUOTES, 'UTF-8'); ?>" loading="lazy" alt="<?= htmlspecialchars($result->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?>" height="60" />
-                                                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= htmlspecialchars($trophy->getGameSlug($utility), ENT_QUOTES, 'UTF-8'); ?>/<?= rawurlencode($result->getOnlineId()); ?>"><?= htmlspecialchars($result->getOnlineId(), ENT_QUOTES, 'UTF-8'); ?></a>
+                                                    <img src="/img/avatar/<?= Html::escape($result->getAvatarUrl()); ?>" loading="lazy" alt="<?= Html::escape($result->getOnlineId()); ?>" height="60" />
+                                                    <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="/game/<?= Html::escape($trophy->getGameSlug($utility)); ?>/<?= rawurlencode($result->getOnlineId()); ?>"><?= Html::escape($result->getOnlineId()); ?></a>
                                                     <?php
                                                     if ($result->hasHiddenTrophies()) {
                                                         echo " <span style='color: #9d9d9d; font-weight: bold;'>(H)</span>";
@@ -266,7 +266,7 @@ require_once("header.php");
                                                     ?>
                                                 </div>
                                             </td>
-                                            <td class="align-middle text-center js-localized-date" style="white-space: nowrap;" data-timestamp="<?= htmlspecialchars($result->getEarnedDate(), ENT_QUOTES, 'UTF-8'); ?>" data-line-break="1">
+                                            <td class="align-middle text-center js-localized-date" style="white-space: nowrap;" data-timestamp="<?= Html::escape($result->getEarnedDate()); ?>" data-line-break="1">
                                             </td>
                                         </tr>
                                         <?php


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the PHP 8.5 modernization series with leftovers that were still using manual filter cloning, unpromoted constructors, repeated `MERGE_*` string checks, and raw `htmlspecialchars` calls.

### Changes
- Add `PlayerLeaderboardFilter::withPageNumber()` via `clone()` and use it from `PlayerLeaderboardPage`
- Finish constructor property promotion on `AutomaticTrophyTitleMergeService` and `ImageHashCalculator` (including `new` defaults)
- Introduce `MergeNpCommunicationId` and wire merge/clone/header/reset/copy call sites through it
- Prefer pipes in `TrophyType::sqlFieldOrder()` and `CronJobCliArguments::fromArgv()`, and simplify `Platform::labelsByValue()`
- Add `#[\NoDiscard]` on title/log formatters; seal `FooterRenderer` as `final readonly`
- Migrate templates/admin pages from `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` to `Html::escape()` for `ENT_SUBSTITUTE` consistency

### Testing
- `php tests/run.php` — all 1027 tests passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29e37755-3640-4162-9c35-8ef8843a1f1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29e37755-3640-4162-9c35-8ef8843a1f1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

