### PR TITLE
Adopt remaining PHP 8.5 idioms for final promotion and NoDiscard

### DIFF
--- a/tests/PaginationRendererTest.php
+++ b/tests/PaginationRendererTest.php
@@ -53,7 +53,7 @@ final class PaginationRendererTest extends TestCase
         $renderer = new PaginationRenderer();
 
         try {
-            $renderer->render(
+            (void) $renderer->render(
                 1,
                 1,
                 static fn (int $page): string => 'page=' . $page,

--- a/tests/PlayerLeaderboardFilterTest.php
+++ b/tests/PlayerLeaderboardFilterTest.php
@@ -6,9 +6,9 @@ require_once __DIR__ . '/../wwwroot/classes/PlayerLeaderboardFilter.php';
 
 final class PlayerLeaderboardFilterTest extends TestCase
 {
-    public function testConstructorNormalizesInputs(): void
+    public function testCreateNormalizesInputs(): void
     {
-        $filter = new PlayerLeaderboardFilter('  US  ', "  cat-01  ", 0);
+        $filter = PlayerLeaderboardFilter::create('  US  ', "  cat-01  ", 0);
 
         $this->assertSame('US', $filter->getCountry());
         $this->assertSame('cat-01', $filter->getAvatar());
@@ -17,9 +17,9 @@ final class PlayerLeaderboardFilterTest extends TestCase
         $this->assertTrue($filter->hasAvatar());
     }
 
-    public function testConstructorTreatsEmptyStringsAsNull(): void
+    public function testCreateTreatsEmptyStringsAsNull(): void
     {
-        $filter = new PlayerLeaderboardFilter('   ', "", 2);
+        $filter = PlayerLeaderboardFilter::create('   ', "", 2);
 
         $this->assertSame(null, $filter->getCountry());
         $this->assertSame(null, $filter->getAvatar());
@@ -49,14 +49,14 @@ final class PlayerLeaderboardFilterTest extends TestCase
 
     public function testGetFilterParametersOnlyIncludesDefinedFilters(): void
     {
-        $filter = new PlayerLeaderboardFilter(null, 'ghost', 4);
+        $filter = PlayerLeaderboardFilter::create(null, 'ghost', 4);
 
         $this->assertSame(['avatar' => 'ghost'], $filter->getFilterParameters());
     }
 
     public function testOffsetAndQueryParameterHelpers(): void
     {
-        $filter = new PlayerLeaderboardFilter('JP', null, 5);
+        $filter = PlayerLeaderboardFilter::create('JP', null, 5);
 
         $this->assertSame(40, $filter->getOffset(10));
         $this->assertSame(

--- a/tests/PlayerRarityLeaderboardServiceTest.php
+++ b/tests/PlayerRarityLeaderboardServiceTest.php
@@ -23,19 +23,19 @@ final class PlayerRarityLeaderboardServiceTest extends TestCase
 
     public function testCountPlayersAppliesCountryAndAvatarFilters(): void
     {
-        $filter = new PlayerLeaderboardFilter('US', 'cat', 1);
+        $filter = PlayerLeaderboardFilter::create('US', 'cat', 1);
         $this->assertSame(1, $this->service->countPlayers($filter));
 
-        $countryOnlyFilter = new PlayerLeaderboardFilter('US', null, 1);
+        $countryOnlyFilter = PlayerLeaderboardFilter::create('US', null, 1);
         $this->assertSame(2, $this->service->countPlayers($countryOnlyFilter));
 
-        $avatarOnlyFilter = new PlayerLeaderboardFilter(null, 'fox', 1);
+        $avatarOnlyFilter = PlayerLeaderboardFilter::create(null, 'fox', 1);
         $this->assertSame(2, $this->service->countPlayers($avatarOnlyFilter));
     }
 
     public function testGetPlayersReturnsOrderedResultsAndHonorsPagination(): void
     {
-        $filter = new PlayerLeaderboardFilter(null, null, 1);
+        $filter = PlayerLeaderboardFilter::create(null, null, 1);
         $firstPage = $this->service->getPlayers($filter, 2);
 
         $this->assertCount(2, $firstPage);
@@ -45,7 +45,7 @@ final class PlayerRarityLeaderboardServiceTest extends TestCase
         $this->assertSame('1', $firstPage[1]['account_id']);
         $this->assertSame(2, (int) $firstPage[1]['ranking']);
 
-        $secondPage = $this->service->getPlayers(new PlayerLeaderboardFilter(null, null, 2), 2);
+        $secondPage = $this->service->getPlayers(PlayerLeaderboardFilter::create(null, null, 2), 2);
         $this->assertCount(1, $secondPage);
         $this->assertSame('3', $secondPage[0]['account_id']);
         $this->assertSame(3, (int) $secondPage[0]['ranking']);

--- a/tests/TrophyListFilterTest.php
+++ b/tests/TrophyListFilterTest.php
@@ -6,10 +6,10 @@ require_once __DIR__ . '/../wwwroot/classes/TrophyListFilter.php';
 
 final class TrophyListFilterTest extends TestCase
 {
-    public function testConstructorNormalizesPageToMinimumOfOne(): void
+    public function testFromPageNormalizesPageToMinimumOfOne(): void
     {
-        $zeroPageFilter = new TrophyListFilter(0);
-        $negativePageFilter = new TrophyListFilter(-10);
+        $zeroPageFilter = TrophyListFilter::fromPage(0);
+        $negativePageFilter = TrophyListFilter::fromPage(-10);
 
         $this->assertSame(1, $zeroPageFilter->getPage());
         $this->assertSame(1, $negativePageFilter->getPage());
@@ -31,21 +31,21 @@ final class TrophyListFilterTest extends TestCase
 
     public function testGetOffsetUsesCurrentPage(): void
     {
-        $filter = new TrophyListFilter(4);
+        $filter = TrophyListFilter::fromPage(4);
 
         $this->assertSame(75, $filter->getOffset(25));
     }
 
     public function testToQueryParametersIncludesNormalizedPage(): void
     {
-        $filter = new TrophyListFilter(-2);
+        $filter = TrophyListFilter::fromPage(-2);
 
         $this->assertSame(['page' => 1], $filter->toQueryParameters());
     }
 
     public function testWithPageNormalizesPageParameter(): void
     {
-        $filter = new TrophyListFilter(2);
+        $filter = TrophyListFilter::fromPage(2);
 
         $this->assertSame(['page' => 5], $filter->withPage(5));
         $this->assertSame(['page' => 1], $filter->withPage(0));
@@ -53,7 +53,7 @@ final class TrophyListFilterTest extends TestCase
 
     public function testWithPageNumberReturnsClonedFilter(): void
     {
-        $filter = new TrophyListFilter(2);
+        $filter = TrophyListFilter::fromPage(2);
         $updated = $filter->withPageNumber(5);
 
         $this->assertSame(2, $filter->getPage());

--- a/wwwroot/classes/Admin/GameDetailFormParser.php
+++ b/wwwroot/classes/Admin/GameDetailFormParser.php
@@ -13,11 +13,13 @@ final readonly class GameDetailFormParser
     /**
      * @return list<string>
      */
+    #[\NoDiscard]
     public function getPlatformOptions(): array
     {
         return Platform::labelOrder();
     }
 
+    #[\NoDiscard]
     public function parseNpCommunicationId(mixed $value): ?string
     {
         if (!is_string($value)) {
@@ -29,6 +31,7 @@ final readonly class GameDetailFormParser
         return $trimmed === '' ? null : $trimmed;
     }
 
+    #[\NoDiscard]
     public function parseGameId(mixed $value): ?int
     {
         if (is_int($value)) {
@@ -55,11 +58,13 @@ final readonly class GameDetailFormParser
         return (int) $trimmed;
     }
 
+    #[\NoDiscard]
     public function parseAction(mixed $value): ?GameDetailAction
     {
         return GameDetailAction::tryFromMixed($value);
     }
 
+    #[\NoDiscard]
     public function parseStatus(mixed $value): ?GameAvailabilityStatus
     {
         if (is_int($value)) {
@@ -85,6 +90,7 @@ final readonly class GameDetailFormParser
     /**
      * @param array<string, mixed> $postData
      */
+    #[\NoDiscard]
     public function createGameDetailFromPost(int $gameId, array $postData, GameAvailabilityStatus $status): GameDetail
     {
         $npCommunicationId = $this->normalizeOptionalString($postData['np_communication_id'] ?? null);
@@ -107,6 +113,7 @@ final readonly class GameDetailFormParser
         );
     }
 
+    #[\NoDiscard]
     public function normalizePlatforms(mixed $value): string
     {
         $candidates = [];
@@ -140,6 +147,7 @@ final readonly class GameDetailFormParser
             |> (fn(array $platforms): string => implode(',', $platforms));
     }
 
+    #[\NoDiscard]
     public function normalizeOptionalString(mixed $value): ?string
     {
         if (!is_string($value)) {
@@ -151,6 +159,7 @@ final readonly class GameDetailFormParser
         return $trimmed === '' ? null : $trimmed;
     }
 
+    #[\NoDiscard]
     public function normalizeObsoleteIds(mixed $value): ?string
     {
         if (!is_string($value)) {

--- a/wwwroot/classes/Admin/PsnGameLookupRequestHandler.php
+++ b/wwwroot/classes/Admin/PsnGameLookupRequestHandler.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/PsnGameLookupRequestResult.php';
 
 final class PsnGameLookupRequestHandler
 {
+    #[\NoDiscard]
     public static function handle(PsnGameLookupService $lookupService, string $gameId): PsnGameLookupRequestResult
     {
         $normalizedGameId = trim($gameId);

--- a/wwwroot/classes/Admin/PsnPlayerLookupRequestHandler.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupRequestHandler.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/PsnPlayerLookupRequestResult.php';
 
 final class PsnPlayerLookupRequestHandler
 {
+    #[\NoDiscard]
     public static function handle(PsnPlayerLookupService $lookupService, string $onlineId): PsnPlayerLookupRequestResult
     {
         $normalizedOnlineId = trim($onlineId);
@@ -58,13 +59,8 @@ final class PsnPlayerLookupRequestHandler
             return [null, null];
         }
 
-        $decoded = base64_decode($npId, true);
-
-        if ($decoded === false || $decoded === '') {
-            return [null, null];
-        }
-
-        $trimmed = trim($decoded);
+        $trimmed = base64_decode($npId, true)
+            |> (fn (string|false $decoded): string => $decoded === false ? '' : trim($decoded));
 
         if ($trimmed === '') {
             return [null, null];

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestHandler.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestHandler.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/PsnTrophyTitleComparisonSource.php';
 
 final class PsnTrophyTitleComparisonRequestHandler
 {
+    #[\NoDiscard]
     public static function handle(PsnTrophyTitleComparisonService $service, string $accountId, string $source): PsnTrophyTitleComparisonRequestResult
     {
         $normalizedAccountId = trim($accountId);

--- a/wwwroot/classes/Admin/TrophyGroupConflictResolver.php
+++ b/wwwroot/classes/Admin/TrophyGroupConflictResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 final readonly class TrophyGroupConflictResolver
 {
+    #[\NoDiscard]
     public function parseNumericGroupId(string $groupId): ?int
     {
         if (!ctype_digit($groupId)) {
@@ -19,6 +20,7 @@ final readonly class TrophyGroupConflictResolver
         return (int) $trimmed;
     }
 
+    #[\NoDiscard]
     public function formatGroupId(int $numericValue, string $originalGroupId): string
     {
         $length = max(strlen($originalGroupId), 3);
@@ -29,6 +31,7 @@ final readonly class TrophyGroupConflictResolver
     /**
      * @param array<string, string> $existingGroupMappings
      */
+    #[\NoDiscard]
     public function determinePreferredGroupOffset(array $existingGroupMappings): ?int
     {
         $parentGroupId = array_find(
@@ -51,6 +54,7 @@ final readonly class TrophyGroupConflictResolver
     /**
      * @param array<string, bool> $existingGroupIds
      */
+    #[\NoDiscard]
     public function determineGroupOffset(array $existingGroupIds): int
     {
         $maxBlock = -1;
@@ -83,6 +87,7 @@ final readonly class TrophyGroupConflictResolver
      * @param array<string, string[]> $parentGroupTrophyNames
      * @param array<string, bool> $usedParentGroups
      */
+    #[\NoDiscard]
     public function findMatchingParentGroupId(
         string $childGroupId,
         array $childGroupTrophyNames,
@@ -109,6 +114,7 @@ final readonly class TrophyGroupConflictResolver
      * @param array<string, bool> $existingGroupIds
      * @return array{groupId: string, preferredOffset: ?int, groupOffset: int}
      */
+    #[\NoDiscard]
     public function allocateNonConflictingGroupId(
         int $numericGroupId,
         string $originalGroupId,

--- a/wwwroot/classes/Admin/TrophyStatusUpdateResultPresenter.php
+++ b/wwwroot/classes/Admin/TrophyStatusUpdateResultPresenter.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/../Html.php';
 
 final readonly class TrophyStatusUpdateResultPresenter
 {
+    #[\NoDiscard]
     public function renderToHtml(TrophyStatusUpdateResult $result): string
     {
         $html = '<p>';

--- a/wwwroot/classes/FooterRenderer.php
+++ b/wwwroot/classes/FooterRenderer.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/Html.php';
 
 final readonly class FooterRenderer
 {
+    #[\NoDiscard]
     public function render(FooterViewModel $viewModel): string
     {
         $yearRangeLabel = Html::escape($viewModel->getYearRangeLabel());

--- a/wwwroot/classes/GameHistoryRenderer.php
+++ b/wwwroot/classes/GameHistoryRenderer.php
@@ -20,6 +20,7 @@ final readonly class GameHistoryRenderer
     /**
      * @param array{previous: mixed, current: mixed}|null $diff
      */
+    #[\NoDiscard]
     public function renderTextDiff(?array $diff, bool $isMultiline = false, bool $hidePrevious = false): string
     {
         if ($diff === null) {
@@ -44,6 +45,7 @@ final readonly class GameHistoryRenderer
     /**
      * @param array{previous: mixed, current: mixed}|null $diff
      */
+    #[\NoDiscard]
     public function renderNumberDiff(?array $diff, bool $hidePrevious = false): string
     {
         if ($diff === null) {
@@ -56,11 +58,13 @@ final readonly class GameHistoryRenderer
         return $this->renderDiffBlocks($previous, $current, $hidePrevious);
     }
 
+    #[\NoDiscard]
     public function renderSingleText(?string $value, bool $isMultiline = false): string
     {
         return $this->formatText($value, $isMultiline);
     }
 
+    #[\NoDiscard]
     public function renderSingleNumber(?int $value): string
     {
         return $this->formatNumber($value);
@@ -69,6 +73,7 @@ final readonly class GameHistoryRenderer
     /**
      * @param array{previous: mixed, current: mixed}|null $diff
      */
+    #[\NoDiscard]
     public function renderIconDiff(
         ?array $diff,
         GameDetails $game,
@@ -98,6 +103,7 @@ final readonly class GameHistoryRenderer
         return $this->renderDiffBlocks($previous, $current, $hidePrevious);
     }
 
+    #[\NoDiscard]
     public function renderSingleIcon(?string $iconUrl, GameDetails $game, HistoryIconType $type, ?string $name): string
     {
         $resolvedPath = $this->resolveIconPath($iconUrl, $game, $type);

--- a/wwwroot/classes/GameLeaderboardFilter.php
+++ b/wwwroot/classes/GameLeaderboardFilter.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 final readonly class GameLeaderboardFilter extends GamePlayerFilter
 {
-    private int $page;
-
-    public function __construct(?string $country, ?string $avatar, int $page)
-    {
+    private function __construct(
+        ?string $country,
+        ?string $avatar,
+        final private int $page,
+    ) {
         parent::__construct($country, $avatar);
-        $this->page = max($page, 1);
     }
 
     /**
@@ -26,7 +26,7 @@ final readonly class GameLeaderboardFilter extends GamePlayerFilter
         $pageValue = $queryParameters['page'] ?? 1;
         $page = is_numeric($pageValue) ? (int) $pageValue : 1;
 
-        return new self($country, $avatar, $page);
+        return new self($country, $avatar, max($page, 1));
     }
 
     public function getPage(): int

--- a/wwwroot/classes/GameLeaderboardPageContext.php
+++ b/wwwroot/classes/GameLeaderboardPageContext.php
@@ -12,11 +12,11 @@ require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
 final readonly class GameLeaderboardPageContext
 {
     private function __construct(
-        private ?GameLeaderboardPage $page,
-        private ?string $title,
-        private ?string $gameSlug,
-        private ?string $redirectLocation,
-        private int $redirectStatusCode,
+        final private ?GameLeaderboardPage $page,
+        final private ?string $title,
+        final private ?string $gameSlug,
+        final private ?string $redirectLocation,
+        final private int $redirectStatusCode,
     ) {
     }
 

--- a/wwwroot/classes/GameRecentPlayersPageContext.php
+++ b/wwwroot/classes/GameRecentPlayersPageContext.php
@@ -12,11 +12,11 @@ require_once __DIR__ . '/GameLeaderboardPlayerNotFoundException.php';
 final readonly class GameRecentPlayersPageContext
 {
     private function __construct(
-        private ?GameRecentPlayersPage $page,
-        private ?string $title,
-        private ?string $gameSlug,
-        private ?string $redirectLocation,
-        private int $redirectStatusCode,
+        final private ?GameRecentPlayersPage $page,
+        final private ?string $title,
+        final private ?string $gameSlug,
+        final private ?string $redirectLocation,
+        final private int $redirectStatusCode,
     ) {
     }
 

--- a/wwwroot/classes/HomepagePage.php
+++ b/wwwroot/classes/HomepagePage.php
@@ -56,6 +56,7 @@ final readonly class HomepagePage
         return clone($this, ['popularGamesFilter' => $filter]);
     }
 
+    #[\NoDiscard]
     public function buildViewModel(): HomepageViewModel
     {
         $newGames = $this->newGamesLimit === null

--- a/wwwroot/classes/MaintenancePageRenderer.php
+++ b/wwwroot/classes/MaintenancePageRenderer.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/Html.php';
 
 final readonly class MaintenancePageRenderer
 {
+    #[\NoDiscard]
     public function render(MaintenancePage $page): string
     {
         $title = $this->escape($page->getTitle());

--- a/wwwroot/classes/NavigationBarRenderer.php
+++ b/wwwroot/classes/NavigationBarRenderer.php
@@ -9,8 +9,8 @@ require_once __DIR__ . '/Html.php';
 final readonly class NavigationBarRenderer
 {
     private function __construct(
-        private NavigationState $state,
-        private NavigationMenu $menu,
+        final private NavigationState $state,
+        final private NavigationMenu $menu,
     ) {
     }
 
@@ -20,6 +20,7 @@ final readonly class NavigationBarRenderer
         return new self($state, $menu ?? NavigationMenu::createDefault($state));
     }
 
+    #[\NoDiscard]
     public function render(): string
     {
         $sort = $this->state->getSort();

--- a/wwwroot/classes/PageMetaDataRenderer.php
+++ b/wwwroot/classes/PageMetaDataRenderer.php
@@ -11,6 +11,7 @@ final readonly class PageMetaDataRenderer
     private const string OG_SITE_NAME = 'PSN 100%';
     private const string TWITTER_CARD = 'summary_large_image';
 
+    #[\NoDiscard]
     public function render(PageMetaData $metaData): string
     {
         if ($metaData->isEmpty()) {

--- a/wwwroot/classes/PaginationItem.php
+++ b/wwwroot/classes/PaginationItem.php
@@ -48,6 +48,7 @@ final readonly class PaginationItem
     /**
      * @param callable(int):string $urlBuilder
      */
+    #[\NoDiscard]
     public function render(callable $urlBuilder): string
     {
         $classNames = ['page-item'];

--- a/wwwroot/classes/PaginationRenderer.php
+++ b/wwwroot/classes/PaginationRenderer.php
@@ -15,6 +15,7 @@ final readonly class PaginationRenderer
     /**
      * @param \Closure(int):array<string, string> $queryParametersFactory
      */
+    #[\NoDiscard]
     public function render(
         int $currentPage,
         int $totalPages,

--- a/wwwroot/classes/Platform.php
+++ b/wwwroot/classes/Platform.php
@@ -12,6 +12,7 @@ enum Platform: string
     case PsVr = 'psvr';
     case PsVr2 = 'psvr2';
 
+    #[\NoDiscard]
     public function label(): string
     {
         return match ($this) {
@@ -28,6 +29,7 @@ enum Platform: string
     /**
      * @return list<string>
      */
+    #[\NoDiscard]
     public static function values(): array
     {
         return array_column(self::cases(), 'value');
@@ -38,6 +40,7 @@ enum Platform: string
      *
      * @return list<string>
      */
+    #[\NoDiscard]
     public static function legacyTrophyServiceLabels(): array
     {
         return [
@@ -53,6 +56,7 @@ enum Platform: string
      *
      * @return list<string>
      */
+    #[\NoDiscard]
     public static function labelOrder(): array
     {
         return [
@@ -69,6 +73,7 @@ enum Platform: string
     /**
      * @return array<string, string>
      */
+    #[\NoDiscard]
     public static function labelsByValue(): array
     {
         return self::cases()

--- a/wwwroot/classes/PlayerAdvisorPageContext.php
+++ b/wwwroot/classes/PlayerAdvisorPageContext.php
@@ -86,13 +86,13 @@ final readonly class PlayerAdvisorPageContext
     }
 
     private function __construct(
-        private PlayerAdvisorPage $playerAdvisorPage,
-        private PlayerSummary $playerSummary,
-        private PlayerAdvisorFilter $filter,
-        private string $playerOnlineId,
-        private int $playerAccountId,
-        private PlayerStatus $playerStatus,
-        private ?string $playerAccountIdValue,
+        final private PlayerAdvisorPage $playerAdvisorPage,
+        final private PlayerSummary $playerSummary,
+        final private PlayerAdvisorFilter $filter,
+        final private string $playerOnlineId,
+        final private int $playerAccountId,
+        final private PlayerStatus $playerStatus,
+        final private ?string $playerAccountIdValue,
     ) {
         $this->playerNavigation = PlayerNavigation::forSection(
             $playerOnlineId,

--- a/wwwroot/classes/PlayerGamesPageContext.php
+++ b/wwwroot/classes/PlayerGamesPageContext.php
@@ -36,12 +36,12 @@ final readonly class PlayerGamesPageContext
      * @param array<string, mixed> $playerData
      */
     private function __construct(
-        private PlayerGamesPage $playerGamesPage,
-        private PlayerSummary $playerSummary,
-        private PlayerGamesFilter $filter,
+        final private PlayerGamesPage $playerGamesPage,
+        final private PlayerSummary $playerSummary,
+        final private PlayerGamesFilter $filter,
         array $playerData,
-        private int $playerAccountId,
-        private PlayerStatus $playerStatus,
+        final private int $playerAccountId,
+        final private PlayerStatus $playerStatus,
     ) {
         $this->metaData = $this->buildMetaData($playerData, $playerSummary);
         $this->title = $this->buildTitle($playerData);

--- a/wwwroot/classes/PlayerLeaderboardFilter.php
+++ b/wwwroot/classes/PlayerLeaderboardFilter.php
@@ -6,12 +6,18 @@ require_once __DIR__ . '/GamePlayerFilter.php';
 
 final readonly class PlayerLeaderboardFilter extends GamePlayerFilter
 {
-    private int $page;
-
-    public function __construct(?string $country, ?string $avatar, int $page)
-    {
+    private function __construct(
+        ?string $country,
+        ?string $avatar,
+        final private int $page,
+    ) {
         parent::__construct($country, $avatar);
-        $this->page = max($page, 1);
+    }
+
+    #[\NoDiscard]
+    public static function create(?string $country, ?string $avatar, int $page): self
+    {
+        return new self($country, $avatar, max($page, 1));
     }
 
     /**

--- a/wwwroot/classes/PlayerLogPageContext.php
+++ b/wwwroot/classes/PlayerLogPageContext.php
@@ -76,12 +76,12 @@ final readonly class PlayerLogPageContext
     }
 
     private function __construct(
-        private PlayerLogPage $playerLogPage,
-        private PlayerSummary $playerSummary,
-        private PlayerLogFilter $filter,
-        private string $playerOnlineId,
-        private int $playerAccountId,
-        private PlayerStatus $playerStatus,
+        final private PlayerLogPage $playerLogPage,
+        final private PlayerSummary $playerSummary,
+        final private PlayerLogFilter $filter,
+        final private string $playerOnlineId,
+        final private int $playerAccountId,
+        final private PlayerStatus $playerStatus,
     ) {
         $this->playerNavigation = PlayerNavigation::forSection($playerOnlineId, PlayerNavigationSection::LOG);
         $this->platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(

--- a/wwwroot/classes/PlayerNavigationRenderer.php
+++ b/wwwroot/classes/PlayerNavigationRenderer.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/Html.php';
 
 final readonly class PlayerNavigationRenderer
 {
+    #[\NoDiscard]
     public function render(PlayerNavigation $navigation): string
     {
         $linksHtml = $navigation->getLinks()

--- a/wwwroot/classes/PlayerPlatformFilterRenderer.php
+++ b/wwwroot/classes/PlayerPlatformFilterRenderer.php
@@ -20,6 +20,7 @@ final readonly class PlayerPlatformFilterRenderer
     /**
      * @param array<string, string> $hiddenInputs
      */
+    #[\NoDiscard]
     public function render(PlayerPlatformFilterOptions $options, array $hiddenInputs = []): string
     {
         $dropdownControls = $this->renderDropdownControls($options);
@@ -35,6 +36,7 @@ final readonly class PlayerPlatformFilterRenderer
 HTML;
     }
 
+    #[\NoDiscard]
     public function renderDropdownControls(PlayerPlatformFilterOptions $options): string
     {
         $buttonLabel = Html::escape($this->buttonLabel);
@@ -50,6 +52,7 @@ HTML;
 HTML;
     }
 
+    #[\NoDiscard]
     public function renderOptionItems(PlayerPlatformFilterOptions $options): string
     {
         return $options->getOptions()

--- a/wwwroot/classes/PlayerQueueMessageBuilder.php
+++ b/wwwroot/classes/PlayerQueueMessageBuilder.php
@@ -93,11 +93,13 @@ final class PlayerQueueMessageBuilder
     /**
      * @return list<array<string, mixed>>
      */
+    #[\NoDiscard]
     public function build(): array
     {
         return $this->parts;
     }
 
+    #[\NoDiscard]
     public function toPlainText(): string
     {
         $text = '';

--- a/wwwroot/classes/PlayerQueueResponse.php
+++ b/wwwroot/classes/PlayerQueueResponse.php
@@ -101,6 +101,7 @@ final readonly class PlayerQueueResponse implements \JsonSerializable
     /**
      * @return array<string, mixed>
      */
+    #[\NoDiscard]
     public function toArray(): array
     {
         $payload = [

--- a/wwwroot/classes/PlayerRandomGamesPageContext.php
+++ b/wwwroot/classes/PlayerRandomGamesPageContext.php
@@ -78,12 +78,12 @@ final readonly class PlayerRandomGamesPageContext
     }
 
     private function __construct(
-        private PlayerRandomGamesPage $playerRandomGamesPage,
-        private PlayerSummary $playerSummary,
-        private PlayerRandomGamesFilter $filter,
-        private string $playerOnlineId,
-        private int $playerAccountId,
-        private PlayerStatus $playerStatus,
+        final private PlayerRandomGamesPage $playerRandomGamesPage,
+        final private PlayerSummary $playerSummary,
+        final private PlayerRandomGamesFilter $filter,
+        final private string $playerOnlineId,
+        final private int $playerAccountId,
+        final private PlayerStatus $playerStatus,
     ) {
         $this->playerNavigation = PlayerNavigation::forSection($playerOnlineId, PlayerNavigationSection::RANDOM);
         $this->platformFilterOptions = PlayerPlatformFilterOptions::fromSelectionCallback(

--- a/wwwroot/classes/PlayerTimelinePageContext.php
+++ b/wwwroot/classes/PlayerTimelinePageContext.php
@@ -70,11 +70,11 @@ final readonly class PlayerTimelinePageContext
     }
 
     private function __construct(
-        private PlayerTimelinePage $playerTimelinePage,
-        private PlayerSummary $playerSummary,
-        private string $playerOnlineId,
-        private int $playerAccountId,
-        private PlayerStatus $playerStatus,
+        final private PlayerTimelinePage $playerTimelinePage,
+        final private PlayerSummary $playerSummary,
+        final private string $playerOnlineId,
+        final private int $playerAccountId,
+        final private PlayerStatus $playerStatus,
     ) {
         $this->playerNavigation = PlayerNavigation::forSection($playerOnlineId, PlayerNavigationSection::TIMELINE);
         $this->title = sprintf("%s's Timeline ~ PSN 100%%", $playerOnlineId);

--- a/wwwroot/classes/TrophyListFilter.php
+++ b/wwwroot/classes/TrophyListFilter.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 final readonly class TrophyListFilter
 {
-    private int $page;
+    private function __construct(
+        final private int $page,
+    ) {
+    }
 
-    public function __construct(int $page)
+    #[\NoDiscard]
+    public static function fromPage(int $page): self
     {
-        $this->page = max($page, 1);
+        return new self(max($page, 1));
     }
 
     /**
@@ -23,7 +27,7 @@ final readonly class TrophyListFilter
             $page = 1;
         }
 
-        return new self((int) $page);
+        return self::fromPage((int) $page);
     }
 
     public function getPage(): int

--- a/wwwroot/classes/TrophyRarity.php
+++ b/wwwroot/classes/TrophyRarity.php
@@ -39,6 +39,7 @@ final readonly class TrophyRarity
         return $this->unobtainable;
     }
 
+    #[\NoDiscard]
     public function renderSpan(string $separator = '<br>', bool $includePercentWhenUnobtainable = false): string
     {
         $parts = [];

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -72,15 +72,13 @@ final readonly class TrophyTitleNameFormatter
             }
         }
 
-        $name = rtrim($name);
-
-        if ($name !== '') {
-            $name = rtrim($name, '.');
-        }
-
-        return trim($name);
+        return $name
+            |> rtrim(...)
+            |> (fn (string $value): string => $value === '' ? $value : rtrim($value, '.'))
+            |> trim(...);
     }
 
+    #[\NoDiscard]
     public function toApaTitleCase(string $title): string
     {
         $title = trim($title);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Continue the PHP 8.5 modernization pass with no backward-compat constraint.

### Changes
- Seal promoted constructor properties with `final private` on page contexts, navigation renderer, and pagination filters (`TrophyListFilter`, `GameLeaderboardFilter`, `PlayerLeaderboardFilter`)
- Move filter construction to factories (`fromPage` / `create`) so page clamping happens before promotion
- Annotate must-use pure helpers, admin request handlers, and HTML renderers with `#[\NoDiscard]`
- Prefer short `|>` pipelines in `TrophyTitleNameFormatter::sanitize()` and NP ID decoding
- Cast discarded `PaginationRenderer::render()` in tests to `(void)` for the new attribute

### Notes
- Non-promoted properties that normalize in the constructor body stay non-`final` (PHP rejects `final private` on declared non-promoted properties)
- Fluent mutators on `PlayerQueueMessageBuilder` intentionally omit `#[\NoDiscard]` because call sites discard intermediate returns

### Verification
- `php tests/run.php` — all 1044 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6eb818c5-8d39-47ad-9a80-11eabc05c60f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6eb818c5-8d39-47ad-9a80-11eabc05c60f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

