### PR TITLE
Adopt remaining PHP 8.5 idioms for promotion, pipes, and NoDiscard

### DIFF
--- a/wwwroot/admin/possible.php
+++ b/wwwroot/admin/possible.php
@@ -6,7 +6,7 @@ require_once '../classes/Admin/PossibleCheaterPage.php';
 require_once '../classes/Admin/PossibleCheaterService.php';
 
 $possibleCheaterService = new PossibleCheaterService($database);
-$possibleCheaterPage = new PossibleCheaterPage($possibleCheaterService);
+$possibleCheaterPage = PossibleCheaterPage::fromService($possibleCheaterService);
 $possibleCheaterReport = $possibleCheaterPage->getReport();
 ?>
 <!doctype html>

--- a/wwwroot/classes/AboutPageScanSummary.php
+++ b/wwwroot/classes/AboutPageScanSummary.php
@@ -4,15 +4,19 @@ declare(strict_types=1);
 
 final readonly class AboutPageScanSummary
 {
-    public function __construct(private int $scannedPlayers, private int $newPlayers)
-    {
+    public function __construct(
+        final private int $scannedPlayers,
+        final private int $newPlayers,
+    ) {
     }
 
+    #[\NoDiscard]
     public function getScannedPlayers(): int
     {
         return $this->scannedPlayers;
     }
 
+    #[\NoDiscard]
     public function getNewPlayers(): int
     {
         return $this->newPlayers;

--- a/wwwroot/classes/Admin/AdminRequest.php
+++ b/wwwroot/classes/Admin/AdminRequest.php
@@ -13,7 +13,7 @@ final readonly class AdminRequest
      */
     public function __construct(
         string|HttpMethod $method,
-        private array $postData,
+        final private array $postData,
     ) {
         $this->method = $method instanceof HttpMethod ? $method : HttpMethod::fromMixed($method);
     }

--- a/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
+++ b/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
@@ -7,16 +7,19 @@ require_once __DIR__ . '/GameRescanProgressListener.php';
 final class CallableGameRescanProgressListener implements GameRescanProgressListener
 {
     /**
-     * @var \Closure(int, string):void
+     * @param Closure(int, string):void $callback
      */
-    private readonly \Closure $callback;
+    public function __construct(private readonly \Closure $callback)
+    {
+    }
 
     /**
      * @param callable(int, string):void $callback
      */
-    public function __construct(callable $callback)
+    #[\NoDiscard]
+    public static function fromCallable(callable $callback): self
     {
-        $this->callback = $callback(...);
+        return new self($callback(...));
     }
 
     #[\Override]

--- a/wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
+++ b/wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
@@ -7,16 +7,19 @@ require_once __DIR__ . '/TrophyMergeProgressListener.php';
 final class CallableTrophyMergeProgressListener implements TrophyMergeProgressListener
 {
     /**
-     * @var \Closure(int, string):void
+     * @param Closure(int, string):void $callback
      */
-    private readonly \Closure $callback;
+    public function __construct(private readonly \Closure $callback)
+    {
+    }
 
     /**
      * @param callable(int, string):void $callback
      */
-    public function __construct(callable $callback)
+    #[\NoDiscard]
+    public static function fromCallable(callable $callback): self
     {
-        $this->callback = $callback(...);
+        return new self($callback(...));
     }
 
     #[\Override]

--- a/wwwroot/classes/Admin/CommandExecutionResult.php
+++ b/wwwroot/classes/Admin/CommandExecutionResult.php
@@ -5,21 +5,24 @@ declare(strict_types=1);
 final readonly class CommandExecutionResult
 {
     public function __construct(
-        private int $exitCode,
-        private string $output
+        final private int $exitCode,
+        final private string $output,
     ) {
     }
 
+    #[\NoDiscard]
     public function isSuccessful(): bool
     {
         return $this->exitCode === 0;
     }
 
+    #[\NoDiscard]
     public function getExitCode(): int
     {
         return $this->exitCode;
     }
 
+    #[\NoDiscard]
     public function getOutput(): string
     {
         return $this->output;

--- a/wwwroot/classes/Admin/PossibleCheaterPage.php
+++ b/wwwroot/classes/Admin/PossibleCheaterPage.php
@@ -7,11 +7,14 @@ require_once __DIR__ . '/PossibleCheaterService.php';
 
 final readonly class PossibleCheaterPage
 {
-    private PossibleCheaterReport $report;
-
-    public function __construct(PossibleCheaterService $service)
+    private function __construct(final private PossibleCheaterReport $report)
     {
-        $this->report = $service->createReport();
+    }
+
+    #[\NoDiscard]
+    public static function fromService(PossibleCheaterService $service): self
+    {
+        return new self($service->createReport());
     }
 
     public function getReport(): PossibleCheaterReport

--- a/wwwroot/classes/Admin/PsnpPlusFixedGame.php
+++ b/wwwroot/classes/Admin/PsnpPlusFixedGame.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 final readonly class PsnpPlusFixedGame
 {
     /**
-     * @var int[]
+     * @param int[] $trophyIds
      */
-    private array $trophyIds;
-
     public function __construct(
-        private int $gameId,
-        private string $gameName,
-        array $trophyIds
+        final private int $gameId,
+        final private string $gameName,
+        /** @var int[] */
+        final private array $trophyIds,
     ) {
         $this->trophyIds = array_map(intval(...), $trophyIds);
     }

--- a/wwwroot/classes/Admin/PsnpPlusFixedGame.php
+++ b/wwwroot/classes/Admin/PsnpPlusFixedGame.php
@@ -5,13 +5,17 @@ declare(strict_types=1);
 final readonly class PsnpPlusFixedGame
 {
     /**
+     * @var int[]
+     */
+    private array $trophyIds;
+
+    /**
      * @param int[] $trophyIds
      */
     public function __construct(
         final private int $gameId,
         final private string $gameName,
-        /** @var int[] */
-        final private array $trophyIds,
+        array $trophyIds,
     ) {
         $this->trophyIds = array_map(intval(...), $trophyIds);
     }

--- a/wwwroot/classes/Admin/PsnpPlusGameDifference.php
+++ b/wwwroot/classes/Admin/PsnpPlusGameDifference.php
@@ -5,40 +5,24 @@ declare(strict_types=1);
 final readonly class PsnpPlusGameDifference
 {
     /**
-     * @var int[]
-     */
-    private array $unobtainableOrders;
-
-    /**
-     * @var int[]
-     */
-    private array $unobtainableTrophyIds;
-
-    /**
-     * @var int[]
-     */
-    private array $obtainableOrders;
-
-    /**
-     * @var int[]
-     */
-    private array $obtainableTrophyIds;
-
-    /**
      * @param int[] $unobtainableOrders
      * @param int[] $unobtainableTrophyIds
      * @param int[] $obtainableOrders
      * @param int[] $obtainableTrophyIds
      */
     public function __construct(
-        private int $gameId,
-        private string $gameName,
-        private string $npCommunicationId,
-        private int $psnprofilesId,
-        array $unobtainableOrders,
-        array $unobtainableTrophyIds,
-        array $obtainableOrders,
-        array $obtainableTrophyIds,
+        final private int $gameId,
+        final private string $gameName,
+        final private string $npCommunicationId,
+        final private int $psnprofilesId,
+        /** @var int[] */
+        final private array $unobtainableOrders,
+        /** @var int[] */
+        final private array $unobtainableTrophyIds,
+        /** @var int[] */
+        final private array $obtainableOrders,
+        /** @var int[] */
+        final private array $obtainableTrophyIds,
     ) {
         $this->unobtainableOrders = array_map(intval(...), $unobtainableOrders);
         $this->unobtainableTrophyIds = array_map(intval(...), $unobtainableTrophyIds);

--- a/wwwroot/classes/Admin/PsnpPlusGameDifference.php
+++ b/wwwroot/classes/Admin/PsnpPlusGameDifference.php
@@ -5,6 +5,26 @@ declare(strict_types=1);
 final readonly class PsnpPlusGameDifference
 {
     /**
+     * @var int[]
+     */
+    private array $unobtainableOrders;
+
+    /**
+     * @var int[]
+     */
+    private array $unobtainableTrophyIds;
+
+    /**
+     * @var int[]
+     */
+    private array $obtainableOrders;
+
+    /**
+     * @var int[]
+     */
+    private array $obtainableTrophyIds;
+
+    /**
      * @param int[] $unobtainableOrders
      * @param int[] $unobtainableTrophyIds
      * @param int[] $obtainableOrders
@@ -15,14 +35,10 @@ final readonly class PsnpPlusGameDifference
         final private string $gameName,
         final private string $npCommunicationId,
         final private int $psnprofilesId,
-        /** @var int[] */
-        final private array $unobtainableOrders,
-        /** @var int[] */
-        final private array $unobtainableTrophyIds,
-        /** @var int[] */
-        final private array $obtainableOrders,
-        /** @var int[] */
-        final private array $obtainableTrophyIds,
+        array $unobtainableOrders,
+        array $unobtainableTrophyIds,
+        array $obtainableOrders,
+        array $obtainableTrophyIds,
     ) {
         $this->unobtainableOrders = array_map(intval(...), $unobtainableOrders);
         $this->unobtainableTrophyIds = array_map(intval(...), $unobtainableTrophyIds);

--- a/wwwroot/classes/Admin/SystemCommandExecutor.php
+++ b/wwwroot/classes/Admin/SystemCommandExecutor.php
@@ -43,12 +43,9 @@ final class SystemCommandExecutor implements CommandExecutorInterface
 
     private function buildCommandString(array $command): string
     {
-        $escapedParts = array_map(
-            escapeshellarg(...),
-            $command
-        );
-
-        return implode(' ', $escapedParts);
+        return $command
+            |> (fn (array $parts): array => array_map(escapeshellarg(...), $parts))
+            |> (fn (array $escapedParts): string => implode(' ', $escapedParts));
     }
 
     private function combineOutput(?string $stdout, ?string $stderr): string

--- a/wwwroot/classes/Admin/WorkerPageResult.php
+++ b/wwwroot/classes/Admin/WorkerPageResult.php
@@ -10,12 +10,16 @@ require_once __DIR__ . '/WorkerSortDirection.php';
 final readonly class WorkerPageResult
 {
     /**
+     * @var list<Worker>
+     */
+    private array $workers;
+
+    /**
      * @param list<Worker> $workers
      * @param array<string, WorkerPageSortLink> $sortLinks
      */
     public function __construct(
-        /** @var list<Worker> */
-        final private array $workers,
+        array $workers,
         final private ?string $successMessage,
         final private ?string $errorMessage,
         final private array $sortLinks,

--- a/wwwroot/classes/Admin/WorkerPageResult.php
+++ b/wwwroot/classes/Admin/WorkerPageResult.php
@@ -10,21 +10,17 @@ require_once __DIR__ . '/WorkerSortDirection.php';
 final readonly class WorkerPageResult
 {
     /**
-     * @var list<Worker>
-     */
-    private readonly array $workers;
-
-    /**
      * @param list<Worker> $workers
      * @param array<string, WorkerPageSortLink> $sortLinks
      */
     public function __construct(
-        array $workers,
-        private readonly ?string $successMessage,
-        private readonly ?string $errorMessage,
-        private readonly array $sortLinks,
-        private readonly WorkerSortField $sortField,
-        private readonly WorkerSortDirection $sortDirection,
+        /** @var list<Worker> */
+        final private array $workers,
+        final private ?string $successMessage,
+        final private ?string $errorMessage,
+        final private array $sortLinks,
+        final private WorkerSortField $sortField,
+        final private WorkerSortDirection $sortDirection,
     ) {
         $this->workers = array_values($workers);
     }

--- a/wwwroot/classes/ChangelogDateGroup.php
+++ b/wwwroot/classes/ChangelogDateGroup.php
@@ -7,12 +7,16 @@ require_once __DIR__ . '/ChangelogEntryPresenter.php';
 final readonly class ChangelogDateGroup
 {
     /**
+     * @var ChangelogEntryPresenter[]
+     */
+    private array $entries;
+
+    /**
      * @param ChangelogEntryPresenter[] $entries
      */
     public function __construct(
         final private string $dateLabel,
-        /** @var ChangelogEntryPresenter[] */
-        final private array $entries,
+        array $entries,
     ) {
         $this->entries = array_values($entries);
     }

--- a/wwwroot/classes/ChangelogDateGroup.php
+++ b/wwwroot/classes/ChangelogDateGroup.php
@@ -7,16 +7,12 @@ require_once __DIR__ . '/ChangelogEntryPresenter.php';
 final readonly class ChangelogDateGroup
 {
     /**
-     * @var ChangelogEntryPresenter[]
-     */
-    private array $entries;
-
-    /**
      * @param ChangelogEntryPresenter[] $entries
      */
     public function __construct(
         final private string $dateLabel,
-        array $entries
+        /** @var ChangelogEntryPresenter[] */
+        final private array $entries,
     ) {
         $this->entries = array_values($entries);
     }

--- a/wwwroot/classes/ChangelogEntryPresenter.php
+++ b/wwwroot/classes/ChangelogEntryPresenter.php
@@ -119,15 +119,15 @@ final readonly class ChangelogEntryPresenter
             return '';
         }
 
-        $badges = array_map(
-            static fn(string $platform): string => sprintf(
-                '<span class="badge rounded-pill text-bg-primary">%s</span>',
-                Html::escape($platform)
-            ),
-            $platforms
-        );
-
-        return implode(' ', $badges);
+        return $platforms
+            |> (fn (array $platformList): array => array_map(
+                static fn (string $platform): string => sprintf(
+                    '<span class="badge rounded-pill text-bg-primary">%s</span>',
+                    Html::escape($platform)
+                ),
+                $platformList,
+            ))
+            |> (fn (array $badges): string => implode(' ', $badges));
     }
 
     private function buildRegionBadge(?string $region): string

--- a/wwwroot/classes/ChangelogService.php
+++ b/wwwroot/classes/ChangelogService.php
@@ -28,13 +28,12 @@ final class ChangelogService
 
     private static function filteredChangeTypesSql(): string
     {
-        return '(' . implode(
-            ', ',
-            array_map(
+        return self::filteredChangeTypes()
+            |> (fn (array $types): array => array_map(
                 static fn (string $type): string => "'" . $type . "'",
-                self::filteredChangeTypes()
-            )
-        ) . ')';
+                $types,
+            ))
+            |> (fn (array $quotedTypes): string => '(' . implode(', ', $quotedTypes) . ')');
     }
 
     public function getTotalChangeCount(): int

--- a/wwwroot/classes/GameHistoryPage.php
+++ b/wwwroot/classes/GameHistoryPage.php
@@ -55,10 +55,10 @@ final class GameHistoryPage
     private ?array $historyEntries = null;
 
     public function __construct(
-        private GameService $gameService,
-        private GameHistoryService $historyService,
-        private GameHeaderService $gameHeaderService,
-        private Utility $utility,
+        private readonly GameService $gameService,
+        private readonly GameHistoryService $historyService,
+        private readonly GameHeaderService $gameHeaderService,
+        private readonly Utility $utility,
         int $gameId,
         ?GameHistoryChangeFilter $historyChangeFilter = null
     ) {

--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 final readonly class GameLeaderboardFilter extends GamePlayerFilter
 {
-    public function __construct(?string $country, ?string $avatar, final private int $page)
+    private int $page;
+
+    public function __construct(?string $country, ?string $avatar, int $page)
     {
         parent::__construct($country, $avatar);
         $this->page = max($page, 1);

--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 final readonly class GameLeaderboardFilter extends GamePlayerFilter
 {
-    private int $page;
-
-    public function __construct(?string $country, ?string $avatar, int $page)
+    public function __construct(?string $country, ?string $avatar, final private int $page)
     {
         parent::__construct($country, $avatar);
         $this->page = max($page, 1);
@@ -40,6 +38,7 @@ final readonly class GameLeaderboardFilter extends GamePlayerFilter
         return clone($this, ['page' => max($page, 1)]);
     }
 
+    #[\NoDiscard]
     public function getOffset(int $limit): int
     {
         return ($this->page - 1) * $limit;

--- a/wwwroot/classes/GamePage.php
+++ b/wwwroot/classes/GamePage.php
@@ -50,9 +50,9 @@ final class GamePage
      * @param array<string, mixed> $queryParameters
      */
     public function __construct(
-        private GameService $gameService,
-        private GameHeaderService $gameHeaderService,
-        private Utility $utility,
+        private readonly GameService $gameService,
+        private readonly GameHeaderService $gameHeaderService,
+        private readonly Utility $utility,
         int $gameId,
         array $queryParameters = [],
         ?string $playerOnlineId = null

--- a/wwwroot/classes/GamePlayerFilter.php
+++ b/wwwroot/classes/GamePlayerFilter.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 readonly class GamePlayerFilter
 {
-    private ?string $country;
-
-    private ?string $avatar;
-
-    public function __construct(?string $country, ?string $avatar)
-    {
+    public function __construct(
+        private ?string $country,
+        private ?string $avatar,
+    ) {
         $this->country = self::normalizeOptionalString($country);
         $this->avatar = self::normalizeOptionalString($avatar);
     }
@@ -49,6 +47,7 @@ readonly class GamePlayerFilter
     /**
      * @return array{country?: string, avatar?: string}
      */
+    #[\NoDiscard]
     public function getFilterParameters(): array
     {
         $parameters = [];

--- a/wwwroot/classes/GamePlayerFilter.php
+++ b/wwwroot/classes/GamePlayerFilter.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 readonly class GamePlayerFilter
 {
-    public function __construct(
-        private ?string $country,
-        private ?string $avatar,
-    ) {
+    private ?string $country;
+
+    private ?string $avatar;
+
+    public function __construct(?string $country, ?string $avatar)
+    {
         $this->country = self::normalizeOptionalString($country);
         $this->avatar = self::normalizeOptionalString($avatar);
     }

--- a/wwwroot/classes/GameRecentPlayersQueryBuilder.php
+++ b/wwwroot/classes/GameRecentPlayersQueryBuilder.php
@@ -48,9 +48,11 @@ final readonly class GameRecentPlayersQueryBuilder
         LIMIT :limit
     SQL;
 
+    private int $limit;
+
     public function __construct(
         final private GamePlayerFilter $filter,
-        final private int $limit,
+        int $limit,
     ) {
         $this->limit = max(1, $limit);
     }

--- a/wwwroot/classes/GameRecentPlayersQueryBuilder.php
+++ b/wwwroot/classes/GameRecentPlayersQueryBuilder.php
@@ -48,11 +48,9 @@ final readonly class GameRecentPlayersQueryBuilder
         LIMIT :limit
     SQL;
 
-    private int $limit;
-
     public function __construct(
-        private GamePlayerFilter $filter,
-        int $limit,
+        final private GamePlayerFilter $filter,
+        final private int $limit,
     ) {
         $this->limit = max(1, $limit);
     }

--- a/wwwroot/classes/HttpRequest.php
+++ b/wwwroot/classes/HttpRequest.php
@@ -17,16 +17,19 @@ readonly class HttpRequest
         return new self($_SERVER ?? []);
     }
 
+    #[\NoDiscard]
     public function getScriptUrl(): ?string
     {
         return $this->getStringServerValue('SCRIPT_URL');
     }
 
+    #[\NoDiscard]
     public function getRequestUri(): ?string
     {
         return $this->getStringServerValue('REQUEST_URI');
     }
 
+    #[\NoDiscard]
     public function getResolvedUri(): string
     {
         $scriptUrl = $this->getScriptUrl();

--- a/wwwroot/classes/ImageHashCalculator.php
+++ b/wwwroot/classes/ImageHashCalculator.php
@@ -10,7 +10,7 @@ final class ImageHashCalculator
     private const int RGBA_CHANNEL_MAX = 255;
 
     public function __construct(
-        private ImageProcessorInterface $imageProcessor = new GdImageProcessor(),
+        private readonly ImageProcessorInterface $imageProcessor = new GdImageProcessor(),
     ) {
     }
 

--- a/wwwroot/classes/PageMetaData.php
+++ b/wwwroot/classes/PageMetaData.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 final readonly class PageMetaData
 {
+    private ?string $title;
+    private ?string $description;
+    private ?string $image;
+    private ?string $url;
+
     public function __construct(
-        final private ?string $title = null,
-        final private ?string $description = null,
-        final private ?string $image = null,
-        final private ?string $url = null,
+        ?string $title = null,
+        ?string $description = null,
+        ?string $image = null,
+        ?string $url = null,
     ) {
         $this->title = self::normalize($title);
         $this->description = self::normalize($description);

--- a/wwwroot/classes/PageMetaData.php
+++ b/wwwroot/classes/PageMetaData.php
@@ -4,16 +4,11 @@ declare(strict_types=1);
 
 final readonly class PageMetaData
 {
-    private ?string $title;
-    private ?string $description;
-    private ?string $image;
-    private ?string $url;
-
     public function __construct(
-        ?string $title = null,
-        ?string $description = null,
-        ?string $image = null,
-        ?string $url = null,
+        final private ?string $title = null,
+        final private ?string $description = null,
+        final private ?string $image = null,
+        final private ?string $url = null,
     ) {
         $this->title = self::normalize($title);
         $this->description = self::normalize($description);

--- a/wwwroot/classes/Pagination.php
+++ b/wwwroot/classes/Pagination.php
@@ -6,12 +6,10 @@ require_once __DIR__ . '/PaginationItem.php';
 
 final readonly class Pagination
 {
-    private int $currentPage;
-
-    private int $totalPages;
-
-    public function __construct(int $currentPage, int $totalPages)
-    {
+    public function __construct(
+        final private int $currentPage,
+        final private int $totalPages,
+    ) {
         $this->totalPages = max(1, $totalPages);
         $this->currentPage = min(max(1, $currentPage), $this->totalPages);
     }
@@ -25,6 +23,7 @@ final readonly class Pagination
     /**
      * @return list<PaginationItem>
      */
+    #[\NoDiscard]
     public function buildItems(): array
     {
         $items = [];

--- a/wwwroot/classes/Pagination.php
+++ b/wwwroot/classes/Pagination.php
@@ -6,10 +6,12 @@ require_once __DIR__ . '/PaginationItem.php';
 
 final readonly class Pagination
 {
-    public function __construct(
-        final private int $currentPage,
-        final private int $totalPages,
-    ) {
+    private int $currentPage;
+
+    private int $totalPages;
+
+    public function __construct(int $currentPage, int $totalPages)
+    {
         $this->totalPages = max(1, $totalPages);
         $this->currentPage = min(max(1, $currentPage), $this->totalPages);
     }

--- a/wwwroot/classes/PlayerAdvisorFilter.php
+++ b/wwwroot/classes/PlayerAdvisorFilter.php
@@ -52,6 +52,7 @@ final readonly class PlayerAdvisorFilter
         return clone($this, ['page' => max($page, 1)]);
     }
 
+    #[\NoDiscard]
     public function getOffset(int $limit): int
     {
         return ($this->page - 1) * $limit;
@@ -88,6 +89,7 @@ final readonly class PlayerAdvisorFilter
     /**
      * @return array<string, string>
      */
+    #[\NoDiscard]
     public function getFilterParameters(): array
     {
         $parameters = [];

--- a/wwwroot/classes/PlayerGamesFilter.php
+++ b/wwwroot/classes/PlayerGamesFilter.php
@@ -145,6 +145,7 @@ final readonly class PlayerGamesFilter
         return $this->limit;
     }
 
+    #[\NoDiscard]
     public function getOffset(): int
     {
         return ($this->page - 1) * $this->limit;
@@ -153,6 +154,7 @@ final readonly class PlayerGamesFilter
     /**
      * @return array<string, string>
      */
+    #[\NoDiscard]
     public function getFilterParameters(): array
     {
         $parameters = [];

--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -6,7 +6,9 @@ require_once __DIR__ . '/GamePlayerFilter.php';
 
 final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
 {
-    public function __construct(?string $country, ?string $avatar, final private int $page)
+    private int $page;
+
+    public function __construct(?string $country, ?string $avatar, int $page)
     {
         parent::__construct($country, $avatar);
         $this->page = max($page, 1);

--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -6,9 +6,7 @@ require_once __DIR__ . '/GamePlayerFilter.php';
 
 final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
 {
-    private int $page;
-
-    public function __construct(?string $country, ?string $avatar, int $page)
+    public function __construct(?string $country, ?string $avatar, final private int $page)
     {
         parent::__construct($country, $avatar);
         $this->page = max($page, 1);
@@ -34,6 +32,7 @@ final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
         return $this->page;
     }
 
+    #[\NoDiscard]
     public function getOffset(int $limit): int
     {
         return ($this->page - 1) * $limit;
@@ -43,6 +42,7 @@ final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
      * @return array{country?: string, avatar?: string}
      */
     #[\Override]
+    #[\NoDiscard]
     public function getFilterParameters(): array
     {
         return parent::getFilterParameters();

--- a/wwwroot/classes/PlayerLogFilter.php
+++ b/wwwroot/classes/PlayerLogFilter.php
@@ -53,6 +53,7 @@ final readonly class PlayerLogFilter
         return $this->page;
     }
 
+    #[\NoDiscard]
     public function getOffset(int $limit): int
     {
         return ($this->page - 1) * $limit;
@@ -79,6 +80,7 @@ final readonly class PlayerLogFilter
     /**
      * @return array<string, string>
      */
+    #[\NoDiscard]
     public function getFilterParameters(): array
     {
         $parameters = [];

--- a/wwwroot/classes/PlayerPlatformFilterRenderer.php
+++ b/wwwroot/classes/PlayerPlatformFilterRenderer.php
@@ -52,12 +52,9 @@ HTML;
 
     public function renderOptionItems(PlayerPlatformFilterOptions $options): string
     {
-        $optionItems = array_map(
-            $this->renderOption(...),
-            $options->getOptions()
-        );
-
-        return implode(PHP_EOL, $optionItems);
+        return $options->getOptions()
+            |> (fn (array $optionList): array => array_map($this->renderOption(...), $optionList))
+            |> (fn (array $optionItems): string => implode(PHP_EOL, $optionItems));
     }
 
     private function renderOption(PlayerPlatformFilterOption $option): string

--- a/wwwroot/classes/PlayerRandomGamesFilter.php
+++ b/wwwroot/classes/PlayerRandomGamesFilter.php
@@ -11,7 +11,7 @@ final readonly class PlayerRandomGamesFilter
      * @param array<string, bool> $selectedPlatforms
      */
     private function __construct(
-        private array $selectedPlatforms,
+        final private array $selectedPlatforms,
     ) {
     }
 

--- a/wwwroot/classes/TrophyImageDownloader.php
+++ b/wwwroot/classes/TrophyImageDownloader.php
@@ -15,9 +15,9 @@ final readonly class TrophyImageDownloader
     public const string PLACEHOLDER_FILENAME = '.png';
 
     public function __construct(
-        private readonly ImageHashCalculator $imageHashCalculator,
-        private readonly ?\Closure $logger = null,
-        private readonly ?\Closure $remoteFileFetcher = null,
+        final private ImageHashCalculator $imageHashCalculator,
+        final private ?\Closure $logger = null,
+        final private ?\Closure $remoteFileFetcher = null,
     ) {
     }
 

--- a/wwwroot/classes/TrophyListFilter.php
+++ b/wwwroot/classes/TrophyListFilter.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 final readonly class TrophyListFilter
 {
-    private int $page;
-
-    public function __construct(int $page)
+    public function __construct(final private int $page)
     {
         $this->page = max($page, 1);
     }
@@ -31,6 +29,7 @@ final readonly class TrophyListFilter
         return $this->page;
     }
 
+    #[\NoDiscard]
     public function getOffset(int $limit): int
     {
         return ($this->page - 1) * $limit;
@@ -39,6 +38,7 @@ final readonly class TrophyListFilter
     /**
      * @return array<string, int>
      */
+    #[\NoDiscard]
     public function getFilterParameters(): array
     {
         return [];

--- a/wwwroot/classes/TrophyListFilter.php
+++ b/wwwroot/classes/TrophyListFilter.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 final readonly class TrophyListFilter
 {
-    public function __construct(final private int $page)
+    private int $page;
+
+    public function __construct(int $page)
     {
         $this->page = max($page, 1);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the PHP 8.5 modernization series with leftovers after recent filter/enum/sealing work.

### Changes
- Promote immutable scalar/DI properties with `final private` where values need no constructor rewriting (`PsnpPlus*` scalars, `WorkerPageResult` messages/sorts, `ChangelogDateGroup` label, `GameRecentPlayersQueryBuilder` filter, `TrophyImageDownloader`, admin progress listeners)
- Prefer pipes for map→implode transforms in `SystemCommandExecutor`, `ChangelogService`, `PlayerPlatformFilterRenderer`, and `ChangelogEntryPresenter`
- Add selective `#[\NoDiscard]` on pure getters/offset/filter builders, `Pagination::buildItems()`, and `HttpRequest` URI accessors
- Switch `PossibleCheaterPage` to a `fromService()` factory with promoted report state
- Prefer `private readonly` for DI deps on `GamePage`, `GameHistoryPage`, and `ImageHashCalculator`
- Leave clamp/normalize fields as classic readonly properties (promoted readonly props cannot be rewritten in constructors)

### Testing
- `php tests/run.php` — all 1027 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b799b6a-3a1b-41e3-9b17-5764cd8d5ef5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b799b6a-3a1b-41e3-9b17-5764cd8d5ef5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

