### PR TITLE
Adopt remaining PHP 8.5 idioms for promotion, readonly, and enums

### DIFF
--- a/tests/GameRecentPlayersServiceTest.php
+++ b/tests/GameRecentPlayersServiceTest.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../wwwroot/classes/GamePlayerFilter.php';
 
 final class GameRecentPlayersServiceTest extends TestCase
 {
-    private const NP_COMMUNICATION_ID = 'NPWR00001';
+    private const string NP_COMMUNICATION_ID = 'NPWR00001';
 
     private PDO $pdo;
 

--- a/tests/LeaderboardPageContextTest.php
+++ b/tests/LeaderboardPageContextTest.php
@@ -130,7 +130,7 @@ final class LeaderboardPageContextTest extends TestCase
 
 final class FakeLeaderboardPageContext extends AbstractLeaderboardPageContext
 {
-    public const TITLE = 'Fake Leaderboard Title';
+    public const string TITLE = 'Fake Leaderboard Title';
 
     private static ?PlayerLeaderboardDataProvider $dataProvider = null;
 

--- a/tests/TrophyTitleCloneServiceTest.php
+++ b/tests/TrophyTitleCloneServiceTest.php
@@ -294,7 +294,7 @@ final class TrophyTitleCloneServiceTest extends TestCase
  */
 final class TrophyTitleCloneServiceTestDatabase extends PDO
 {
-    private const NEXT_TROPHY_TITLE_ID = 2;
+    private const int NEXT_TROPHY_TITLE_ID = 2;
 
     public function __construct()
     {

--- a/wwwroot/admin/detail.php
+++ b/wwwroot/admin/detail.php
@@ -59,7 +59,7 @@ $requestedNpCommunicationId = (string) ($_GET['np_communication_id'] ?? '');
                 </p>
                 <form method="post" autocomplete="off">
                     <?php AdminBootstrap::renderCsrfField(); ?>
-                    <input type="hidden" name="action" value="update-detail">
+                    <input type="hidden" name="action" value="<?= Html::escape(GameDetailAction::UpdateDetail->value); ?>">
                     <input type="hidden" name="game" value="<?= $gameDetail->getId(); ?>"><br>
                     Name:<br>
                     <input type="text" name="name" style="width: 859px;" value="<?= Html::escape($gameDetail->getName()); ?>"><br>

--- a/wwwroot/admin/log.php
+++ b/wwwroot/admin/log.php
@@ -14,7 +14,7 @@ $formatter = new LogEntryFormatter($database, $utility);
 $logService = new LogService($database, $formatter);
 $logPage = new LogPage($logService);
 
-$pageResult = $logPage->handle($_GET, $_POST, $_SERVER['REQUEST_METHOD'] ?? 'GET');
+$pageResult = $logPage->handle($_GET, $_POST, $_SERVER['REQUEST_METHOD'] ?? HttpMethod::Get->value);
 
 $pagination = '';
 

--- a/wwwroot/admin/merge.php
+++ b/wwwroot/admin/merge.php
@@ -47,9 +47,9 @@ $message = $requestHandler->handle($_POST ?? []);
                     <div class="col-12 col-md-6 col-xl-4">
                         <label class="form-label" for="merge-method">Method</label>
                         <select class="form-select" id="merge-method" name="method">
-                            <option value="order">Order</option>
-                            <option value="name">Name</option>
-                            <option value="icon">Icon</option>
+                            <option value="<?= Html::escape(TrophyMergeMethod::Order->value); ?>">Order</option>
+                            <option value="<?= Html::escape(TrophyMergeMethod::Name->value); ?>">Name</option>
+                            <option value="<?= Html::escape(TrophyMergeMethod::Icon->value); ?>">Icon</option>
                         </select>
                     </div>
                 </div>

--- a/wwwroot/admin/report.php
+++ b/wwwroot/admin/report.php
@@ -8,7 +8,7 @@ require_once '../classes/Admin/PlayerReportAdminPage.php';
 
 $playerReportAdminService = new PlayerReportAdminService($database);
 $playerReportAdminPage = new PlayerReportAdminPage($playerReportAdminService);
-$pageResult = $playerReportAdminPage->handle($_GET ?? [], $_POST ?? [], $_SERVER['REQUEST_METHOD'] ?? 'GET');
+$pageResult = $playerReportAdminPage->handle($_GET ?? [], $_POST ?? [], $_SERVER['REQUEST_METHOD'] ?? HttpMethod::Get->value);
 
 $reportedPlayers = $pageResult->getReportedPlayers();
 $successMessage = $pageResult->getSuccessMessage();

--- a/wwwroot/admin/reset.php
+++ b/wwwroot/admin/reset.php
@@ -33,8 +33,8 @@ $error = $result->getErrorMessage();
                 <input type="number" name="game"><br>
                 Reset or Delete:<br>
                 <select name="status">
-                    <option value="0">Reset</option>
-                    <option value="1">Delete</option>
+                    <option value="<?= Html::escape((string) GameResetAction::RESET->value); ?>">Reset</option>
+                    <option value="<?= Html::escape((string) GameResetAction::DELETE->value); ?>">Delete</option>
                 </select><br><br>
                 <input type="submit" value="Submit">
             </form>

--- a/wwwroot/admin/unobtainable.php
+++ b/wwwroot/admin/unobtainable.php
@@ -21,7 +21,7 @@ $trophyStatusInputParser = new TrophyStatusInputParser($database);
 $trophyStatusService = new TrophyStatusService($database);
 $trophyStatusPage = new TrophyStatusPage($trophyStatusInputParser, $trophyStatusService);
 
-$requestMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$requestMethod = $_SERVER['REQUEST_METHOD'] ?? HttpMethod::Get->value;
 $postData = $_POST ?? [];
 $queryData = $_GET ?? [];
 

--- a/wwwroot/admin/workers.php
+++ b/wwwroot/admin/workers.php
@@ -121,13 +121,13 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                                     <input
                                                         id="refresh-token-<?= Html::escape((string) $worker->getId()); ?>"
                                                         type="password"
-                                                        name="refresh_token"
+                                                        name="<?= Html::escape(WorkerCredentialField::RefreshToken->value); ?>"
                                                         class="form-control form-control-sm"
                                                         placeholder="<?= Html::escape(WorkerCredentialMasker::mask($worker->getRefreshToken())); ?>"
                                                         maxlength="36"
                                                         autocomplete="off"
                                                         data-worker-credential-input
-                                                        data-worker-credential="refresh_token"
+                                                        data-worker-credential="<?= Html::escape(WorkerCredentialField::RefreshToken->value); ?>"
                                                         data-worker-id="<?= Html::escape((string) $worker->getId()); ?>"
                                                     >
                                                     <button
@@ -152,13 +152,13 @@ $scanStartSortIndicator = $scanStartSortLink?->getIndicator() ?? '';
                                                     <input
                                                         id="npsso-<?= Html::escape((string) $worker->getId()); ?>"
                                                         type="password"
-                                                        name="npsso"
+                                                        name="<?= Html::escape(WorkerCredentialField::Npsso->value); ?>"
                                                         class="form-control form-control-sm"
                                                         placeholder="<?= Html::escape(WorkerCredentialMasker::mask($worker->getNpsso())); ?>"
                                                         maxlength="64"
                                                         autocomplete="off"
                                                         data-worker-credential-input
-                                                        data-worker-credential="npsso"
+                                                        data-worker-credential="<?= Html::escape(WorkerCredentialField::Npsso->value); ?>"
                                                         data-worker-id="<?= Html::escape((string) $worker->getId()); ?>"
                                                     >
                                                     <button

--- a/wwwroot/classes/AboutPagePlayer.php
+++ b/wwwroot/classes/AboutPagePlayer.php
@@ -37,7 +37,7 @@ final readonly class AboutPagePlayer
             isset($row['level']) ? (int) $row['level'] : null,
             isset($row['progress']) ? (string) $row['progress'] : null,
             isset($row['rank_last_week']) ? (int) $row['rank_last_week'] : 0,
-            PlayerStatus::fromValue(isset($row['status']) ? (int) $row['status'] : 0),
+            PlayerStatus::fromValue(isset($row['status']) ? (int) $row['status'] : PlayerStatus::NORMAL->value),
             isset($row['trophy_count_npwr']) ? (int) $row['trophy_count_npwr'] : 0,
             isset($row['trophy_count_sony']) ? (int) $row['trophy_count_sony'] : 0,
             isset($row['ranking']) ? (int) $row['ranking'] : null,

--- a/wwwroot/classes/Admin/AdminLoginThrottleService.php
+++ b/wwwroot/classes/Admin/AdminLoginThrottleService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-final class AdminLoginThrottleService
+final readonly class AdminLoginThrottleService
 {
     public const int MAX_FAILURES = 5;
 

--- a/wwwroot/classes/Admin/AdminUserRepository.php
+++ b/wwwroot/classes/Admin/AdminUserRepository.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-final class AdminUserRepository
+final readonly class AdminUserRepository
 {
     private const string SQL_ADMIN_COUNT = <<<'SQL'
         SELECT

--- a/wwwroot/classes/Admin/DeletePlayerService.php
+++ b/wwwroot/classes/Admin/DeletePlayerService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-final class DeletePlayerService
+final readonly class DeletePlayerService
 {
     public function __construct(private readonly PDO $database)
     {

--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -103,8 +103,6 @@ class GameCopyService
             )
         SQL;
 
-    private readonly PDO $database;
-
     private readonly TrophyHistoryRecorder $historyRecorder;
 
     private readonly TrophyGroupConflictResolver $groupConflictResolver;
@@ -114,13 +112,12 @@ class GameCopyService
     private readonly MergeTrophyCopier $trophyCopier;
 
     public function __construct(
-        PDO $database,
+        private readonly PDO $database,
         ?TrophyHistoryRecorder $historyRecorder = null,
         ?TrophyGroupConflictResolver $groupConflictResolver = null,
         ?MergeTrophyGroupCopier $groupCopier = null,
         ?MergeTrophyCopier $trophyCopier = null,
     ) {
-        $this->database = $database;
         $this->historyRecorder = $historyRecorder ?? new TrophyHistoryRecorder($database);
         $this->groupConflictResolver = $groupConflictResolver ?? new TrophyGroupConflictResolver();
         $this->groupCopier = $groupCopier ?? new MergeTrophyGroupCopier($database, $this->groupConflictResolver);

--- a/wwwroot/classes/Admin/GameDetail.php
+++ b/wwwroot/classes/Admin/GameDetail.php
@@ -32,7 +32,7 @@ final readonly class GameDetail
         $setVersion = (string) ($row['set_version'] ?? '');
         $region = isset($row['region']) ? (string) $row['region'] : null;
         $psnprofilesId = isset($row['psnprofiles_id']) ? (string) $row['psnprofiles_id'] : null;
-        $status = GameAvailabilityStatus::fromInt((int) ($row['status'] ?? 0));
+        $status = GameAvailabilityStatus::fromInt((int) ($row['status'] ?? GameAvailabilityStatus::NORMAL->value));
         $obsoleteIds = isset($row['obsolete_ids']) ? (string) $row['obsolete_ids'] : null;
 
         return new self(

--- a/wwwroot/classes/Admin/GameDetailService.php
+++ b/wwwroot/classes/Admin/GameDetailService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../ChangelogEntry.php';
 
-final class GameDetailService
+final readonly class GameDetailService
 {
     public function __construct(
         private readonly PDO $database,

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -24,9 +24,6 @@ use Tustin\PlayStation\Client;
 
 final class GameRescanService
 {
-    private readonly PDO $database;
-    private readonly TrophyCalculator $trophyCalculator;
-
     private readonly TrophyHistoryRecorder $historyRecorder;
 
     private readonly ImageHashCalculator $imageHashCalculator;
@@ -44,8 +41,8 @@ final class GameRescanService
     private ?\Closure $logListener = null;
 
     public function __construct(
-        PDO $database,
-        TrophyCalculator $trophyCalculator,
+        private readonly PDO $database,
+        private readonly TrophyCalculator $trophyCalculator,
         ?TrophyHistoryRecorder $historyRecorder = null,
         ?ImageHashCalculator $imageHashCalculator = null,
         ?PsnGameLookupService $psnGameLookupService = null,
@@ -58,8 +55,6 @@ final class GameRescanService
         ?GameRescanCatalogUpdater $catalogUpdater = null,
     )
     {
-        $this->database = $database;
-        $this->trophyCalculator = $trophyCalculator;
         $this->historyRecorder = $historyRecorder ?? new TrophyHistoryRecorder($database);
         $this->imageHashCalculator = $imageHashCalculator ?? new ImageHashCalculator();
         $this->psnGameLookupService = $psnGameLookupService ?? PsnGameLookupService::fromDatabase($database);

--- a/wwwroot/classes/Admin/PossibleCheaterRuleGroup.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleGroup.php
@@ -38,10 +38,10 @@ final readonly class PossibleCheaterRuleGroup
         $label = (string) ($data['label'] ?? '');
         $conditions = is_array($data['conditions'] ?? null) ? $data['conditions'] : [];
 
-        $rules = [];
-        foreach ($conditions as $condition) {
-            $rules[] = PossibleCheaterRule::fromString((string) $condition);
-        }
+        $rules = array_map(
+            static fn (mixed $condition): PossibleCheaterRule => PossibleCheaterRule::fromString((string) $condition),
+            $conditions,
+        );
 
         return new self($label, $rules);
     }

--- a/wwwroot/classes/Admin/PsnTrophyApiAdapter.php
+++ b/wwwroot/classes/Admin/PsnTrophyApiAdapter.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/PsnTrophyTypeApiAdapter.php';
+require_once __DIR__ . '/../TrophyType.php';
 
 final readonly class PsnTrophyApiAdapter
 {
@@ -25,7 +26,7 @@ final readonly class PsnTrophyApiAdapter
 
     public function type(): PsnTrophyTypeApiAdapter
     {
-        return new PsnTrophyTypeApiAdapter((string) ($this->rawTrophy['trophyType'] ?? 'bronze'));
+        return new PsnTrophyTypeApiAdapter((string) ($this->rawTrophy['trophyType'] ?? TrophyType::Bronze->value));
     }
 
     public function name(): string

--- a/wwwroot/classes/Admin/WorkerPage.php
+++ b/wwwroot/classes/Admin/WorkerPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/AdminRequest.php';
 require_once __DIR__ . '/WorkerAction.php';
+require_once __DIR__ . '/WorkerCredentialField.php';
 require_once __DIR__ . '/WorkerService.php';
 require_once __DIR__ . '/CommandExecutionResult.php';
 require_once __DIR__ . '/WorkerPageSortLink.php';
@@ -73,7 +74,7 @@ final class WorkerPage
             return [null, 'Invalid worker selected.'];
         }
 
-        $npsso = $request->getPostString('npsso');
+        $npsso = $request->getPostString(WorkerCredentialField::Npsso->value);
 
         if ($npsso === '') {
             return [null, 'The NPSSO value cannot be empty.'];
@@ -107,7 +108,7 @@ final class WorkerPage
             return [null, 'Invalid worker selected.'];
         }
 
-        $refreshToken = $request->getPostString('refresh_token');
+        $refreshToken = $request->getPostString(WorkerCredentialField::RefreshToken->value);
 
         if ($refreshToken === '') {
             return [null, 'The refresh token cannot be empty.'];

--- a/wwwroot/classes/AutomaticTrophyTitleMergeService.php
+++ b/wwwroot/classes/AutomaticTrophyTitleMergeService.php
@@ -178,7 +178,7 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
             'name' => (string) $row['name'],
             'platform' => $platform,
             'platforms' => $this->parsePlatforms($platform),
-            'status' => (int) ($row['status'] ?? 0),
+            'status' => (int) ($row['status'] ?? GameAvailabilityStatus::NORMAL->value),
         ];
     }
 
@@ -223,7 +223,7 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
                 'platforms' => $this->parsePlatforms($platform),
                 'is_clone' => MergeNpCommunicationId::matches($npCommunicationId),
                 'matches_by_order' => $comparison['orderMatches'],
-                'status' => (int) ($row['status'] ?? 0),
+                'status' => (int) ($row['status'] ?? GameAvailabilityStatus::NORMAL->value),
             ];
         }
 

--- a/wwwroot/classes/AvatarService.php
+++ b/wwwroot/classes/AvatarService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/Avatar.php';
 require_once __DIR__ . '/PlayerStatus.php';
 
-final class AvatarService
+final readonly class AvatarService
 {
     public function __construct(private readonly PDO $database)
     {

--- a/wwwroot/classes/ChangelogPage.php
+++ b/wwwroot/classes/ChangelogPage.php
@@ -167,10 +167,7 @@ final readonly class ChangelogPage
         $grouped = [];
         foreach ($presenters as $presenter) {
             $dateLabel = $presenter->getDateLabel();
-            if (!array_key_exists($dateLabel, $grouped)) {
-                $grouped[$dateLabel] = [];
-            }
-
+            $grouped[$dateLabel] ??= [];
             $grouped[$dateLabel][] = $presenter;
         }
 

--- a/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../TrophyCatalogSynchronizer.php';
 require_once __DIR__ . '/../TrophyImageDirectories.php';
 require_once __DIR__ . '/../TrophyImageDownloader.php';
 require_once __DIR__ . '/../TrophyTitleNameFormatter.php';
+require_once __DIR__ . '/../Platform.php';
 require_once __DIR__ . '/PlayerScanTitleHeaderSyncResult.php';
 require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
 
@@ -111,7 +112,7 @@ final class PlayerScanTitleHeaderSynchronizer
         foreach ($trophyTitle->platform() as $platform) {
             $platformValue = $platform->value;
             if ($platformValue === 'PSPC') {
-                $platformValue = 'PC';
+                $platformValue = Platform::Pc->label();
             }
 
             $platforms .= $platformValue . ',';

--- a/wwwroot/classes/Game/GameDetails.php
+++ b/wwwroot/classes/Game/GameDetails.php
@@ -62,7 +62,7 @@ final readonly class GameDetails
             (int) ($row['owners_completed'] ?? 0),
             (int) ($row['owners'] ?? 0),
             (string) ($row['difficulty'] ?? '0'),
-            GameAvailabilityStatus::fromInt((int) ($row['status'] ?? 0)),
+            GameAvailabilityStatus::fromInt((int) ($row['status'] ?? GameAvailabilityStatus::NORMAL->value)),
             (int) ($row['rarity_points'] ?? 0),
             (int) ($row['in_game_rarity_points'] ?? 0),
             self::parseObsoleteIds($row['obsolete_ids'] ?? null),

--- a/wwwroot/classes/Game/GameTrophyRow.php
+++ b/wwwroot/classes/Game/GameTrophyRow.php
@@ -54,7 +54,7 @@ final readonly class GameTrophyRow
         $this->iconUrl = (string) ($data['icon_url'] ?? '');
         $this->rarityPercent = (float) ($data['rarity_percent'] ?? 0.0);
         $this->inGameRarityPercent = (float) ($data['in_game_rarity_percent'] ?? 0.0);
-        $this->status = TrophyMetaStatus::fromMixed($data['status'] ?? 0);
+        $this->status = TrophyMetaStatus::fromMixed($data['status'] ?? TrophyMetaStatus::Obtainable->value);
         $this->progressTargetValue = isset($data['progress_target_value'])
             ? (int) $data['progress_target_value']
             : null;

--- a/wwwroot/classes/GameHistoryService.php
+++ b/wwwroot/classes/GameHistoryService.php
@@ -258,7 +258,7 @@ final class GameHistoryService
      */
     private static function toNullableInt(array $row, string $key): ?int
     {
-        if (!array_key_exists($key, $row) || $row[$key] === null) {
+        if (!isset($row[$key])) {
             return null;
         }
 

--- a/wwwroot/classes/GameLeaderboardService.php
+++ b/wwwroot/classes/GameLeaderboardService.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/GameLeaderboardRow.php';
 require_once __DIR__ . '/PlayerStatus.php';
 
-final class GameLeaderboardService
+final readonly class GameLeaderboardService
 {
     public const int PAGE_SIZE = 50;
 

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/PlayerStatus.php';
 require_once __DIR__ . '/SearchQueryHelper.php';
 require_once __DIR__ . '/PsnOnlineIdValidator.php';
 
-final class GameListService
+final readonly class GameListService
 {
     private const int PAGE_LIMIT = 40;
 

--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/Game/GamePlayerProgress.php';
 require_once __DIR__ . '/GameRecentPlayer.php';
 require_once __DIR__ . '/GameRecentPlayersQueryBuilder.php';
 
-final class GameRecentPlayersService
+final readonly class GameRecentPlayersService
 {
     public const int RECENT_PLAYERS_LIMIT = 10;
 

--- a/wwwroot/classes/GameStatusService.php
+++ b/wwwroot/classes/GameStatusService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/GameAvailabilityStatus.php';
 
-final class GameStatusService
+final readonly class GameStatusService
 {
     public function __construct(private readonly PDO $database)
     {

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/PlatformSql.php';
 require_once __DIR__ . '/TrophyGroupId.php';
 
-final class HomepageContentService
+final readonly class HomepageContentService
 {
     private const int DEFAULT_NEW_GAME_LIMIT = 8;
     private const int DEFAULT_NEW_DLCS_LIMIT = 8;

--- a/wwwroot/classes/ImageHashCalculator.php
+++ b/wwwroot/classes/ImageHashCalculator.php
@@ -177,7 +177,7 @@ final class ImageHashCalculator
     {
         $hex = '';
         foreach (str_split($bin, 4) as $chunk) {
-            $hex .= dechex(bindec($chunk));
+            $hex .= $chunk |> bindec(...) |> dechex(...);
         }
         return $hex;
     }

--- a/wwwroot/classes/IpRateLimitService.php
+++ b/wwwroot/classes/IpRateLimitService.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/IpRateLimitBucket.php';
 /**
  * Fixed-window IP rate limiting backed by the ip_rate_limit table.
  */
-final class IpRateLimitService
+final readonly class IpRateLimitService
 {
     public function __construct(private readonly PDO $database)
     {

--- a/wwwroot/classes/MaintenancePageStylesheet.php
+++ b/wwwroot/classes/MaintenancePageStylesheet.php
@@ -30,13 +30,6 @@ final readonly class MaintenancePageStylesheet
         return new self(BootstrapAssets::stylesheetUrl());
     }
 
-    #[\Deprecated(message: 'Use bootstrap() for the self-hosted stylesheet.')]
-    #[\NoDiscard]
-    public static function bootstrapCdn(string $version = BootstrapAssets::VERSION): self
-    {
-        return self::bootstrap($version);
-    }
-
     public function getHref(): string
     {
         return $this->href;

--- a/wwwroot/classes/PlayerAdvisorPageContext.php
+++ b/wwwroot/classes/PlayerAdvisorPageContext.php
@@ -190,7 +190,7 @@ final readonly class PlayerAdvisorPageContext
      */
     private static function extractPlayerStatus(array $playerData): PlayerStatus
     {
-        return PlayerStatus::fromValue((int) ($playerData['status'] ?? 0));
+        return PlayerStatus::fromValue((int) ($playerData['status'] ?? PlayerStatus::NORMAL->value));
     }
 
     /**

--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/TrophyMetaStatus.php';
 require_once __DIR__ . '/Utility.php';
 
-final class PlayerAdvisorService
+final readonly class PlayerAdvisorService
 {
     public const int PAGE_SIZE = 50;
 

--- a/wwwroot/classes/PlayerGame.php
+++ b/wwwroot/classes/PlayerGame.php
@@ -42,7 +42,7 @@ final readonly class PlayerGame
             (string) ($row['name'] ?? ''),
             (string) ($row['icon_url'] ?? ''),
             (string) ($row['platform'] ?? ''),
-            GameAvailabilityStatus::fromInt((int) ($row['status'] ?? 0)),
+            GameAvailabilityStatus::fromInt((int) ($row['status'] ?? GameAvailabilityStatus::NORMAL->value)),
             (int) ($row['max_rarity_points'] ?? 0),
             (int) ($row['max_in_game_rarity_points'] ?? 0),
             (int) ($row['bronze'] ?? 0),

--- a/wwwroot/classes/PlayerGamesPageContext.php
+++ b/wwwroot/classes/PlayerGamesPageContext.php
@@ -250,7 +250,7 @@ final readonly class PlayerGamesPageContext
      */
     private static function extractPlayerStatus(array $playerData): PlayerStatus
     {
-        return PlayerStatus::fromValue((int) ($playerData['status'] ?? 0));
+        return PlayerStatus::fromValue((int) ($playerData['status'] ?? PlayerStatus::NORMAL->value));
     }
 
     private function extractString(mixed $value): string

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/SearchQueryHelper.php';
 require_once __DIR__ . '/DateDurationSummary.php';
 require_once __DIR__ . '/TrophyGroupId.php';
 
-final class PlayerGamesService
+final readonly class PlayerGamesService
 {
     public function __construct(
         private readonly PDO $database,

--- a/wwwroot/classes/PlayerHeaderViewModel.php
+++ b/wwwroot/classes/PlayerHeaderViewModel.php
@@ -227,7 +227,7 @@ final readonly class PlayerHeaderViewModel
 
     private function getStatus(): PlayerStatus
     {
-        return PlayerStatus::fromValue((int) ($this->player['status'] ?? 0));
+        return PlayerStatus::fromValue((int) ($this->player['status'] ?? PlayerStatus::NORMAL->value));
     }
 
     private function hasHiddenTrophies(): bool

--- a/wwwroot/classes/PlayerLeaderboardPage.php
+++ b/wwwroot/classes/PlayerLeaderboardPage.php
@@ -9,8 +9,6 @@ require_once __DIR__ . '/PlayerLeaderboardFilter.php';
 
 final readonly class PlayerLeaderboardPage
 {
-    private PlayerLeaderboardFilter $requestedFilter;
-
     private ChangelogPaginator $paginator;
 
     /**
@@ -18,13 +16,13 @@ final readonly class PlayerLeaderboardPage
      */
     private array $players;
 
-    public function __construct(PlayerLeaderboardDataProvider $service, PlayerLeaderboardFilter $filter)
-    {
-        $this->requestedFilter = $filter;
-
-        if ($filter->getPage() === 1 && $service instanceof AbstractPlayerLeaderboardService) {
-            $result = $service->getPlayersWithTotal($filter, $service->getPageSize());
-            $totalPlayers = $result->totalPlayers ?? $service->countPlayers($filter);
+    public function __construct(
+        PlayerLeaderboardDataProvider $service,
+        private PlayerLeaderboardFilter $requestedFilter,
+    ) {
+        if ($this->requestedFilter->getPage() === 1 && $service instanceof AbstractPlayerLeaderboardService) {
+            $result = $service->getPlayersWithTotal($this->requestedFilter, $service->getPageSize());
+            $totalPlayers = $result->totalPlayers ?? $service->countPlayers($this->requestedFilter);
             $this->paginator = new ChangelogPaginator(
                 1,
                 $totalPlayers,
@@ -32,9 +30,9 @@ final readonly class PlayerLeaderboardPage
             );
             $this->players = $result->players;
         } else {
-            $totalPlayers = $service->countPlayers($filter);
+            $totalPlayers = $service->countPlayers($this->requestedFilter);
             $this->paginator = new ChangelogPaginator(
-                $filter->getPage(),
+                $this->requestedFilter->getPage(),
                 $totalPlayers,
                 $service->getPageSize()
             );

--- a/wwwroot/classes/PlayerLogEntry.php
+++ b/wwwroot/classes/PlayerLogEntry.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 require_once __DIR__ . '/CommaSeparatedValues.php';
 require_once __DIR__ . '/Platform.php';
 require_once __DIR__ . '/TrophyType.php';
+require_once __DIR__ . '/TrophyMetaStatus.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
 
 final readonly class PlayerLogEntry
 {
@@ -45,7 +47,7 @@ final readonly class PlayerLogEntry
             trophyIcon: (string) ($row['trophy_icon'] ?? ''),
             rarityPercent: self::toNullableString($row['rarity_percent'] ?? null),
             inGameRarityPercent: self::toNullableString($row['in_game_rarity_percent'] ?? null),
-            trophyStatus: (int) ($row['trophy_status'] ?? 0),
+            trophyStatus: (int) ($row['trophy_status'] ?? TrophyMetaStatus::Obtainable->value),
             progressTargetValue: self::toNullableInt($row['progress_target_value'] ?? null),
             progress: self::toNullableInt($row['progress'] ?? null),
             isEarned: (int) ($row['earned'] ?? 0) === 1,
@@ -53,7 +55,7 @@ final readonly class PlayerLogEntry
             rewardImageUrl: self::toNullableString($row['reward_image_url'] ?? null),
             gameId: (int) ($row['game_id'] ?? 0),
             gameName: (string) ($row['game_name'] ?? ''),
-            gameStatus: (int) ($row['game_status'] ?? 0),
+            gameStatus: (int) ($row['game_status'] ?? GameAvailabilityStatus::NORMAL->value),
             gameIcon: (string) ($row['game_icon'] ?? ''),
             platforms: (string) ($row['platform'] ?? ''),
             earnedDate: (string) ($row['earned_date'] ?? '')
@@ -192,7 +194,8 @@ final readonly class PlayerLogEntry
 
     public function requiresWarning(): bool
     {
-        return $this->gameStatus !== 0 || $this->trophyStatus !== 0;
+        return $this->gameStatus !== GameAvailabilityStatus::NORMAL->value
+            || $this->trophyStatus !== TrophyMetaStatus::Obtainable->value;
     }
 
     public function getEarnedDate(): string

--- a/wwwroot/classes/PlayerLogPageContext.php
+++ b/wwwroot/classes/PlayerLogPageContext.php
@@ -171,6 +171,6 @@ final readonly class PlayerLogPageContext
 
     private static function extractPlayerStatus(array $playerData): PlayerStatus
     {
-        return PlayerStatus::fromValue((int) ($playerData['status'] ?? 0));
+        return PlayerStatus::fromValue((int) ($playerData['status'] ?? PlayerStatus::NORMAL->value));
     }
 }

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -373,7 +373,7 @@ class PlayerQueueService
      */
     private function toOptionalString(array $row, string $key): ?string
     {
-        if (!array_key_exists($key, $row) || $row[$key] === null) {
+        if (!isset($row[$key])) {
             return null;
         }
 
@@ -385,7 +385,7 @@ class PlayerQueueService
      */
     private function toOptionalInt(array $row, string $key): ?int
     {
-        if (!array_key_exists($key, $row) || $row[$key] === null) {
+        if (!isset($row[$key])) {
             return null;
         }
 

--- a/wwwroot/classes/PlayerRandomGamesPage.php
+++ b/wwwroot/classes/PlayerRandomGamesPage.php
@@ -10,8 +10,6 @@ require_once __DIR__ . '/PlayerStatus.php';
 
 final readonly class PlayerRandomGamesPage
 {
-    private PlayerRandomGamesFilter $filter;
-
     private PlayerSummary $playerSummary;
 
     /**
@@ -19,18 +17,14 @@ final readonly class PlayerRandomGamesPage
      */
     private array $randomGames;
 
-    private PlayerStatus $playerStatus;
-
     public function __construct(
         PlayerRandomGamesService $randomGamesService,
         PlayerSummaryService $summaryService,
-        PlayerRandomGamesFilter $filter,
+        private PlayerRandomGamesFilter $filter,
         int $accountId,
-        PlayerStatus $playerStatus,
+        private PlayerStatus $playerStatus,
     ) {
-        $this->filter = $filter;
         $this->playerSummary = $summaryService->getSummary($accountId);
-        $this->playerStatus = $playerStatus;
         $this->randomGames = $this->shouldLoadRandomGames()
             ? $randomGamesService->getRandomGames($accountId, $filter)
             : [];

--- a/wwwroot/classes/PlayerRandomGamesPageContext.php
+++ b/wwwroot/classes/PlayerRandomGamesPageContext.php
@@ -178,6 +178,6 @@ final readonly class PlayerRandomGamesPageContext
      */
     private static function extractPlayerStatus(array $playerData): PlayerStatus
     {
-        return PlayerStatus::fromValue((int) ($playerData['status'] ?? 0));
+        return PlayerStatus::fromValue((int) ($playerData['status'] ?? PlayerStatus::NORMAL->value));
     }
 }

--- a/wwwroot/classes/PlayerTimelinePage.php
+++ b/wwwroot/classes/PlayerTimelinePage.php
@@ -12,18 +12,15 @@ final readonly class PlayerTimelinePage
 {
     private PlayerSummary $playerSummary;
 
-    private PlayerStatus $playerStatus;
-
     private ?PlayerTimelineData $timelineData;
 
     public function __construct(
         PlayerTimelineService $timelineService,
         PlayerSummaryService $summaryService,
         int $accountId,
-        PlayerStatus $playerStatus,
+        private PlayerStatus $playerStatus,
     ) {
         $this->playerSummary = $summaryService->getSummary($accountId);
-        $this->playerStatus = $playerStatus;
         $this->timelineData = $this->shouldLoadTimeline()
             ? $timelineService->getTimelineData($accountId)
             : null;
@@ -38,14 +35,6 @@ final readonly class PlayerTimelinePage
     {
         return $this->timelineData;
     }
-
-    // /**
-    //  * @return PlayerTimeline[]
-    //  */
-    // public function getTimeline(): array
-    // {
-    //     return $this->timelines;
-    // }
 
     public function shouldShowFlaggedMessage(): bool
     {

--- a/wwwroot/classes/PlayerTimelinePageContext.php
+++ b/wwwroot/classes/PlayerTimelinePageContext.php
@@ -161,6 +161,6 @@ final readonly class PlayerTimelinePageContext
      */
     private static function extractPlayerStatus(array $playerData): PlayerStatus
     {
-        return PlayerStatus::fromValue((int) ($playerData['status'] ?? 0));
+        return PlayerStatus::fromValue((int) ($playerData['status'] ?? PlayerStatus::NORMAL->value));
     }
 }

--- a/wwwroot/classes/TrophyDetails.php
+++ b/wwwroot/classes/TrophyDetails.php
@@ -53,7 +53,7 @@ final readonly class TrophyDetails
             (string) ($data['trophy_icon'] ?? ''),
             (float) ($data['rarity_percent'] ?? 0.0),
             (float) ($data['in_game_rarity_percent'] ?? 0.0),
-            TrophyMetaStatus::fromMixed($data['status'] ?? 0),
+            TrophyMetaStatus::fromMixed($data['status'] ?? TrophyMetaStatus::Obtainable->value),
             isset($data['progress_target_value']) ? (string) $data['progress_target_value'] : null,
             isset($data['reward_name']) ? (string) $data['reward_name'] : null,
             isset($data['reward_image_url']) ? (string) $data['reward_image_url'] : null,

--- a/wwwroot/classes/TrophyListService.php
+++ b/wwwroot/classes/TrophyListService.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/TrophyListItem.php';
 require_once __DIR__ . '/TrophyMetaStatus.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
 
-final class TrophyListService
+final readonly class TrophyListService
 {
     public const int PAGE_SIZE = 50;
 

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -17,8 +17,6 @@ class TrophyMergeService
 {
     private readonly NestedDatabaseTransactionRunner $transactionRunner;
 
-    private ?TrophyMergeEarnedCopier $earnedCopier = null;
-
     private ?TrophyMergeMappingService $mappingService = null;
 
     private ?TrophyMergeMetadataRepository $metadataRepository = null;
@@ -30,10 +28,9 @@ class TrophyMergeService
     public function __construct(
         private readonly PDO $database,
         ?NestedDatabaseTransactionRunner $transactionRunner = null,
-        ?TrophyMergeEarnedCopier $earnedCopier = null,
+        private ?TrophyMergeEarnedCopier $earnedCopier = null,
     ) {
         $this->transactionRunner = $transactionRunner ?? new NestedDatabaseTransactionRunner($database);
-        $this->earnedCopier = $earnedCopier;
     }
 
     public function mergeSpecificTrophies(int $parentTrophyId, array $childTrophyIds): string

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -59,7 +59,7 @@ final readonly class TrophyTitleNameFormatter
         }
 
         if (str_ends_with($name, ' -')) {
-            $name = rtrim(substr($name, 0, -2));
+            $name = substr($name, 0, -2) |> rtrim(...);
         }
 
         $separatorPosition = strpos($name, ' - ');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Continue the PHP 8.5 modernization series with leftover production improvements that no longer need backward compatibility.

### Changes
- Finish constructor property promotion on `PlayerRandomGamesPage`, `PlayerTimelinePage`, `PlayerLeaderboardPage`, `GameRescanService`, `GameCopyService`, and `TrophyMergeService`
- Seal stateless final services/repositories as `final readonly` (list/leaderboard/status/avatar/admin helpers, etc.)
- Prefer existing backed enums for admin form values (`GameResetAction`, `GameDetailAction`, `TrophyMergeMethod`, `WorkerCredentialField`, `HttpMethod`, `TrophyType`, `Platform`) and status defaults (`GameAvailabilityStatus`, `PlayerStatus`, `TrophyMetaStatus`)
- Apply small 8.5 cleanups: pipes (`ImageHashCalculator`, `TrophyTitleNameFormatter`), `??=` grouping, `isset` for nullable row reads, `array_map` in `PossibleCheaterRuleGroup`
- Remove unused deprecated `MaintenancePageStylesheet::bootstrapCdn()`
- Type the last three untyped test class constants

### Tests
- Full suite: `php tests/run.php` — **All 1033 tests passed**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-845a6e2a-5dfd-46a7-a42f-571fcbad86c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-845a6e2a-5dfd-46a7-a42f-571fcbad86c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

