### PR TITLE
Adopt remaining PHP 8.5 idioms for routes, regions, and changelog types

### DIFF
--- a/tests/Php85IdiomEnumsTest.php
+++ b/tests/Php85IdiomEnumsTest.php
@@ -17,6 +17,10 @@ require_once __DIR__ . '/../wwwroot/classes/PlayerTimelineStatus.php';
 require_once __DIR__ . '/../wwwroot/classes/HistoryIconType.php';
 require_once __DIR__ . '/../wwwroot/classes/HistoryDiffTokenState.php';
 require_once __DIR__ . '/../wwwroot/classes/LeaderboardView.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerRouteView.php';
+require_once __DIR__ . '/../wwwroot/classes/RouteName.php';
+require_once __DIR__ . '/../wwwroot/classes/AvatarSize.php';
+require_once __DIR__ . '/../wwwroot/classes/GameRegion.php';
 require_once __DIR__ . '/../wwwroot/classes/NpServiceName.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterDateOperator.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerTimelineEntry.php';
@@ -177,6 +181,45 @@ final class Php85IdiomEnumsTest extends TestCase
         $this->assertSame('leaderboard_rarity.php', LeaderboardView::Rarity->includeFile());
         $this->assertSame('leaderboard_in_game_rarity.php', LeaderboardView::InGameRarity->includeFile());
         $this->assertSame(null, LeaderboardView::tryFrom('unknown'));
+    }
+
+    public function testPlayerRouteViewIncludeFiles(): void
+    {
+        $this->assertSame('player_advisor.php', PlayerRouteView::Advisor->includeFile());
+        $this->assertSame('player_log.php', PlayerRouteView::Log->includeFile());
+        $this->assertSame('player_random.php', PlayerRouteView::Random->includeFile());
+        $this->assertSame('player_report.php', PlayerRouteView::Report->includeFile());
+        $this->assertSame('player_timeline.php', PlayerRouteView::Timeline->includeFile());
+        $this->assertSame(null, PlayerRouteView::tryFrom('unknown'));
+    }
+
+    public function testRouteNameValues(): void
+    {
+        $this->assertSame('game-history', RouteName::GameHistory->value);
+        $this->assertSame('player', RouteName::Player->value);
+        $this->assertSame(RouteName::Trophy, RouteName::tryFrom('trophy'));
+        $this->assertSame(null, RouteName::tryFrom('unknown'));
+    }
+
+    public function testAvatarSizePreferenceOrder(): void
+    {
+        $this->assertSame(
+            [AvatarSize::Xl, AvatarSize::L, AvatarSize::M, AvatarSize::S],
+            AvatarSize::preferenceOrder()
+        );
+        $this->assertSame('xl', AvatarSize::Xl->value);
+    }
+
+    public function testGameRegionSqlSortCaseExpression(): void
+    {
+        $this->assertSame(0, GameRegion::Na->sortRank());
+        $this->assertSame(3, GameRegion::Hk->sortRank());
+
+        $expression = GameRegion::sqlSortCaseExpression('region');
+        $this->assertStringContainsString("WHEN region = 'NA' THEN 0", $expression);
+        $this->assertStringContainsString('WHEN region IS NULL THEN 2', $expression);
+        $this->assertStringContainsString("WHEN region = 'AS' THEN 5", $expression);
+        $this->assertStringContainsString('ELSE 6', $expression);
     }
 
     public function testNpServiceNamePreferForPlatformLabels(): void

--- a/tests/TrophyMergeMetadataRepositoryTest.php
+++ b/tests/TrophyMergeMetadataRepositoryTest.php
@@ -71,13 +71,13 @@ final class TrophyMergeMetadataRepositoryTest extends TestCase
 
     public function testLogChangeInsertsChangelogRow(): void
     {
-        $this->repository->logChange('GAME_MERGE', 10, 20);
+        $this->repository->logChange(ChangelogEntryType::GAME_MERGE, 10, 20);
 
         $row = $this->database
             ->query("SELECT change_type, param_1, param_2 FROM psn100_change")
             ->fetch(PDO::FETCH_ASSOC);
 
-        $this->assertSame('GAME_MERGE', $row['change_type']);
+        $this->assertSame(ChangelogEntryType::GAME_MERGE->value, $row['change_type']);
         $this->assertSame(10, (int) $row['param_1']);
         $this->assertSame(20, (int) $row['param_2']);
     }

--- a/wwwroot/classes/Admin/PsnpPlusService.php
+++ b/wwwroot/classes/Admin/PsnpPlusService.php
@@ -133,7 +133,8 @@ final class PsnpPlusService
 
         $rows = $statement->fetchAll(PDO::FETCH_COLUMN);
 
-        return array_map(intval(...), $rows === false ? [] : $rows);
+        return ($rows === false ? [] : $rows)
+            |> (fn (array $values): array => array_map(intval(...), $values));
     }
 
     /**
@@ -193,7 +194,8 @@ final class PsnpPlusService
 
         $rows = $statement->fetchAll(PDO::FETCH_COLUMN);
 
-        return array_map(strval(...), $rows === false ? [] : $rows);
+        return ($rows === false ? [] : $rows)
+            |> (fn (array $values): array => array_map(strval(...), $values));
     }
 
     private function findGameByNpCommunicationId(string $npCommunicationId): ?PsnpPlusGame
@@ -224,8 +226,10 @@ final class PsnpPlusService
             return [];
         }
 
-        $zeroBasedOrders = array_map(static fn (int $order): int => $order - 1, $orders);
-        $placeholders = implode(',', array_fill(0, count($zeroBasedOrders), '?'));
+        $zeroBasedOrders = $orders
+            |> (fn (array $values): array => array_map(static fn (int $order): int => $order - 1, $values));
+        $placeholders = $zeroBasedOrders
+            |> (fn (array $values): string => implode(',', array_fill(0, count($values), '?')));
 
         $sql = sprintf(
             'SELECT order_id, id FROM trophy WHERE np_communication_id = ? AND order_id IN (%s)',
@@ -281,6 +285,7 @@ final class PsnpPlusService
 
         $rows = $statement->fetchAll(PDO::FETCH_COLUMN);
 
-        return array_map(intval(...), $rows === false ? [] : $rows);
+        return ($rows === false ? [] : $rows)
+            |> (fn (array $values): array => array_map(intval(...), $values));
     }
 }

--- a/wwwroot/classes/AvatarSize.php
+++ b/wwwroot/classes/AvatarSize.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+enum AvatarSize: string
+{
+    case Xl = 'xl';
+    case L = 'l';
+    case M = 'm';
+    case S = 's';
+
+    /**
+     * Preferred download order when synchronizing a player avatar from PSN.
+     *
+     * @return list<self>
+     */
+    #[\NoDiscard]
+    public static function preferenceOrder(): array
+    {
+        return [self::Xl, self::L, self::M, self::S];
+    }
+}

--- a/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../ImageHashCalculator.php';
+require_once __DIR__ . '/../AvatarSize.php';
 
 /**
  * Downloads PSN profile avatars, deduplicates them via perceptual hash, and caches
@@ -25,8 +26,8 @@ final class PlayerAvatarSynchronizer
         $avatarUrls = $user->avatarUrls();
         $avatarFilename = '';
 
-        foreach (['xl', 'l', 'm', 's'] as $size) {
-            $avatarUrl = $avatarUrls[$size];
+        foreach (AvatarSize::preferenceOrder() as $size) {
+            $avatarUrl = $avatarUrls[$size->value];
 
             $query = $this->database->prepare(
                 'SELECT md5_hash, extension FROM psn100_avatars WHERE avatar_url = :avatar_url'
@@ -73,7 +74,7 @@ final class PlayerAvatarSynchronizer
                     'INSERT INTO psn100_avatars(size, avatar_url, md5_hash, extension)
                     VALUES(:size, :avatar_url, :md5_hash, :extension)'
                 );
-                $query->bindValue(':size', $size, PDO::PARAM_STR);
+                $query->bindValue(':size', $size->value, PDO::PARAM_STR);
                 $query->bindValue(':avatar_url', $avatarUrl, PDO::PARAM_STR);
                 $query->bindValue(':md5_hash', $newPHash, PDO::PARAM_STR);
                 $query->bindValue(':extension', $extension, PDO::PARAM_STR);

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/Game/GameHeaderData.php';
 require_once __DIR__ . '/Game/GameHeaderParent.php';
 require_once __DIR__ . '/Game/GameHeaderStack.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
+require_once __DIR__ . '/GameRegion.php';
 require_once __DIR__ . '/MergeNpCommunicationId.php';
 require_once __DIR__ . '/PsnpPlusClient.php';
 require_once __DIR__ . '/Html.php';
@@ -246,27 +247,22 @@ class GameHeaderService
     private function findChildPsnprofilesIds(string $parentNpCommunicationId): array
     {
         $query = $this->database->prepare(
-            <<<'SQL'
-            SELECT
-                psnprofiles_id
-            FROM
-                trophy_title_meta
-            WHERE
-                parent_np_communication_id = :parent_np_communication_id
-                AND psnprofiles_id IS NOT NULL
-            ORDER BY
-                CASE
-                    WHEN region = 'NA' THEN 0
-                    WHEN region = 'EU' THEN 1
-                    WHEN region IS NULL THEN 2
-                    WHEN region = 'HK' THEN 3
-                    WHEN region = 'JP' THEN 4
-                    WHEN region = 'AS' THEN 5
-                    ELSE 6
-                END,
-                region,
-                psnprofiles_id
-            SQL
+            sprintf(
+                <<<'SQL'
+                SELECT
+                    psnprofiles_id
+                FROM
+                    trophy_title_meta
+                WHERE
+                    parent_np_communication_id = :parent_np_communication_id
+                    AND psnprofiles_id IS NOT NULL
+                ORDER BY
+                    %s,
+                    region,
+                    psnprofiles_id
+                SQL,
+                GameRegion::sqlSortCaseExpression('region')
+            )
         );
         $query->bindValue(':parent_np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
         $query->execute();

--- a/wwwroot/classes/GameRegion.php
+++ b/wwwroot/classes/GameRegion.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+enum GameRegion: string
+{
+    case Na = 'NA';
+    case Eu = 'EU';
+    case Hk = 'HK';
+    case Jp = 'JP';
+    case As = 'AS';
+
+    #[\NoDiscard]
+    public function sortRank(): int
+    {
+        return match ($this) {
+            self::Na => 0,
+            self::Eu => 1,
+            self::Hk => 3,
+            self::Jp => 4,
+            self::As => 5,
+        };
+    }
+
+    /**
+     * SQL CASE expression that ranks known regions, NULL, then everything else.
+     */
+    #[\NoDiscard]
+    public static function sqlSortCaseExpression(string $column = 'region'): string
+    {
+        $lines = ['CASE'];
+
+        foreach ([self::Na, self::Eu] as $region) {
+            $lines[] = sprintf(
+                "    WHEN %s = '%s' THEN %d",
+                $column,
+                $region->value,
+                $region->sortRank()
+            );
+        }
+
+        $lines[] = sprintf('    WHEN %s IS NULL THEN 2', $column);
+
+        foreach ([self::Hk, self::Jp, self::As] as $region) {
+            $lines[] = sprintf(
+                "    WHEN %s = '%s' THEN %d",
+                $column,
+                $region->value,
+                $region->sortRank()
+            );
+        }
+
+        $lines[] = '    ELSE 6';
+        $lines[] = 'END';
+
+        return implode("\n", $lines);
+    }
+}

--- a/wwwroot/classes/GameResetService.php
+++ b/wwwroot/classes/GameResetService.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/ChangelogEntry.php';
 require_once __DIR__ . '/GameResetAction.php';
 require_once __DIR__ . '/MergeNpCommunicationId.php';
 
@@ -67,7 +68,7 @@ final readonly class GameResetService
             );
         });
 
-        $this->logChange('GAME_RESET', $gameId);
+        $this->logChange(ChangelogEntryType::GAME_RESET, $gameId);
 
         return sprintf('Game %d was reset.', $gameId);
     }
@@ -109,7 +110,7 @@ final readonly class GameResetService
             );
         });
 
-        $this->logChange('GAME_DELETE', $gameId, $gameName);
+        $this->logChange(ChangelogEntryType::GAME_DELETE, $gameId, $gameName);
 
         return sprintf('Game %d was deleted.', $gameId);
     }
@@ -157,15 +158,15 @@ final readonly class GameResetService
         return $gameName === false ? null : (string) $gameName;
     }
 
-    private function logChange(string $changeType, int $gameId, ?string $extra = null): void
+    private function logChange(ChangelogEntryType $changeType, int $gameId, ?string $extra = null): void
     {
         if ($extra === null) {
             $query = $this->database->prepare('INSERT INTO `psn100_change` (`change_type`, `param_1`) VALUES (:change_type, :param_1)');
-            $query->bindValue(':change_type', $changeType, PDO::PARAM_STR);
+            $query->bindValue(':change_type', $changeType->value, PDO::PARAM_STR);
             $query->bindValue(':param_1', $gameId, PDO::PARAM_INT);
         } else {
             $query = $this->database->prepare('INSERT INTO `psn100_change` (`change_type`, `param_1`, `extra`) VALUES (:change_type, :param_1, :extra)');
-            $query->bindValue(':change_type', $changeType, PDO::PARAM_STR);
+            $query->bindValue(':change_type', $changeType->value, PDO::PARAM_STR);
             $query->bindValue(':param_1', $gameId, PDO::PARAM_INT);
             $query->bindValue(':extra', $extra, PDO::PARAM_STR);
         }

--- a/wwwroot/classes/GameTrophyFilter.php
+++ b/wwwroot/classes/GameTrophyFilter.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/RequestParameter.php';
 
 final readonly class GameTrophyFilter
 {
-    private function __construct(private bool $unearnedOnly)
+    private function __construct(final private bool $unearnedOnly)
     {
     }
 

--- a/wwwroot/classes/MaintenancePageRenderer.php
+++ b/wwwroot/classes/MaintenancePageRenderer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/MaintenancePage.php';
 require_once __DIR__ . '/Html.php';
 
-final class MaintenancePageRenderer
+final readonly class MaintenancePageRenderer
 {
     public function render(MaintenancePage $page): string
     {
@@ -52,29 +52,29 @@ HTML
             return '';
         }
 
-        $links = array_map(
-            function (MaintenancePageStylesheet $stylesheet): string {
-                $attributes = [
-                    sprintf('rel="%s"', $this->escape($stylesheet->getRel())),
-                    sprintf('href="%s"', $this->escape($stylesheet->getHref())),
-                ];
+        return $stylesheets
+            |> (fn (array $sheets): array => array_map($this->renderStylesheetLink(...), $sheets))
+            |> (fn (array $links): string => implode("\n", $links));
+    }
 
-                $integrity = $stylesheet->getIntegrity();
-                if ($integrity !== null && $integrity !== '') {
-                    $attributes[] = sprintf('integrity="%s"', $this->escape($integrity));
-                }
+    private function renderStylesheetLink(MaintenancePageStylesheet $stylesheet): string
+    {
+        $attributes = [
+            sprintf('rel="%s"', $this->escape($stylesheet->getRel())),
+            sprintf('href="%s"', $this->escape($stylesheet->getHref())),
+        ];
 
-                $crossorigin = $stylesheet->getCrossorigin();
-                if ($crossorigin !== null && $crossorigin !== '') {
-                    $attributes[] = sprintf('crossorigin="%s"', $this->escape($crossorigin));
-                }
+        $integrity = $stylesheet->getIntegrity();
+        if ($integrity !== null && $integrity !== '') {
+            $attributes[] = sprintf('integrity="%s"', $this->escape($integrity));
+        }
 
-                return '        <link ' . implode(' ', $attributes) . '>';
-            },
-            $stylesheets
-        );
+        $crossorigin = $stylesheet->getCrossorigin();
+        if ($crossorigin !== null && $crossorigin !== '') {
+            $attributes[] = sprintf('crossorigin="%s"', $this->escape($crossorigin));
+        }
 
-        return implode("\n", $links);
+        return '        <link ' . implode(' ', $attributes) . '>';
     }
 
     private function escape(string $value): string

--- a/wwwroot/classes/PlayerNavigation.php
+++ b/wwwroot/classes/PlayerNavigation.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerNavigationSection.php';
+require_once __DIR__ . '/PlayerRouteView.php';
 require_once __DIR__ . '/PlayerUrlBuilder.php';
 
 final readonly class PlayerNavigation
@@ -35,17 +36,17 @@ final readonly class PlayerNavigation
             ),
             new PlayerNavigationLink(
                 'Timeline',
-                $playerPath . '/timeline',
+                $playerPath . '/' . PlayerRouteView::Timeline->value,
                 $this->isActive(PlayerNavigationSection::TIMELINE)
             ),
             new PlayerNavigationLink(
                 'Log',
-                $playerPath . '/log',
+                $playerPath . '/' . PlayerRouteView::Log->value,
                 $this->isActive(PlayerNavigationSection::LOG)
             ),
             new PlayerNavigationLink(
                 'Trophy Advisor',
-                $playerPath . '/advisor',
+                $playerPath . '/' . PlayerRouteView::Advisor->value,
                 $this->isActive(PlayerNavigationSection::TROPHY_ADVISOR)
             ),
             new PlayerNavigationLink(
@@ -55,7 +56,7 @@ final readonly class PlayerNavigation
             ),
             new PlayerNavigationLink(
                 'Random Games',
-                $playerPath . '/random',
+                $playerPath . '/' . PlayerRouteView::Random->value,
                 $this->isActive(PlayerNavigationSection::RANDOM)
             ),
         ];

--- a/wwwroot/classes/PlayerRouteView.php
+++ b/wwwroot/classes/PlayerRouteView.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+enum PlayerRouteView: string
+{
+    case Advisor = 'advisor';
+    case Log = 'log';
+    case Random = 'random';
+    case Report = 'report';
+    case Timeline = 'timeline';
+
+    #[\NoDiscard]
+    public function includeFile(): string
+    {
+        return match ($this) {
+            self::Advisor => 'player_advisor.php',
+            self::Log => 'player_log.php',
+            self::Random => 'player_random.php',
+            self::Report => 'player_report.php',
+            self::Timeline => 'player_timeline.php',
+        };
+    }
+}

--- a/wwwroot/classes/PlayerUrlBuilder.php
+++ b/wwwroot/classes/PlayerUrlBuilder.php
@@ -2,31 +2,38 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PlayerRouteView.php';
+require_once __DIR__ . '/RouteName.php';
+
 final readonly class PlayerUrlBuilder
 {
     #[\NoDiscard]
     public static function playerPath(string $onlineId): string
     {
-        return self::buildPath('player', rawurlencode($onlineId));
+        return self::buildPath(RouteName::Player->value, rawurlencode($onlineId));
     }
 
     #[\NoDiscard]
     public static function playerReportPath(string $onlineId): string
     {
-        return self::buildPath('player', rawurlencode($onlineId), 'report');
+        return self::buildPath(
+            RouteName::Player->value,
+            rawurlencode($onlineId),
+            PlayerRouteView::Report->value
+        );
     }
 
     #[\NoDiscard]
     public static function gamePlayerPath(string $gameSlug, string $onlineId): string
     {
-        return self::buildPath('game', $gameSlug, rawurlencode($onlineId));
+        return self::buildPath(RouteName::Game->value, $gameSlug, rawurlencode($onlineId));
     }
 
     #[\NoDiscard]
     public static function gamePath(string $gameSlug, ?string $onlineId = null): string
     {
         if ($onlineId === null || $onlineId === '') {
-            return self::buildPath('game', $gameSlug);
+            return self::buildPath(RouteName::Game->value, $gameSlug);
         }
 
         return self::gamePlayerPath($gameSlug, $onlineId);

--- a/wwwroot/classes/RouteName.php
+++ b/wwwroot/classes/RouteName.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+enum RouteName: string
+{
+    case About = 'about';
+    case Avatar = 'avatar';
+    case Changelog = 'changelog';
+    case Game = 'game';
+    case GameHistory = 'game-history';
+    case GameLeaderboard = 'game-leaderboard';
+    case GameRecentPlayers = 'game-recent-players';
+    case Leaderboard = 'leaderboard';
+    case Player = 'player';
+    case Trophy = 'trophy';
+}

--- a/wwwroot/classes/Router.php
+++ b/wwwroot/classes/Router.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/RouteResult.php';
+require_once __DIR__ . '/RouteName.php';
 require_once __DIR__ . '/GameRepository.php';
 require_once __DIR__ . '/TrophyRepository.php';
 require_once __DIR__ . '/PlayerRepository.php';
@@ -30,16 +31,16 @@ class Router
     ) {
         $this->defaultHandler = new HomeRouteHandler('home.php');
         $this->routeHandlers = [
-            'about' => new SimpleRouteHandler('about.php', '/about/'),
-            'avatar' => new SimpleRouteHandler('avatars.php', '/avatar/'),
-            'changelog' => new SimpleRouteHandler('changelog.php', '/changelog/'),
-            'game' => new GameRouteHandler($gameRepository, 'game.php', '/game/', 'games.php'),
-            'game-history' => new GameRouteHandler($gameRepository, 'game_history.php', '/game/'),
-            'game-leaderboard' => new GameRouteHandler($gameRepository, 'game_leaderboard.php', '/game/'),
-            'game-recent-players' => new GameRouteHandler($gameRepository, 'game_recent_players.php', '/game/'),
-            'leaderboard' => new LeaderboardRouteHandler(),
-            'player' => new PlayerRouteHandler($playerRepository),
-            'trophy' => new TrophyRouteHandler($trophyRepository),
+            RouteName::About->value => new SimpleRouteHandler('about.php', '/about/'),
+            RouteName::Avatar->value => new SimpleRouteHandler('avatars.php', '/avatar/'),
+            RouteName::Changelog->value => new SimpleRouteHandler('changelog.php', '/changelog/'),
+            RouteName::Game->value => new GameRouteHandler($gameRepository, 'game.php', '/game/', 'games.php'),
+            RouteName::GameHistory->value => new GameRouteHandler($gameRepository, 'game_history.php', '/game/'),
+            RouteName::GameLeaderboard->value => new GameRouteHandler($gameRepository, 'game_leaderboard.php', '/game/'),
+            RouteName::GameRecentPlayers->value => new GameRouteHandler($gameRepository, 'game_recent_players.php', '/game/'),
+            RouteName::Leaderboard->value => new LeaderboardRouteHandler(),
+            RouteName::Player->value => new PlayerRouteHandler($playerRepository),
+            RouteName::Trophy->value => new TrophyRouteHandler($trophyRepository),
         ];
     }
 
@@ -54,15 +55,18 @@ class Router
         }
 
         $segments = explode('/', $normalizedPath);
-        $route = array_first($segments);
-        $routeSegments = array_slice($segments, 1);
+        $routeName = RouteName::tryFrom(array_first($segments) ?? '');
 
-        $handler = $this->routeHandlers[$route] ?? null;
+        if ($routeName === null) {
+            return RouteResult::notFound();
+        }
+
+        $handler = $this->routeHandlers[$routeName->value] ?? null;
 
         if (!$handler instanceof RouteHandlerInterface) {
             return RouteResult::notFound();
         }
 
-        return $handler->handle($routeSegments);
+        return $handler->handle(array_slice($segments, 1));
     }
 }

--- a/wwwroot/classes/Routing/PlayerRouteHandler.php
+++ b/wwwroot/classes/Routing/PlayerRouteHandler.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../PlayerRepository.php';
+require_once __DIR__ . '/../PlayerRouteView.php';
 require_once __DIR__ . '/../PlayerUrlBuilder.php';
 require_once __DIR__ . '/RouteHandlerInterface.php';
 
@@ -38,22 +39,21 @@ final readonly class PlayerRouteHandler implements RouteHandlerInterface
             return RouteResult::redirect('/player/');
         }
 
-        $view = (string) (array_first($segments) ?? '');
-
+        $viewSegment = (string) (array_first($segments) ?? '');
         $variables = [
             'accountId' => $accountId,
             'player' => $player,
             'onlineId' => $onlineId,
         ];
 
-        return match ($view) {
-            '' => RouteResult::include('player.php', $variables),
-            'advisor' => RouteResult::include('player_advisor.php', $variables),
-            'log' => RouteResult::include('player_log.php', $variables),
-            'random' => RouteResult::include('player_random.php', $variables),
-            'report' => RouteResult::include('player_report.php', $variables),
-            'timeline' => RouteResult::include('player_timeline.php', $variables),
-            default => RouteResult::redirect(PlayerUrlBuilder::playerPath($onlineId)),
-        };
+        if ($viewSegment === '') {
+            return RouteResult::include('player.php', $variables);
+        }
+
+        $view = PlayerRouteView::tryFrom($viewSegment);
+
+        return $view !== null
+            ? RouteResult::include($view->includeFile(), $variables)
+            : RouteResult::redirect(PlayerUrlBuilder::playerPath($onlineId));
     }
 }

--- a/wwwroot/classes/TrophyMergeMetadataRepository.php
+++ b/wwwroot/classes/TrophyMergeMetadataRepository.php
@@ -109,12 +109,12 @@ SQL
         $this->updateParentPlatform($parentNpCommunicationId, $childNpCommunicationId);
     }
 
-    public function logChange(string $changeType, int $param1, int $param2): void
+    public function logChange(ChangelogEntryType $changeType, int $param1, int $param2): void
     {
         $query = $this->database->prepare(
             'INSERT INTO `psn100_change` (`change_type`, `param_1`, `param_2`) VALUES (:change_type, :param_1, :param_2)'
         );
-        $query->bindValue(':change_type', $changeType, PDO::PARAM_STR);
+        $query->bindValue(':change_type', $changeType->value, PDO::PARAM_STR);
         $query->bindValue(':param_1', $param1, PDO::PARAM_INT);
         $query->bindValue(':param_2', $param2, PDO::PARAM_INT);
         $query->execute();

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -160,7 +160,7 @@ class TrophyMergeService
             $this->metadataRepository()->updateParentRelationship($childNpCommunicationId, $parentNpCommunicationId);
             $this->notifyProgress($progressListener, 96, 'Parent relationship updated.');
             $this->notifyProgress($progressListener, 98, 'Logging merge activity…');
-            $this->metadataRepository()->logChange('GAME_MERGE', $childGameId, $parentGameId);
+            $this->metadataRepository()->logChange(ChangelogEntryType::GAME_MERGE, $childGameId, $parentGameId);
             $this->notifyProgress($progressListener, 100, 'Merge process complete.');
         });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the PHP 8.5 modernization series with leftovers after recent promotion/pipe/NoDiscard work.

### Changes
- Add `PlayerRouteView`, `RouteName`, `AvatarSize`, and `GameRegion` backed enums; wire them through routing, URL building, navigation, avatar sync, and PSNP+ note ordering
- Finish `ChangelogEntryType` adoption in `GameResetService` and trophy-merge changelog logging
- Prefer pipes for map→implode/cast transforms in `MaintenancePageRenderer` and `PsnpPlusService`
- Seal `MaintenancePageRenderer` as `final readonly` and promote `GameTrophyFilter`'s immutable flag with `final private`

### Testing
- `php tests/run.php` — all 1031 tests passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe8bdae9-0fb7-4a5d-b56c-4ba21c099296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe8bdae9-0fb7-4a5d-b56c-4ba21c099296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

