### PR TITLE
Fix game URLs with Unicode symbols (×) redirecting to homepage

### DIFF
--- a/tests/NavigationStateTest.php
+++ b/tests/NavigationStateTest.php
@@ -61,4 +61,15 @@ final class NavigationStateTest extends TestCase
         $this->assertSame('', $navigationState->getHomeClass());
         $this->assertTrue($navigationState->isSectionActive('trophy'));
     }
+
+    public function testGameSectionActiveWhenUriContainsDecodedUnicode(): void
+    {
+        $server = ['REQUEST_URI' => '/game/1163-collar-' . "\u{00D7}" . '-malice-unlimited'];
+
+        $navigationState = NavigationState::fromGlobals($server, []);
+
+        $this->assertSame(' active', $navigationState->getGameClass());
+        $this->assertSame('', $navigationState->getHomeClass());
+        $this->assertTrue($navigationState->isSectionActive('game'));
+    }
 }

--- a/tests/RequestUriPathTest.php
+++ b/tests/RequestUriPathTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/RequestUriPath.php';
+
+final class RequestUriPathTest extends TestCase
+{
+    public function testFromUriReturnsAsciiPathUnchanged(): void
+    {
+        $this->assertSame(
+            '/game/123-example',
+            RequestUriPath::fromUri('/game/123-example')
+        );
+    }
+
+    public function testFromUriPercentEncodesDecodedUnicodeBeforeParsing(): void
+    {
+        $path = '/game/1163-collar-' . "\u{00D7}" . '-malice-unlimited';
+
+        $this->assertSame(
+            '/game/1163-collar-%C3%97-malice-unlimited',
+            RequestUriPath::fromUri($path)
+        );
+    }
+
+    public function testFromUriPreservesAlreadyEncodedUnicode(): void
+    {
+        $this->assertSame(
+            '/game/1163-collar-%C3%97-malice-unlimited',
+            RequestUriPath::fromUri('/game/1163-collar-%C3%97-malice-unlimited')
+        );
+    }
+}

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -153,6 +153,46 @@ final class RouterTest extends TestCase
         );
     }
 
+    public function testDispatchRoutesGameUrlsWithDecodedUnicodeSlug(): void
+    {
+        // Apache SCRIPT_URL often contains decoded UTF-8 (×) rather than %C3%97.
+        // RequestUriPath re-encodes before parsing, so the handler sees the encoded segment.
+        $encodedSegment = '1163-collar-%C3%97-malice-unlimited';
+        $this->gameRepository->idsBySegment[$encodedSegment] = 1163;
+
+        $result = $this->router->dispatch('/game/1163-collar-' . "\u{00D7}" . '-malice-unlimited');
+
+        $this->assertSame([$encodedSegment], array_filter($this->gameRepository->receivedSegments));
+        $this->assertTrue($result->shouldInclude());
+        $this->assertSame('game.php', $result->getInclude());
+        $this->assertSame(
+            [
+                'gameId' => 1163,
+                'player' => null,
+            ],
+            $result->getVariables()
+        );
+    }
+
+    public function testDispatchRoutesGameUrlsWithPercentEncodedUnicodeSlug(): void
+    {
+        $segment = '1163-collar-%C3%97-malice-unlimited';
+        $this->gameRepository->idsBySegment[$segment] = 1163;
+
+        $result = $this->router->dispatch('/game/' . $segment);
+
+        $this->assertSame([$segment], array_filter($this->gameRepository->receivedSegments));
+        $this->assertTrue($result->shouldInclude());
+        $this->assertSame('game.php', $result->getInclude());
+        $this->assertSame(
+            [
+                'gameId' => 1163,
+                'player' => null,
+            ],
+            $result->getVariables()
+        );
+    }
+
     public function testDispatchIgnoresInvalidGamePlayerSegment(): void
     {
         $this->gameRepository->idsBySegment['123-example'] = 123;

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -24,6 +24,19 @@ final class UtilityTest extends TestCase
         $this->assertSame('100percent-ready-for-2024', $slug);
     }
 
+    public function testSlugifyRemovesMultiplicationSignAndOtherSymbols(): void
+    {
+        $utility = new Utility();
+
+        $this->assertSame(
+            'collar-malice-unlimited',
+            $utility->slugify('Collar × Malice: Unlimited')
+        );
+        $this->assertSame('game', $utility->slugify('★ game'));
+        $this->assertSame('hello-world', $utility->slugify('Hello → World'));
+        $this->assertSame('cafe', $utility->slugify('Café™'));
+    }
+
     public function testGetCountryNameReturnsLocaleDisplayNameWhenAvailable(): void
     {
         $utility = new Utility();

--- a/wwwroot/classes/NavigationState.php
+++ b/wwwroot/classes/NavigationState.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/NavigationSection.php';
 require_once __DIR__ . '/NavigationSectionState.php';
 require_once __DIR__ . '/RequestParameter.php';
+require_once __DIR__ . '/RequestUriPath.php';
 require_once __DIR__ . '/Html.php';
 
 final readonly class NavigationState
@@ -24,7 +25,7 @@ final readonly class NavigationState
     #[\NoDiscard]
     public static function fromGlobals(array $server, array $queryParameters): self
     {
-        $requestPath = Uri\Rfc3986\Uri::parse((string) ($server['REQUEST_URI'] ?? '/'))?->getPath() ?? '/';
+        $requestPath = RequestUriPath::fromUri((string) ($server['REQUEST_URI'] ?? '/')) ?: '/';
 
         $sort = self::sanitizeQueryValue($queryParameters['sort'] ?? '');
         $player = self::sanitizeQueryValue($queryParameters['player'] ?? '');

--- a/wwwroot/classes/RequestUriPath.php
+++ b/wwwroot/classes/RequestUriPath.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Extracts a path from a request URI that may contain non-ASCII bytes.
+ *
+ * Apache often exposes decoded UTF-8 in SCRIPT_URL / REQUEST_URI, but
+ * {@see Uri\Rfc3986\Uri::parse()} only accepts ASCII or percent-encoded URIs.
+ */
+final class RequestUriPath
+{
+    #[\NoDiscard]
+    public static function fromUri(string $requestUri): string
+    {
+        $asciiUri = preg_replace_callback(
+            '/[^\x00-\x7F]+/',
+            static fn (array $matches): string => rawurlencode($matches[0]),
+            $requestUri
+        ) ?? $requestUri;
+
+        return Uri\Rfc3986\Uri::parse($asciiUri)?->getPath() ?? '';
+    }
+}

--- a/wwwroot/classes/Router.php
+++ b/wwwroot/classes/Router.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/RouteResult.php';
 require_once __DIR__ . '/RouteName.php';
+require_once __DIR__ . '/RequestUriPath.php';
 require_once __DIR__ . '/GameRepository.php';
 require_once __DIR__ . '/TrophyRepository.php';
 require_once __DIR__ . '/PlayerRepository.php';
@@ -47,8 +48,7 @@ class Router
     #[\NoDiscard]
     public function dispatch(string $requestUri): RouteResult
     {
-        $normalizedPath = (Uri\Rfc3986\Uri::parse($requestUri)?->getPath() ?? '')
-            |> (fn (string $path): string => trim($path, '/'));
+        $normalizedPath = trim(RequestUriPath::fromUri($requestUri), '/');
 
         if ($normalizedPath === '') {
             return $this->defaultHandler->handle([]);

--- a/wwwroot/classes/Utility.php
+++ b/wwwroot/classes/Utility.php
@@ -22,16 +22,17 @@ class Utility
             |> (fn(string $value): string => str_replace(['&', '%', ' - '], ['and', 'percent', ' '], $value));
 
         $slug = self::getSlugTransliterator()->transliterate($text);
-        if (is_string($slug) && $slug !== '') {
-            return $slug;
+        if (!is_string($slug) || $slug === '') {
+            $slug = $text;
         }
 
-        $slug = $text
+        // Always collapse to ASCII URL-safe characters. ICU leaves symbols such as
+        // "×" (U+00D7) in place after punctuation removal, and those break routing
+        // when Apache exposes a decoded SCRIPT_URL to PHP.
+        return $slug
             |> strtolower(...)
             |> (fn(string $value): string => preg_replace('/[^a-z0-9]+/', '-', $value) ?? $value)
             |> (fn(string $value): string => trim($value, '-'));
-
-        return $slug;
     }
 
     #[\NoDiscard]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Game titles containing symbols like `×` (U+00D7), e.g. **Collar × Malice: Unlimited**, produced URLs such as:

`/game/1163-collar-%C3%97-malice-unlimited`

Visiting those URLs sent users back to `/` instead of the game page.

## Root cause

1. **`Utility::slugify()`** kept math/other symbols in the slug. ICU’s `[:Punctuation:] Remove` does not remove `×` (Symbol, Math).
2. Links/bookmarks often reached PHP as **decoded UTF-8** in Apache’s `SCRIPT_URL` (preferred by `HttpRequest::getResolvedUri()`).
3. **`Uri\Rfc3986\Uri::parse()`** rejects non-ASCII URIs and returned `null`, so `Router` treated the path as empty and served the homepage.

## Fix

- Always collapse slugify output to ASCII `[a-z0-9-]` (e.g. `collar-malice-unlimited`).
- Add `RequestUriPath` to percent-encode non-ASCII bytes before RFC 3986 parsing; use it from `Router` and `NavigationState`.
- Existing `%C3%97` bookmarks still resolve by numeric game id.

## Tests

- Slugify cases for `×`, `★`, `→`, `™`
- Router dispatch for decoded and percent-encoded Unicode game slugs
- `RequestUriPath` and NavigationState coverage
- Full suite: **1040 tests passed**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d277fa6-9b17-469e-b3b4-571a0e262726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d277fa6-9b17-469e-b3b4-571a0e262726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

