### PR TITLE
Add colon after Arcade/Console Archives game title prefixes

### DIFF
--- a/database/archive_series_title_colon_backfill.sql
+++ b/database/archive_series_title_colon_backfill.sql
@@ -1,0 +1,23 @@
+-- Insert a colon after Arcade/Console Archives series prefixes for existing titles.
+-- Safe to re-run: rows that already include the colon are skipped.
+--
+-- Examples:
+--   Arcade Archives 2 Ace Driver  -> Arcade Archives 2: Ace Driver
+--   Arcade Archives Ace Driver    -> Arcade Archives: Ace Driver
+--   Console Archives Cool Boarders -> Console Archives: Cool Boarders
+
+UPDATE trophy_title
+SET name = REGEXP_REPLACE(name, '^(Arcade Archives 2)[[:space:]]+', '$1: ', 1, 0, 'i')
+WHERE REGEXP_LIKE(name, '^Arcade Archives 2[[:space:]]+', 'i')
+  AND NOT REGEXP_LIKE(name, '^Arcade Archives 2[[:space:]]*:', 'i');
+
+UPDATE trophy_title
+SET name = REGEXP_REPLACE(name, '^(Arcade Archives)[[:space:]]+', '$1: ', 1, 0, 'i')
+WHERE REGEXP_LIKE(name, '^Arcade Archives[[:space:]]+', 'i')
+  AND NOT REGEXP_LIKE(name, '^Arcade Archives[[:space:]]*:', 'i')
+  AND NOT REGEXP_LIKE(name, '^Arcade Archives 2[[:space:]]', 'i');
+
+UPDATE trophy_title
+SET name = REGEXP_REPLACE(name, '^(Console Archives)[[:space:]]+', '$1: ', 1, 0, 'i')
+WHERE REGEXP_LIKE(name, '^Console Archives[[:space:]]+', 'i')
+  AND NOT REGEXP_LIKE(name, '^Console Archives[[:space:]]*:', 'i');

--- a/database/archive_series_title_colon_backfill.sql
+++ b/database/archive_series_title_colon_backfill.sql
@@ -15,7 +15,7 @@ UPDATE trophy_title
 SET name = REGEXP_REPLACE(name, '^(Arcade Archives)[[:space:]]+', '$1: ', 1, 0, 'i')
 WHERE REGEXP_LIKE(name, '^Arcade Archives[[:space:]]+', 'i')
   AND NOT REGEXP_LIKE(name, '^Arcade Archives[[:space:]]*:', 'i')
-  AND NOT REGEXP_LIKE(name, '^Arcade Archives 2[[:space:]]', 'i');
+  AND NOT REGEXP_LIKE(name, '^Arcade Archives 2($|[[:space:]]|:)', 'i');
 
 UPDATE trophy_title
 SET name = REGEXP_REPLACE(name, '^(Console Archives)[[:space:]]+', '$1: ', 1, 0, 'i')

--- a/tests/PlayerScanTitleHeaderSynchronizerTest.php
+++ b/tests/PlayerScanTitleHeaderSynchronizerTest.php
@@ -124,6 +124,56 @@ final class PlayerScanTitleHeaderSynchronizerTest extends TestCase
         $this->assertSame('02.00', $row['set_version']);
     }
 
+    public function testSyncRewritesStoredNameWhenOnlyMissingFormatterNormalization(): void
+    {
+        file_put_contents($this->titleIconDirectory . 'existing.png', 'icon-bytes');
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, name, detail, icon_url, platform, set_version)
+            VALUES ('NPWR12345_00', 'Arcade Archives Ace Driver', 'Details', 'existing.png', 'PS5', '01.00')"
+        );
+
+        $result = $this->synchronizer->sync(new PlayerScanTitleHeaderTestTrophyTitle(
+            'NPWR12345_00',
+            name: 'Arcade Archives Ace Driver',
+        ));
+
+        $this->assertTrue($result->titleDataChanged);
+        $this->assertFalse($result->titleNeedsUpdate);
+        $this->assertFalse($result->isNewTitle);
+
+        $query = $this->database->prepare(
+            'SELECT name FROM trophy_title WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', 'NPWR12345_00', PDO::PARAM_STR);
+        $query->execute();
+
+        $this->assertSame('Arcade Archives: Ace Driver', $query->fetchColumn());
+    }
+
+    public function testSyncDoesNotOverwriteIntentionalTitleRename(): void
+    {
+        file_put_contents($this->titleIconDirectory . 'existing.png', 'icon-bytes');
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, name, detail, icon_url, platform, set_version)
+            VALUES ('NPWR12345_00', 'Dig Dug (Arcade Archives)', 'Details', 'existing.png', 'PS5', '01.00')"
+        );
+
+        $result = $this->synchronizer->sync(new PlayerScanTitleHeaderTestTrophyTitle(
+            'NPWR12345_00',
+            name: 'Arcade Archives Dig Dug',
+        ));
+
+        $this->assertFalse($result->titleDataChanged);
+
+        $query = $this->database->prepare(
+            'SELECT name FROM trophy_title WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', 'NPWR12345_00', PDO::PARAM_STR);
+        $query->execute();
+
+        $this->assertSame('Dig Dug (Arcade Archives)', $query->fetchColumn());
+    }
+
     private function removeDirectory(string $directory): void
     {
         if (!is_dir($directory)) {
@@ -169,6 +219,7 @@ final class PlayerScanTitleHeaderTestTrophyTitle
         private readonly array $platforms = [new PlayerScanTitleHeaderTestPlatform('PS5')],
         private readonly string $detail = 'Details',
         private readonly string $trophySetVersion = '01.00',
+        private readonly string $name = 'Example Game',
     ) {
     }
 
@@ -179,7 +230,7 @@ final class PlayerScanTitleHeaderTestTrophyTitle
 
     public function name(): string
     {
-        return 'Example Game';
+        return $this->name;
     }
 
     public function detail(): string

--- a/tests/TrophyCatalogSynchronizerTest.php
+++ b/tests/TrophyCatalogSynchronizerTest.php
@@ -155,4 +155,27 @@ final class TrophyCatalogSynchronizerTest extends TestCase
         $this->assertSame(7, $method->getNumberOfParameters());
         $this->assertSame('int', (string) $method->getReturnType());
     }
+
+    public function testUpdateTrophyTitleNameUpdatesExistingRow(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, name, detail, icon_url, platform, set_version)
+            VALUES ('NPWR00001_00', 'Arcade Archives Ace Driver', 'Details', 'icon.png', 'PS5', '01.00')"
+        );
+
+        $affected = $this->synchronizer->updateTrophyTitleName(
+            'NPWR00001_00',
+            'Arcade Archives: Ace Driver'
+        );
+
+        $this->assertSame(1, $affected);
+
+        $query = $this->database->prepare(
+            'SELECT name FROM trophy_title WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', 'NPWR00001_00', PDO::PARAM_STR);
+        $query->execute();
+
+        $this->assertSame('Arcade Archives: Ace Driver', $query->fetchColumn());
+    }
 }

--- a/tests/TrophyCatalogSynchronizerTest.php
+++ b/tests/TrophyCatalogSynchronizerTest.php
@@ -165,7 +165,8 @@ final class TrophyCatalogSynchronizerTest extends TestCase
 
         $affected = $this->synchronizer->updateTrophyTitleName(
             'NPWR00001_00',
-            'Arcade Archives: Ace Driver'
+            'Arcade Archives: Ace Driver',
+            'Arcade Archives Ace Driver'
         );
 
         $this->assertSame(1, $affected);
@@ -177,5 +178,29 @@ final class TrophyCatalogSynchronizerTest extends TestCase
         $query->execute();
 
         $this->assertSame('Arcade Archives: Ace Driver', $query->fetchColumn());
+    }
+
+    public function testUpdateTrophyTitleNameSkipsWhenStoredNameChanged(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, name, detail, icon_url, platform, set_version)
+            VALUES ('NPWR00001_00', 'Dig Dug (Arcade Archives)', 'Details', 'icon.png', 'PS5', '01.00')"
+        );
+
+        $affected = $this->synchronizer->updateTrophyTitleName(
+            'NPWR00001_00',
+            'Arcade Archives: Dig Dug',
+            'Arcade Archives Dig Dug'
+        );
+
+        $this->assertSame(0, $affected);
+
+        $query = $this->database->prepare(
+            'SELECT name FROM trophy_title WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':np_communication_id', 'NPWR00001_00', PDO::PARAM_STR);
+        $query->execute();
+
+        $this->assertSame('Dig Dug (Arcade Archives)', $query->fetchColumn());
     }
 }

--- a/tests/TrophyCatalogSynchronizerTest.php
+++ b/tests/TrophyCatalogSynchronizerTest.php
@@ -203,4 +203,30 @@ final class TrophyCatalogSynchronizerTest extends TestCase
 
         $this->assertSame('Dig Dug (Arcade Archives)', $query->fetchColumn());
     }
+
+    public function testUpdateTrophyTitleNameUsesBinaryCollationOnMysql(): void
+    {
+        $method = new ReflectionMethod(TrophyCatalogSynchronizer::class, 'exactNameMatchSql');
+
+        $mysqlPdo = new class ('sqlite::memory:') extends PDO {
+            public function getAttribute(int $attribute): mixed
+            {
+                if ($attribute === PDO::ATTR_DRIVER_NAME) {
+                    return 'mysql';
+                }
+
+                return parent::getAttribute($attribute);
+            }
+        };
+
+        $synchronizer = (new ReflectionClass(TrophyCatalogSynchronizer::class))
+            ->newInstanceWithoutConstructor();
+        $databaseProperty = new ReflectionProperty(TrophyCatalogSynchronizer::class, 'database');
+        $databaseProperty->setValue($synchronizer, $mysqlPdo);
+
+        $this->assertSame(
+            'name COLLATE utf8mb4_bin = :expected_current_name',
+            $method->invoke($synchronizer)
+        );
+    }
 }

--- a/tests/TrophyTitleNamingTest.php
+++ b/tests/TrophyTitleNamingTest.php
@@ -119,12 +119,18 @@ final class TrophyTitleNamingTest extends TestCase
         $this->assertSame('Arcade Archives 2: Raiden Fighters', $formatted);
     }
 
-    public function testShouldRewriteStoredNameWhenOnlyMissingNormalization(): void
+    public function testShouldRewriteStoredNameOnlyForLegacyArchiveColonForms(): void
     {
         $this->assertTrue(
             $this->formatter->shouldRewriteStoredName(
                 'Arcade Archives Ace Driver',
                 'Arcade Archives: Ace Driver'
+            )
+        );
+        $this->assertTrue(
+            $this->formatter->shouldRewriteStoredName(
+                'Console Archives Cool Boarders',
+                'Console Archives: Cool Boarders'
             )
         );
         $this->assertFalse(
@@ -137,6 +143,18 @@ final class TrophyTitleNamingTest extends TestCase
             $this->formatter->shouldRewriteStoredName(
                 'Dig Dug (Arcade Archives)',
                 'Arcade Archives: Dig Dug'
+            )
+        );
+        $this->assertFalse(
+            $this->formatter->shouldRewriteStoredName(
+                'Bus Simulator : World Tour',
+                'Bus Simulator: World Tour'
+            )
+        );
+        $this->assertFalse(
+            $this->formatter->shouldRewriteStoredName(
+                'BUS SIMULATOR: WORLD TOUR',
+                'Bus Simulator: World Tour'
             )
         );
     }

--- a/tests/TrophyTitleNamingTest.php
+++ b/tests/TrophyTitleNamingTest.php
@@ -118,4 +118,26 @@ final class TrophyTitleNamingTest extends TestCase
 
         $this->assertSame('Arcade Archives 2: Raiden Fighters', $formatted);
     }
+
+    public function testShouldRewriteStoredNameWhenOnlyMissingNormalization(): void
+    {
+        $this->assertTrue(
+            $this->formatter->shouldRewriteStoredName(
+                'Arcade Archives Ace Driver',
+                'Arcade Archives: Ace Driver'
+            )
+        );
+        $this->assertFalse(
+            $this->formatter->shouldRewriteStoredName(
+                'Arcade Archives: Ace Driver',
+                'Arcade Archives: Ace Driver'
+            )
+        );
+        $this->assertFalse(
+            $this->formatter->shouldRewriteStoredName(
+                'Dig Dug (Arcade Archives)',
+                'Arcade Archives: Dig Dug'
+            )
+        );
+    }
 }

--- a/tests/TrophyTitleNamingTest.php
+++ b/tests/TrophyTitleNamingTest.php
@@ -129,6 +129,12 @@ final class TrophyTitleNamingTest extends TestCase
         );
         $this->assertTrue(
             $this->formatter->shouldRewriteStoredName(
+                'Arcade Archives 2 Ace Driver',
+                'Arcade Archives 2: Ace Driver'
+            )
+        );
+        $this->assertTrue(
+            $this->formatter->shouldRewriteStoredName(
                 'Console Archives Cool Boarders',
                 'Console Archives: Cool Boarders'
             )
@@ -155,6 +161,18 @@ final class TrophyTitleNamingTest extends TestCase
             $this->formatter->shouldRewriteStoredName(
                 'BUS SIMULATOR: WORLD TOUR',
                 'Bus Simulator: World Tour'
+            )
+        );
+        $this->assertFalse(
+            $this->formatter->shouldRewriteStoredName(
+                'ARCADE ARCHIVES ACE DRIVER',
+                'Arcade Archives: Ace Driver'
+            )
+        );
+        $this->assertFalse(
+            $this->formatter->shouldRewriteStoredName(
+                'arcade archives ace driver',
+                'Arcade Archives: Ace Driver'
             )
         );
     }

--- a/tests/TrophyTitleNamingTest.php
+++ b/tests/TrophyTitleNamingTest.php
@@ -74,4 +74,48 @@ final class TrophyTitleNamingTest extends TestCase
     {
         $this->assertSame('', $this->formatter->format('   '));
     }
+
+    public function testArcadeArchives2TitlesGetAColonAfterTheSeriesPrefix(): void
+    {
+        $formatted = $this->formatter->format('Arcade Archives 2 Ace Driver');
+
+        $this->assertSame('Arcade Archives 2: Ace Driver', $formatted);
+    }
+
+    public function testArcadeArchivesTitlesGetAColonAfterTheSeriesPrefix(): void
+    {
+        $formatted = $this->formatter->format('Arcade Archives Ace Driver');
+
+        $this->assertSame('Arcade Archives: Ace Driver', $formatted);
+    }
+
+    public function testConsoleArchivesTitlesGetAColonAfterTheSeriesPrefix(): void
+    {
+        $formatted = $this->formatter->format('Console Archives Cool Boarders');
+
+        $this->assertSame('Console Archives: Cool Boarders', $formatted);
+    }
+
+    public function testArchiveSeriesTitlesThatAlreadyHaveAColonAreUnchanged(): void
+    {
+        $this->assertSame(
+            'Arcade Archives 2: Ace Driver',
+            $this->formatter->format('Arcade Archives 2: Ace Driver')
+        );
+        $this->assertSame(
+            'Arcade Archives: Ace Driver',
+            $this->formatter->format('Arcade Archives: Ace Driver')
+        );
+        $this->assertSame(
+            'Console Archives: Cool Boarders',
+            $this->formatter->format('Console Archives: Cool Boarders')
+        );
+    }
+
+    public function testArcadeArchives2IsPreferredOverArcadeArchives(): void
+    {
+        $formatted = $this->formatter->format('arcade archives 2 raiden fighters');
+
+        $this->assertSame('Arcade Archives 2: Raiden Fighters', $formatted);
+    }
 }

--- a/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
@@ -94,7 +94,12 @@ final class PlayerScanTitleHeaderSynchronizer
                 $sanitizedTitleName,
             )
         ) {
-            $nameAffectedRows = $this->catalogSynchronizer->updateTrophyTitleName($npid, $sanitizedTitleName);
+            $storedName = (string) ($existingTitle['name'] ?? '');
+            $nameAffectedRows = $this->catalogSynchronizer->updateTrophyTitleName(
+                $npid,
+                $sanitizedTitleName,
+                $storedName,
+            );
 
             if ($nameAffectedRows > 0) {
                 $titleDataChanged = true;

--- a/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
@@ -87,6 +87,20 @@ final class PlayerScanTitleHeaderSynchronizer
             }
         }
 
+        if (
+            $existingTitle !== null
+            && $this->titleFormatter()->shouldRewriteStoredName(
+                (string) ($existingTitle['name'] ?? ''),
+                $sanitizedTitleName,
+            )
+        ) {
+            $nameAffectedRows = $this->catalogSynchronizer->updateTrophyTitleName($npid, $sanitizedTitleName);
+
+            if ($nameAffectedRows > 0) {
+                $titleDataChanged = true;
+            }
+        }
+
         $metaQuery = $this->database->prepare('INSERT IGNORE INTO trophy_title_meta (
                 np_communication_id,
                 message

--- a/wwwroot/classes/TrophyCatalogSynchronizer.php
+++ b/wwwroot/classes/TrophyCatalogSynchronizer.php
@@ -167,7 +167,8 @@ final class TrophyCatalogSynchronizer
      * Conditionally rewrite a title name only when it still matches $expectedCurrentName.
      *
      * The expected-name predicate prevents a concurrent admin rename from being
-     * overwritten by a stale header-sync snapshot.
+     * overwritten by a stale header-sync snapshot. MySQL compares with utf8mb4_bin
+     * so case- or accent-only renames are treated as changes.
      */
     public function updateTrophyTitleName(
         string $npCommunicationId,
@@ -178,7 +179,7 @@ final class TrophyCatalogSynchronizer
             'UPDATE trophy_title
             SET name = :name
             WHERE np_communication_id = :np_communication_id
-                AND name = :expected_current_name'
+                AND ' . $this->exactNameMatchSql()
         );
         $query->bindValue(':name', $name, PDO::PARAM_STR);
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
@@ -186,6 +187,15 @@ final class TrophyCatalogSynchronizer
         $query->execute();
 
         return (int) $query->rowCount();
+    }
+
+    private function exactNameMatchSql(): string
+    {
+        $driver = $this->database->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        return $driver === 'mysql'
+            ? 'name COLLATE utf8mb4_bin = :expected_current_name'
+            : 'name = :expected_current_name';
     }
 
     public function upsertTrophyTitle(

--- a/wwwroot/classes/TrophyCatalogSynchronizer.php
+++ b/wwwroot/classes/TrophyCatalogSynchronizer.php
@@ -163,6 +163,20 @@ final class TrophyCatalogSynchronizer
         return $row === false ? null : $row;
     }
 
+    public function updateTrophyTitleName(string $npCommunicationId, string $name): int
+    {
+        $query = $this->database->prepare(
+            'UPDATE trophy_title
+            SET name = :name
+            WHERE np_communication_id = :np_communication_id'
+        );
+        $query->bindValue(':name', $name, PDO::PARAM_STR);
+        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+
+        return (int) $query->rowCount();
+    }
+
     public function upsertTrophyTitle(
         string $npCommunicationId,
         string $name,

--- a/wwwroot/classes/TrophyCatalogSynchronizer.php
+++ b/wwwroot/classes/TrophyCatalogSynchronizer.php
@@ -163,15 +163,26 @@ final class TrophyCatalogSynchronizer
         return $row === false ? null : $row;
     }
 
-    public function updateTrophyTitleName(string $npCommunicationId, string $name): int
-    {
+    /**
+     * Conditionally rewrite a title name only when it still matches $expectedCurrentName.
+     *
+     * The expected-name predicate prevents a concurrent admin rename from being
+     * overwritten by a stale header-sync snapshot.
+     */
+    public function updateTrophyTitleName(
+        string $npCommunicationId,
+        string $name,
+        string $expectedCurrentName,
+    ): int {
         $query = $this->database->prepare(
             'UPDATE trophy_title
             SET name = :name
-            WHERE np_communication_id = :np_communication_id'
+            WHERE np_communication_id = :np_communication_id
+                AND name = :expected_current_name'
         );
         $query->bindValue(':name', $name, PDO::PARAM_STR);
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
+        $query->bindValue(':expected_current_name', $expectedCurrentName, PDO::PARAM_STR);
         $query->execute();
 
         return (int) $query->rowCount();

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -75,7 +75,46 @@ final readonly class TrophyTitleNameFormatter
         return $name
             |> rtrim(...)
             |> (fn (string $value): string => $value === '' ? $value : rtrim($value, '.'))
-            |> trim(...);
+            |> trim(...)
+            |> $this->ensureArchiveSeriesColon(...);
+    }
+
+    /**
+     * Inserts a colon after known archive-series prefixes when missing.
+     *
+     * Longer prefixes are matched first so "Arcade Archives 2" wins over "Arcade Archives".
+     */
+    private function ensureArchiveSeriesColon(string $name): string
+    {
+        if ($name === '') {
+            return $name;
+        }
+
+        $prefixes = [
+            'Arcade Archives 2',
+            'Arcade Archives',
+            'Console Archives',
+        ];
+
+        foreach ($prefixes as $prefix) {
+            if (preg_match('/^' . preg_quote($prefix, '/') . '\b/i', $name, $matches) !== 1) {
+                continue;
+            }
+
+            $remainder = substr($name, strlen($matches[0]));
+
+            if (preg_match('/^\s*:/', $remainder) === 1) {
+                return $name;
+            }
+
+            if (preg_match('/^\s+(\S.*)$/u', $remainder, $rest) !== 1) {
+                return $name;
+            }
+
+            return $matches[0] . ': ' . $rest[1];
+        }
+
+        return $name;
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -18,14 +18,24 @@ final readonly class TrophyTitleNameFormatter
     }
 
     /**
-     * True when $storedName is only missing normalization that format() would apply,
-     * so rewriting it to $formattedName will not overwrite an intentional rename.
+     * True when $storedName is specifically a legacy Arcade/Console Archives title
+     * missing the series colon, and formatting it yields $formattedName.
+     *
+     * Other formatter differences (colon spacing, title case, etc.) are treated as
+     * intentional stored values and are not rewritten on scan.
      */
     #[\NoDiscard]
     public function shouldRewriteStoredName(string $storedName, string $formattedName): bool
     {
-        return $storedName !== $formattedName
-            && $this->format($storedName) === $formattedName;
+        if ($storedName === $formattedName) {
+            return false;
+        }
+
+        if ($this->ensureArchiveSeriesColon($storedName) === $storedName) {
+            return false;
+        }
+
+        return $this->format($storedName) === $formattedName;
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -17,6 +17,17 @@ final readonly class TrophyTitleNameFormatter
             |> $this->toApaTitleCase(...);
     }
 
+    /**
+     * True when $storedName is only missing normalization that format() would apply,
+     * so rewriting it to $formattedName will not overwrite an intentional rename.
+     */
+    #[\NoDiscard]
+    public function shouldRewriteStoredName(string $storedName, string $formattedName): bool
+    {
+        return $storedName !== $formattedName
+            && $this->format($storedName) === $formattedName;
+    }
+
     #[\NoDiscard]
     public function sanitize(string $name): string
     {

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -19,10 +19,10 @@ final readonly class TrophyTitleNameFormatter
 
     /**
      * True when $storedName is specifically a legacy Arcade/Console Archives title
-     * missing the series colon, and formatting it yields $formattedName.
+     * missing only the series colon relative to $formattedName.
      *
-     * Other formatter differences (colon spacing, title case, etc.) are treated as
-     * intentional stored values and are not rewritten on scan.
+     * Compares the colon-only transformation directly so intentional casing or other
+     * formatter differences are preserved on scan.
      */
     #[\NoDiscard]
     public function shouldRewriteStoredName(string $storedName, string $formattedName): bool
@@ -31,11 +31,7 @@ final readonly class TrophyTitleNameFormatter
             return false;
         }
 
-        if ($this->ensureArchiveSeriesColon($storedName) === $storedName) {
-            return false;
-        }
-
-        return $this->format($storedName) === $formattedName;
+        return $this->ensureArchiveSeriesColon($storedName) === $formattedName;
     }
 
     #[\NoDiscard]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Extend `TrophyTitleNameFormatter` so titles beginning with **Arcade Archives 2**, **Arcade Archives**, or **Console Archives** get a colon after that series prefix when the name is stored (e.g. `Console Archives Cool Boarders` → `Console Archives: Cool Boarders`).
- Longer prefix wins first (`Arcade Archives 2` before `Arcade Archives`), and titles that already include the colon are left alone.
- Persist the fix for existing catalog rows: header sync rewrites stored names only when the colon-only transform exactly matches the formatted name (preserving intentional casing and other differences), and `database/archive_series_title_colon_backfill.sql` can bulk-update production data without corrupting existing `Arcade Archives 2:` titles.
- Name rewrites are compare-and-swap on the original stored value using `utf8mb4_bin`, so concurrent renames—including case/accent-only changes—are not overwritten by a stale sync snapshot.
- Cover the new behavior in `TrophyTitleNamingTest`, `PlayerScanTitleHeaderSynchronizerTest`, and `TrophyCatalogSynchronizerTest`.

## Test plan
- [x] Run `php tests/run.php` — all 1055 tests passed
- [ ] Run `mysql psn100 < database/archive_series_title_colon_backfill.sql` on an environment with existing Arcade/Console Archives titles
- [ ] Spot-check formatting via a player scan that inserts or re-syncs an Arcade/Console Archives title

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b737381-06d2-4fe8-93ad-290809ed31b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b737381-06d2-4fe8-93ad-290809ed31b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

