### PR TITLE
Adopt remaining PHP 8.5 WhatWg, NoDiscard, and sealing idioms

### DIFF
--- a/tests/AdminAuthServiceTest.php
+++ b/tests/AdminAuthServiceTest.php
@@ -91,7 +91,7 @@ final class AdminAuthServiceTest extends TestCase
     {
         $this->insertAdmin('admin-user', password_hash('secret-password', PASSWORD_DEFAULT));
         $service = $this->createAuthService();
-        $service->login('admin-user', 'secret-password', '192.0.2.32');
+        (void) $service->login('admin-user', 'secret-password', '192.0.2.32');
 
         $service->logout();
 
@@ -107,7 +107,7 @@ final class AdminAuthServiceTest extends TestCase
         $ipAddress = '192.0.2.33';
 
         for ($index = 0; $index < AdminLoginThrottleService::MAX_FAILURES; $index++) {
-            $service->login('admin-user', 'wrong-password', $ipAddress);
+            (void) $service->login('admin-user', 'wrong-password', $ipAddress);
         }
 
         $this->assertTrue($service->isLoginLocked($ipAddress));

--- a/tests/IpRateLimitServiceTest.php
+++ b/tests/IpRateLimitServiceTest.php
@@ -40,7 +40,7 @@ final class IpRateLimitServiceTest extends TestCase
     public function testCheckAndRecordBlocksRequestsAboveLimit(): void
     {
         for ($index = 0; $index < 60; $index++) {
-            $this->service->checkAndRecord('192.0.2.11', IpRateLimitBucket::QueuePoll);
+            (void) $this->service->checkAndRecord('192.0.2.11', IpRateLimitBucket::QueuePoll);
         }
 
         $this->assertFalse(
@@ -51,7 +51,7 @@ final class IpRateLimitServiceTest extends TestCase
     public function testDifferentBucketsTrackSeparately(): void
     {
         for ($index = 0; $index < 30; $index++) {
-            $this->service->checkAndRecord('192.0.2.12', IpRateLimitBucket::ScanLogPoll);
+            (void) $this->service->checkAndRecord('192.0.2.12', IpRateLimitBucket::ScanLogPoll);
         }
 
         $this->assertFalse(
@@ -78,7 +78,7 @@ final class IpRateLimitServiceTest extends TestCase
     public function testQueueSubmitBucketTracksSeparatelyFromQueuePoll(): void
     {
         for ($index = 0; $index < 10; $index++) {
-            $this->service->checkAndRecord('192.0.2.14', IpRateLimitBucket::QueueSubmit);
+            (void) $this->service->checkAndRecord('192.0.2.14', IpRateLimitBucket::QueueSubmit);
         }
 
         $this->assertFalse(
@@ -105,7 +105,7 @@ final class IpRateLimitServiceTest extends TestCase
     public function testUnknownClientBucketIsSeparateFromKnownIp(): void
     {
         for ($index = 0; $index < 10; $index++) {
-            $this->service->checkAndRecord('', IpRateLimitBucket::QueueSubmit);
+            (void) $this->service->checkAndRecord('', IpRateLimitBucket::QueueSubmit);
         }
 
         $this->assertFalse(
@@ -132,7 +132,7 @@ final class IpRateLimitServiceTest extends TestCase
     public function testPlayerReportBucketTracksSeparatelyFromQueueSubmit(): void
     {
         for ($index = 0; $index < 5; $index++) {
-            $this->service->checkAndRecord('192.0.2.17', IpRateLimitBucket::PlayerReport);
+            (void) $this->service->checkAndRecord('192.0.2.17', IpRateLimitBucket::PlayerReport);
         }
 
         $this->assertFalse(

--- a/tests/RequestUriPathTest.php
+++ b/tests/RequestUriPathTest.php
@@ -31,4 +31,28 @@ final class RequestUriPathTest extends TestCase
             RequestUriPath::fromUri('/game/1163-collar-%C3%97-malice-unlimited')
         );
     }
+
+    public function testFromUriStripsQueryAndFragment(): void
+    {
+        $this->assertSame(
+            '/player/example',
+            RequestUriPath::fromUri('/player/example?tab=log#latest')
+        );
+    }
+
+    public function testFromUriReturnsRootForEmptyInput(): void
+    {
+        $this->assertSame('/', RequestUriPath::fromUri(''));
+        $this->assertSame('/', RequestUriPath::fromUri('/'));
+    }
+
+    public function testFromUriReturnsEmptyStringForMalformedAbsoluteUri(): void
+    {
+        $this->assertSame('', RequestUriPath::fromUri('http://['));
+    }
+
+    public function testFromUriPercentEncodesSpaces(): void
+    {
+        $this->assertSame('/a%20b', RequestUriPath::fromUri('/a b'));
+    }
 }

--- a/wwwroot/admin/report.php
+++ b/wwwroot/admin/report.php
@@ -43,7 +43,7 @@ $errorMessage = $pageResult->getErrorMessage();
                         <?= Html::escape($reportedPlayer->getOnlineId()); ?>
                     </a>
                     <div class="mt-2">
-                        <?= nl2br(Html::escape($reportedPlayer->getExplanation())); ?>
+                        <?= $reportedPlayer->getExplanation() |> Html::escape(...) |> nl2br(...); ?>
                     </div>
                     <div class="mt-2">
                         <form method="post" class="d-inline js-report-delete-form">

--- a/wwwroot/classes/AbstractPlayerLeaderboardService.php
+++ b/wwwroot/classes/AbstractPlayerLeaderboardService.php
@@ -21,7 +21,7 @@ abstract readonly class AbstractPlayerLeaderboardService implements PlayerLeader
             p.status = 
         SQL . PlayerStatus::NORMAL->value;
 
-    public function __construct(protected \PDO $database)
+    public function __construct(final protected \PDO $database)
     {
     }
 

--- a/wwwroot/classes/Admin/AdminAuthService.php
+++ b/wwwroot/classes/Admin/AdminAuthService.php
@@ -4,23 +4,25 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/AdminLoginThrottleService.php';
 
-final class AdminAuthService
+final readonly class AdminAuthService
 {
     private const string SESSION_AUTHENTICATED_KEY = 'admin_authenticated';
 
     private const string SESSION_USERNAME_KEY = 'admin_username';
 
     public function __construct(
-        private readonly AdminUserRepository $adminUserRepository,
-        private readonly ?AdminLoginThrottleService $loginThrottle = null,
+        private AdminUserRepository $adminUserRepository,
+        private ?AdminLoginThrottleService $loginThrottle = null,
     ) {
     }
 
+    #[\NoDiscard('Check whether admin authentication is configured before allowing login.')]
     public function isConfigured(): bool
     {
         return $this->adminUserRepository->hasAnyAdmin();
     }
 
+    #[\NoDiscard('Check authentication state before granting access to admin pages.')]
     public function isAuthenticated(): bool
     {
         return ($_SESSION[self::SESSION_AUTHENTICATED_KEY] ?? false) === true;
@@ -37,6 +39,7 @@ final class AdminAuthService
         return is_string($username) && $username !== '' ? $username : null;
     }
 
+    #[\NoDiscard('Check whether the client IP is locked out before attempting login.')]
     public function isLoginLocked(string $ipAddress): bool
     {
         return $this->loginThrottle?->isLocked($ipAddress) ?? false;
@@ -47,6 +50,7 @@ final class AdminAuthService
         return $this->loginThrottle?->getLockoutRemainingSeconds($ipAddress) ?? 0;
     }
 
+    #[\NoDiscard('The login result must be checked before treating the session as authenticated.')]
     public function login(string $username, #[\SensitiveParameter] string $password, string $ipAddress = ''): bool
     {
         if ($ipAddress !== '' && $this->isLoginLocked($ipAddress)) {

--- a/wwwroot/classes/Admin/AdminUserRepository.php
+++ b/wwwroot/classes/Admin/AdminUserRepository.php
@@ -24,11 +24,13 @@ final readonly class AdminUserRepository
     {
     }
 
+    #[\NoDiscard('Check whether any admin account exists before treating the install as configured.')]
     public function hasAnyAdmin(): bool
     {
         return (int) $this->database->query(self::SQL_ADMIN_COUNT)->fetchColumn() > 0;
     }
 
+    #[\NoDiscard('The credential verification result must be checked before granting admin access.')]
     public function verifyCredentials(string $username, #[\SensitiveParameter] string $password): bool
     {
         if ($username === '' || $password === '') {

--- a/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
+++ b/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/GameRescanProgressListener.php';
 
-final class CallableGameRescanProgressListener implements GameRescanProgressListener
+final readonly class CallableGameRescanProgressListener implements GameRescanProgressListener
 {
     /**
      * @param Closure(int, string):void $callback
      */
-    public function __construct(private readonly \Closure $callback)
+    public function __construct(private \Closure $callback)
     {
     }
 

--- a/wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
+++ b/wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/TrophyMergeProgressListener.php';
 
-final class CallableTrophyMergeProgressListener implements TrophyMergeProgressListener
+final readonly class CallableTrophyMergeProgressListener implements TrophyMergeProgressListener
 {
     /**
      * @param Closure(int, string):void $callback
      */
-    public function __construct(private readonly \Closure $callback)
+    public function __construct(private \Closure $callback)
     {
     }
 

--- a/wwwroot/classes/Admin/PlayerReportDeletionRequest.php
+++ b/wwwroot/classes/Admin/PlayerReportDeletionRequest.php
@@ -44,6 +44,7 @@ final readonly class PlayerReportDeletionRequest
         return $this->deleteId !== null || $this->errorMessage !== null;
     }
 
+    #[\NoDiscard('Check whether the deletion request is valid before deleting a report.')]
     public function isValidDeletion(): bool
     {
         return $this->deleteId !== null && !$this->hasError();

--- a/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
@@ -61,7 +61,7 @@ final class PlayerAvatarSynchronizer
                     $newPHash = $matchedPHash;
                 }
 
-                $path = Uri\Rfc3986\Uri::parse($avatarUrl)?->getPath() ?? '';
+                $path = Uri\WhatWg\Url::parse($avatarUrl)?->getPath() ?? '';
                 $extension = pathinfo($path, PATHINFO_EXTENSION) |> strtolower(...);
                 $avatarFilename = $newPHash . '.' . $extension;
                 $avatarPath = $this->avatarStorageDirectory . $avatarFilename;

--- a/wwwroot/classes/Cron/PlayerScanCompletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionService.php
@@ -13,9 +13,9 @@ require_once __DIR__ . '/../TrophyRarityName.php';
  *
  * Encapsulates post-scan aggregation that was previously embedded in ThirtyMinuteCronJob.
  */
-final class PlayerScanCompletionService
+final readonly class PlayerScanCompletionService
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(private PDO $database)
     {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanQueueSelector.php
+++ b/wwwroot/classes/Cron/PlayerScanQueueSelector.php
@@ -19,11 +19,11 @@ require_once __DIR__ . '/../PlayerStatus.php';
  * Stale-player cutoffs are computed with MySQL NOW() so they stay aligned with
  * the database session clock and INTERVAL month arithmetic.
  */
-final class PlayerScanQueueSelector
+final readonly class PlayerScanQueueSelector
 {
     public function __construct(
-        private readonly PDO $database,
-        private readonly ?string $selectionSql = null,
+        private PDO $database,
+        private ?string $selectionSql = null,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanStaleGameDeletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanStaleGameDeletionService.php
@@ -7,9 +7,9 @@ declare(strict_types=1);
  *
  * Encapsulates missing-game deletion logic that was previously embedded in ThirtyMinuteCronJob.
  */
-final class PlayerScanStaleGameDeletionService
+final readonly class PlayerScanStaleGameDeletionService
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(private PDO $database)
     {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
@@ -15,14 +15,14 @@ use Tustin\Haste\Exception\NotFoundHttpException;
  * Encapsulates per-title trophy progress synchronization that was previously embedded in
  * ThirtyMinuteCronJob.
  */
-final class PlayerScanTrophyProgressSynchronizer
+final readonly class PlayerScanTrophyProgressSynchronizer
 {
     public function __construct(
-        private readonly PDO $database,
-        private readonly TrophyCalculator $trophyCalculator,
-        private readonly Psn100Logger $logger,
-        private readonly PlayerEarnedTrophyPersister $earnedTrophyPersister,
-        private readonly AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService,
+        private PDO $database,
+        private TrophyCalculator $trophyCalculator,
+        private Psn100Logger $logger,
+        private PlayerEarnedTrophyPersister $earnedTrophyPersister,
+        private AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleRefresher.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleRefresher.php
@@ -12,12 +12,12 @@ require_once __DIR__ . '/WorkerScanCoordinator.php';
  * Encapsulates PSN title icon and last-updated-date retry logic that was
  * previously embedded in ThirtyMinuteCronJob.
  */
-final class PlayerScanTrophyTitleRefresher
+final readonly class PlayerScanTrophyTitleRefresher
 {
     public function __construct(
-        private readonly Psn100Logger $logger,
-        private readonly PlayerScanTitleMetadataHelper $titleMetadataHelper,
-        private readonly WorkerScanCoordinator $workerScanCoordinator,
+        private Psn100Logger $logger,
+        private PlayerScanTitleMetadataHelper $titleMetadataHelper,
+        private WorkerScanCoordinator $workerScanCoordinator,
     ) {
     }
 

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
@@ -9,11 +9,11 @@ require_once __DIR__ . '/../TrophyCalculator.php';
 require_once __DIR__ . '/../Psn100Logger.php';
 require_once __DIR__ . '/ThirtyMinuteCronJob.php';
 
-final class ThirtyMinuteCronJobApplication
+final readonly class ThirtyMinuteCronJobApplication
 {
     private function __construct(
-        private readonly CronJobEntryPoint $entryPoint,
-        private readonly CronJobCliArguments $cliArguments,
+        private CronJobEntryPoint $entryPoint,
+        private CronJobCliArguments $cliArguments,
     ) {
     }
 

--- a/wwwroot/classes/Cron/WorkerScanCoordinator.php
+++ b/wwwroot/classes/Cron/WorkerScanCoordinator.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * Encapsulates setting table updates that were previously embedded in
  * ThirtyMinuteCronJob so the main scan loop can focus on PSN API orchestration.
  */
-final class WorkerScanCoordinator
+final readonly class WorkerScanCoordinator
 {
     private const \Closure DEFAULT_SLEEPER = sleep(...);
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly \Closure $sleeper = self::DEFAULT_SLEEPER,
+        private PDO $database,
+        private \Closure $sleeper = self::DEFAULT_SLEEPER,
     ) {
     }
 

--- a/wwwroot/classes/CsrfTokenManager.php
+++ b/wwwroot/classes/CsrfTokenManager.php
@@ -43,9 +43,10 @@ final readonly class CsrfTokenManager
         return hash_equals($expectedToken, $submittedToken);
     }
 
+    #[\NoDiscard]
     public static function hiddenField(string $scope): string
     {
-        $token = Html::escape(self::getToken($scope));
+        $token = self::getToken($scope) |> Html::escape(...);
 
         return '<input type="hidden" name="_csrf_token" value="' . $token . '">';
     }

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -307,7 +307,7 @@ class GameHeaderService
 
             $url = trim($matches['url'][0]);
             $linkText = $matches['text'][0];
-            $scheme = Uri\Rfc3986\Uri::parse($url)?->getScheme();
+            $scheme = Uri\WhatWg\Url::parse($url)?->getScheme();
 
             if ($scheme === 'http' || $scheme === 'https') {
                 $formatted .= sprintf(

--- a/wwwroot/classes/GameMessageSanitizer.php
+++ b/wwwroot/classes/GameMessageSanitizer.php
@@ -110,7 +110,7 @@ final readonly class GameMessageSanitizer
 
     private static function isSafeHttpUrl(string $url): bool
     {
-        $scheme = Uri\Rfc3986\Uri::parse($url)?->getScheme();
+        $scheme = Uri\WhatWg\Url::parse($url)?->getScheme();
 
         return $scheme === 'http' || $scheme === 'https';
     }

--- a/wwwroot/classes/ImageHashCalculator.php
+++ b/wwwroot/classes/ImageHashCalculator.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/ImageProcessor.php';
 
-final class ImageHashCalculator
+final readonly class ImageHashCalculator
 {
     private const int GD_ALPHA_MAX = 127;
     private const int RGBA_CHANNEL_MAX = 255;
 
     public function __construct(
-        private readonly ImageProcessorInterface $imageProcessor = new GdImageProcessor(),
+        private ImageProcessorInterface $imageProcessor = new GdImageProcessor(),
     ) {
     }
 

--- a/wwwroot/classes/IpRateLimitService.php
+++ b/wwwroot/classes/IpRateLimitService.php
@@ -14,6 +14,7 @@ final readonly class IpRateLimitService
     {
     }
 
+    #[\NoDiscard('Check whether the IP is still within its rate limit.')]
     public function isAllowed(string $ipAddress, IpRateLimitBucket $bucket): bool
     {
         [$maxRequests, $windowSeconds] = $bucket->limits();
@@ -36,9 +37,10 @@ final readonly class IpRateLimitService
 
     public function recordRequest(string $ipAddress, IpRateLimitBucket $bucket): void
     {
-        $this->checkAndRecord($ipAddress, $bucket);
+        (void) $this->checkAndRecord($ipAddress, $bucket);
     }
 
+    #[\NoDiscard('Check the allow/deny result; use recordRequest() when it is intentionally irrelevant.')]
     public function checkAndRecord(string $ipAddress, IpRateLimitBucket $bucket): bool
     {
         [$maxRequests, $windowSeconds] = $bucket->limits();

--- a/wwwroot/classes/Leaderboard/AbstractLeaderboardPageContext.php
+++ b/wwwroot/classes/Leaderboard/AbstractLeaderboardPageContext.php
@@ -31,9 +31,9 @@ abstract class AbstractLeaderboardPageContext
      * @param array<string, mixed> $queryParameters
      */
     protected function __construct(
-        private PlayerLeaderboardPage $leaderboardPage,
-        private PlayerLeaderboardFilter $filter,
-        private Utility $utility,
+        final private PlayerLeaderboardPage $leaderboardPage,
+        final private PlayerLeaderboardFilter $filter,
+        final private Utility $utility,
         array $queryParameters,
     ) {
         $this->filterParameters = $leaderboardPage->getFilterParameters();

--- a/wwwroot/classes/Leaderboard/AbstractLeaderboardRow.php
+++ b/wwwroot/classes/Leaderboard/AbstractLeaderboardRow.php
@@ -16,16 +16,16 @@ abstract readonly class AbstractLeaderboardRow
      * @param array<string, int|string> $filterParameters
      */
     public function __construct(
-        protected array $player,
-        private PlayerLeaderboardFilter $filter,
-        private Utility $utility,
+        final protected array $player,
+        final private PlayerLeaderboardFilter $filter,
+        final private Utility $utility,
         ?string $highlightedPlayerId,
         /** @var array<string, int|string> */
-        private array $filterParameters,
-        private string $rankingField,
-        private string $rankingLastWeekField,
-        private string $countryRankingField,
-        private string $countryRankingLastWeekField,
+        final private array $filterParameters,
+        final private string $rankingField,
+        final private string $rankingLastWeekField,
+        final private string $countryRankingField,
+        final private string $countryRankingLastWeekField,
     ) {
         $this->highlightedPlayerId = $highlightedPlayerId !== null ? trim($highlightedPlayerId) : null;
     }

--- a/wwwroot/classes/PlayerQueuePollTokenManager.php
+++ b/wwwroot/classes/PlayerQueuePollTokenManager.php
@@ -27,6 +27,7 @@ final readonly class PlayerQueuePollTokenManager
         return $token;
     }
 
+    #[\NoDiscard('The poll-token validation result must be checked before serving queue status.')]
     public function validate(string $playerName, #[\SensitiveParameter] string $submittedToken): bool
     {
         if ($playerName === '' || $submittedToken === '') {

--- a/wwwroot/classes/PlayerQueueService.php
+++ b/wwwroot/classes/PlayerQueueService.php
@@ -233,6 +233,7 @@ class PlayerQueueService
         return new IpSubmissionLockExecutor($this->requireDatabase());
     }
 
+    #[\NoDiscard('The validation result must be checked before accepting a queue player name.')]
     public function isValidPlayerName(string $playerName): bool
     {
         return PsnOnlineIdValidator::isValidOnlineId($playerName);

--- a/wwwroot/classes/PsnOnlineIdValidator.php
+++ b/wwwroot/classes/PsnOnlineIdValidator.php
@@ -13,6 +13,7 @@ final readonly class PsnOnlineIdValidator
     public const string INVALID_MESSAGE = 'PSN name must contain between three and 16 characters, start with a letter, and can consist of letters, numbers, hyphens (-) and underscores (_). Letters are not case-sensitive.';
     private const string PATTERN = '/^[a-zA-Z][a-zA-Z0-9_-]{2,15}$/';
 
+    #[\NoDiscard('The validation result must be checked before accepting a PSN online ID.')]
     public static function isValidOnlineId(string $onlineId): bool
     {
         return $onlineId !== '' && preg_match(self::PATTERN, $onlineId) === 1;

--- a/wwwroot/classes/RequestUriPath.php
+++ b/wwwroot/classes/RequestUriPath.php
@@ -5,20 +5,20 @@ declare(strict_types=1);
 /**
  * Extracts a path from a request URI that may contain non-ASCII bytes.
  *
- * Apache often exposes decoded UTF-8 in SCRIPT_URL / REQUEST_URI, but
- * {@see Uri\Rfc3986\Uri::parse()} only accepts ASCII or percent-encoded URIs.
+ * Apache often exposes decoded UTF-8 in SCRIPT_URL / REQUEST_URI. The WHATWG
+ * URL parser accepts those bytes and percent-encodes the resulting path the
+ * same way browsers do, so Unicode game URLs route correctly.
  */
 final class RequestUriPath
 {
+    private const string BASE_URI = 'http://localhost/';
+
     #[\NoDiscard]
     public static function fromUri(string $requestUri): string
     {
-        $asciiUri = preg_replace_callback(
-            '/[^\x00-\x7F]+/',
-            static fn (array $matches): string => rawurlencode($matches[0]),
-            $requestUri
-        ) ?? $requestUri;
-
-        return Uri\Rfc3986\Uri::parse($asciiUri)?->getPath() ?? '';
+        return Uri\WhatWg\Url::parse(
+            $requestUri,
+            new Uri\WhatWg\Url(self::BASE_URI),
+        )?->getPath() ?? '';
     }
 }

--- a/wwwroot/classes/Router.php
+++ b/wwwroot/classes/Router.php
@@ -48,7 +48,9 @@ class Router
     #[\NoDiscard]
     public function dispatch(string $requestUri): RouteResult
     {
-        $normalizedPath = trim(RequestUriPath::fromUri($requestUri), '/');
+        $normalizedPath = $requestUri
+            |> RequestUriPath::fromUri(...)
+            |> (fn (string $path): string => trim($path, '/'));
 
         if ($normalizedPath === '') {
             return $this->defaultHandler->handle([]);

--- a/wwwroot/classes/TrophyImageDownloader.php
+++ b/wwwroot/classes/TrophyImageDownloader.php
@@ -177,7 +177,7 @@ final readonly class TrophyImageDownloader
             $hash = md5($contents);
         }
 
-        $path = Uri\Rfc3986\Uri::parse($url)?->getPath() ?? '';
+        $path = Uri\WhatWg\Url::parse($url)?->getPath() ?? '';
         $extension = pathinfo($path, PATHINFO_EXTENSION) |> strtolower(...);
         $extension = $extension === '' ? '' : '.' . $extension;
 

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -133,7 +133,7 @@ require_once("header.php");
                                             
                                             <div>
                                                 <b><?= Html::escape($trophyGroup->getName()); ?></b><br>
-                                                <?= nl2br(Html::escape($trophyGroup->getDetail())); ?>
+                                                <?= $trophyGroup->getDetail() |> Html::escape(...) |> nl2br(...); ?>
                                             </div>
 
                                             <div class="ms-auto">
@@ -246,7 +246,7 @@ require_once("header.php");
                                                         <b><?= Html::escape($trophyRow->getName()); ?></b>
                                                     </a>
                                                 </span>
-                                                <?= nl2br(Html::escape($trophyRow->getDetail())); ?>
+                                                <?= $trophyRow->getDetail() |> Html::escape(...) |> nl2br(...); ?>
                                                 <?php
                                                 $progressDisplay = $trophyRow->getProgressDisplay();
                                                 if ($progressDisplay !== null) {

--- a/wwwroot/player_advisor.php
+++ b/wwwroot/player_advisor.php
@@ -127,7 +127,7 @@ require_once("header.php");
                                                                 <b><?= $trophyName; ?></b>
                                                             </a>
                                                         </span>
-                                                        <?= nl2br(Html::escape($trophy->getTrophyDetail())); ?>
+                                                        <?= $trophy->getTrophyDetail() |> Html::escape(...) |> nl2br(...); ?>
                                                         <?php
                                                         if ($progressLabel !== null) {
                                                             echo '<br><b>' . Html::escape($progressLabel) . '</b>';

--- a/wwwroot/player_log.php
+++ b/wwwroot/player_log.php
@@ -132,7 +132,7 @@ require_once("header.php");
                                                                 <b><?= Html::escape($trophy->getTrophyName()); ?></b>
                                                             </a>
                                                         </span>
-                                                        <?= nl2br(Html::escape($trophy->getTrophyDetail())); ?>
+                                                        <?= $trophy->getTrophyDetail() |> Html::escape(...) |> nl2br(...); ?>
                                                         <?php
                                                         if ($progressDisplay !== null) {
                                                             echo '<br><b>' . Html::escape($progressDisplay) . '</b>';

--- a/wwwroot/trophies.php
+++ b/wwwroot/trophies.php
@@ -68,7 +68,7 @@ require_once('header.php');
                                                             <b><?= Html::escape($trophy->getTrophyName()); ?></b>
                                                         </a>
                                                     </span>
-                                                    <?= nl2br(Html::escape($trophy->getTrophyDetail())); ?>
+                                                    <?= $trophy->getTrophyDetail() |> Html::escape(...) |> nl2br(...); ?>
                                                     <?php
                                                     $progressTargetValue = $trophy->getProgressTargetValue();
                                                     if ($progressTargetValue !== null) {

--- a/wwwroot/trophy.php
+++ b/wwwroot/trophy.php
@@ -102,7 +102,7 @@ require_once("header.php");
                                                 </div>
 
                                                 <div>
-                                                    <?= nl2br(Html::escape($trophy->getDetail())); ?>
+                                                    <?= $trophy->getDetail() |> Html::escape(...) |> nl2br(...); ?>
                                                     <?php
                                                     $progressTargetValue = $trophy->getProgressTargetValue();
                                                     if ($progressTargetValue !== null) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the PHP 8.5 modernization series with leftovers after recent Unicode routing and promotion/enum work. No backward compatibility is required.

### Changes
- Replace `RequestUriPath`'s manual non-ASCII encoding + `Uri\Rfc3986\Uri` with `Uri\WhatWg\Url` (browser-compatible Unicode path handling) and extend coverage
- Annotate security-critical bool APIs with `#[\NoDiscard]` (PSN ID validation, IP rate limits, admin auth/credentials, poll tokens, report deletion) and cast intentional discards to `(void)`
- Seal promoted properties on abstract leaderboard types with `final`
- Mark immutable cron/admin helpers as `final readonly` (`ImageHashCalculator`, scan coordinators/services, progress listeners, `AdminAuthService`)
- Prefer pipes for CSRF hidden fields, router path normalization, and `escape`→`nl2br` template output
- Prefer `Uri\WhatWg\Url` for HTTP(S) link scheme checks and remote image path/extension extraction

### Tests
- Extended `RequestUriPathTest` for query/fragment stripping, empty input, malformed URIs, and spaces
- Full suite: `php tests/run.php` — **All 1044 tests passed**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a928d671-f38f-4712-92a3-7aa4945bec89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a928d671-f38f-4712-92a3-7aa4945bec89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

