### PR TITLE
Adopt remaining PHP 8.5 pipes, readonly sealing, and NoDiscard

### DIFF
--- a/tests/PaginationItemTest.php
+++ b/tests/PaginationItemTest.php
@@ -10,7 +10,7 @@ final class PaginationItemTest extends TestCase
     {
         $item = PaginationItem::forPage(2, 'Page 2')
             ->markAsActive()
-            ->setAriaLabel('Current Page');
+            ->withAriaLabel('Current Page');
 
         $html = $item->render(static fn (int $page): string => '/page/' . $page);
 
@@ -23,7 +23,7 @@ final class PaginationItemTest extends TestCase
     public function testRenderEscapesLabelAndUrl(): void
     {
         $item = PaginationItem::forPage(5, '<Next>')
-            ->setAriaLabel('Go to >');
+            ->withAriaLabel('Go to >');
 
         $html = $item->render(static fn (int $page): string => '/page/' . $page . '?q=<script>');
 

--- a/wwwroot/admin/unobtainable.php
+++ b/wwwroot/admin/unobtainable.php
@@ -48,7 +48,7 @@ $status = TrophyMetaStatus::fromMixed($statusInput);
                 Game ID:<br>
                 <input type="text" name="game" /><br>
                 Trophy ID:<br>
-                <textarea name="trophy" rows="10" cols="30"><?= Html::escape(str_replace(",", PHP_EOL, $trophyInput)); ?></textarea>
+                <textarea name="trophy" rows="10" cols="30"><?= str_replace(",", PHP_EOL, $trophyInput) |> Html::escape(...); ?></textarea>
                 <br>
                 Status:<br>
                 <select name="status">

--- a/wwwroot/classes/AboutPagePlayerArraySerializer.php
+++ b/wwwroot/classes/AboutPagePlayerArraySerializer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/AboutPagePlayer.php';
 
-final class AboutPagePlayerArraySerializer
+final readonly class AboutPagePlayerArraySerializer
 {
     /**
      * @return array<string, mixed>

--- a/wwwroot/classes/Admin/AdminBootstrap.php
+++ b/wwwroot/classes/Admin/AdminBootstrap.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/AdminAuthService.php';
 require_once __DIR__ . '/AdminLoginThrottleService.php';
 require_once __DIR__ . '/AdminUserRepository.php';
 
-final class AdminBootstrap
+final readonly class AdminBootstrap
 {
     public static function requireAuthenticatedAdminPage(): void
     {
@@ -54,7 +54,7 @@ final class AdminBootstrap
 
     public static function renderCsrfMetaTag(): void
     {
-        $token = Html::escape(self::getCsrfToken());
+        $token = self::getCsrfToken() |> Html::escape(...);
         echo '<meta name="csrf-token" content="' . $token . '">';
     }
 

--- a/wwwroot/classes/Admin/GameDetailFormParser.php
+++ b/wwwroot/classes/Admin/GameDetailFormParser.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/GameDetailAction.php';
 require_once __DIR__ . '/../CommaSeparatedValues.php';
 require_once __DIR__ . '/../GameAvailabilityStatus.php';
 
-final class GameDetailFormParser
+final readonly class GameDetailFormParser
 {
     /**
      * @return list<string>

--- a/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
+++ b/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
@@ -316,7 +316,8 @@ final class GameRescanCatalogUpdater
             return true;
         }
 
-        return version_compare(trim($newVersion), $normalizedCurrentVersion, '>=');
+        return trim($newVersion)
+            |> (fn (string $version): bool => version_compare($version, $normalizedCurrentVersion, '>='));
     }
 
     /**

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -241,8 +241,9 @@ final class PsnPlayerLookupService
 
         if (is_object($profile)) {
             try {
-                $encoded = json_encode($profile, JSON_THROW_ON_ERROR);
-                $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
+                $decoded = $profile
+                    |> (fn (object $value): string => json_encode($value, JSON_THROW_ON_ERROR))
+                    |> (fn (string $json): mixed => json_decode($json, true, 512, JSON_THROW_ON_ERROR));
 
                 if (is_array($decoded)) {
                     return $decoded;

--- a/wwwroot/classes/Admin/PsnTrophyApiPayloadInspector.php
+++ b/wwwroot/classes/Admin/PsnTrophyApiPayloadInspector.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/PsnGameLookupException.php';
 /**
  * Normalizes PSN trophy API payloads and validates npCommunicationId integrity.
  */
-final class PsnTrophyApiPayloadInspector
+final readonly class PsnTrophyApiPayloadInspector
 {
     /**
      * @return array<string, mixed>
@@ -20,8 +20,9 @@ final class PsnTrophyApiPayloadInspector
 
         if (is_object($response)) {
             try {
-                $encoded = json_encode($response, JSON_THROW_ON_ERROR);
-                $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
+                $decoded = $response
+                    |> (fn (object $value): string => json_encode($value, JSON_THROW_ON_ERROR))
+                    |> (fn (string $json): mixed => json_decode($json, true, 512, JSON_THROW_ON_ERROR));
 
                 if (is_array($decoded)) {
                     return $decoded;

--- a/wwwroot/classes/Admin/PsnTrophyGroupAssembler.php
+++ b/wwwroot/classes/Admin/PsnTrophyGroupAssembler.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * under trophyGroups are used. Group metadata from the trophyGroups endpoint
  * wins when present.
  */
-final class PsnTrophyGroupAssembler
+final readonly class PsnTrophyGroupAssembler
 {
     /**
      * @return array<int, array{trophyGroupId: string, trophyGroupName: string, trophyGroupDetail: string, trophyGroupIconUrl: string, trophies: array<int, array<string, mixed>>}>

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -327,8 +327,9 @@ final class PsnTrophyTitleComparisonService
 
         if (is_object($payload)) {
             try {
-                $encoded = json_encode($payload, JSON_THROW_ON_ERROR);
-                $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
+                $decoded = $payload
+                    |> (fn (object $value): string => json_encode($value, JSON_THROW_ON_ERROR))
+                    |> (fn (string $json): mixed => json_decode($json, true, 512, JSON_THROW_ON_ERROR));
 
                 if (is_array($decoded)) {
                     return $decoded;

--- a/wwwroot/classes/Admin/SystemCommandExecutor.php
+++ b/wwwroot/classes/Admin/SystemCommandExecutor.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-final class SystemCommandExecutor implements CommandExecutorInterface
+final readonly class SystemCommandExecutor implements CommandExecutorInterface
 {
     /**
      * @param array<int, string> $command

--- a/wwwroot/classes/Admin/TrophyGroupConflictResolver.php
+++ b/wwwroot/classes/Admin/TrophyGroupConflictResolver.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-final class TrophyGroupConflictResolver
+final readonly class TrophyGroupConflictResolver
 {
     public function parseNumericGroupId(string $groupId): ?int
     {

--- a/wwwroot/classes/Admin/TrophyStatusUpdateResultPresenter.php
+++ b/wwwroot/classes/Admin/TrophyStatusUpdateResultPresenter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/TrophyStatusUpdateResult.php';
 require_once __DIR__ . '/../Html.php';
 
-final class TrophyStatusUpdateResultPresenter
+final readonly class TrophyStatusUpdateResultPresenter
 {
     public function renderToHtml(TrophyStatusUpdateResult $result): string
     {

--- a/wwwroot/classes/Admin/WorkerCredentialMasker.php
+++ b/wwwroot/classes/Admin/WorkerCredentialMasker.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-final class WorkerCredentialMasker
+final readonly class WorkerCredentialMasker
 {
     private const string MASK_CHAR = '•';
     private const int MASK_LENGTH = 8;
@@ -22,6 +22,7 @@ final class WorkerCredentialMasker
             . substr($secret, -self::VISIBLE_SUFFIX_LENGTH);
     }
 
+    #[\NoDiscard('Check whether a worker credential is configured before treating it as usable.')]
     public static function isConfigured(#[\SensitiveParameter] string $secret): bool
     {
         return $secret !== '';

--- a/wwwroot/classes/ApplicationContainer.php
+++ b/wwwroot/classes/ApplicationContainer.php
@@ -105,6 +105,7 @@ class ApplicationContainer
         return $this->templateRenderer;
     }
 
+    #[\NoDiscard]
     public function createApplication(HttpRequest $request): Application
     {
         return new Application(
@@ -114,6 +115,7 @@ class ApplicationContainer
         );
     }
 
+    #[\NoDiscard]
     public function createRequestFromGlobals(): HttpRequest
     {
         return HttpRequest::fromGlobals();

--- a/wwwroot/classes/Cron/CronCliAccessGuard.php
+++ b/wwwroot/classes/Cron/CronCliAccessGuard.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * Apache should also deny web access (see wwwroot/cron/.htaccess.example). This guard
  * covers the PHP built-in server, misconfigured virtual hosts, and other SAPIs.
  */
-final class CronCliAccessGuard
+final readonly class CronCliAccessGuard
 {
     public static function requireCliExecution(): void
     {

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -374,8 +374,9 @@ final class PlayerScanProfileSynchronizer
 
         if (is_object($profile)) {
             try {
-                $encoded = json_encode($profile, JSON_THROW_ON_ERROR);
-                $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
+                $decoded = $profile
+                    |> (fn (object $value): string => json_encode($value, JSON_THROW_ON_ERROR))
+                    |> (fn (string $json): mixed => json_decode($json, true, 512, JSON_THROW_ON_ERROR));
 
                 if (is_array($decoded)) {
                     return $decoded;

--- a/wwwroot/classes/Cron/PlayerScanTitleMetadataHelper.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleMetadataHelper.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * Extracted from ThirtyMinuteCronJob so timestamp/set-version rules can be tested
  * without reflection on the cron orchestrator.
  */
-final class PlayerScanTitleMetadataHelper
+final readonly class PlayerScanTitleMetadataHelper
 {
     public function gameTimestampsMatch(string $sonyTimestamp, string $dbTimestamp): bool
     {
@@ -103,7 +103,8 @@ final class PlayerScanTitleMetadataHelper
             return false;
         }
 
-        return version_compare(trim($newVersion), $normalizedCurrentVersion, '<');
+        return trim($newVersion)
+            |> (fn (string $version): bool => version_compare($version, $normalizedCurrentVersion, '<'));
     }
 
     public function resolveSetVersionForUpdate(string $newVersion, mixed $currentVersion): string
@@ -114,7 +115,10 @@ final class PlayerScanTitleMetadataHelper
             return trim($newVersion);
         }
 
-        if (version_compare(trim($newVersion), $normalizedCurrentVersion, '<')) {
+        if (
+            trim($newVersion)
+                |> (fn (string $version): bool => version_compare($version, $normalizedCurrentVersion, '<'))
+        ) {
             return $normalizedCurrentVersion;
         }
 

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -303,7 +303,7 @@ class GameHeaderService
             $matchText = $matches[0][0];
             $matchPosition = $matches[0][1];
 
-            $formatted .= Html::escape(substr($note, $offset, $matchPosition - $offset));
+            $formatted .= substr($note, $offset, $matchPosition - $offset) |> Html::escape(...);
 
             $url = trim($matches['url'][0]);
             $linkText = $matches['text'][0];
@@ -322,7 +322,7 @@ class GameHeaderService
             $offset = $matchPosition + strlen($matchText);
         }
 
-        $formatted .= Html::escape(substr($note, $offset));
+        $formatted .= substr($note, $offset) |> Html::escape(...);
 
         return $formatted;
     }

--- a/wwwroot/classes/GameHistoryChangeFilter.php
+++ b/wwwroot/classes/GameHistoryChangeFilter.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * Filters raw game history rows down to entries with meaningful changes and
  * annotates each row with field-level diff metadata for rendering.
  */
-final class GameHistoryChangeFilter
+final readonly class GameHistoryChangeFilter
 {
     /**
      * @param array<int, array{

--- a/wwwroot/classes/GameMessageSanitizer.php
+++ b/wwwroot/classes/GameMessageSanitizer.php
@@ -70,12 +70,12 @@ final readonly class GameMessageSanitizer
             $matchText = $matches[0][0];
             $matchPosition = $matches[0][1];
 
-            $sanitized .= Html::escape(substr($text, $offset, $matchPosition - $offset));
+            $sanitized .= substr($text, $offset, $matchPosition - $offset) |> Html::escape(...);
             $sanitized .= '<br>';
             $offset = $matchPosition + strlen($matchText);
         }
 
-        $sanitized .= Html::escape(substr($text, $offset));
+        $sanitized .= substr($text, $offset) |> Html::escape(...);
 
         return $sanitized;
     }

--- a/wwwroot/classes/ImageHashCalculator.php
+++ b/wwwroot/classes/ImageHashCalculator.php
@@ -160,9 +160,15 @@ final readonly class ImageHashCalculator
             $hash .= $this->binToHex($aBits);
 
             // Calculate average color across all 72 sampled pixels
-            $hash .= str_pad(dechex((int) ($rTotal / 72)), 2, '0', STR_PAD_LEFT);
-            $hash .= str_pad(dechex((int) ($gTotal / 72)), 2, '0', STR_PAD_LEFT);
-            $hash .= str_pad(dechex((int) ($bTotal / 72)), 2, '0', STR_PAD_LEFT);
+            $hash .= (int) ($rTotal / 72)
+                |> dechex(...)
+                |> (fn (string $hex): string => str_pad($hex, 2, '0', STR_PAD_LEFT));
+            $hash .= (int) ($gTotal / 72)
+                |> dechex(...)
+                |> (fn (string $hex): string => str_pad($hex, 2, '0', STR_PAD_LEFT));
+            $hash .= (int) ($bTotal / 72)
+                |> dechex(...)
+                |> (fn (string $hex): string => str_pad($hex, 2, '0', STR_PAD_LEFT));
 
             return $hash;
         } finally {

--- a/wwwroot/classes/ImageProcessor.php
+++ b/wwwroot/classes/ImageProcessor.php
@@ -26,7 +26,7 @@ interface ImageProcessorInterface
     public function getColorComponents(\GdImage $image, int $color): array;
 }
 
-final class GdImageProcessor implements ImageProcessorInterface
+final readonly class GdImageProcessor implements ImageProcessorInterface
 {
     #[\Override]
     public function isSupported(): bool

--- a/wwwroot/classes/NavigationBarRenderer.php
+++ b/wwwroot/classes/NavigationBarRenderer.php
@@ -6,11 +6,11 @@ require_once __DIR__ . '/NavigationState.php';
 require_once __DIR__ . '/NavigationMenu.php';
 require_once __DIR__ . '/Html.php';
 
-final class NavigationBarRenderer
+final readonly class NavigationBarRenderer
 {
     private function __construct(
-        private readonly NavigationState $state,
-        private readonly NavigationMenu $menu,
+        private NavigationState $state,
+        private NavigationMenu $menu,
     ) {
     }
 

--- a/wwwroot/classes/NavigationState.php
+++ b/wwwroot/classes/NavigationState.php
@@ -137,7 +137,7 @@ final readonly class NavigationState
     {
         $value = RequestParameter::firstScalar($value) ?? '';
 
-        return Html::escape((string) $value);
+        return ((string) $value) |> Html::escape(...);
     }
 
     private static function resolveActiveSection(string $requestPath): NavigationSection

--- a/wwwroot/classes/PageMetaDataRenderer.php
+++ b/wwwroot/classes/PageMetaDataRenderer.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/PageMetaData.php';
 require_once __DIR__ . '/Html.php';
 require_once __DIR__ . '/SiteUrl.php';
 
-final class PageMetaDataRenderer
+final readonly class PageMetaDataRenderer
 {
     private const string OG_SITE_NAME = 'PSN 100%';
     private const string TWITTER_CARD = 'summary_large_image';
@@ -54,7 +54,7 @@ final class PageMetaDataRenderer
             return null;
         }
 
-        return Html::escape(SiteUrl::absolute($value));
+        return SiteUrl::absolute($value) |> Html::escape(...);
     }
 
     private function escape(?string $value): ?string

--- a/wwwroot/classes/Pagination.php
+++ b/wwwroot/classes/Pagination.php
@@ -32,7 +32,7 @@ final readonly class Pagination
 
         if ($this->currentPage > 1) {
             $items[] = PaginationItem::forPage($this->currentPage - 1, '<')
-                ->setAriaLabel('Previous');
+                ->withAriaLabel('Previous');
         }
 
         if ($this->currentPage > 3) {
@@ -66,7 +66,7 @@ final readonly class Pagination
 
         if ($this->currentPage < $this->totalPages) {
             $items[] = PaginationItem::forPage($this->currentPage + 1, '>')
-                ->setAriaLabel('Next');
+                ->withAriaLabel('Next');
         }
 
         return $items;

--- a/wwwroot/classes/PaginationItem.php
+++ b/wwwroot/classes/PaginationItem.php
@@ -40,7 +40,7 @@ final readonly class PaginationItem
     }
 
     #[\NoDiscard]
-    public function setAriaLabel(?string $ariaLabel): self
+    public function withAriaLabel(?string $ariaLabel): self
     {
         return clone($this, ['ariaLabel' => $ariaLabel]);
     }
@@ -87,7 +87,7 @@ final readonly class PaginationItem
 
         $label = Html::escape($this->label);
         $href = Html::escape($href);
-        $classAttribute = Html::escape(implode(' ', $classNames));
+        $classAttribute = implode(' ', $classNames) |> Html::escape(...);
 
         return '<li class="' . $classAttribute . '"><a class="page-link" href="' . $href . '"'
             . $attributesString . '>' . $label . '</a></li>';

--- a/wwwroot/classes/Platform.php
+++ b/wwwroot/classes/Platform.php
@@ -71,10 +71,11 @@ enum Platform: string
      */
     public static function labelsByValue(): array
     {
-        return array_combine(
-            array_column(self::cases(), 'value'),
-            array_map(static fn (self $platform): string => $platform->label(), self::cases()),
-        );
+        return self::cases()
+            |> (fn (array $platforms): array => array_combine(
+                array_column($platforms, 'value'),
+                array_map(static fn (self $platform): string => $platform->label(), $platforms),
+            ));
     }
 
     /**

--- a/wwwroot/classes/PlayerLogEntry.php
+++ b/wwwroot/classes/PlayerLogEntry.php
@@ -244,6 +244,8 @@ final readonly class PlayerLogEntry
 
     private function usesPs5Assets(): bool
     {
-        return Platform::usesPlayStation5Assets(strtoupper($this->platforms));
+        return $this->platforms
+            |> strtoupper(...)
+            |> Platform::usesPlayStation5Assets(...);
     }
 }

--- a/wwwroot/classes/PlayerPlatformFilterRenderer.php
+++ b/wwwroot/classes/PlayerPlatformFilterRenderer.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 require_once __DIR__ . '/PlayerPlatformFilterOptions.php';
 require_once __DIR__ . '/Html.php';
 
-final class PlayerPlatformFilterRenderer
+final readonly class PlayerPlatformFilterRenderer
 {
-    public function __construct(private readonly string $buttonLabel = 'Filter')
+    public function __construct(private string $buttonLabel = 'Filter')
     {
     }
 

--- a/wwwroot/classes/PlayerStatusNotice.php
+++ b/wwwroot/classes/PlayerStatusNotice.php
@@ -32,7 +32,7 @@ final readonly class PlayerStatusNotice
     {
         $message = sprintf(
             'This player seems to have a <a class="link-underline link-underline-opacity-0 link-underline-opacity-100-hover" href="%s">private</a> profile.',
-            Html::escape(self::PRIVATE_PROFILE_URL)
+            self::PRIVATE_PROFILE_URL |> Html::escape(...)
         );
 
         return new self(PlayerStatusNoticeType::Private, $message);

--- a/wwwroot/classes/RequestParameter.php
+++ b/wwwroot/classes/RequestParameter.php
@@ -33,24 +33,16 @@ final readonly class RequestParameter
     #[\NoDiscard]
     public static function toBool(mixed $value): bool
     {
-        if ($value === null) {
-            return false;
-        }
-
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return $value !== 0;
-        }
-
-        if (!is_string($value) && !is_numeric($value)) {
-            return false;
-        }
-
-        $normalized = ((string) $value) |> trim(...) |> strtolower(...);
-
-        return !in_array($normalized, ['', '0', 'false', 'off', 'no'], true);
+        return match (true) {
+            $value === null => false,
+            is_bool($value) => $value,
+            is_int($value) => $value !== 0,
+            !is_string($value) && !is_numeric($value) => false,
+            default => !in_array(
+                ((string) $value) |> trim(...) |> strtolower(...),
+                ['', '0', 'false', 'off', 'no'],
+                true,
+            ),
+        };
     }
 }

--- a/wwwroot/classes/RequestUriPath.php
+++ b/wwwroot/classes/RequestUriPath.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * URL parser accepts those bytes and percent-encodes the resulting path the
  * same way browsers do, so Unicode game URLs route correctly.
  */
-final class RequestUriPath
+final readonly class RequestUriPath
 {
     private const string BASE_URI = 'http://localhost/';
 

--- a/wwwroot/classes/SessionManager.php
+++ b/wwwroot/classes/SessionManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/RequestParameter.php';
 
-final class SessionManager
+final readonly class SessionManager
 {
     public static function ensureStarted(): void
     {

--- a/wwwroot/header.php
+++ b/wwwroot/header.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/classes/StaticAsset.php';
 require_once __DIR__ . '/classes/BootstrapAssets.php';
 
 SessionManager::ensureStarted();
-$publicCsrfToken = Html::escape(CsrfTokenManager::getToken('public'));
+$publicCsrfToken = CsrfTokenManager::getToken('public') |> Html::escape(...);
 
 $metaTagHtml = '';
 if (isset($metaData) && $metaData instanceof PageMetaData) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the PHP 8.5 modernization pass on code that prior idiom PRs left behind.

- Prefer `|>` for nested escapes/transforms (`Html::escape`, `str_pad(dechex(...))`, version compares, JSON object→array roundtrips, platform label maps)
- Seal additional stateless helpers as `final readonly class`
- Rename `PaginationItem::setAriaLabel()` to `withAriaLabel()` (clone-with wither)
- Add `#[\NoDiscard]` on `WorkerCredentialMasker::isConfigured()` and `ApplicationContainer` factories
- Simplify `RequestParameter::toBool()` with `match (true)`

Property hooks were considered for normalized/clamped value objects, but hooked properties cannot be `readonly`, so those types stay on constructor normalization + `clone($this, [...])`.

## Test plan

- [x] `php tests/run.php` — all 1044 tests passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be4d85a3-daa0-4b9b-9bd3-20d70ed203a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be4d85a3-daa0-4b9b-9bd3-20d70ed203a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

