### PR TITLE
Restore children to normal when deleting/resetting a merged game

### DIFF
--- a/tests/GameCopyHandlerTest.php
+++ b/tests/GameCopyHandlerTest.php
@@ -44,6 +44,25 @@ final class GameCopyHandlerTest extends TestCase
         $this->assertSame('&lt;script&gt;alert(&quot;copy&quot;)&lt;/script&gt;', $message);
     }
 
+    public function testHandleEscapesInvalidArgumentExceptionMessage(): void
+    {
+        $handler = new GameCopyHandler(
+            new ThrowingGameCopyService(
+                new InvalidArgumentException('A child game can only have one parent. This game is already merged into MERGE_000001.')
+            )
+        );
+
+        $message = $handler->handle([
+            'child' => '1',
+            'parent' => '2',
+        ]);
+
+        $this->assertSame(
+            'A child game can only have one parent. This game is already merged into MERGE_000001.',
+            $message
+        );
+    }
+
     public function testHandleReturnsGenericMessageForUnexpectedErrors(): void
     {
         $handler = new GameCopyHandler(

--- a/tests/GameCopyServiceParentOwnershipTest.php
+++ b/tests/GameCopyServiceParentOwnershipTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/Admin/GameCopyService.php';
+
+final class GameCopyServiceParentOwnershipTest extends TestCase
+{
+    private PDO $database;
+    private GameCopyService $service;
+
+    protected function setUp(): void
+    {
+        $this->database = new PDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->createTables();
+        $this->service = new GameCopyService($this->database);
+    }
+
+    public function testCopyChildToParentRejectsDifferentExistingParent(): void
+    {
+        $this->insertTitle(1, 'MERGE_000001');
+        $this->insertTitle(2, 'MERGE_000002');
+        $this->insertTitle(3, 'NPWR_CHILD01');
+        $this->insertMeta('MERGE_000001');
+        $this->insertMeta('MERGE_000002');
+        $this->insertMeta('NPWR_CHILD01', 'MERGE_000001');
+
+        try {
+            $this->service->copyChildToParent(3, 2);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'A child game can only have one parent. This game is already merged into MERGE_000001.',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assertSame(
+            'MERGE_000001',
+            $this->database
+                ->query("SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NPWR_CHILD01'")
+                ->fetchColumn()
+        );
+    }
+
+    public function testCopyChildToParentRejectsLegacyConflictingMergeMappings(): void
+    {
+        $this->insertTitle(1, 'MERGE_000003');
+        $this->insertTitle(2, 'MERGE_000004');
+        $this->insertTitle(3, 'NPWR_CHILD01');
+        $this->insertMeta('MERGE_000003');
+        $this->insertMeta('MERGE_000004');
+        $this->insertMeta('NPWR_CHILD01');
+        $this->database->exec(
+            "INSERT INTO trophy_merge (
+                child_np_communication_id, child_group_id, child_order_id,
+                parent_np_communication_id, parent_group_id, parent_order_id
+             ) VALUES
+             ('NPWR_CHILD01', 'default', 1, 'MERGE_000003', 'default', 1),
+             ('NPWR_CHILD01', 'default', 2, 'MERGE_000004', 'default', 1)"
+        );
+
+        try {
+            $this->service->copyChildToParent(3, 1);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'A child game can only have one parent. This game has conflicting merge mappings to '
+                . 'MERGE_000003, MERGE_000004 and must be repaired before continuing.',
+                $exception->getMessage()
+            );
+        }
+    }
+
+    private function createTables(): void
+    {
+        $this->database->exec(
+            'CREATE TABLE trophy_title (
+                id INTEGER PRIMARY KEY,
+                np_communication_id TEXT NOT NULL
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                message TEXT NOT NULL DEFAULT \'\',
+                status INTEGER NOT NULL DEFAULT 0,
+                parent_np_communication_id TEXT NULL
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_merge (
+                child_np_communication_id TEXT NOT NULL,
+                child_group_id TEXT NOT NULL,
+                child_order_id INTEGER NOT NULL,
+                parent_np_communication_id TEXT NOT NULL,
+                parent_group_id TEXT NOT NULL,
+                parent_order_id INTEGER NOT NULL
+            )'
+        );
+    }
+
+    private function insertTitle(int $id, string $npCommunicationId): void
+    {
+        $statement = $this->database->prepare(
+            'INSERT INTO trophy_title (id, np_communication_id) VALUES (:id, :np)'
+        );
+        $statement->bindValue(':id', $id, PDO::PARAM_INT);
+        $statement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
+        $statement->execute();
+    }
+
+    private function insertMeta(string $npCommunicationId, ?string $parentNpCommunicationId = null): void
+    {
+        $statement = $this->database->prepare(
+            'INSERT INTO trophy_title_meta (np_communication_id, status, parent_np_communication_id, message)
+             VALUES (:np, :status, :parent, \'\')'
+        );
+        $statement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(
+            ':status',
+            $parentNpCommunicationId === null ? 0 : 2,
+            PDO::PARAM_INT
+        );
+        $statement->bindValue(
+            ':parent',
+            $parentNpCommunicationId,
+            $parentNpCommunicationId === null ? PDO::PARAM_NULL : PDO::PARAM_STR
+        );
+        $statement->execute();
+    }
+}

--- a/tests/GameResetServiceTest.php
+++ b/tests/GameResetServiceTest.php
@@ -174,30 +174,6 @@ final class GameResetServiceTest extends TestCase
         $this->assertSame(0, (int) $this->database->query('SELECT COUNT(*) FROM trophy_merge')->fetchColumn());
     }
 
-    public function testProcessResetKeepsMergedStatusWhenChildStillMappedToAnotherParent(): void
-    {
-        $this->insertMergedGame('MERGE-ONE', 1, 'Merged Game One', 4, 1);
-        $this->insertMergedGame('MERGE-TWO', 2, 'Merged Game Two', 3, 1);
-        $this->insertChildGame('NPWR-SHARED', 3, 'Shared Child', null, GameAvailabilityStatus::MERGED);
-        $this->insertTrophyMerge('NPWR-SHARED', 'MERGE-ONE');
-        $this->insertTrophyMerge('NPWR-SHARED', 'MERGE-TWO');
-
-        $this->service->process(1, GameResetAction::RESET);
-
-        $child = $this->database
-            ->query("SELECT parent_np_communication_id, status FROM trophy_title_meta WHERE np_communication_id = 'NPWR-SHARED'")
-            ->fetch(PDO::FETCH_ASSOC);
-        $this->assertTrue($child !== false);
-        $this->assertSame(null, $child['parent_np_communication_id']);
-        $this->assertSame(GameAvailabilityStatus::MERGED->value, (int) $child['status']);
-        $this->assertSame(
-            1,
-            (int) $this->database->query(
-                "SELECT COUNT(*) FROM trophy_merge WHERE parent_np_communication_id = 'MERGE-TWO'"
-            )->fetchColumn()
-        );
-    }
-
     public function testProcessThrowsWhenGameEntryIsMissing(): void
     {
         try {

--- a/tests/GameResetServiceTest.php
+++ b/tests/GameResetServiceTest.php
@@ -26,7 +26,7 @@ final class GameResetServiceTest extends TestCase
         $this->insertMergedGame('MERGE-123', 1, 'Merged Game', 25, 10);
         $this->insertChildGame('NPWR-OTHER', 2, 'Child Game', 'MERGE-123', GameAvailabilityStatus::MERGED);
 
-        $this->database->exec("INSERT INTO trophy_merge (parent_np_communication_id) VALUES ('MERGE-123')");
+        $this->insertTrophyMerge('NPWR-OTHER', 'MERGE-123');
         $this->database->exec("INSERT INTO trophy_title_player (np_communication_id, account_id) VALUES ('MERGE-123', 1001)");
         $this->database->exec("INSERT INTO trophy_earned (np_communication_id, account_id) VALUES ('MERGE-123', 1001)");
         $this->database->exec("INSERT INTO trophy_group_player (np_communication_id) VALUES ('MERGE-123')");
@@ -75,7 +75,7 @@ final class GameResetServiceTest extends TestCase
         $this->insertMergedGame('MERGE-456', 1, 'Merged Game', 12, 4);
         $this->insertChildGame('NPWR-OTHER', 2, 'Child Game', 'MERGE-456', GameAvailabilityStatus::MERGED);
 
-        $this->database->exec("INSERT INTO trophy_merge (parent_np_communication_id) VALUES ('MERGE-456')");
+        $this->insertTrophyMerge('NPWR-OTHER', 'MERGE-456');
         $this->database->exec("INSERT INTO trophy (np_communication_id) VALUES ('MERGE-456')");
         $this->database->exec("INSERT INTO trophy_title_player (np_communication_id, account_id) VALUES ('MERGE-456', 1002)");
         $this->database->exec("INSERT INTO trophy_earned (np_communication_id, account_id) VALUES ('MERGE-456', 1002)");
@@ -139,6 +139,9 @@ final class GameResetServiceTest extends TestCase
             "INSERT INTO trophy_title_meta (np_communication_id, owners, owners_completed, parent_np_communication_id, status)
              VALUES ('NPWR-DELISTED', 1, 0, 'MERGE-789', " . GameAvailabilityStatus::DELISTED->value . ')'
         );
+        $this->insertTrophyMerge('NPWR-CHILD-A', 'MERGE-789');
+        $this->insertTrophyMerge('NPWR-CHILD-B', 'MERGE-789');
+        $this->insertTrophyMerge('NPWR-OTHER-PARENT', 'MERGE-OTHER');
 
         $this->service->process(1, GameResetAction::DELETE);
 
@@ -156,6 +159,43 @@ final class GameResetServiceTest extends TestCase
             ->fetch(PDO::FETCH_ASSOC);
         $this->assertSame(null, $delistedSibling['parent_np_communication_id']);
         $this->assertSame(GameAvailabilityStatus::DELISTED->value, (int) $delistedSibling['status']);
+    }
+
+    public function testProcessDeleteRestoresTrophyOnlyMergedChildrenWithoutParentLink(): void
+    {
+        $this->insertMergedGame('MERGE-TROPHY', 1, 'Merged Game', 4, 1);
+        // Trophy-only merges mark status MERGED but never set parent_np_communication_id.
+        $this->insertChildGame('NPWR-TROPHY-CHILD', 2, 'Trophy Child', null, GameAvailabilityStatus::MERGED);
+        $this->insertTrophyMerge('NPWR-TROPHY-CHILD', 'MERGE-TROPHY');
+
+        $this->service->process(1, GameResetAction::DELETE);
+
+        $this->assertChildRestoredToNormal('NPWR-TROPHY-CHILD');
+        $this->assertSame(0, (int) $this->database->query('SELECT COUNT(*) FROM trophy_merge')->fetchColumn());
+    }
+
+    public function testProcessResetKeepsMergedStatusWhenChildStillMappedToAnotherParent(): void
+    {
+        $this->insertMergedGame('MERGE-ONE', 1, 'Merged Game One', 4, 1);
+        $this->insertMergedGame('MERGE-TWO', 2, 'Merged Game Two', 3, 1);
+        $this->insertChildGame('NPWR-SHARED', 3, 'Shared Child', null, GameAvailabilityStatus::MERGED);
+        $this->insertTrophyMerge('NPWR-SHARED', 'MERGE-ONE');
+        $this->insertTrophyMerge('NPWR-SHARED', 'MERGE-TWO');
+
+        $this->service->process(1, GameResetAction::RESET);
+
+        $child = $this->database
+            ->query("SELECT parent_np_communication_id, status FROM trophy_title_meta WHERE np_communication_id = 'NPWR-SHARED'")
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertTrue($child !== false);
+        $this->assertSame(null, $child['parent_np_communication_id']);
+        $this->assertSame(GameAvailabilityStatus::MERGED->value, (int) $child['status']);
+        $this->assertSame(
+            1,
+            (int) $this->database->query(
+                "SELECT COUNT(*) FROM trophy_merge WHERE parent_np_communication_id = 'MERGE-TWO'"
+            )->fetchColumn()
+        );
     }
 
     public function testProcessThrowsWhenGameEntryIsMissing(): void
@@ -203,7 +243,7 @@ final class GameResetServiceTest extends TestCase
     public function testProcessRollsBackWhenStatementFails(): void
     {
         $this->insertMergedGame('MERGE-999', 9, 'Merge Failure Game', 33, 12);
-        $this->database->exec("INSERT INTO trophy_merge (parent_np_communication_id) VALUES ('MERGE-999')");
+        $this->insertTrophyMerge('NPWR-FAIL', 'MERGE-999');
         $this->database->exec('CREATE TRIGGER fail_delete BEFORE DELETE ON trophy_merge BEGIN SELECT RAISE(ABORT, "delete failure"); END;');
 
         try {
@@ -242,7 +282,10 @@ final class GameResetServiceTest extends TestCase
             obsolete_ids TEXT NULL,
             psnprofiles_id TEXT NULL
         )');
-        $this->database->exec('CREATE TABLE trophy_merge (parent_np_communication_id TEXT)');
+        $this->database->exec('CREATE TABLE trophy_merge (
+            child_np_communication_id TEXT NOT NULL,
+            parent_np_communication_id TEXT NOT NULL
+        )');
         $this->database->exec('CREATE TABLE trophy_earned (
             np_communication_id TEXT,
             account_id INTEGER
@@ -287,7 +330,7 @@ final class GameResetServiceTest extends TestCase
         string $npCommunicationId,
         int $gameId,
         string $name,
-        string $parentNpCommunicationId,
+        ?string $parentNpCommunicationId,
         GameAvailabilityStatus $status
     ): void {
         $statement = $this->database->prepare('INSERT INTO trophy_title (id, np_communication_id, name) VALUES (:id, :np, :name)');
@@ -301,8 +344,18 @@ final class GameResetServiceTest extends TestCase
              VALUES (:np, 5, 2, :parent, :status)'
         );
         $statement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
-        $statement->bindValue(':parent', $parentNpCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(':parent', $parentNpCommunicationId, $parentNpCommunicationId === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
         $statement->bindValue(':status', $status->value, PDO::PARAM_INT);
+        $statement->execute();
+    }
+
+    private function insertTrophyMerge(string $childNpCommunicationId, string $parentNpCommunicationId): void
+    {
+        $statement = $this->database->prepare(
+            'INSERT INTO trophy_merge (child_np_communication_id, parent_np_communication_id) VALUES (:child, :parent)'
+        );
+        $statement->bindValue(':child', $childNpCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(':parent', $parentNpCommunicationId, PDO::PARAM_STR);
         $statement->execute();
     }
 

--- a/tests/GameResetServiceTest.php
+++ b/tests/GameResetServiceTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../wwwroot/classes/GameAvailabilityStatus.php';
 require_once __DIR__ . '/../wwwroot/classes/GameResetAction.php';
 require_once __DIR__ . '/../wwwroot/classes/GameResetService.php';
 
@@ -23,8 +24,7 @@ final class GameResetServiceTest extends TestCase
     public function testProcessResetsMergedGame(): void
     {
         $this->insertMergedGame('MERGE-123', 1, 'Merged Game', 25, 10);
-        $this->database->exec("INSERT INTO trophy_title (id, np_communication_id, name) VALUES (2, 'NPWR-OTHER', 'Child Game')");
-        $this->database->exec("INSERT INTO trophy_title_meta (np_communication_id, owners, owners_completed, parent_np_communication_id) VALUES ('NPWR-OTHER', 5, 2, 'MERGE-123')");
+        $this->insertChildGame('NPWR-OTHER', 2, 'Child Game', 'MERGE-123', GameAvailabilityStatus::MERGED);
 
         $this->database->exec("INSERT INTO trophy_merge (parent_np_communication_id) VALUES ('MERGE-123')");
         $this->database->exec("INSERT INTO trophy_title_player (np_communication_id, account_id) VALUES ('MERGE-123', 1001)");
@@ -45,8 +45,7 @@ final class GameResetServiceTest extends TestCase
         $this->assertSame(0, (int) $owners);
         $this->assertSame(0, (int) $ownersCompleted);
 
-        $childParent = $this->database->query("SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NPWR-OTHER'")->fetchColumn();
-        $this->assertSame(null, $childParent);
+        $this->assertChildRestoredToNormal('NPWR-OTHER');
 
         $changes = $this->database
             ->query('SELECT change_type, param_1, extra FROM psn100_change')
@@ -74,8 +73,7 @@ final class GameResetServiceTest extends TestCase
     public function testProcessDeletesMergedGame(): void
     {
         $this->insertMergedGame('MERGE-456', 1, 'Merged Game', 12, 4);
-        $this->database->exec("INSERT INTO trophy_title (id, np_communication_id, name) VALUES (2, 'NPWR-OTHER', 'Child Game')");
-        $this->database->exec("INSERT INTO trophy_title_meta (np_communication_id, owners, owners_completed, parent_np_communication_id) VALUES ('NPWR-OTHER', 5, 2, 'MERGE-456')");
+        $this->insertChildGame('NPWR-OTHER', 2, 'Child Game', 'MERGE-456', GameAvailabilityStatus::MERGED);
 
         $this->database->exec("INSERT INTO trophy_merge (parent_np_communication_id) VALUES ('MERGE-456')");
         $this->database->exec("INSERT INTO trophy (np_communication_id) VALUES ('MERGE-456')");
@@ -104,8 +102,7 @@ final class GameResetServiceTest extends TestCase
         $remainingTitle = $this->database->query('SELECT COUNT(*) FROM trophy_title WHERE id = 1')->fetchColumn();
         $this->assertSame(0, (int) $remainingTitle);
 
-        $childParent = $this->database->query("SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NPWR-OTHER'")->fetchColumn();
-        $this->assertSame(null, $childParent);
+        $this->assertChildRestoredToNormal('NPWR-OTHER');
 
         $changes = $this->database
             ->query('SELECT change_type, param_1, extra FROM psn100_change')
@@ -130,6 +127,37 @@ final class GameResetServiceTest extends TestCase
         );
     }
 
+    public function testProcessDeleteRestoresMultipleMergedChildrenToNormal(): void
+    {
+        $this->insertMergedGame('MERGE-789', 1, 'Merged Game', 8, 3);
+        $this->insertChildGame('NPWR-CHILD-A', 2, 'Child A', 'MERGE-789', GameAvailabilityStatus::MERGED);
+        $this->insertChildGame('NPWR-CHILD-B', 3, 'Child B', 'MERGE-789', GameAvailabilityStatus::MERGED);
+        // Unrelated title must keep its own status and parent link.
+        $this->insertChildGame('NPWR-OTHER-PARENT', 4, 'Other Child', 'MERGE-OTHER', GameAvailabilityStatus::MERGED);
+        $this->database->exec("INSERT INTO trophy_title (id, np_communication_id, name) VALUES (5, 'NPWR-DELISTED', 'Delisted Sibling')");
+        $this->database->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, owners, owners_completed, parent_np_communication_id, status)
+             VALUES ('NPWR-DELISTED', 1, 0, 'MERGE-789', " . GameAvailabilityStatus::DELISTED->value . ')'
+        );
+
+        $this->service->process(1, GameResetAction::DELETE);
+
+        $this->assertChildRestoredToNormal('NPWR-CHILD-A');
+        $this->assertChildRestoredToNormal('NPWR-CHILD-B');
+
+        $otherChild = $this->database
+            ->query("SELECT parent_np_communication_id, status FROM trophy_title_meta WHERE np_communication_id = 'NPWR-OTHER-PARENT'")
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('MERGE-OTHER', $otherChild['parent_np_communication_id']);
+        $this->assertSame(GameAvailabilityStatus::MERGED->value, (int) $otherChild['status']);
+
+        $delistedSibling = $this->database
+            ->query("SELECT parent_np_communication_id, status FROM trophy_title_meta WHERE np_communication_id = 'NPWR-DELISTED'")
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame(null, $delistedSibling['parent_np_communication_id']);
+        $this->assertSame(GameAvailabilityStatus::DELISTED->value, (int) $delistedSibling['status']);
+    }
+
     public function testProcessThrowsWhenGameEntryIsMissing(): void
     {
         try {
@@ -143,7 +171,10 @@ final class GameResetServiceTest extends TestCase
     public function testProcessThrowsWhenGameIsNotMerged(): void
     {
         $this->database->exec("INSERT INTO trophy_title (id, np_communication_id, name) VALUES (5, 'NPWR-123', 'Regular Game')");
-        $this->database->exec("INSERT INTO trophy_title_meta (np_communication_id, owners, owners_completed, parent_np_communication_id) VALUES ('NPWR-123', 1, 0, NULL)");
+        $this->database->exec(
+            "INSERT INTO trophy_title_meta (np_communication_id, owners, owners_completed, parent_np_communication_id, status)
+             VALUES ('NPWR-123', 1, 0, NULL, " . GameAvailabilityStatus::NORMAL->value . ')'
+        );
 
         try {
             $this->service->process(5, GameResetAction::RESET);
@@ -207,6 +238,7 @@ final class GameResetServiceTest extends TestCase
             rarity_points INTEGER NOT NULL DEFAULT 0,
             in_game_rarity_points INTEGER NOT NULL DEFAULT 0,
             parent_np_communication_id TEXT,
+            status INTEGER NOT NULL DEFAULT 0,
             obsolete_ids TEXT NULL,
             psnprofiles_id TEXT NULL
         )');
@@ -240,10 +272,51 @@ final class GameResetServiceTest extends TestCase
         $statement->bindValue(':name', $name, PDO::PARAM_STR);
         $statement->execute();
 
-        $statement = $this->database->prepare('INSERT INTO trophy_title_meta (np_communication_id, owners, owners_completed, parent_np_communication_id) VALUES (:np, :owners, :owners_completed, NULL)');
+        $statement = $this->database->prepare(
+            'INSERT INTO trophy_title_meta (np_communication_id, owners, owners_completed, parent_np_communication_id, status)
+             VALUES (:np, :owners, :owners_completed, NULL, :status)'
+        );
         $statement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
         $statement->bindValue(':owners', $owners, PDO::PARAM_INT);
         $statement->bindValue(':owners_completed', $ownersCompleted, PDO::PARAM_INT);
+        $statement->bindValue(':status', GameAvailabilityStatus::NORMAL->value, PDO::PARAM_INT);
         $statement->execute();
+    }
+
+    private function insertChildGame(
+        string $npCommunicationId,
+        int $gameId,
+        string $name,
+        string $parentNpCommunicationId,
+        GameAvailabilityStatus $status
+    ): void {
+        $statement = $this->database->prepare('INSERT INTO trophy_title (id, np_communication_id, name) VALUES (:id, :np, :name)');
+        $statement->bindValue(':id', $gameId, PDO::PARAM_INT);
+        $statement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(':name', $name, PDO::PARAM_STR);
+        $statement->execute();
+
+        $statement = $this->database->prepare(
+            'INSERT INTO trophy_title_meta (np_communication_id, owners, owners_completed, parent_np_communication_id, status)
+             VALUES (:np, 5, 2, :parent, :status)'
+        );
+        $statement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(':parent', $parentNpCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(':status', $status->value, PDO::PARAM_INT);
+        $statement->execute();
+    }
+
+    private function assertChildRestoredToNormal(string $npCommunicationId): void
+    {
+        $child = $this->database
+            ->query(
+                "SELECT parent_np_communication_id, status FROM trophy_title_meta WHERE np_communication_id = "
+                . $this->database->quote($npCommunicationId)
+            )
+            ->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertNotFalse($child);
+        $this->assertSame(null, $child['parent_np_communication_id']);
+        $this->assertSame(GameAvailabilityStatus::NORMAL->value, (int) $child['status']);
     }
 }

--- a/tests/GameResetServiceTest.php
+++ b/tests/GameResetServiceTest.php
@@ -315,7 +315,7 @@ final class GameResetServiceTest extends TestCase
             )
             ->fetch(PDO::FETCH_ASSOC);
 
-        $this->assertNotFalse($child);
+        $this->assertTrue($child !== false, 'Expected child trophy_title_meta row to exist.');
         $this->assertSame(null, $child['parent_np_communication_id']);
         $this->assertSame(GameAvailabilityStatus::NORMAL->value, (int) $child['status']);
     }

--- a/tests/TrophyMergeMetadataRepositoryTest.php
+++ b/tests/TrophyMergeMetadataRepositoryTest.php
@@ -82,6 +82,35 @@ final class TrophyMergeMetadataRepositoryTest extends TestCase
         $this->assertSame(20, (int) $row['param_2']);
     }
 
+    public function testLockChildMetaForParentAssignmentCreatesMissingMetaRow(): void
+    {
+        $this->insertGame(1, 'NP_CHILD', 'PS4');
+
+        $this->repository->lockChildMetaForParentAssignment('NP_CHILD');
+
+        $row = $this->database
+            ->query("SELECT message, status, parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NP_CHILD'")
+            ->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertTrue($row !== false);
+        $this->assertSame('', $row['message']);
+        $this->assertSame(0, (int) $row['status']);
+        $this->assertSame(null, $row['parent_np_communication_id']);
+    }
+
+    public function testLockChildMetaForParentAssignmentKeepsExistingParent(): void
+    {
+        $this->insertGame(1, 'NP_CHILD', 'PS4');
+        $this->insertMeta('NP_CHILD', 'MERGE_000001', 2);
+
+        $this->repository->lockChildMetaForParentAssignment('NP_CHILD');
+
+        $parent = $this->database
+            ->query("SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NP_CHILD'")
+            ->fetchColumn();
+        $this->assertSame('MERGE_000001', $parent);
+    }
+
     private function createTables(): void
     {
         $this->database->exec(
@@ -95,6 +124,7 @@ final class TrophyMergeMetadataRepositoryTest extends TestCase
         $this->database->exec(
             'CREATE TABLE trophy_title_meta (
                 np_communication_id TEXT PRIMARY KEY,
+                message TEXT NOT NULL DEFAULT \'\',
                 parent_np_communication_id TEXT NULL,
                 status INTEGER NOT NULL DEFAULT 0,
                 obsolete_ids TEXT NULL,

--- a/tests/TrophyMergeMetadataRepositoryTest.php
+++ b/tests/TrophyMergeMetadataRepositoryTest.php
@@ -86,7 +86,9 @@ final class TrophyMergeMetadataRepositoryTest extends TestCase
     {
         $this->insertGame(1, 'NP_CHILD', 'PS4');
 
-        $this->repository->lockChildMetaForParentAssignment('NP_CHILD');
+        $lockedParent = $this->repository->lockChildMetaForParentAssignment('NP_CHILD');
+
+        $this->assertSame(null, $lockedParent);
 
         $row = $this->database
             ->query("SELECT message, status, parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NP_CHILD'")
@@ -98,17 +100,14 @@ final class TrophyMergeMetadataRepositoryTest extends TestCase
         $this->assertSame(null, $row['parent_np_communication_id']);
     }
 
-    public function testLockChildMetaForParentAssignmentKeepsExistingParent(): void
+    public function testLockChildMetaForParentAssignmentReturnsExistingParent(): void
     {
         $this->insertGame(1, 'NP_CHILD', 'PS4');
         $this->insertMeta('NP_CHILD', 'MERGE_000001', 2);
 
-        $this->repository->lockChildMetaForParentAssignment('NP_CHILD');
+        $lockedParent = $this->repository->lockChildMetaForParentAssignment('NP_CHILD');
 
-        $parent = $this->database
-            ->query("SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NP_CHILD'")
-            ->fetchColumn();
-        $this->assertSame('MERGE_000001', $parent);
+        $this->assertSame('MERGE_000001', $lockedParent);
     }
 
     private function createTables(): void

--- a/tests/TrophyMergeServiceSpecificTrophiesTest.php
+++ b/tests/TrophyMergeServiceSpecificTrophiesTest.php
@@ -191,7 +191,7 @@ final class TrophyMergeServiceSpecificTrophiesTest extends TestCase
         } catch (InvalidArgumentException $exception) {
             $this->assertSame(
                 'A child game can only have one parent. This game has conflicting merge mappings to '
-                . 'MERGE_000008, MERGE_000009 and must be repaired before merging again.',
+                . 'MERGE_000008, MERGE_000009 and must be repaired before continuing.',
                 $exception->getMessage()
             );
         }
@@ -215,7 +215,7 @@ final class TrophyMergeServiceSpecificTrophiesTest extends TestCase
         } catch (InvalidArgumentException $exception) {
             $this->assertSame(
                 'A child game can only have one parent. This game has conflicting parents '
-                . 'MERGE_000010 and MERGE_000011 and must be repaired before merging again.',
+                . 'MERGE_000010 and MERGE_000011 and must be repaired before continuing.',
                 $exception->getMessage()
             );
         }

--- a/tests/TrophyMergeServiceSpecificTrophiesTest.php
+++ b/tests/TrophyMergeServiceSpecificTrophiesTest.php
@@ -82,6 +82,94 @@ final class TrophyMergeServiceSpecificTrophiesTest extends TestCase
         $this->assertSame('MERGE_000002', $childBParent);
     }
 
+    public function testMergeSpecificTrophiesAllowsAdditionalTrophiesForSameParent(): void
+    {
+        $this->insertTitle(1, 'MERGE_000003', 'PS5');
+        $this->insertTitle(2, 'NPWR_CHILD01', 'PS4');
+        $this->insertMeta('MERGE_000003');
+        $this->insertMeta('NPWR_CHILD01');
+        $this->insertTrophy(10, 'MERGE_000003', 'default', 1);
+        $this->insertTrophy(11, 'MERGE_000003', 'default', 2);
+        $this->insertTrophy(20, 'NPWR_CHILD01', 'default', 1);
+        $this->insertTrophy(21, 'NPWR_CHILD01', 'default', 2);
+
+        $this->service->mergeSpecificTrophies(10, [20]);
+        $message = $this->service->mergeSpecificTrophies(11, [21]);
+
+        $this->assertSame('The trophies have been merged.', $message);
+        $this->assertSame(
+            'MERGE_000003',
+            $this->database
+                ->query("SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NPWR_CHILD01'")
+                ->fetchColumn()
+        );
+        $this->assertSame(
+            2,
+            (int) $this->database->query(
+                "SELECT COUNT(*) FROM trophy_merge WHERE child_np_communication_id = 'NPWR_CHILD01'"
+            )->fetchColumn()
+        );
+    }
+
+    public function testMergeSpecificTrophiesRejectsSecondParent(): void
+    {
+        $this->insertTitle(1, 'MERGE_000004', 'PS5');
+        $this->insertTitle(2, 'MERGE_000005', 'PS5');
+        $this->insertTitle(3, 'NPWR_CHILD01', 'PS4');
+        $this->insertMeta('MERGE_000004');
+        $this->insertMeta('MERGE_000005');
+        $this->insertMeta('NPWR_CHILD01');
+        $this->insertTrophy(10, 'MERGE_000004', 'default', 1);
+        $this->insertTrophy(11, 'MERGE_000005', 'default', 1);
+        $this->insertTrophy(20, 'NPWR_CHILD01', 'default', 1);
+        $this->insertTrophy(21, 'NPWR_CHILD01', 'default', 2);
+
+        $this->service->mergeSpecificTrophies(10, [20]);
+
+        try {
+            $this->service->mergeSpecificTrophies(11, [21]);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'A child game can only have one parent. This game is already merged into MERGE_000004.',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assertSame(
+            'MERGE_000004',
+            $this->database
+                ->query("SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NPWR_CHILD01'")
+                ->fetchColumn()
+        );
+        $this->assertSame(
+            0,
+            (int) $this->database->query(
+                "SELECT COUNT(*) FROM trophy_merge WHERE parent_np_communication_id = 'MERGE_000005'"
+            )->fetchColumn()
+        );
+    }
+
+    public function testMergeGamesRejectsSecondParent(): void
+    {
+        $this->insertTitle(1, 'MERGE_000006', 'PS5');
+        $this->insertTitle(2, 'MERGE_000007', 'PS5');
+        $this->insertTitle(3, 'NPWR_CHILD01', 'PS4');
+        $this->insertMeta('MERGE_000006');
+        $this->insertMeta('MERGE_000007');
+        $this->insertMeta('NPWR_CHILD01', 'MERGE_000006');
+
+        try {
+            $this->service->mergeGames(3, 2, TrophyMergeMethod::Order);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'A child game can only have one parent. This game is already merged into MERGE_000006.',
+                $exception->getMessage()
+            );
+        }
+    }
+
     private function createTables(): void
     {
         $this->database->exec(
@@ -134,13 +222,25 @@ final class TrophyMergeServiceSpecificTrophiesTest extends TestCase
         $statement->execute();
     }
 
-    private function insertMeta(string $npCommunicationId): void
+    private function insertMeta(string $npCommunicationId, ?string $parentNpCommunicationId = null): void
     {
         $statement = $this->database->prepare(
             'INSERT INTO trophy_title_meta (np_communication_id, status, parent_np_communication_id, message)
-             VALUES (:np, 0, NULL, \'\')'
+             VALUES (:np, :status, :parent, \'\')'
         );
         $statement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(
+            ':status',
+            $parentNpCommunicationId === null
+                ? GameAvailabilityStatus::NORMAL->value
+                : GameAvailabilityStatus::MERGED->value,
+            PDO::PARAM_INT
+        );
+        $statement->bindValue(
+            ':parent',
+            $parentNpCommunicationId,
+            $parentNpCommunicationId === null ? PDO::PARAM_NULL : PDO::PARAM_STR
+        );
         $statement->execute();
     }
 

--- a/tests/TrophyMergeServiceSpecificTrophiesTest.php
+++ b/tests/TrophyMergeServiceSpecificTrophiesTest.php
@@ -170,6 +170,57 @@ final class TrophyMergeServiceSpecificTrophiesTest extends TestCase
         }
     }
 
+    public function testMergeSpecificTrophiesRejectsLegacyConflictingMergeMappings(): void
+    {
+        $this->insertTitle(1, 'MERGE_000008', 'PS5');
+        $this->insertTitle(2, 'MERGE_000009', 'PS5');
+        $this->insertTitle(3, 'NPWR_CHILD01', 'PS4');
+        $this->insertMeta('MERGE_000008');
+        $this->insertMeta('MERGE_000009');
+        $this->insertMeta('NPWR_CHILD01');
+        $this->insertTrophy(10, 'MERGE_000008', 'default', 1);
+        $this->insertTrophy(20, 'NPWR_CHILD01', 'default', 3);
+        // Legacy state: trophies from the same child were mapped to two different parents.
+        $this->insertTrophyMergeMapping('NPWR_CHILD01', 'default', 1, 'MERGE_000008', 'default', 1);
+        $this->insertTrophyMergeMapping('NPWR_CHILD01', 'default', 2, 'MERGE_000009', 'default', 1);
+
+        try {
+            // Even merging into the lexicographically first parent must fail until repaired.
+            $this->service->mergeSpecificTrophies(10, [20]);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'A child game can only have one parent. This game has conflicting merge mappings to '
+                . 'MERGE_000008, MERGE_000009 and must be repaired before merging again.',
+                $exception->getMessage()
+            );
+        }
+    }
+
+    public function testMergeSpecificTrophiesRejectsMetaAndMergeParentMismatch(): void
+    {
+        $this->insertTitle(1, 'MERGE_000010', 'PS5');
+        $this->insertTitle(2, 'MERGE_000011', 'PS5');
+        $this->insertTitle(3, 'NPWR_CHILD01', 'PS4');
+        $this->insertMeta('MERGE_000010');
+        $this->insertMeta('MERGE_000011');
+        $this->insertMeta('NPWR_CHILD01', 'MERGE_000010');
+        $this->insertTrophy(10, 'MERGE_000010', 'default', 1);
+        $this->insertTrophy(20, 'NPWR_CHILD01', 'default', 2);
+        $this->insertTrophyMergeMapping('NPWR_CHILD01', 'default', 1, 'MERGE_000011', 'default', 1);
+
+        try {
+            $this->service->mergeSpecificTrophies(10, [20]);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'A child game can only have one parent. This game has conflicting parents '
+                . 'MERGE_000010 and MERGE_000011 and must be repaired before merging again.',
+                $exception->getMessage()
+            );
+        }
+    }
+
     private function createTables(): void
     {
         $this->database->exec(
@@ -254,6 +305,40 @@ final class TrophyMergeServiceSpecificTrophiesTest extends TestCase
         $statement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
         $statement->bindValue(':group_id', $groupId, PDO::PARAM_STR);
         $statement->bindValue(':order_id', $orderId, PDO::PARAM_INT);
+        $statement->execute();
+    }
+
+    private function insertTrophyMergeMapping(
+        string $childNpCommunicationId,
+        string $childGroupId,
+        int $childOrderId,
+        string $parentNpCommunicationId,
+        string $parentGroupId,
+        int $parentOrderId
+    ): void {
+        $statement = $this->database->prepare(
+            'INSERT INTO trophy_merge (
+                child_np_communication_id,
+                child_group_id,
+                child_order_id,
+                parent_np_communication_id,
+                parent_group_id,
+                parent_order_id
+             ) VALUES (
+                :child_np,
+                :child_group,
+                :child_order,
+                :parent_np,
+                :parent_group,
+                :parent_order
+             )'
+        );
+        $statement->bindValue(':child_np', $childNpCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(':child_group', $childGroupId, PDO::PARAM_STR);
+        $statement->bindValue(':child_order', $childOrderId, PDO::PARAM_INT);
+        $statement->bindValue(':parent_np', $parentNpCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(':parent_group', $parentGroupId, PDO::PARAM_STR);
+        $statement->bindValue(':parent_order', $parentOrderId, PDO::PARAM_INT);
         $statement->execute();
     }
 }

--- a/tests/TrophyMergeServiceSpecificTrophiesTest.php
+++ b/tests/TrophyMergeServiceSpecificTrophiesTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wwwroot/classes/GameAvailabilityStatus.php';
+require_once __DIR__ . '/../wwwroot/classes/TrophyMergeService.php';
+
+final class TrophyMergeServiceSpecificTrophiesTest extends TestCase
+{
+    private PDO $database;
+    private TrophyMergeService $service;
+
+    protected function setUp(): void
+    {
+        $this->database = new TrophyMergeServiceSpecificTrophiesTestPDO('sqlite::memory:');
+        $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->createTables();
+
+        $this->service = new TrophyMergeService($this->database);
+    }
+
+    public function testMergeSpecificTrophiesSetsParentRelationshipAndMergedStatus(): void
+    {
+        $this->insertTitle(1, 'MERGE_000001', 'PS5');
+        $this->insertTitle(2, 'NPWR_CHILD01', 'PS4');
+        $this->insertMeta('MERGE_000001');
+        $this->insertMeta('NPWR_CHILD01');
+        $this->insertTrophy(10, 'MERGE_000001', 'default', 1);
+        $this->insertTrophy(20, 'NPWR_CHILD01', 'default', 1);
+
+        $message = $this->service->mergeSpecificTrophies(10, [20]);
+
+        $this->assertSame('The trophies have been merged.', $message);
+
+        $childMeta = $this->database
+            ->query("SELECT status, parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NPWR_CHILD01'")
+            ->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertTrue($childMeta !== false);
+        $this->assertSame(GameAvailabilityStatus::MERGED->value, (int) $childMeta['status']);
+        $this->assertSame('MERGE_000001', $childMeta['parent_np_communication_id']);
+
+        $parentPlatform = $this->database
+            ->query("SELECT platform FROM trophy_title WHERE np_communication_id = 'MERGE_000001'")
+            ->fetchColumn();
+        $this->assertSame('PS4,PS5', $parentPlatform);
+
+        $mappingCount = $this->database
+            ->query(
+                "SELECT COUNT(*) FROM trophy_merge
+                 WHERE child_np_communication_id = 'NPWR_CHILD01'
+                   AND parent_np_communication_id = 'MERGE_000001'"
+            )
+            ->fetchColumn();
+        $this->assertSame(1, (int) $mappingCount);
+    }
+
+    public function testMergeSpecificTrophiesUpdatesParentForEachDistinctChildGame(): void
+    {
+        $this->insertTitle(1, 'MERGE_000002', 'PS5');
+        $this->insertTitle(2, 'NPWR_CHILD_A', 'PS4');
+        $this->insertTitle(3, 'NPWR_CHILD_B', 'PS5');
+        $this->insertMeta('MERGE_000002');
+        $this->insertMeta('NPWR_CHILD_A');
+        $this->insertMeta('NPWR_CHILD_B');
+        $this->insertTrophy(11, 'MERGE_000002', 'default', 1);
+        $this->insertTrophy(12, 'MERGE_000002', 'default', 2);
+        $this->insertTrophy(21, 'NPWR_CHILD_A', 'default', 1);
+        $this->insertTrophy(31, 'NPWR_CHILD_B', 'default', 1);
+
+        $this->service->mergeSpecificTrophies(11, [21]);
+        $this->service->mergeSpecificTrophies(12, [31]);
+
+        $childAParent = $this->database
+            ->query("SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NPWR_CHILD_A'")
+            ->fetchColumn();
+        $childBParent = $this->database
+            ->query("SELECT parent_np_communication_id FROM trophy_title_meta WHERE np_communication_id = 'NPWR_CHILD_B'")
+            ->fetchColumn();
+
+        $this->assertSame('MERGE_000002', $childAParent);
+        $this->assertSame('MERGE_000002', $childBParent);
+    }
+
+    private function createTables(): void
+    {
+        $this->database->exec(
+            'CREATE TABLE trophy_title (
+                id INTEGER PRIMARY KEY,
+                np_communication_id TEXT NOT NULL,
+                platform TEXT NOT NULL DEFAULT \'\',
+                platinum INTEGER NOT NULL DEFAULT 0,
+                bronze INTEGER NOT NULL DEFAULT 0,
+                silver INTEGER NOT NULL DEFAULT 0,
+                gold INTEGER NOT NULL DEFAULT 0
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_title_meta (
+                np_communication_id TEXT PRIMARY KEY,
+                status INTEGER NOT NULL DEFAULT 0,
+                parent_np_communication_id TEXT NULL,
+                message TEXT NOT NULL DEFAULT \'\'
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy (
+                id INTEGER PRIMARY KEY,
+                np_communication_id TEXT NOT NULL,
+                group_id TEXT NOT NULL,
+                order_id INTEGER NOT NULL
+            )'
+        );
+        $this->database->exec(
+            'CREATE TABLE trophy_merge (
+                child_np_communication_id TEXT NOT NULL,
+                child_group_id TEXT NOT NULL,
+                child_order_id INTEGER NOT NULL,
+                parent_np_communication_id TEXT NOT NULL,
+                parent_group_id TEXT NOT NULL,
+                parent_order_id INTEGER NOT NULL
+            )'
+        );
+    }
+
+    private function insertTitle(int $id, string $npCommunicationId, string $platform): void
+    {
+        $statement = $this->database->prepare(
+            'INSERT INTO trophy_title (id, np_communication_id, platform) VALUES (:id, :np, :platform)'
+        );
+        $statement->bindValue(':id', $id, PDO::PARAM_INT);
+        $statement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(':platform', $platform, PDO::PARAM_STR);
+        $statement->execute();
+    }
+
+    private function insertMeta(string $npCommunicationId): void
+    {
+        $statement = $this->database->prepare(
+            'INSERT INTO trophy_title_meta (np_communication_id, status, parent_np_communication_id, message)
+             VALUES (:np, 0, NULL, \'\')'
+        );
+        $statement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
+        $statement->execute();
+    }
+
+    private function insertTrophy(int $id, string $npCommunicationId, string $groupId, int $orderId): void
+    {
+        $statement = $this->database->prepare(
+            'INSERT INTO trophy (id, np_communication_id, group_id, order_id)
+             VALUES (:id, :np, :group_id, :order_id)'
+        );
+        $statement->bindValue(':id', $id, PDO::PARAM_INT);
+        $statement->bindValue(':np', $npCommunicationId, PDO::PARAM_STR);
+        $statement->bindValue(':group_id', $groupId, PDO::PARAM_STR);
+        $statement->bindValue(':order_id', $orderId, PDO::PARAM_INT);
+        $statement->execute();
+    }
+}
+
+/**
+ * SQLite stand-in that accepts MySQL INSERT IGNORE and no-ops heavy player-progress SQL.
+ */
+final class TrophyMergeServiceSpecificTrophiesTestPDO extends PDO
+{
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        $query = str_ireplace('INSERT IGNORE', 'INSERT OR IGNORE', $query);
+        $normalized = preg_replace('/\s+/', ' ', trim($query)) ?? '';
+
+        if (
+            str_contains($normalized, 'ON DUPLICATE KEY')
+            || str_contains($normalized, 'INSERT INTO trophy_group_player')
+            || str_contains($normalized, 'INSERT INTO trophy_title_player')
+            || str_contains($normalized, 'FROM player')
+        ) {
+            return new TrophyMergeServiceSpecificTrophiesNoOpStatement();
+        }
+
+        return parent::prepare($query, $options);
+    }
+}
+
+final class TrophyMergeServiceSpecificTrophiesNoOpStatement extends PDOStatement
+{
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetch(int $mode = PDO::FETCH_DEFAULT, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0): mixed
+    {
+        return false;
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args): array
+    {
+        return [];
+    }
+}

--- a/tests/TrophyMergeServiceTransactionTest.php
+++ b/tests/TrophyMergeServiceTransactionTest.php
@@ -185,6 +185,14 @@ final class MergeGamesTransactionPDO extends PDO
             return new MergeGamesNpCommunicationIdStatement();
         }
 
+        if (str_starts_with($normalized, 'SELECT parent_np_communication_id FROM trophy_title_meta')) {
+            return new MergeGamesEmptyParentStatement();
+        }
+
+        if (str_starts_with($normalized, 'SELECT DISTINCT parent_np_communication_id FROM trophy_merge')) {
+            return new MergeGamesEmptyParentListStatement();
+        }
+
         if (str_starts_with($normalized, 'UPDATE trophy_title_meta SET status = 2 WHERE np_communication_id = :np_communication_id')) {
             throw new RuntimeException('Failed while marking child game as merged.');
         }
@@ -195,6 +203,42 @@ final class MergeGamesTransactionPDO extends PDO
     public function recordMappingInsert(): void
     {
         $this->mappingInserted = true;
+    }
+}
+
+final class MergeGamesEmptyParentStatement extends PDOStatement
+{
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchColumn(int $column = 0): false
+    {
+        return false;
+    }
+}
+
+final class MergeGamesEmptyParentListStatement extends PDOStatement
+{
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args): array
+    {
+        return [];
     }
 }
 

--- a/tests/TrophyMergeServiceTransactionTest.php
+++ b/tests/TrophyMergeServiceTransactionTest.php
@@ -185,6 +185,10 @@ final class MergeGamesTransactionPDO extends PDO
             return new MergeGamesNpCommunicationIdStatement();
         }
 
+        if (str_starts_with($normalized, 'SELECT 1 FROM trophy_title_meta')) {
+            return new MergeGamesMetaExistsStatement();
+        }
+
         if (str_starts_with($normalized, 'SELECT parent_np_communication_id FROM trophy_title_meta')) {
             return new MergeGamesEmptyParentStatement();
         }
@@ -200,9 +204,37 @@ final class MergeGamesTransactionPDO extends PDO
         throw new RuntimeException('Unexpected SQL in mergeGames transaction test: ' . $statement);
     }
 
+    public function getAttribute(int $attribute): mixed
+    {
+        if ($attribute === PDO::ATTR_DRIVER_NAME) {
+            // Exercise the SQLite lock path so this fake PDO does not need FOR UPDATE stubs.
+            return 'sqlite';
+        }
+
+        return parent::getAttribute($attribute);
+    }
+
     public function recordMappingInsert(): void
     {
         $this->mappingInserted = true;
+    }
+}
+
+final class MergeGamesMetaExistsStatement extends PDOStatement
+{
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR): bool
+    {
+        return true;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+
+    public function fetchColumn(int $column = 0): int
+    {
+        return 1;
     }
 }
 

--- a/wwwroot/classes/Admin/GameCopyHandler.php
+++ b/wwwroot/classes/Admin/GameCopyHandler.php
@@ -34,7 +34,7 @@ final class GameCopyHandler
                 $copyIconUrl,
                 $copySetVersion
             );
-        } catch (RuntimeException $exception) {
+        } catch (InvalidArgumentException | RuntimeException $exception) {
             return $this->escape($exception->getMessage());
         } catch (Throwable $exception) {
             return 'An unexpected error occurred while copying game data.';

--- a/wwwroot/classes/Admin/GameCopyService.php
+++ b/wwwroot/classes/Admin/GameCopyService.php
@@ -6,6 +6,9 @@ require_once __DIR__ . '/../TrophyHistoryRecorder.php';
 require_once __DIR__ . '/../ChangelogEntry.php';
 require_once __DIR__ . '/../TrophyRarityName.php';
 require_once __DIR__ . '/../MergeNpCommunicationId.php';
+require_once __DIR__ . '/../NestedDatabaseTransactionRunner.php';
+require_once __DIR__ . '/../TrophyMergeMetadataRepository.php';
+require_once __DIR__ . '/../TrophyMergeParentOwnershipGuard.php';
 require_once __DIR__ . '/MergeTrophyCopier.php';
 require_once __DIR__ . '/MergeTrophyGroupCopier.php';
 require_once __DIR__ . '/TrophyGroupConflictResolver.php';
@@ -13,6 +16,8 @@ require_once __DIR__ . '/../TrophyGroupId.php';
 
 class GameCopyService
 {
+    private ?TrophyMergeParentOwnershipGuard $parentOwnershipGuard = null;
+
     private const string TROPHY_UPDATE_QUERY = <<<'SQL'
         WITH
             tg_org AS(
@@ -138,6 +143,11 @@ class GameCopyService
 
             $this->ensureChildIsNotMergeTitle($childNpCommunicationId);
             $this->ensureParentIsMergeTitle($parentNpCommunicationId);
+            // Prevent trophy_merge rewrites from moving a child that already belongs to another parent.
+            $this->parentOwnershipGuard()->lockAndAssertChildrenCanUseParent(
+                [$childNpCommunicationId],
+                $parentNpCommunicationId
+            );
 
             $this->copyTrophyTitle(
                 $childNpCommunicationId,
@@ -207,6 +217,17 @@ class GameCopyService
         if (!MergeNpCommunicationId::matches($parentNpCommunicationId)) {
             throw new RuntimeException('Parent must be a merge title.');
         }
+    }
+
+    private function parentOwnershipGuard(): TrophyMergeParentOwnershipGuard
+    {
+        return $this->parentOwnershipGuard ??= new TrophyMergeParentOwnershipGuard(
+            $this->database,
+            new TrophyMergeMetadataRepository(
+                $this->database,
+                new NestedDatabaseTransactionRunner($this->database)
+            )
+        );
     }
 
     private function copyTrophyTitle(

--- a/wwwroot/classes/GameResetService.php
+++ b/wwwroot/classes/GameResetService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/ChangelogEntry.php';
+require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/GameResetAction.php';
 require_once __DIR__ . '/MergeNpCommunicationId.php';
 
@@ -62,10 +63,7 @@ final readonly class GameResetService
                 'UPDATE trophy_title_meta SET owners = 0, owners_completed = 0 WHERE np_communication_id = :np_communication_id',
                 [':np_communication_id' => $npCommunicationId]
             );
-            $this->executeStatement(
-                'UPDATE trophy_title_meta SET parent_np_communication_id = NULL WHERE parent_np_communication_id = :np_communication_id',
-                [':np_communication_id' => $npCommunicationId]
-            );
+            $this->restoreChildGamesForParent($npCommunicationId);
         });
 
         $this->logChange(ChangelogEntryType::GAME_RESET, $gameId);
@@ -100,12 +98,10 @@ final readonly class GameResetService
                 'DELETE FROM trophy_group WHERE np_communication_id = :np_communication_id',
                 [':np_communication_id' => $npCommunicationId]
             );
+            // Unmerge children before deleting the parent title so they are not left hidden as MERGED.
+            $this->restoreChildGamesForParent($npCommunicationId);
             $this->executeStatement(
                 'DELETE FROM trophy_title WHERE np_communication_id = :np_communication_id',
-                [':np_communication_id' => $npCommunicationId]
-            );
-            $this->executeStatement(
-                'UPDATE trophy_title_meta SET parent_np_communication_id = NULL WHERE parent_np_communication_id = :np_communication_id',
                 [':np_communication_id' => $npCommunicationId]
             );
         });
@@ -113,6 +109,25 @@ final readonly class GameResetService
         $this->logChange(ChangelogEntryType::GAME_DELETE, $gameId, $gameName);
 
         return sprintf('Game %d was deleted.', $gameId);
+    }
+
+    /**
+     * Clear the merge parent link and restore MERGED children to NORMAL so they remain visible.
+     */
+    private function restoreChildGamesForParent(string $npCommunicationId): void
+    {
+        $mergedStatus = GameAvailabilityStatus::MERGED->value;
+        $normalStatus = GameAvailabilityStatus::NORMAL->value;
+
+        $this->executeStatement(
+            <<<SQL
+            UPDATE trophy_title_meta
+            SET parent_np_communication_id = NULL,
+                status = CASE WHEN status = {$mergedStatus} THEN {$normalStatus} ELSE status END
+            WHERE parent_np_communication_id = :np_communication_id
+            SQL,
+            [':np_communication_id' => $npCommunicationId]
+        );
     }
 
     /**

--- a/wwwroot/classes/GameResetService.php
+++ b/wwwroot/classes/GameResetService.php
@@ -45,10 +45,7 @@ final readonly class GameResetService
     private function resetGame(int $gameId, string $npCommunicationId): string
     {
         $this->executeWithinTransaction(function () use ($npCommunicationId): void {
-            $this->executeStatement(
-                'DELETE FROM trophy_merge WHERE parent_np_communication_id = :np_communication_id',
-                [':np_communication_id' => $npCommunicationId]
-            );
+            $this->detachChildrenFromParent($npCommunicationId);
             // Per-partition deletes on trophy_earned (see deleteTrophyEarnedForTitle).
             $this->deleteTrophyEarnedForTitle($npCommunicationId);
             $this->executeStatement(
@@ -63,7 +60,6 @@ final readonly class GameResetService
                 'UPDATE trophy_title_meta SET owners = 0, owners_completed = 0 WHERE np_communication_id = :np_communication_id',
                 [':np_communication_id' => $npCommunicationId]
             );
-            $this->restoreChildGamesForParent($npCommunicationId);
         });
 
         $this->logChange(ChangelogEntryType::GAME_RESET, $gameId);
@@ -76,10 +72,8 @@ final readonly class GameResetService
         $gameName = $this->getGameName($gameId) ?? '';
 
         $this->executeWithinTransaction(function () use ($npCommunicationId): void {
-            $this->executeStatement(
-                'DELETE FROM trophy_merge WHERE parent_np_communication_id = :np_communication_id',
-                [':np_communication_id' => $npCommunicationId]
-            );
+            // Unmerge children before deleting the parent title so they are not left hidden as MERGED.
+            $this->detachChildrenFromParent($npCommunicationId);
             $this->executeStatement(
                 'DELETE FROM trophy WHERE np_communication_id = :np_communication_id',
                 [':np_communication_id' => $npCommunicationId]
@@ -98,8 +92,6 @@ final readonly class GameResetService
                 'DELETE FROM trophy_group WHERE np_communication_id = :np_communication_id',
                 [':np_communication_id' => $npCommunicationId]
             );
-            // Unmerge children before deleting the parent title so they are not left hidden as MERGED.
-            $this->restoreChildGamesForParent($npCommunicationId);
             $this->executeStatement(
                 'DELETE FROM trophy_title WHERE np_communication_id = :np_communication_id',
                 [':np_communication_id' => $npCommunicationId]
@@ -112,21 +104,99 @@ final readonly class GameResetService
     }
 
     /**
-     * Clear the merge parent link and restore MERGED children to NORMAL so they remain visible.
+     * Remove this parent's trophy_merge mappings, clear parent links, and restore orphaned
+     * MERGED children to NORMAL. Includes trophy-only merges that never set parent_np_communication_id.
      */
-    private function restoreChildGamesForParent(string $npCommunicationId): void
+    private function detachChildrenFromParent(string $npCommunicationId): void
     {
+        $childNpCommunicationIds = $this->collectChildNpCommunicationIds($npCommunicationId);
+
+        $this->executeStatement(
+            'DELETE FROM trophy_merge WHERE parent_np_communication_id = :np_communication_id',
+            [':np_communication_id' => $npCommunicationId]
+        );
+
+        $this->executeStatement(
+            'UPDATE trophy_title_meta SET parent_np_communication_id = NULL WHERE parent_np_communication_id = :np_communication_id',
+            [':np_communication_id' => $npCommunicationId]
+        );
+
+        $this->restoreOrphanedMergedChildren($childNpCommunicationIds);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectChildNpCommunicationIds(string $parentNpCommunicationId): array
+    {
+        $childIds = [];
+
+        $mappedChildren = $this->database->prepare(
+            <<<'SQL'
+            SELECT DISTINCT child_np_communication_id
+            FROM trophy_merge
+            WHERE parent_np_communication_id = :np_communication_id
+            SQL
+        );
+        $mappedChildren->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+        $mappedChildren->execute();
+
+        while (($childId = $mappedChildren->fetchColumn()) !== false) {
+            $childIds[(string) $childId] = true;
+        }
+
+        $linkedChildren = $this->database->prepare(
+            <<<'SQL'
+            SELECT np_communication_id
+            FROM trophy_title_meta
+            WHERE parent_np_communication_id = :np_communication_id
+            SQL
+        );
+        $linkedChildren->bindValue(':np_communication_id', $parentNpCommunicationId, PDO::PARAM_STR);
+        $linkedChildren->execute();
+
+        while (($childId = $linkedChildren->fetchColumn()) !== false) {
+            $childIds[(string) $childId] = true;
+        }
+
+        return array_keys($childIds);
+    }
+
+    /**
+     * @param list<string> $childNpCommunicationIds
+     */
+    private function restoreOrphanedMergedChildren(array $childNpCommunicationIds): void
+    {
+        if ($childNpCommunicationIds === []) {
+            return;
+        }
+
         $mergedStatus = GameAvailabilityStatus::MERGED->value;
         $normalStatus = GameAvailabilityStatus::NORMAL->value;
+        $placeholders = [];
+        $parameters = [];
+
+        foreach ($childNpCommunicationIds as $index => $childNpCommunicationId) {
+            $placeholder = ':child_' . $index;
+            $placeholders[] = $placeholder;
+            $parameters[$placeholder] = $childNpCommunicationId;
+        }
+
+        $placeholderList = implode(', ', $placeholders);
 
         $this->executeStatement(
             <<<SQL
             UPDATE trophy_title_meta
-            SET parent_np_communication_id = NULL,
-                status = CASE WHEN status = {$mergedStatus} THEN {$normalStatus} ELSE status END
-            WHERE parent_np_communication_id = :np_communication_id
+            SET status = {$normalStatus}
+            WHERE np_communication_id IN ({$placeholderList})
+              AND status = {$mergedStatus}
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM trophy_merge
+                  WHERE trophy_merge.child_np_communication_id = trophy_title_meta.np_communication_id
+              )
             SQL,
-            [':np_communication_id' => $npCommunicationId]
+            $parameters
         );
     }
 

--- a/wwwroot/classes/TrophyMergeMetadataRepository.php
+++ b/wwwroot/classes/TrophyMergeMetadataRepository.php
@@ -21,29 +21,38 @@ final class TrophyMergeMetadataRepository
     /**
      * Ensure the child meta row exists and lock it for the rest of the current transaction.
      *
+     * Returns the current parent from the locked row. Callers must use this value for ownership
+     * checks — under MySQL REPEATABLE READ, a later non-locking SELECT can still see a stale
+     * snapshot even after FOR UPDATE waits for a concurrent merger to commit.
+     *
      * This serializes concurrent merges of the same child title so two parents cannot be assigned
      * when different trophies are merged at the same time.
      */
-    public function lockChildMetaForParentAssignment(string $childNpCommunicationId): void
+    public function lockChildMetaForParentAssignment(string $childNpCommunicationId): ?string
     {
         $this->ensureChildMetaRowExists($childNpCommunicationId);
 
-        if ($this->isSqlite()) {
-            return;
-        }
-
-        $query = $this->database->prepare(
-            <<<'SQL'
+        $sql = <<<'SQL'
             SELECT parent_np_communication_id
             FROM trophy_title_meta
             WHERE np_communication_id = :np_communication_id
             LIMIT 1
-            FOR UPDATE
-            SQL
-        );
+            SQL;
+
+        if (!$this->isSqlite()) {
+            $sql .= "\nFOR UPDATE";
+        }
+
+        $query = $this->database->prepare($sql);
         $query->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
         $query->execute();
-        $query->fetchColumn();
+
+        $parent = $query->fetchColumn();
+        if ($parent === false || $parent === null || $parent === '') {
+            return null;
+        }
+
+        return (string) $parent;
     }
 
     public function markGameAsMergedByNpId(string $npCommunicationId): void

--- a/wwwroot/classes/TrophyMergeMetadataRepository.php
+++ b/wwwroot/classes/TrophyMergeMetadataRepository.php
@@ -18,6 +18,34 @@ final class TrophyMergeMetadataRepository
     ) {
     }
 
+    /**
+     * Ensure the child meta row exists and lock it for the rest of the current transaction.
+     *
+     * This serializes concurrent merges of the same child title so two parents cannot be assigned
+     * when different trophies are merged at the same time.
+     */
+    public function lockChildMetaForParentAssignment(string $childNpCommunicationId): void
+    {
+        $this->ensureChildMetaRowExists($childNpCommunicationId);
+
+        if ($this->isSqlite()) {
+            return;
+        }
+
+        $query = $this->database->prepare(
+            <<<'SQL'
+            SELECT parent_np_communication_id
+            FROM trophy_title_meta
+            WHERE np_communication_id = :np_communication_id
+            LIMIT 1
+            FOR UPDATE
+            SQL
+        );
+        $query->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $query->execute();
+        $query->fetchColumn();
+    }
+
     public function markGameAsMergedByNpId(string $npCommunicationId): void
     {
         $this->transactionRunner->execute(function () use ($npCommunicationId): void {
@@ -118,6 +146,58 @@ SQL
         $query->bindValue(':param_1', $param1, PDO::PARAM_INT);
         $query->bindValue(':param_2', $param2, PDO::PARAM_INT);
         $query->execute();
+    }
+
+    private function ensureChildMetaRowExists(string $childNpCommunicationId): void
+    {
+        $exists = $this->database->prepare(
+            'SELECT 1 FROM trophy_title_meta WHERE np_communication_id = :np_communication_id'
+        );
+        $exists->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $exists->execute();
+
+        if ($exists->fetchColumn() !== false) {
+            return;
+        }
+
+        try {
+            $insert = $this->database->prepare(
+                <<<'SQL'
+                INSERT INTO trophy_title_meta (
+                    np_communication_id,
+                    message,
+                    status
+                ) VALUES (
+                    :np_communication_id,
+                    '',
+                    0
+                )
+                SQL
+            );
+            $insert->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+            $insert->execute();
+        } catch (PDOException $exception) {
+            if (!$this->isDuplicateKeyException($exception)) {
+                throw $exception;
+            }
+        }
+    }
+
+    private function isDuplicateKeyException(PDOException $exception): bool
+    {
+        if ($exception->getCode() === '23000') {
+            return true;
+        }
+
+        $message = $exception->getMessage();
+
+        return str_contains($message, 'UNIQUE constraint failed')
+            || str_contains($message, 'Duplicate entry');
+    }
+
+    private function isSqlite(): bool
+    {
+        return $this->database->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite';
     }
 
     private function updateParentPlatform(string $parentNpCommunicationId, string $childNpCommunicationId): void

--- a/wwwroot/classes/TrophyMergeParentOwnershipGuard.php
+++ b/wwwroot/classes/TrophyMergeParentOwnershipGuard.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/TrophyMergeMetadataRepository.php';
+
+/**
+ * Enforces that a child trophy title may belong to at most one merge parent.
+ */
+final class TrophyMergeParentOwnershipGuard
+{
+    public function __construct(
+        private readonly PDO $database,
+        private readonly TrophyMergeMetadataRepository $metadataRepository
+    ) {
+    }
+
+    /**
+     * Best-effort unlocked check for early rejection before opening a write transaction.
+     */
+    public function assertChildCanUseParent(string $childNpCommunicationId, string $parentNpCommunicationId): void
+    {
+        $this->assertChildOwnership(
+            $childNpCommunicationId,
+            $parentNpCommunicationId,
+            $this->readMetaParent($childNpCommunicationId),
+            currentReadMergeParents: false
+        );
+    }
+
+    /**
+     * Lock child meta rows in sorted order, then enforce the single-parent rule using
+     * current-read values from the locks (safe under MySQL REPEATABLE READ).
+     *
+     * @param list<string> $childNpCommunicationIds
+     */
+    public function lockAndAssertChildrenCanUseParent(
+        array $childNpCommunicationIds,
+        string $parentNpCommunicationId
+    ): void {
+        $uniqueChildNpCommunicationIds = array_values(array_unique($childNpCommunicationIds));
+        sort($uniqueChildNpCommunicationIds, SORT_STRING);
+
+        foreach ($uniqueChildNpCommunicationIds as $childNpCommunicationId) {
+            $lockedMetaParent = $this->metadataRepository->lockChildMetaForParentAssignment(
+                $childNpCommunicationId
+            );
+            $this->assertChildOwnership(
+                $childNpCommunicationId,
+                $parentNpCommunicationId,
+                $lockedMetaParent,
+                currentReadMergeParents: true
+            );
+        }
+    }
+
+    private function assertChildOwnership(
+        string $childNpCommunicationId,
+        string $parentNpCommunicationId,
+        ?string $metaParent,
+        bool $currentReadMergeParents
+    ): void {
+        $mergeParents = $this->findParentsFromTrophyMerge(
+            $childNpCommunicationId,
+            forUpdate: $currentReadMergeParents
+                && $this->database->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'sqlite'
+        );
+
+        if (count($mergeParents) > 1) {
+            throw new InvalidArgumentException(
+                'A child game can only have one parent. This game has conflicting merge mappings to '
+                . implode(', ', $mergeParents)
+                . ' and must be repaired before continuing.'
+            );
+        }
+
+        $mergeParent = $mergeParents === [] ? null : array_first($mergeParents);
+
+        if (
+            $metaParent !== null
+            && $mergeParent !== null
+            && $metaParent !== $mergeParent
+        ) {
+            throw new InvalidArgumentException(
+                'A child game can only have one parent. This game has conflicting parents '
+                . $metaParent
+                . ' and '
+                . $mergeParent
+                . ' and must be repaired before continuing.'
+            );
+        }
+
+        $existingParent = $metaParent ?? $mergeParent;
+
+        if ($existingParent === null || $existingParent === $parentNpCommunicationId) {
+            return;
+        }
+
+        throw new InvalidArgumentException(
+            'A child game can only have one parent. This game is already merged into '
+            . $existingParent
+            . '.'
+        );
+    }
+
+    private function readMetaParent(string $childNpCommunicationId): ?string
+    {
+        $metaQuery = $this->database->prepare(
+            <<<'SQL'
+            SELECT parent_np_communication_id
+            FROM trophy_title_meta
+            WHERE np_communication_id = :np_communication_id
+            SQL
+        );
+        $metaQuery->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $metaQuery->execute();
+
+        $parentFromMeta = $metaQuery->fetchColumn();
+        if ($parentFromMeta === false || $parentFromMeta === null || $parentFromMeta === '') {
+            return null;
+        }
+
+        return (string) $parentFromMeta;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function findParentsFromTrophyMerge(string $childNpCommunicationId, bool $forUpdate): array
+    {
+        $sql = <<<'SQL'
+            SELECT DISTINCT parent_np_communication_id
+            FROM trophy_merge
+            WHERE child_np_communication_id = :np_communication_id
+            ORDER BY parent_np_communication_id
+            SQL;
+
+        if ($forUpdate) {
+            $sql .= "\nFOR UPDATE";
+        }
+
+        $mergeQuery = $this->database->prepare($sql);
+        $mergeQuery->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $mergeQuery->execute();
+
+        /** @var list<string> $parents */
+        $parents = $mergeQuery->fetchAll(PDO::FETCH_COLUMN);
+
+        return $parents;
+    }
+}

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/TrophyMergeEarnedCopier.php';
 require_once __DIR__ . '/TrophyMergeMappingService.php';
 require_once __DIR__ . '/TrophyMergeMetadataRepository.php';
 require_once __DIR__ . '/TrophyMergeMethod.php';
+require_once __DIR__ . '/TrophyMergeParentOwnershipGuard.php';
 require_once __DIR__ . '/TrophyMergePlayerProgressUpdater.php';
 require_once __DIR__ . '/TrophyTitleCloneService.php';
 
@@ -20,6 +21,8 @@ class TrophyMergeService
     private ?TrophyMergeMappingService $mappingService = null;
 
     private ?TrophyMergeMetadataRepository $metadataRepository = null;
+
+    private ?TrophyMergeParentOwnershipGuard $parentOwnershipGuard = null;
 
     private ?TrophyMergePlayerProgressUpdater $playerProgressUpdater = null;
 
@@ -56,7 +59,10 @@ class TrophyMergeService
                 throw new InvalidArgumentException("Child can't be a merge title.");
             }
 
-            $this->assertChildCanUseParent($childTrophy['np_communication_id'], $parentNpCommunicationId);
+            $this->parentOwnershipGuard()->assertChildCanUseParent(
+                $childTrophy['np_communication_id'],
+                $parentNpCommunicationId
+            );
 
             $childTrophies[] = [
                 'id' => $childTrophyId,
@@ -65,7 +71,7 @@ class TrophyMergeService
         }
 
         $this->transactionRunner->execute(function () use ($parentTrophy, $parentTrophyId, $parentNpCommunicationId, $childTrophies): void {
-            $this->lockAndAssertChildrenCanUseParent(
+            $this->parentOwnershipGuard()->lockAndAssertChildrenCanUseParent(
                 array_map(
                     static fn (array $childData): string => $childData['trophy']['np_communication_id'],
                     $childTrophies
@@ -124,7 +130,10 @@ class TrophyMergeService
         }
 
         $this->notifyProgress($progressListener, 10, 'Validating merge configuration…');
-        $this->assertChildCanUseParent($childNpCommunicationId, $parentNpCommunicationId);
+        $this->parentOwnershipGuard()->assertChildCanUseParent(
+            $childNpCommunicationId,
+            $parentNpCommunicationId
+        );
 
         $message = '';
 
@@ -137,7 +146,10 @@ class TrophyMergeService
             $progressListener,
             &$message
         ): void {
-            $this->lockAndAssertChildrenCanUseParent([$childNpCommunicationId], $parentNpCommunicationId);
+            $this->parentOwnershipGuard()->lockAndAssertChildrenCanUseParent(
+                [$childNpCommunicationId],
+                $parentNpCommunicationId
+            );
 
             $this->notifyProgress($progressListener, 30, $method->progressLabel());
 
@@ -238,141 +250,6 @@ SQL
         return $trophy;
     }
 
-    /**
-     * Lock child meta rows in sorted order, then enforce the single-parent rule using
-     * current-read values from the locks (safe under MySQL REPEATABLE READ).
-     *
-     * @param list<string> $childNpCommunicationIds
-     */
-    private function lockAndAssertChildrenCanUseParent(
-        array $childNpCommunicationIds,
-        string $parentNpCommunicationId
-    ): void {
-        $uniqueChildNpCommunicationIds = array_values(array_unique($childNpCommunicationIds));
-        sort($uniqueChildNpCommunicationIds, SORT_STRING);
-
-        foreach ($uniqueChildNpCommunicationIds as $childNpCommunicationId) {
-            $lockedMetaParent = $this->metadataRepository()->lockChildMetaForParentAssignment(
-                $childNpCommunicationId
-            );
-            $this->assertChildOwnership(
-                $childNpCommunicationId,
-                $parentNpCommunicationId,
-                $lockedMetaParent,
-                currentReadMergeParents: true
-            );
-        }
-    }
-
-    /**
-     * A parent may have many children, but each child game may only have one parent.
-     * Merging additional trophies into the same parent is allowed.
-     */
-    private function assertChildCanUseParent(string $childNpCommunicationId, string $parentNpCommunicationId): void
-    {
-        $this->assertChildOwnership(
-            $childNpCommunicationId,
-            $parentNpCommunicationId,
-            $this->readMetaParent($childNpCommunicationId),
-            currentReadMergeParents: false
-        );
-    }
-
-    private function assertChildOwnership(
-        string $childNpCommunicationId,
-        string $parentNpCommunicationId,
-        ?string $metaParent,
-        bool $currentReadMergeParents
-    ): void {
-        $mergeParents = $this->findParentsFromTrophyMerge(
-            $childNpCommunicationId,
-            forUpdate: $currentReadMergeParents
-                && $this->database->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'sqlite'
-        );
-
-        if (count($mergeParents) > 1) {
-            throw new InvalidArgumentException(
-                'A child game can only have one parent. This game has conflicting merge mappings to '
-                . implode(', ', $mergeParents)
-                . ' and must be repaired before merging again.'
-            );
-        }
-
-        $mergeParent = $mergeParents === [] ? null : array_first($mergeParents);
-
-        if (
-            $metaParent !== null
-            && $mergeParent !== null
-            && $metaParent !== $mergeParent
-        ) {
-            throw new InvalidArgumentException(
-                'A child game can only have one parent. This game has conflicting parents '
-                . $metaParent
-                . ' and '
-                . $mergeParent
-                . ' and must be repaired before merging again.'
-            );
-        }
-
-        $existingParent = $metaParent ?? $mergeParent;
-
-        if ($existingParent === null || $existingParent === $parentNpCommunicationId) {
-            return;
-        }
-
-        throw new InvalidArgumentException(
-            'A child game can only have one parent. This game is already merged into '
-            . $existingParent
-            . '.'
-        );
-    }
-
-    private function readMetaParent(string $childNpCommunicationId): ?string
-    {
-        $metaQuery = $this->database->prepare(
-            <<<'SQL'
-            SELECT parent_np_communication_id
-            FROM trophy_title_meta
-            WHERE np_communication_id = :np_communication_id
-            SQL
-        );
-        $metaQuery->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-        $metaQuery->execute();
-
-        $parentFromMeta = $metaQuery->fetchColumn();
-        if ($parentFromMeta === false || $parentFromMeta === null || $parentFromMeta === '') {
-            return null;
-        }
-
-        return (string) $parentFromMeta;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function findParentsFromTrophyMerge(string $childNpCommunicationId, bool $forUpdate): array
-    {
-        $sql = <<<'SQL'
-            SELECT DISTINCT parent_np_communication_id
-            FROM trophy_merge
-            WHERE child_np_communication_id = :np_communication_id
-            ORDER BY parent_np_communication_id
-            SQL;
-
-        if ($forUpdate) {
-            $sql .= "\nFOR UPDATE";
-        }
-
-        $mergeQuery = $this->database->prepare($sql);
-        $mergeQuery->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
-        $mergeQuery->execute();
-
-        /** @var list<string> $parents */
-        $parents = $mergeQuery->fetchAll(PDO::FETCH_COLUMN);
-
-        return $parents;
-    }
-
     private function getGameIdByTrophyId(int $trophyId): int
     {
         $query = $this->database->prepare(
@@ -420,6 +297,14 @@ SQL
         return $this->metadataRepository ??= new TrophyMergeMetadataRepository(
             $this->database,
             $this->transactionRunner
+        );
+    }
+
+    private function parentOwnershipGuard(): TrophyMergeParentOwnershipGuard
+    {
+        return $this->parentOwnershipGuard ??= new TrophyMergeParentOwnershipGuard(
+            $this->database,
+            $this->metadataRepository()
         );
     }
 

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -239,7 +239,8 @@ SQL
     }
 
     /**
-     * Lock child meta rows in sorted order, then enforce the single-parent rule.
+     * Lock child meta rows in sorted order, then enforce the single-parent rule using
+     * current-read values from the locks (safe under MySQL REPEATABLE READ).
      *
      * @param list<string> $childNpCommunicationIds
      */
@@ -251,8 +252,12 @@ SQL
         sort($uniqueChildNpCommunicationIds, SORT_STRING);
 
         foreach ($uniqueChildNpCommunicationIds as $childNpCommunicationId) {
-            $this->metadataRepository()->lockChildMetaForParentAssignment($childNpCommunicationId);
-            $this->assertChildCanUseParent($childNpCommunicationId, $parentNpCommunicationId);
+            $lockedMetaParent = $this->metadataRepository()->lockChildMetaForParentAssignment(
+                $childNpCommunicationId
+            );
+            $existingParent = $lockedMetaParent
+                ?? $this->findCurrentParentFromTrophyMerge($childNpCommunicationId);
+            $this->assertExistingParentAllowed($existingParent, $parentNpCommunicationId);
         }
     }
 
@@ -262,8 +267,14 @@ SQL
      */
     private function assertChildCanUseParent(string $childNpCommunicationId, string $parentNpCommunicationId): void
     {
-        $existingParent = $this->findExistingParent($childNpCommunicationId);
+        $this->assertExistingParentAllowed(
+            $this->findExistingParent($childNpCommunicationId),
+            $parentNpCommunicationId
+        );
+    }
 
+    private function assertExistingParentAllowed(?string $existingParent, string $parentNpCommunicationId): void
+    {
         if ($existingParent === null || $existingParent === $parentNpCommunicationId) {
             return;
         }
@@ -292,14 +303,35 @@ SQL
             return (string) $parentFromMeta;
         }
 
-        $mergeQuery = $this->database->prepare(
-            <<<'SQL'
+        return $this->findParentFromTrophyMerge($childNpCommunicationId, forUpdate: false);
+    }
+
+    /**
+     * Current-read lookup of legacy trophy_merge parents. FOR UPDATE avoids REPEATABLE READ
+     * snapshot staleness after waiting on the child meta row lock.
+     */
+    private function findCurrentParentFromTrophyMerge(string $childNpCommunicationId): ?string
+    {
+        return $this->findParentFromTrophyMerge(
+            $childNpCommunicationId,
+            forUpdate: $this->database->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'sqlite'
+        );
+    }
+
+    private function findParentFromTrophyMerge(string $childNpCommunicationId, bool $forUpdate): ?string
+    {
+        $sql = <<<'SQL'
             SELECT DISTINCT parent_np_communication_id
             FROM trophy_merge
             WHERE child_np_communication_id = :np_communication_id
             ORDER BY parent_np_communication_id
-            SQL
-        );
+            SQL;
+
+        if ($forUpdate) {
+            $sql .= "\nFOR UPDATE";
+        }
+
+        $mergeQuery = $this->database->prepare($sql);
         $mergeQuery->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
         $mergeQuery->execute();
 

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -255,9 +255,12 @@ SQL
             $lockedMetaParent = $this->metadataRepository()->lockChildMetaForParentAssignment(
                 $childNpCommunicationId
             );
-            $existingParent = $lockedMetaParent
-                ?? $this->findCurrentParentFromTrophyMerge($childNpCommunicationId);
-            $this->assertExistingParentAllowed($existingParent, $parentNpCommunicationId);
+            $this->assertChildOwnership(
+                $childNpCommunicationId,
+                $parentNpCommunicationId,
+                $lockedMetaParent,
+                currentReadMergeParents: true
+            );
         }
     }
 
@@ -267,14 +270,52 @@ SQL
      */
     private function assertChildCanUseParent(string $childNpCommunicationId, string $parentNpCommunicationId): void
     {
-        $this->assertExistingParentAllowed(
-            $this->findExistingParent($childNpCommunicationId),
-            $parentNpCommunicationId
+        $this->assertChildOwnership(
+            $childNpCommunicationId,
+            $parentNpCommunicationId,
+            $this->readMetaParent($childNpCommunicationId),
+            currentReadMergeParents: false
         );
     }
 
-    private function assertExistingParentAllowed(?string $existingParent, string $parentNpCommunicationId): void
-    {
+    private function assertChildOwnership(
+        string $childNpCommunicationId,
+        string $parentNpCommunicationId,
+        ?string $metaParent,
+        bool $currentReadMergeParents
+    ): void {
+        $mergeParents = $this->findParentsFromTrophyMerge(
+            $childNpCommunicationId,
+            forUpdate: $currentReadMergeParents
+                && $this->database->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'sqlite'
+        );
+
+        if (count($mergeParents) > 1) {
+            throw new InvalidArgumentException(
+                'A child game can only have one parent. This game has conflicting merge mappings to '
+                . implode(', ', $mergeParents)
+                . ' and must be repaired before merging again.'
+            );
+        }
+
+        $mergeParent = $mergeParents === [] ? null : array_first($mergeParents);
+
+        if (
+            $metaParent !== null
+            && $mergeParent !== null
+            && $metaParent !== $mergeParent
+        ) {
+            throw new InvalidArgumentException(
+                'A child game can only have one parent. This game has conflicting parents '
+                . $metaParent
+                . ' and '
+                . $mergeParent
+                . ' and must be repaired before merging again.'
+            );
+        }
+
+        $existingParent = $metaParent ?? $mergeParent;
+
         if ($existingParent === null || $existingParent === $parentNpCommunicationId) {
             return;
         }
@@ -286,7 +327,7 @@ SQL
         );
     }
 
-    private function findExistingParent(string $childNpCommunicationId): ?string
+    private function readMetaParent(string $childNpCommunicationId): ?string
     {
         $metaQuery = $this->database->prepare(
             <<<'SQL'
@@ -299,26 +340,17 @@ SQL
         $metaQuery->execute();
 
         $parentFromMeta = $metaQuery->fetchColumn();
-        if ($parentFromMeta !== false && $parentFromMeta !== null && $parentFromMeta !== '') {
-            return (string) $parentFromMeta;
+        if ($parentFromMeta === false || $parentFromMeta === null || $parentFromMeta === '') {
+            return null;
         }
 
-        return $this->findParentFromTrophyMerge($childNpCommunicationId, forUpdate: false);
+        return (string) $parentFromMeta;
     }
 
     /**
-     * Current-read lookup of legacy trophy_merge parents. FOR UPDATE avoids REPEATABLE READ
-     * snapshot staleness after waiting on the child meta row lock.
+     * @return list<string>
      */
-    private function findCurrentParentFromTrophyMerge(string $childNpCommunicationId): ?string
-    {
-        return $this->findParentFromTrophyMerge(
-            $childNpCommunicationId,
-            forUpdate: $this->database->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'sqlite'
-        );
-    }
-
-    private function findParentFromTrophyMerge(string $childNpCommunicationId, bool $forUpdate): ?string
+    private function findParentsFromTrophyMerge(string $childNpCommunicationId, bool $forUpdate): array
     {
         $sql = <<<'SQL'
             SELECT DISTINCT parent_np_communication_id
@@ -338,7 +370,7 @@ SQL
         /** @var list<string> $parents */
         $parents = $mergeQuery->fetchAll(PDO::FETCH_COLUMN);
 
-        return $parents === [] ? null : array_first($parents);
+        return $parents;
     }
 
     private function getGameIdByTrophyId(int $trophyId): int

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -82,6 +82,10 @@ class TrophyMergeService
 
                 $this->updateTrophyGroupPlayer($childGameId);
                 $this->updateTrophyTitlePlayer($childGameId);
+                $this->metadataRepository()->updateParentRelationship(
+                    $childTrophy['np_communication_id'],
+                    $parentTrophy['np_communication_id']
+                );
             }
         });
 

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -65,12 +65,17 @@ class TrophyMergeService
         }
 
         $this->transactionRunner->execute(function () use ($parentTrophy, $parentTrophyId, $parentNpCommunicationId, $childTrophies): void {
+            $this->lockAndAssertChildrenCanUseParent(
+                array_map(
+                    static fn (array $childData): string => $childData['trophy']['np_communication_id'],
+                    $childTrophies
+                ),
+                $parentNpCommunicationId
+            );
+
             foreach ($childTrophies as $childData) {
                 $childTrophyId = $childData['id'];
                 $childTrophy = $childData['trophy'];
-
-                // Re-check inside the transaction in case another merge landed first.
-                $this->assertChildCanUseParent($childTrophy['np_communication_id'], $parentNpCommunicationId);
 
                 $this->insertTrophyMergeMappingFromIds($childTrophyId, $parentTrophyId);
                 $this->metadataRepository()->markGameAsMergedByNpId($childTrophy['np_communication_id']);
@@ -132,8 +137,7 @@ class TrophyMergeService
             $progressListener,
             &$message
         ): void {
-            // Re-check inside the transaction in case another merge landed first.
-            $this->assertChildCanUseParent($childNpCommunicationId, $parentNpCommunicationId);
+            $this->lockAndAssertChildrenCanUseParent([$childNpCommunicationId], $parentNpCommunicationId);
 
             $this->notifyProgress($progressListener, 30, $method->progressLabel());
 
@@ -232,6 +236,24 @@ SQL
         $trophy['order_id'] = (int) $trophy['order_id'];
 
         return $trophy;
+    }
+
+    /**
+     * Lock child meta rows in sorted order, then enforce the single-parent rule.
+     *
+     * @param list<string> $childNpCommunicationIds
+     */
+    private function lockAndAssertChildrenCanUseParent(
+        array $childNpCommunicationIds,
+        string $parentNpCommunicationId
+    ): void {
+        $uniqueChildNpCommunicationIds = array_values(array_unique($childNpCommunicationIds));
+        sort($uniqueChildNpCommunicationIds, SORT_STRING);
+
+        foreach ($uniqueChildNpCommunicationIds as $childNpCommunicationId) {
+            $this->metadataRepository()->lockChildMetaForParentAssignment($childNpCommunicationId);
+            $this->assertChildCanUseParent($childNpCommunicationId, $parentNpCommunicationId);
+        }
     }
 
     /**

--- a/wwwroot/classes/TrophyMergeService.php
+++ b/wwwroot/classes/TrophyMergeService.php
@@ -46,6 +46,7 @@ class TrophyMergeService
         }
 
         $childTrophies = [];
+        $parentNpCommunicationId = $parentTrophy['np_communication_id'];
 
         foreach ($childTrophyIds as $childTrophyId) {
             $childTrophyId = (int) $childTrophyId;
@@ -55,16 +56,21 @@ class TrophyMergeService
                 throw new InvalidArgumentException("Child can't be a merge title.");
             }
 
+            $this->assertChildCanUseParent($childTrophy['np_communication_id'], $parentNpCommunicationId);
+
             $childTrophies[] = [
                 'id' => $childTrophyId,
                 'trophy' => $childTrophy,
             ];
         }
 
-        $this->transactionRunner->execute(function () use ($parentTrophy, $parentTrophyId, $childTrophies): void {
+        $this->transactionRunner->execute(function () use ($parentTrophy, $parentTrophyId, $parentNpCommunicationId, $childTrophies): void {
             foreach ($childTrophies as $childData) {
                 $childTrophyId = $childData['id'];
                 $childTrophy = $childData['trophy'];
+
+                // Re-check inside the transaction in case another merge landed first.
+                $this->assertChildCanUseParent($childTrophy['np_communication_id'], $parentNpCommunicationId);
 
                 $this->insertTrophyMergeMappingFromIds($childTrophyId, $parentTrophyId);
                 $this->metadataRepository()->markGameAsMergedByNpId($childTrophy['np_communication_id']);
@@ -75,7 +81,7 @@ class TrophyMergeService
                     $childTrophy['np_communication_id'],
                     $childTrophy['group_id'],
                     (int) $childTrophy['order_id'],
-                    $parentTrophy['np_communication_id'],
+                    $parentNpCommunicationId,
                     $parentTrophy['group_id'],
                     (int) $parentTrophy['order_id']
                 );
@@ -84,7 +90,7 @@ class TrophyMergeService
                 $this->updateTrophyTitlePlayer($childGameId);
                 $this->metadataRepository()->updateParentRelationship(
                     $childTrophy['np_communication_id'],
-                    $parentTrophy['np_communication_id']
+                    $parentNpCommunicationId
                 );
             }
         });
@@ -113,6 +119,7 @@ class TrophyMergeService
         }
 
         $this->notifyProgress($progressListener, 10, 'Validating merge configuration…');
+        $this->assertChildCanUseParent($childNpCommunicationId, $parentNpCommunicationId);
 
         $message = '';
 
@@ -125,6 +132,9 @@ class TrophyMergeService
             $progressListener,
             &$message
         ): void {
+            // Re-check inside the transaction in case another merge landed first.
+            $this->assertChildCanUseParent($childNpCommunicationId, $parentNpCommunicationId);
+
             $this->notifyProgress($progressListener, 30, $method->progressLabel());
 
             match ($method) {
@@ -222,6 +232,59 @@ SQL
         $trophy['order_id'] = (int) $trophy['order_id'];
 
         return $trophy;
+    }
+
+    /**
+     * A parent may have many children, but each child game may only have one parent.
+     * Merging additional trophies into the same parent is allowed.
+     */
+    private function assertChildCanUseParent(string $childNpCommunicationId, string $parentNpCommunicationId): void
+    {
+        $existingParent = $this->findExistingParent($childNpCommunicationId);
+
+        if ($existingParent === null || $existingParent === $parentNpCommunicationId) {
+            return;
+        }
+
+        throw new InvalidArgumentException(
+            'A child game can only have one parent. This game is already merged into '
+            . $existingParent
+            . '.'
+        );
+    }
+
+    private function findExistingParent(string $childNpCommunicationId): ?string
+    {
+        $metaQuery = $this->database->prepare(
+            <<<'SQL'
+            SELECT parent_np_communication_id
+            FROM trophy_title_meta
+            WHERE np_communication_id = :np_communication_id
+            SQL
+        );
+        $metaQuery->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $metaQuery->execute();
+
+        $parentFromMeta = $metaQuery->fetchColumn();
+        if ($parentFromMeta !== false && $parentFromMeta !== null && $parentFromMeta !== '') {
+            return (string) $parentFromMeta;
+        }
+
+        $mergeQuery = $this->database->prepare(
+            <<<'SQL'
+            SELECT DISTINCT parent_np_communication_id
+            FROM trophy_merge
+            WHERE child_np_communication_id = :np_communication_id
+            ORDER BY parent_np_communication_id
+            SQL
+        );
+        $mergeQuery->bindValue(':np_communication_id', $childNpCommunicationId, PDO::PARAM_STR);
+        $mergeQuery->execute();
+
+        /** @var list<string> $parents */
+        $parents = $mergeQuery->fetchAll(PDO::FETCH_COLUMN);
+
+        return $parents === [] ? null : array_first($parents);
     }
 
     private function getGameIdByTrophyId(int $trophyId): int


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
When an admin resets or deletes a merged (`MERGE_*`) game, child titles kept `status = MERGED` and could disappear from lists. Trophy-only merges also failed to set `parent_np_communication_id`, and other admin flows could split a child across two parents.

## Changes
- **`GameResetService`**: on reset/delete, restore children to `NORMAL` and clear parent links.
- **`TrophyMergeService::mergeSpecificTrophies()`**: set `parent_np_communication_id`.
- **`TrophyMergeParentOwnershipGuard`**: shared single-parent enforcement with meta row locking / current reads under MySQL REPEATABLE READ, plus rejection of legacy multi-parent conflicts.
- **`GameCopyService`**: use the same ownership guard before copy can rewrite `trophy_merge` rows to a different parent.

## Test plan
- [x] `php tests/run.php` — all 1069 tests passed
- [ ] Admin reset/delete restores children to Normal
- [ ] Trophy-only merges store `parent_np_communication_id`
- [ ] Second-parent merge/copy is rejected
- [ ] Legacy multi-parent mappings are rejected until repaired
- [ ] Additional trophies/copy into the same parent still works

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9687174b-bce5-4791-a298-6734f981e015?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9687174b-bce5-4791-a298-6734f981e015&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

