### PR TITLE
Adopt remaining PHP 8.5 idioms for groups, countries, and promotion

### DIFF
--- a/tests/AdminWorkerPageTest.php
+++ b/tests/AdminWorkerPageTest.php
@@ -43,13 +43,15 @@ final class AdminWorkerPageTest extends TestCase
         $this->assertSame(WorkerSortField::Id, $result->getSortField());
         $this->assertSame(WorkerSortDirection::Desc, $result->getSortDirection());
 
-        $idSortLink = $result->getSortLink('id');
+        $idSortLink = $result->getSortLink(WorkerSortField::Id);
         $this->assertTrue($idSortLink instanceof WorkerPageSortLink);
+        $this->assertSame(WorkerSortField::Id, $idSortLink->getField());
         $this->assertSame('?sort=id&direction=asc', $idSortLink->getUrl());
         $this->assertSame(' ▼', $idSortLink->getIndicator());
 
-        $scanSortLink = $result->getSortLink('scan_start');
+        $scanSortLink = $result->getSortLink(WorkerSortField::ScanStart);
         $this->assertTrue($scanSortLink instanceof WorkerPageSortLink);
+        $this->assertSame(WorkerSortField::ScanStart, $scanSortLink->getField());
         $this->assertSame('?sort=scan_start&direction=asc', $scanSortLink->getUrl());
         $this->assertSame('', $scanSortLink->getIndicator());
     }

--- a/tests/Php85IdiomEnumsTest.php
+++ b/tests/Php85IdiomEnumsTest.php
@@ -25,6 +25,8 @@ require_once __DIR__ . '/../wwwroot/classes/NpServiceName.php';
 require_once __DIR__ . '/../wwwroot/classes/Admin/PossibleCheaterDateOperator.php';
 require_once __DIR__ . '/../wwwroot/classes/PlayerTimelineEntry.php';
 require_once __DIR__ . '/../wwwroot/classes/Platform.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyGroupId.php';
+require_once __DIR__ . '/../wwwroot/classes/PlayerCountryCode.php';
 
 final class Php85IdiomEnumsTest extends TestCase
 {
@@ -237,5 +239,24 @@ final class Php85IdiomEnumsTest extends TestCase
         $this->assertSame(PossibleCheaterDateOperator::LessThan, PossibleCheaterDateOperator::tryFromMixed('<'));
         $this->assertSame(null, PossibleCheaterDateOperator::tryFromMixed(''));
         $this->assertSame(null, PossibleCheaterDateOperator::tryFromMixed(null));
+    }
+
+    public function testTrophyGroupIdDefaultSqlLiteral(): void
+    {
+        $this->assertSame('default', TrophyGroupId::Default->value);
+        $this->assertSame("'default'", TrophyGroupId::Default->toSqlLiteral());
+        $this->assertTrue(TrophyGroupId::Default->isDefault());
+    }
+
+    public function testPlayerCountryCodeUnknownHelpers(): void
+    {
+        $this->assertSame('zz', PlayerCountryCode::Unknown->value);
+        $this->assertTrue(PlayerCountryCode::isUnknown(null));
+        $this->assertTrue(PlayerCountryCode::isUnknown(''));
+        $this->assertTrue(PlayerCountryCode::isUnknown(' ZZ '));
+        $this->assertFalse(PlayerCountryCode::isUnknown('us'));
+        $this->assertSame('us', PlayerCountryCode::normalize(' US '));
+        $this->assertSame('zz', PlayerCountryCode::orUnknown(null));
+        $this->assertSame('se', PlayerCountryCode::orUnknown('SE'));
     }
 }

--- a/wwwroot/admin/workers.php
+++ b/wwwroot/admin/workers.php
@@ -20,8 +20,8 @@ $workers = $pageResult->getWorkers();
 $successMessage = $pageResult->getSuccessMessage();
 $errorMessage = $pageResult->getErrorMessage();
 
-$idSortLink = $pageResult->getSortLink('id');
-$scanStartSortLink = $pageResult->getSortLink('scan_start');
+$idSortLink = $pageResult->getSortLink(WorkerSortField::Id);
+$scanStartSortLink = $pageResult->getSortLink(WorkerSortField::ScanStart);
 
 $idSortUrl = $idSortLink?->getUrl() ?? '?sort=id&direction=asc';
 $scanStartSortUrl = $scanStartSortLink?->getUrl() ?? '?sort=scan_start&direction=asc';

--- a/wwwroot/classes/Admin/AdminNavigation.php
+++ b/wwwroot/classes/Admin/AdminNavigation.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 final readonly class AdminNavigationItem
 {
     public function __construct(
-        private string $label,
-        private string $href,
+        final private string $label,
+        final private string $href,
     ) {
     }
 

--- a/wwwroot/classes/Admin/DeletePlayerConfirmation.php
+++ b/wwwroot/classes/Admin/DeletePlayerConfirmation.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final readonly class DeletePlayerConfirmation
 {
-    public function __construct(private string $accountId, private ?string $onlineId)
+    public function __construct(final private string $accountId, final private ?string $onlineId)
     {
     }
 

--- a/wwwroot/classes/Admin/DeletePlayerRequestResult.php
+++ b/wwwroot/classes/Admin/DeletePlayerRequestResult.php
@@ -7,9 +7,9 @@ require_once __DIR__ . '/DeletePlayerConfirmation.php';
 final readonly class DeletePlayerRequestResult
 {
     private function __construct(
-        private ?string $successMessage,
-        private ?string $errorMessage,
-        private ?DeletePlayerConfirmation $confirmation
+        final private ?string $successMessage,
+        final private ?string $errorMessage,
+        final private ?DeletePlayerConfirmation $confirmation
     ) {
     }
 

--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../MergeNpCommunicationId.php';
 require_once __DIR__ . '/MergeTrophyCopier.php';
 require_once __DIR__ . '/MergeTrophyGroupCopier.php';
 require_once __DIR__ . '/TrophyGroupConflictResolver.php';
+require_once __DIR__ . '/../TrophyGroupId.php';
 
 class GameCopyService
 {
@@ -340,7 +341,7 @@ class GameCopyService
              LIMIT 1'
         );
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->bindValue(':group_id', 'default', PDO::PARAM_STR);
+        $query->bindValue(':group_id', TrophyGroupId::Default->value, PDO::PARAM_STR);
         $query->execute();
 
         $isBaseList = $query->fetchColumn() !== false;

--- a/wwwroot/classes/Admin/GameDetailPageResult.php
+++ b/wwwroot/classes/Admin/GameDetailPageResult.php
@@ -7,9 +7,9 @@ require_once __DIR__ . '/GameDetail.php';
 final readonly class GameDetailPageResult
 {
     public function __construct(
-        private ?GameDetail $gameDetail,
-        private ?string $successMessage,
-        private ?string $errorMessage,
+        final private ?GameDetail $gameDetail,
+        final private ?string $successMessage,
+        final private ?string $errorMessage,
     ) {
     }
 

--- a/wwwroot/classes/Admin/GameResetRequestResult.php
+++ b/wwwroot/classes/Admin/GameResetRequestResult.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 final readonly class GameResetRequestResult
 {
     private function __construct(
-        private ?string $successMessage,
-        private ?string $errorMessage,
+        final private ?string $successMessage,
+        final private ?string $errorMessage,
     ) {
     }
 

--- a/wwwroot/classes/Admin/PlayerReportAdminPageResult.php
+++ b/wwwroot/classes/Admin/PlayerReportAdminPageResult.php
@@ -10,9 +10,9 @@ final readonly class PlayerReportAdminPageResult
      * @param ReportedPlayer[] $reportedPlayers
      */
     public function __construct(
-        private array $reportedPlayers,
-        private ?string $successMessage = null,
-        private ?string $errorMessage = null,
+        final private array $reportedPlayers,
+        final private ?string $successMessage = null,
+        final private ?string $errorMessage = null,
     ) {
     }
 

--- a/wwwroot/classes/Admin/PossibleCheaterRuleTuple.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleTuple.php
@@ -7,10 +7,10 @@ require_once __DIR__ . '/PossibleCheaterDateOperator.php';
 final readonly class PossibleCheaterRuleTuple
 {
     public function __construct(
-        private string $npCommunicationId,
-        private int $orderId,
-        private ?PossibleCheaterDateOperator $dateOperator,
-        private ?string $dateValue,
+        final private string $npCommunicationId,
+        final private int $orderId,
+        final private ?PossibleCheaterDateOperator $dateOperator,
+        final private ?string $dateValue,
     ) {
     }
 

--- a/wwwroot/classes/Admin/PsnGameLookupRequestResult.php
+++ b/wwwroot/classes/Admin/PsnGameLookupRequestResult.php
@@ -8,9 +8,9 @@ final readonly class PsnGameLookupRequestResult
      * @param array<string, mixed>|null $result
      */
     public function __construct(
-        private string $normalizedGameId,
-        private ?array $result,
-        private ?string $errorMessage
+        final private string $normalizedGameId,
+        final private ?array $result,
+        final private ?string $errorMessage
     ) {
     }
 

--- a/wwwroot/classes/Admin/PsnPlayerLookupRequestResult.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupRequestResult.php
@@ -8,11 +8,11 @@ final readonly class PsnPlayerLookupRequestResult
      * @param array<string, mixed>|null $result
      */
     public function __construct(
-        private string $normalizedOnlineId,
-        private ?array $result,
-        private ?string $errorMessage,
-        private ?string $decodedNpId,
-        private ?string $npCountry
+        final private string $normalizedOnlineId,
+        final private ?array $result,
+        final private ?string $errorMessage,
+        final private ?string $decodedNpId,
+        final private ?string $npCountry
     ) {
     }
 

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestResult.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestResult.php
@@ -8,10 +8,10 @@ final readonly class PsnTrophyTitleComparisonRequestResult
      * @param array<string, mixed>|null $result
      */
     public function __construct(
-        private string $normalizedAccountId,
-        private string $normalizedSource,
-        private ?array $result,
-        private ?string $errorMessage,
+        final private string $normalizedAccountId,
+        final private string $normalizedSource,
+        final private ?array $result,
+        final private ?string $errorMessage,
     ) {
     }
 

--- a/wwwroot/classes/Admin/PsnpPlusMissingGame.php
+++ b/wwwroot/classes/Admin/PsnpPlusMissingGame.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final readonly class PsnpPlusMissingGame
 {
-    public function __construct(private int $psnprofilesId)
+    public function __construct(final private int $psnprofilesId)
     {
     }
 
@@ -15,6 +15,8 @@ final readonly class PsnpPlusMissingGame
 
     public function getPsnprofilesUrl(): string
     {
-        return 'https://psnprofiles.com/trophies/' . $this->psnprofilesId;
+        $path = 'https://psnprofiles.com/trophies/' . $this->psnprofilesId;
+
+        return Uri\Rfc3986\Uri::parse($path)?->toRawString() ?? $path;
     }
 }

--- a/wwwroot/classes/Admin/ReportedPlayer.php
+++ b/wwwroot/classes/Admin/ReportedPlayer.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 final readonly class ReportedPlayer
 {
     public function __construct(
-        private int $reportId,
-        private string $onlineId,
-        private string $explanation
+        final private int $reportId,
+        final private string $onlineId,
+        final private string $explanation
     ) {}
 
     public function getReportId(): int

--- a/wwwroot/classes/Admin/WorkerPage.php
+++ b/wwwroot/classes/Admin/WorkerPage.php
@@ -32,8 +32,8 @@ final class WorkerPage
         $workers = $this->workerService->fetchWorkers($sortField, $sortDirection);
 
         $sortLinks = [
-            'id' => $this->createSortLink(WorkerSortField::Id, $sortField, $sortDirection),
-            'scan_start' => $this->createSortLink(WorkerSortField::ScanStart, $sortField, $sortDirection),
+            WorkerSortField::Id->value => $this->createSortLink(WorkerSortField::Id, $sortField, $sortDirection),
+            WorkerSortField::ScanStart->value => $this->createSortLink(WorkerSortField::ScanStart, $sortField, $sortDirection),
         ];
 
         return new WorkerPageResult(
@@ -211,6 +211,6 @@ final class WorkerPage
             'direction' => $nextDirection->value,
         ];
 
-        return new WorkerPageSortLink($field->value, '?' . http_build_query($query), $indicator);
+        return new WorkerPageSortLink($field, '?' . http_build_query($query), $indicator);
     }
 }

--- a/wwwroot/classes/Admin/WorkerPageResult.php
+++ b/wwwroot/classes/Admin/WorkerPageResult.php
@@ -55,9 +55,11 @@ final readonly class WorkerPageResult
         return $this->sortLinks;
     }
 
-    public function getSortLink(string $field): ?WorkerPageSortLink
+    public function getSortLink(WorkerSortField|string $field): ?WorkerPageSortLink
     {
-        return $this->sortLinks[$field] ?? null;
+        $key = $field instanceof WorkerSortField ? $field->value : $field;
+
+        return $this->sortLinks[$key] ?? null;
     }
 
     public function getSortField(): WorkerSortField

--- a/wwwroot/classes/Admin/WorkerPageSortLink.php
+++ b/wwwroot/classes/Admin/WorkerPageSortLink.php
@@ -2,16 +2,18 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/WorkerSortField.php';
+
 final readonly class WorkerPageSortLink
 {
     public function __construct(
-        private string $field,
-        private string $url,
-        private string $indicator,
+        final private WorkerSortField $field,
+        final private string $url,
+        final private string $indicator,
     ) {
     }
 
-    public function getField(): string
+    public function getField(): WorkerSortField
     {
         return $this->field;
     }

--- a/wwwroot/classes/ChangelogEntryPresenter.php
+++ b/wwwroot/classes/ChangelogEntryPresenter.php
@@ -146,7 +146,8 @@ final readonly class ChangelogEntryPresenter
     {
         $idPart = $id !== null ? (string) $id : '';
         $name = $name ?? '';
-        $url = '/game/' . $idPart . '-' . $this->utility->slugify($name);
+        $path = '/game/' . $idPart . '-' . $this->utility->slugify($name);
+        $url = Uri\Rfc3986\Uri::parse($path)?->toRawString() ?? $path;
 
         return sprintf(
             '<a href="%s">%s</a>',

--- a/wwwroot/classes/Cron/CronJobCliArguments.php
+++ b/wwwroot/classes/Cron/CronJobCliArguments.php
@@ -7,7 +7,7 @@ final readonly class CronJobCliArguments
     /**
      * @param array<string, mixed> $arguments
      */
-    private function __construct(private array $arguments)
+    private function __construct(final private array $arguments)
     {
     }
 

--- a/wwwroot/classes/Cron/HourlyCronJob.php
+++ b/wwwroot/classes/Cron/HourlyCronJob.php
@@ -84,10 +84,12 @@ final readonly class HourlyCronJob implements CronJobInterface
             )
         SQL;
 
+    private const \Closure DEFAULT_SLEEPER = sleep(...);
+
     public function __construct(
         final private PDO $database,
         final private int $retryDelaySeconds = 3,
-        final private \Closure $sleeper = sleep(...),
+        final private \Closure $sleeper = self::DEFAULT_SLEEPER,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerCountryResolver.php
+++ b/wwwroot/classes/Cron/PlayerCountryResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Tustin\PlayStation\Client;
 
+require_once __DIR__ . '/../PlayerCountryCode.php';
+
 /**
  * Resolves and persists player country codes during PSN profile scans.
  *
@@ -48,16 +50,16 @@ final class PlayerCountryResolver
     ): string {
         $country = $countryFromNpId;
 
-        if ($country === null || strtolower($country) === 'zz') {
+        if (PlayerCountryCode::isUnknown($country)) {
             $storedCountry = $this->fetchStoredCountryByAccountId($accountId);
 
             if (is_string($storedCountry) && $storedCountry !== '') {
                 $country = $storedCountry;
             } else {
-                $country = 'zz';
+                $country = PlayerCountryCode::Unknown->value;
             }
 
-            if (strtolower($country) === 'zz') {
+            if (PlayerCountryCode::isUnknown($country)) {
                 $resolvedCountry = $this->findPlayerCountry($client, $onlineId);
 
                 if ($resolvedCountry !== null) {
@@ -69,11 +71,7 @@ final class PlayerCountryResolver
             $this->updatePlayerCountry($accountId, $country);
         }
 
-        if (!is_string($country) || $country === '') {
-            return 'zz';
-        }
-
-        return $country;
+        return PlayerCountryCode::orUnknown(is_string($country) ? $country : null);
     }
 
     public function fetchStoredCountryByAccountId(string $accountId): ?string
@@ -105,9 +103,9 @@ final class PlayerCountryResolver
                         return null;
                     }
 
-                    $normalizedCountry = strtolower($country);
+                    $normalizedCountry = PlayerCountryCode::normalize($country);
 
-                    if ($normalizedCountry === 'zz') {
+                    if ($normalizedCountry === null || PlayerCountryCode::isUnknown($normalizedCountry)) {
                         return null;
                     }
 

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
 require_once __DIR__ . '/PlayerAvatarSynchronizer.php';
 require_once __DIR__ . '/../ImageHashCalculator.php';
 require_once __DIR__ . '/PlayerCountryResolver.php';
+require_once __DIR__ . '/../PlayerCountryCode.php';
 require_once __DIR__ . '/PlayerScanPrivacyService.php';
 require_once __DIR__ . '/../PlayerRepository.php';
 require_once __DIR__ . '/../PlayerStatus.php';
@@ -70,7 +71,7 @@ final class PlayerScanProfileSynchronizer
         }
 
         $user = $resolved->user;
-        $country = $resolved->country ?? 'zz';
+        $country = PlayerCountryCode::orUnknown($resolved->country);
 
         if ($user === null) {
             return PlayerScanProfileSyncResult::skipPlayer();
@@ -161,7 +162,7 @@ final class PlayerScanProfileSynchronizer
                 $originalOnlineId = (string) $player['online_id'];
                 $existingAccountId = $this->normalizeAccountIdValue($player['account_id'] ?? null);
                 $profileLookup = $this->lookupPlayerProfile($client, $originalOnlineId);
-                $country = 'zz';
+                $country = PlayerCountryCode::Unknown->value;
 
                 if ($profileLookup !== null) {
                     $profile = $profileLookup['profile'] ?? null;

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -30,6 +30,7 @@ require_once __DIR__ . '/PlayerScanTrophySummaryAccessResult.php';
 require_once __DIR__ . '/PlayerScanTrophyTitleRefresher.php';
 require_once __DIR__ . '/PlayerScanTrophyTitleLoop.php';
 require_once __DIR__ . '/PlayerScanTrophyTitleLoopResult.php';
+require_once __DIR__ . '/../PlayerCountryCode.php';
 
 use Tustin\Haste\Exception\NotFoundHttpException;
 use Tustin\Haste\Exception\UnauthorizedHttpException;
@@ -195,7 +196,7 @@ final readonly class ThirtyMinuteCronJob implements CronJobInterface
 
             $player = $profileSyncResult->player;
             $user = $profileSyncResult->user;
-            $country = $profileSyncResult->country ?? 'zz';
+            $country = PlayerCountryCode::orUnknown($profileSyncResult->country);
 
             if ($user === null) {
                 continue;

--- a/wwwroot/classes/Game/GameTrophyGroup.php
+++ b/wwwroot/classes/Game/GameTrophyGroup.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../TrophyGroupId.php';
+
 final readonly class GameTrophyGroup
 {
     /**
@@ -64,7 +66,7 @@ final readonly class GameTrophyGroup
 
     public function isDefaultGroup(): bool
     {
-        return $this->id === 'default';
+        return $this->id === TrophyGroupId::Default->value;
     }
 
     public function getBronzeCount(): int

--- a/wwwroot/classes/Game/GameTrophyRow.php
+++ b/wwwroot/classes/Game/GameTrophyRow.php
@@ -193,7 +193,9 @@ final readonly class GameTrophyRow
             ? '/' . $playerOnlineId
             : '';
 
-        return '/trophy/' . $this->id . '-' . $slug . $playerSegment;
+        $path = '/trophy/' . $this->id . '-' . $slug . $playerSegment;
+
+        return Uri\Rfc3986\Uri::parse($path)?->toRawString() ?? $path;
     }
 
     public function getTypeColor(): string

--- a/wwwroot/classes/GameAvailabilityStatus.php
+++ b/wwwroot/classes/GameAvailabilityStatus.php
@@ -18,6 +18,7 @@ enum GameAvailabilityStatus: int
         return self::tryFrom($status) ?? self::NORMAL;
     }
 
+    #[\NoDiscard]
     public function isUnavailable(): bool
     {
         return match ($this) {
@@ -29,6 +30,7 @@ enum GameAvailabilityStatus: int
         };
     }
 
+    #[\NoDiscard]
     public function changeType(): ChangelogEntryType
     {
         return match ($this) {
@@ -40,6 +42,7 @@ enum GameAvailabilityStatus: int
         };
     }
 
+    #[\NoDiscard]
     public function statusText(): string
     {
         return match ($this) {
@@ -51,6 +54,7 @@ enum GameAvailabilityStatus: int
         };
     }
 
+    #[\NoDiscard]
     public function label(): string
     {
         return match ($this) {
@@ -62,6 +66,7 @@ enum GameAvailabilityStatus: int
         };
     }
 
+    #[\NoDiscard]
     public function warningMessage(): ?string
     {
         return match ($this) {
@@ -73,6 +78,7 @@ enum GameAvailabilityStatus: int
         };
     }
 
+    #[\NoDiscard]
     public function badgeLabel(): ?string
     {
         return match ($this) {

--- a/wwwroot/classes/GameHistoryService.php
+++ b/wwwroot/classes/GameHistoryService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/TrophyMetaStatus.php';
+require_once __DIR__ . '/TrophyGroupId.php';
 
 final class GameHistoryService
 {
@@ -102,8 +103,9 @@ final class GameHistoryService
      */
     private function fetchGroupChanges(array $historyIds): array
     {
+        $defaultGroupId = TrophyGroupId::Default->toSqlLiteral();
         $rows = $this->fetchRows(
-            <<<'SQL'
+            <<<SQL
             SELECT
                 title_history_id,
                 group_id,
@@ -115,8 +117,8 @@ final class GameHistoryService
             WHERE
                 title_history_id IN (%s)
             ORDER BY
-                CASE WHEN group_id = 'default' THEN 0 ELSE 1 END,
-                CASE WHEN group_id = 'default' THEN 0 ELSE group_id + 0 END,
+                CASE WHEN group_id = {$defaultGroupId} THEN 0 ELSE 1 END,
+                CASE WHEN group_id = {$defaultGroupId} THEN 0 ELSE group_id + 0 END,
                 group_id
             SQL,
             $historyIds
@@ -143,8 +145,9 @@ final class GameHistoryService
     */
     private function fetchTrophyChanges(array $historyIds): array
     {
+        $defaultGroupId = TrophyGroupId::Default->toSqlLiteral();
         $rows = $this->fetchRows(
-            <<<'SQL'
+            <<<SQL
             SELECT
                 th.title_history_id,
                 th.group_id,
@@ -165,8 +168,8 @@ final class GameHistoryService
             WHERE
                 th.title_history_id IN (%s)
             ORDER BY
-                CASE WHEN th.group_id = 'default' THEN 0 ELSE 1 END,
-                CASE WHEN th.group_id = 'default' THEN 0 ELSE th.group_id + 0 END,
+                CASE WHEN th.group_id = {$defaultGroupId} THEN 0 ELSE 1 END,
+                CASE WHEN th.group_id = {$defaultGroupId} THEN 0 ELSE th.group_id + 0 END,
                 th.order_id
             SQL,
             $historyIds

--- a/wwwroot/classes/GameService.php
+++ b/wwwroot/classes/GameService.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/Game/GamePlayerProgress.php';
 require_once __DIR__ . '/Game/GameTrophyGroupPlayer.php';
 require_once __DIR__ . '/GameTrophySort.php';
+require_once __DIR__ . '/TrophyGroupId.php';
 require_once __DIR__ . '/TrophyType.php';
 
 class GameService
@@ -134,8 +135,9 @@ class GameService
      */
     public function getTrophyGroups(string $npCommunicationId): array
     {
+        $defaultGroupId = TrophyGroupId::Default->toSqlLiteral();
         $query = $this->database->prepare(
-            <<<'SQL'
+            <<<SQL
             SELECT
                 *
             FROM
@@ -143,7 +145,7 @@ class GameService
             WHERE
                 np_communication_id = :np_communication_id
             ORDER BY
-                (group_id != 'default'),
+                (group_id != {$defaultGroupId}),
                 group_id
             SQL
         );

--- a/wwwroot/classes/Homepage/HomepageDlc.php
+++ b/wwwroot/classes/Homepage/HomepageDlc.php
@@ -9,13 +9,13 @@ final readonly class HomepageDlc extends HomepageTitle
     private function __construct(
         int $id,
         string $gameName,
-        private string $groupId,
-        private string $groupName,
+        final private string $groupId,
+        final private string $groupName,
         string $iconUrl,
         string $platform,
-        private int $gold,
-        private int $silver,
-        private int $bronze,
+        final private int $gold,
+        final private int $silver,
+        final private int $bronze,
     ) {
         parent::__construct($id, $gameName, $iconUrl, $platform, HistoryIconType::Group);
     }

--- a/wwwroot/classes/Homepage/HomepageItem.php
+++ b/wwwroot/classes/Homepage/HomepageItem.php
@@ -12,9 +12,9 @@ abstract readonly class HomepageItem
     private const string MISSING_PS4_ICON = '/img/missing-ps4-game.png';
 
     protected function __construct(
-        private string $iconUrl,
-        private string $platform,
-        private HistoryIconType $iconType,
+        final private string $iconUrl,
+        final private string $platform,
+        final private HistoryIconType $iconType,
     ) {
     }
 

--- a/wwwroot/classes/Homepage/HomepageNewGame.php
+++ b/wwwroot/classes/Homepage/HomepageNewGame.php
@@ -11,10 +11,10 @@ final readonly class HomepageNewGame extends HomepageTitle
         string $name,
         string $iconUrl,
         string $platform,
-        private int $platinum,
-        private int $gold,
-        private int $silver,
-        private int $bronze,
+        final private int $platinum,
+        final private int $gold,
+        final private int $silver,
+        final private int $bronze,
     ) {
         parent::__construct($id, $name, $iconUrl, $platform, HistoryIconType::Title);
     }

--- a/wwwroot/classes/Homepage/HomepagePopularGame.php
+++ b/wwwroot/classes/Homepage/HomepagePopularGame.php
@@ -11,7 +11,7 @@ final readonly class HomepagePopularGame extends HomepageTitle
         string $name,
         string $iconUrl,
         string $platform,
-        private int $recentPlayers,
+        final private int $recentPlayers,
     ) {
         parent::__construct($id, $name, $iconUrl, $platform, HistoryIconType::Title);
     }

--- a/wwwroot/classes/Homepage/HomepageTitle.php
+++ b/wwwroot/classes/Homepage/HomepageTitle.php
@@ -7,8 +7,8 @@ require_once __DIR__ . '/../HistoryIconType.php';
 readonly class HomepageTitle extends HomepageItem
 {
     protected function __construct(
-        private int $id,
-        private string $name,
+        final private int $id,
+        final private string $name,
         string $iconUrl,
         string $platform,
         HistoryIconType $iconType,

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/HomepagePopularGamesFilter.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/PlatformSql.php';
+require_once __DIR__ . '/TrophyGroupId.php';
 
 final class HomepageContentService
 {
@@ -65,6 +66,7 @@ final class HomepageContentService
     public function getNewDlcs(int $limit = self::DEFAULT_NEW_DLCS_LIMIT): array
     {
         $mergedStatus = GameAvailabilityStatus::MERGED->value;
+        $defaultGroupId = TrophyGroupId::Default->toSqlLiteral();
 
         $query = $this->database->prepare(
             <<<SQL
@@ -84,7 +86,7 @@ final class HomepageContentService
                 JOIN trophy_title_meta ttm USING (np_communication_id)
             WHERE
                 ttm.status <> {$mergedStatus}
-                AND tg.group_id <> 'default'
+                AND tg.group_id <> {$defaultGroupId}
             ORDER BY
                 tg.id DESC
             LIMIT

--- a/wwwroot/classes/MaintenancePageStylesheet.php
+++ b/wwwroot/classes/MaintenancePageStylesheet.php
@@ -31,6 +31,7 @@ final readonly class MaintenancePageStylesheet
     }
 
     #[\Deprecated(message: 'Use bootstrap() for the self-hosted stylesheet.')]
+    #[\NoDiscard]
     public static function bootstrapCdn(string $version = BootstrapAssets::VERSION): self
     {
         return self::bootstrap($version);

--- a/wwwroot/classes/PlayerCountryCode.php
+++ b/wwwroot/classes/PlayerCountryCode.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Sentinel and helpers for player country codes stored on the player table.
+ *
+ * Unknown/unset countries are persisted as "zz" (ISO 3166 user-assigned code).
+ */
+enum PlayerCountryCode: string
+{
+    case Unknown = 'zz';
+
+    #[\NoDiscard]
+    public static function normalize(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $normalized = $value |> trim(...) |> strtolower(...);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    #[\NoDiscard]
+    public static function isUnknown(mixed $value): bool
+    {
+        $normalized = self::normalize($value);
+
+        return $normalized === null || $normalized === self::Unknown->value;
+    }
+
+    /**
+     * Resolve a country value to a stored code, falling back to Unknown.
+     */
+    #[\NoDiscard]
+    public static function orUnknown(?string $value): string
+    {
+        return self::normalize($value) ?? self::Unknown->value;
+    }
+}

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/PlatformSql.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/SearchQueryHelper.php';
 require_once __DIR__ . '/DateDurationSummary.php';
+require_once __DIR__ . '/TrophyGroupId.php';
 
 final class PlayerGamesService
 {
@@ -115,9 +116,9 @@ final class PlayerGamesService
             return '';
         }
 
-        return "JOIN trophy_group_player tgp ON tgp.account_id = ttp.account_id
+        return 'JOIN trophy_group_player tgp ON tgp.account_id = ttp.account_id
                 AND tgp.np_communication_id = ttp.np_communication_id
-                AND tgp.group_id = 'default'";
+                AND tgp.group_id = ' . TrophyGroupId::Default->toSqlLiteral();
     }
 
     private function buildWhereClause(PlayerGamesFilter $filter): string

--- a/wwwroot/classes/PlayerNavigation.php
+++ b/wwwroot/classes/PlayerNavigation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/PlayerNavigationSection.php';
 require_once __DIR__ . '/PlayerRouteView.php';
 require_once __DIR__ . '/PlayerUrlBuilder.php';
+require_once __DIR__ . '/GameListSort.php';
 
 final readonly class PlayerNavigation
 {
@@ -25,38 +26,35 @@ final readonly class PlayerNavigation
      */
     public function getLinks(): array
     {
-        $playerPath = PlayerUrlBuilder::playerPath($this->onlineId);
-        $encodedOnlineId = rawurlencode($this->onlineId);
-
         return [
             new PlayerNavigationLink(
                 'Games',
-                $playerPath,
+                PlayerUrlBuilder::playerPath($this->onlineId),
                 $this->isActive(PlayerNavigationSection::GAMES)
             ),
             new PlayerNavigationLink(
                 'Timeline',
-                $playerPath . '/' . PlayerRouteView::Timeline->value,
+                PlayerUrlBuilder::playerViewPath($this->onlineId, PlayerRouteView::Timeline),
                 $this->isActive(PlayerNavigationSection::TIMELINE)
             ),
             new PlayerNavigationLink(
                 'Log',
-                $playerPath . '/' . PlayerRouteView::Log->value,
+                PlayerUrlBuilder::playerViewPath($this->onlineId, PlayerRouteView::Log),
                 $this->isActive(PlayerNavigationSection::LOG)
             ),
             new PlayerNavigationLink(
                 'Trophy Advisor',
-                $playerPath . '/' . PlayerRouteView::Advisor->value,
+                PlayerUrlBuilder::playerViewPath($this->onlineId, PlayerRouteView::Advisor),
                 $this->isActive(PlayerNavigationSection::TROPHY_ADVISOR)
             ),
             new PlayerNavigationLink(
                 'Game Advisor',
-                '/game?sort=completion&filter=true&player=' . $encodedOnlineId,
+                PlayerUrlBuilder::gameAdvisorPath($this->onlineId),
                 $this->isActive(PlayerNavigationSection::GAME_ADVISOR)
             ),
             new PlayerNavigationLink(
                 'Random Games',
-                $playerPath . '/' . PlayerRouteView::Random->value,
+                PlayerUrlBuilder::playerViewPath($this->onlineId, PlayerRouteView::Random),
                 $this->isActive(PlayerNavigationSection::RANDOM)
             ),
         ];

--- a/wwwroot/classes/PlayerReportResult.php
+++ b/wwwroot/classes/PlayerReportResult.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/Html.php';
 
 final readonly class PlayerReportResult
 {
-    private function __construct(private bool $hasMessage, private bool $success, private string $message)
+    private function __construct(final private bool $hasMessage, final private bool $success, final private string $message)
     {
     }
 

--- a/wwwroot/classes/PlayerUrlBuilder.php
+++ b/wwwroot/classes/PlayerUrlBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PlayerRouteView.php';
 require_once __DIR__ . '/RouteName.php';
+require_once __DIR__ . '/GameListSort.php';
 
 final readonly class PlayerUrlBuilder
 {
@@ -16,11 +17,38 @@ final readonly class PlayerUrlBuilder
     #[\NoDiscard]
     public static function playerReportPath(string $onlineId): string
     {
+        return self::playerViewPath($onlineId, PlayerRouteView::Report);
+    }
+
+    #[\NoDiscard]
+    public static function playerViewPath(string $onlineId, PlayerRouteView $view): string
+    {
         return self::buildPath(
             RouteName::Player->value,
             rawurlencode($onlineId),
-            PlayerRouteView::Report->value
+            $view->value
         );
+    }
+
+    #[\NoDiscard]
+    public static function gameAdvisorPath(string $onlineId): string
+    {
+        $path = '/' . RouteName::Game->value;
+        $query = http_build_query(
+            [
+                'sort' => GameListSort::Completion->value,
+                'filter' => 'true',
+                'player' => $onlineId,
+            ],
+            '',
+            '&',
+            PHP_QUERY_RFC3986
+        );
+
+        return Uri\Rfc3986\Uri::parse($path)
+            ?->withQuery($query)
+            ->toRawString()
+            ?? $path . '?' . $query;
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/StaticAsset.php
+++ b/wwwroot/classes/StaticAsset.php
@@ -14,6 +14,11 @@ final readonly class StaticAsset
             return $webPath;
         }
 
-        return $webPath . '?v=' . filemtime($fullPath);
+        $versionQuery = 'v=' . filemtime($fullPath);
+
+        return Uri\Rfc3986\Uri::parse($webPath)
+            ?->withQuery($versionQuery)
+            ->toRawString()
+            ?? $webPath . '?' . $versionQuery;
     }
 }

--- a/wwwroot/classes/TrophyGroupId.php
+++ b/wwwroot/classes/TrophyGroupId.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Known PlayStation trophy group identifiers.
+ *
+ * Sony uses the literal "default" for a title's base trophy list; DLC groups use
+ * other identifiers (typically numeric strings).
+ */
+enum TrophyGroupId: string
+{
+    case Default = 'default';
+
+    /**
+     * Quote the enum value for safe embedding in SQL string literals.
+     */
+    #[\NoDiscard]
+    public function toSqlLiteral(): string
+    {
+        return "'" . $this->value . "'";
+    }
+
+    #[\NoDiscard]
+    public function isDefault(): bool
+    {
+        return $this === self::Default;
+    }
+}

--- a/wwwroot/classes/TrophyListItem.php
+++ b/wwwroot/classes/TrophyListItem.php
@@ -154,12 +154,16 @@ final readonly class TrophyListItem
 
     public function getGameUrl(Utility $utility): string
     {
-        return '/game/' . $this->gameId . '-' . $utility->slugify($this->gameName);
+        $path = '/game/' . $this->gameId . '-' . $utility->slugify($this->gameName);
+
+        return Uri\Rfc3986\Uri::parse($path)?->toRawString() ?? $path;
     }
 
     public function getTrophyUrl(Utility $utility): string
     {
-        return '/trophy/' . $this->trophyId . '-' . $utility->slugify($this->trophyName);
+        $path = '/trophy/' . $this->trophyId . '-' . $utility->slugify($this->trophyName);
+
+        return Uri\Rfc3986\Uri::parse($path)?->toRawString() ?? $path;
     }
 
     private function usesPlayStation5Assets(): bool

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -20,13 +20,8 @@ final readonly class TrophyTitleNameFormatter
     #[\NoDiscard]
     public function sanitize(string $name): string
     {
-        $name = trim($name);
-
-        if ($name === '') {
-            return $name;
-        }
-
         $name = $name
+            |> trim(...)
             |> (fn(string $value): string => str_replace(['™', '®', '©'], '', $value))
             |> (fn(string $value): string => str_replace('–', '-', $value))
             |> (fn(string $value): string => str_replace(['’', '´', '`'], '\'', $value))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Continue the PHP 8.5 modernization series with leftover production improvements that no longer need backward compatibility.

### Changes
- Add `TrophyGroupId` and `PlayerCountryCode` backed enums for the `'default'` trophy group and `'zz'` unknown-country sentinels, and update SQL/cron call sites to use them
- Align `HourlyCronJob` with `DailyCronJob`/`WeeklyCronJob` via `private const \Closure DEFAULT_SLEEPER = sleep(...)`
- Prefer `Uri\Rfc3986\Uri` for cache-busted static assets, player navigation / game-advisor URLs, and remaining path builders
- Finish `final private` promotion on immutable admin/homepage DTOs that do not need constructor-body normalization
- Annotate pure `GameAvailabilityStatus` helpers and `MaintenancePageStylesheet::bootstrapCdn()` with `#[\NoDiscard]`
- Type `WorkerPageSortLink` with `WorkerSortField` and extend player URL helpers (`playerViewPath`, `gameAdvisorPath`)
- Fold `TrophyTitleNameFormatter::sanitize()` leading `trim` into its existing pipe chain

### Tests
- Extended `Php85IdiomEnumsTest` and `AdminWorkerPageTest` for the new enums / sort-link typing
- Full suite: `php tests/run.php` — **All 1033 tests passed**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-413e9e1e-047e-43ae-93dd-983f027e1191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-413e9e1e-047e-43ae-93dd-983f027e1191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

