### PR TITLE
Adopt remaining PHP 8.5 idioms for final promotion and pipes

### DIFF
--- a/wwwroot/classes/AboutPageService.php
+++ b/wwwroot/classes/AboutPageService.php
@@ -12,8 +12,8 @@ final readonly class AboutPageService implements AboutPageDataProviderInterface
     private const int DEFAULT_SCAN_LOG_LIMIT = 10;
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly Utility $utility
+        final private PDO $database,
+        final private Utility $utility
     ) {
     }
 

--- a/wwwroot/classes/Admin/AdminLoginThrottleService.php
+++ b/wwwroot/classes/Admin/AdminLoginThrottleService.php
@@ -8,7 +8,7 @@ final readonly class AdminLoginThrottleService
 
     public const int LOCK_SECONDS = 900;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/Admin/AdminUserRepository.php
+++ b/wwwroot/classes/Admin/AdminUserRepository.php
@@ -20,7 +20,7 @@ final readonly class AdminUserRepository
         LIMIT 1
         SQL;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/Admin/CheaterRequestHandler.php
+++ b/wwwroot/classes/Admin/CheaterRequestHandler.php
@@ -8,9 +8,9 @@ require_once __DIR__ . '/AdminRequest.php';
 require_once __DIR__ . '/CheaterRequestResult.php';
 require_once __DIR__ . '/CheaterService.php';
 
-final class CheaterRequestHandler
+final readonly class CheaterRequestHandler
 {
-    public function __construct(private readonly CheaterService $cheaterService)
+    public function __construct(final private CheaterService $cheaterService)
     {
     }
 

--- a/wwwroot/classes/Admin/CheaterService.php
+++ b/wwwroot/classes/Admin/CheaterService.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../PlayerStatus.php';
 
-final class CheaterService
+final readonly class CheaterService
 {
     public function __construct(
-        private readonly PDO $database,
+        final private PDO $database,
     ) {
     }
 

--- a/wwwroot/classes/Admin/DeletePlayerRequestHandler.php
+++ b/wwwroot/classes/Admin/DeletePlayerRequestHandler.php
@@ -7,9 +7,9 @@ require_once __DIR__ . '/DeletePlayerRequestResult.php';
 require_once __DIR__ . '/DeletePlayerService.php';
 require_once __DIR__ . '/../Html.php';
 
-final class DeletePlayerRequestHandler
+final readonly class DeletePlayerRequestHandler
 {
-    public function __construct(private readonly DeletePlayerService $service)
+    public function __construct(final private DeletePlayerService $service)
     {
     }
 

--- a/wwwroot/classes/Admin/DeletePlayerService.php
+++ b/wwwroot/classes/Admin/DeletePlayerService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final readonly class DeletePlayerService
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/Admin/GameCopyHandler.php
+++ b/wwwroot/classes/Admin/GameCopyHandler.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 require_once __DIR__ . '/../Html.php';
 require_once __DIR__ . '/../RequestParameter.php';
 
-final class GameCopyHandler
+final readonly class GameCopyHandler
 {
-    public function __construct(private readonly GameCopyService $gameCopyService)
+    public function __construct(final private GameCopyService $gameCopyService)
     {
     }
 

--- a/wwwroot/classes/Admin/GameDetailService.php
+++ b/wwwroot/classes/Admin/GameDetailService.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../ChangelogEntry.php';
 final readonly class GameDetailService
 {
     public function __construct(
-        private readonly PDO $database,
+        final private PDO $database,
     ) {
     }
 

--- a/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
+++ b/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
@@ -17,15 +17,15 @@ use Tustin\PlayStation\Client;
 /**
  * Refreshes trophy title, group, and trophy catalog rows during admin game rescans.
  */
-final class GameRescanCatalogUpdater
+final readonly class GameRescanCatalogUpdater
 {
     public function __construct(
-        private readonly PDO $database,
-        private readonly TrophyCatalogSynchronizer $trophyCatalogSynchronizer,
-        private readonly TrophyMetaRepository $trophyMetaRepository,
-        private readonly GameRescanGroupDataFetcher $groupDataFetcher,
-        private readonly TrophyImageDirectories $imageDirectories,
-        private readonly TrophyImageDownloader $imageDownloader,
+        final private PDO $database,
+        final private TrophyCatalogSynchronizer $trophyCatalogSynchronizer,
+        final private TrophyMetaRepository $trophyMetaRepository,
+        final private GameRescanGroupDataFetcher $groupDataFetcher,
+        final private TrophyImageDirectories $imageDirectories,
+        final private TrophyImageDownloader $imageDownloader,
     ) {
     }
 

--- a/wwwroot/classes/Admin/GameRescanProcessor.php
+++ b/wwwroot/classes/Admin/GameRescanProcessor.php
@@ -7,9 +7,9 @@ require_once __DIR__ . '/../Psn100Logger.php';
 require_once __DIR__ . '/GameRescanService.php';
 require_once __DIR__ . '/GameRescanRequestHandler.php';
 
-final class GameRescanProcessor
+final readonly class GameRescanProcessor
 {
-    public function __construct(private readonly GameRescanRequestHandler $requestHandler)
+    public function __construct(final private GameRescanRequestHandler $requestHandler)
     {
     }
 

--- a/wwwroot/classes/Admin/GameRescanRequestHandler.php
+++ b/wwwroot/classes/Admin/GameRescanRequestHandler.php
@@ -8,9 +8,9 @@ require_once __DIR__ . '/AdminStreamEventType.php';
 require_once __DIR__ . '/GameRescanProgressListener.php';
 require_once __DIR__ . '/CallableGameRescanProgressListener.php';
 
-final class GameRescanRequestHandler
+final readonly class GameRescanRequestHandler
 {
-    public function __construct(private readonly GameRescanService $gameRescanService)
+    public function __construct(final private GameRescanService $gameRescanService)
     {
     }
 

--- a/wwwroot/classes/Admin/GameResetRequestHandler.php
+++ b/wwwroot/classes/Admin/GameResetRequestHandler.php
@@ -9,9 +9,9 @@ require_once __DIR__ . '/GameResetRequestResult.php';
 require_once __DIR__ . '/../GameResetAction.php';
 require_once __DIR__ . '/../GameResetService.php';
 
-final class GameResetRequestHandler
+final readonly class GameResetRequestHandler
 {
-    public function __construct(private readonly GameResetService $gameResetService)
+    public function __construct(final private GameResetService $gameResetService)
     {
     }
 

--- a/wwwroot/classes/Admin/PlayerReportAdminService.php
+++ b/wwwroot/classes/Admin/PlayerReportAdminService.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/ReportedPlayer.php';
 
-final class PlayerReportAdminService
+final readonly class PlayerReportAdminService
 {
     public function __construct(
-        private readonly PDO $database,
+        final private PDO $database,
     ) {
     }
 

--- a/wwwroot/classes/Admin/PsnGameLookupRequestHandler.php
+++ b/wwwroot/classes/Admin/PsnGameLookupRequestHandler.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/PsnGameLookupService.php';
 require_once __DIR__ . '/PsnGameLookupException.php';
 require_once __DIR__ . '/PsnGameLookupRequestResult.php';
 
-final class PsnGameLookupRequestHandler
+final readonly class PsnGameLookupRequestHandler
 {
     #[\NoDiscard]
     public static function handle(PsnGameLookupService $lookupService, string $gameId): PsnGameLookupRequestResult

--- a/wwwroot/classes/Admin/PsnPlayerLookupRequestHandler.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupRequestHandler.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/PsnPlayerLookupService.php';
 require_once __DIR__ . '/PsnPlayerLookupException.php';
 require_once __DIR__ . '/PsnPlayerLookupRequestResult.php';
 
-final class PsnPlayerLookupRequestHandler
+final readonly class PsnPlayerLookupRequestHandler
 {
     #[\NoDiscard]
     public static function handle(PsnPlayerLookupService $lookupService, string $onlineId): PsnPlayerLookupRequestResult

--- a/wwwroot/classes/Admin/PsnTrophyLookupGroupDataProvider.php
+++ b/wwwroot/classes/Admin/PsnTrophyLookupGroupDataProvider.php
@@ -12,10 +12,10 @@ use Tustin\PlayStation\Client;
 /**
  * Fetches PSN trophy group data and adapts raw API payloads to objects used during game rescans.
  */
-final class PsnTrophyLookupGroupDataProvider implements GameRescanGroupDataFetcher
+final readonly class PsnTrophyLookupGroupDataProvider implements GameRescanGroupDataFetcher
 {
     public function __construct(
-        private readonly PsnGameLookupService $psnGameLookupService,
+        final private PsnGameLookupService $psnGameLookupService,
     ) {
     }
 

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestHandler.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonRequestHandler.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/PsnTrophyTitleComparisonRequestResult.php';
 require_once __DIR__ . '/PsnTrophyTitleComparisonService.php';
 require_once __DIR__ . '/PsnTrophyTitleComparisonSource.php';
 
-final class PsnTrophyTitleComparisonRequestHandler
+final readonly class PsnTrophyTitleComparisonRequestHandler
 {
     #[\NoDiscard]
     public static function handle(PsnTrophyTitleComparisonService $service, string $accountId, string $source): PsnTrophyTitleComparisonRequestResult

--- a/wwwroot/classes/Admin/TrophyStatusInputParser.php
+++ b/wwwroot/classes/Admin/TrophyStatusInputParser.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 /**
  * Resolves admin trophy-status form input into trophy IDs.
  */
-final class TrophyStatusInputParser
+final readonly class TrophyStatusInputParser
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/Admin/WorkerCredentialRevealHandler.php
+++ b/wwwroot/classes/Admin/WorkerCredentialRevealHandler.php
@@ -7,9 +7,9 @@ require_once __DIR__ . '/WorkerCredentialField.php';
 require_once __DIR__ . '/WorkerCredentialRevealResult.php';
 require_once __DIR__ . '/WorkerService.php';
 
-final class WorkerCredentialRevealHandler
+final readonly class WorkerCredentialRevealHandler
 {
-    public function __construct(private readonly WorkerService $workerService)
+    public function __construct(final private WorkerService $workerService)
     {
     }
 

--- a/wwwroot/classes/Admin/WorkerPage.php
+++ b/wwwroot/classes/Admin/WorkerPage.php
@@ -12,9 +12,9 @@ require_once __DIR__ . '/WorkerPageResult.php';
 require_once __DIR__ . '/WorkerSortField.php';
 require_once __DIR__ . '/WorkerSortDirection.php';
 
-final class WorkerPage
+final readonly class WorkerPage
 {
-    public function __construct(private readonly WorkerService $workerService)
+    public function __construct(final private WorkerService $workerService)
     {
     }
 

--- a/wwwroot/classes/AvatarService.php
+++ b/wwwroot/classes/AvatarService.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/PlayerStatus.php';
 
 final readonly class AvatarService
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/Cron/CronJobEntryPoint.php
+++ b/wwwroot/classes/Cron/CronJobEntryPoint.php
@@ -12,9 +12,9 @@ require_once __DIR__ . '/CronJobInterface.php';
  * job should run while this class takes care of configuring the environment
  * and validating the job factory.
  */
-final class CronJobEntryPoint
+final readonly class CronJobEntryPoint
 {
-    private function __construct(private readonly CronJobBootstrapper $bootstrapper)
+    private function __construct(final private CronJobBootstrapper $bootstrapper)
     {
     }
 

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJob.php
@@ -56,11 +56,11 @@ final readonly class ThirtyMinuteCronJob implements CronJobInterface
     private readonly PlayerScanTrophyTitleLoop $trophyTitleLoop;
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly TrophyCalculator $trophyCalculator,
-        private readonly Psn100Logger $logger,
-        private readonly TrophyHistoryRecorder $historyRecorder,
-        private readonly int $workerId,
+        final private PDO $database,
+        final private TrophyCalculator $trophyCalculator,
+        final private Psn100Logger $logger,
+        final private TrophyHistoryRecorder $historyRecorder,
+        final private int $workerId,
         ?AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService = null,
         ?ImageHashCalculator $imageHashCalculator = null,
         ?WorkerScanCoordinator $workerScanCoordinator = null,

--- a/wwwroot/classes/CsrfTokenManager.php
+++ b/wwwroot/classes/CsrfTokenManager.php
@@ -18,7 +18,7 @@ final readonly class CsrfTokenManager
         $token = $_SESSION[$sessionKey] ?? null;
 
         if (!is_string($token) || $token === '') {
-            $token = bin2hex(random_bytes(32));
+            $token = random_bytes(32) |> bin2hex(...);
             $_SESSION[$sessionKey] = $token;
         }
 

--- a/wwwroot/classes/GameHistoryService.php
+++ b/wwwroot/classes/GameHistoryService.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 require_once __DIR__ . '/TrophyMetaStatus.php';
 require_once __DIR__ . '/TrophyGroupId.php';
 
-final class GameHistoryService
+final readonly class GameHistoryService
 {
     private const int INVALID_HISTORY_ID = 0;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/GameLeaderboardService.php
+++ b/wwwroot/classes/GameLeaderboardService.php
@@ -10,7 +10,7 @@ final readonly class GameLeaderboardService
 {
     public const int PAGE_SIZE = 50;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/GameListService.php
+++ b/wwwroot/classes/GameListService.php
@@ -16,8 +16,8 @@ final readonly class GameListService
     private const int PAGE_LIMIT = 40;
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly SearchQueryHelper $searchQueryHelper
+        final private PDO $database,
+        final private SearchQueryHelper $searchQueryHelper
     ) {
     }
 

--- a/wwwroot/classes/GameMessageSanitizer.php
+++ b/wwwroot/classes/GameMessageSanitizer.php
@@ -21,7 +21,7 @@ final readonly class GameMessageSanitizer
             $matchText = $matches[0][0];
             $matchPosition = $matches[0][1];
 
-            $sanitized .= self::sanitizePlainText(substr($message, $offset, $matchPosition - $offset));
+            $sanitized .= substr($message, $offset, $matchPosition - $offset) |> self::sanitizePlainText(...);
 
             $attributes = $matches[1][0];
             $linkContent = $matches[2][0];
@@ -45,7 +45,7 @@ final readonly class GameMessageSanitizer
             $offset = $matchPosition + strlen($matchText);
         }
 
-        $sanitized .= self::sanitizePlainText(substr($message, $offset));
+        $sanitized .= substr($message, $offset) |> self::sanitizePlainText(...);
 
         return $sanitized;
     }

--- a/wwwroot/classes/GameRecentPlayersService.php
+++ b/wwwroot/classes/GameRecentPlayersService.php
@@ -11,7 +11,7 @@ final readonly class GameRecentPlayersService
 {
     public const int RECENT_PLAYERS_LIMIT = 10;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/GameStatusService.php
+++ b/wwwroot/classes/GameStatusService.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/GameAvailabilityStatus.php';
 
 final readonly class GameStatusService
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/HomepageContentService.php
+++ b/wwwroot/classes/HomepageContentService.php
@@ -19,7 +19,7 @@ final readonly class HomepageContentService
     private const int DEFAULT_NEW_DLCS_LIMIT = 8;
     private const int DEFAULT_POPULAR_GAME_LIMIT = 10;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/ImageHashCalculator.php
+++ b/wwwroot/classes/ImageHashCalculator.php
@@ -189,13 +189,10 @@ final readonly class ImageHashCalculator
     }
 
     /**
-     * Calculates the Hamming Distance between two hashes.
-     * * @param string $h1 First hash (38 chars)
-     * @param string $h2 Second hash (38 chars)
-     * @return int Number of differing bits. 
-     * A distance <= 10 is usually considered the same image.
+     * Hamming distance between two equal-length hex hashes.
+     * Distance <= 10 is usually treated as the same image.
      */
-    public function getHammingDistance(string $h1, string $h2): int 
+    public function getHammingDistance(string $h1, string $h2): int
     {
         if (strlen($h1) !== strlen($h2)) return 152;
 

--- a/wwwroot/classes/IpRateLimitService.php
+++ b/wwwroot/classes/IpRateLimitService.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/IpRateLimitBucket.php';
  */
 final readonly class IpRateLimitService
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/PlayerAdvisorService.php
+++ b/wwwroot/classes/PlayerAdvisorService.php
@@ -14,8 +14,8 @@ final readonly class PlayerAdvisorService
     public const int PAGE_SIZE = 50;
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly Utility $utility,
+        final private PDO $database,
+        final private Utility $utility,
     ) {
     }
 

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -14,8 +14,8 @@ require_once __DIR__ . '/TrophyGroupId.php';
 final readonly class PlayerGamesService
 {
     public function __construct(
-        private readonly PDO $database,
-        private readonly SearchQueryHelper $searchQueryHelper
+        final private PDO $database,
+        final private SearchQueryHelper $searchQueryHelper
     ) {
     }
 

--- a/wwwroot/classes/PlayerQueueEndpoint.php
+++ b/wwwroot/classes/PlayerQueueEndpoint.php
@@ -7,11 +7,11 @@ require_once __DIR__ . '/PlayerQueueController.php';
 require_once __DIR__ . '/PlayerQueueResponse.php';
 require_once __DIR__ . '/JsonResponseEmitter.php';
 
-final class PlayerQueueEndpoint
+final readonly class PlayerQueueEndpoint
 {
     private function __construct(
-        private readonly PlayerQueueController $controller,
-        private readonly JsonResponseEmitter $jsonResponder,
+        final private PlayerQueueController $controller,
+        final private JsonResponseEmitter $jsonResponder,
     ) {
     }
 

--- a/wwwroot/classes/PlayerQueuePollTokenManager.php
+++ b/wwwroot/classes/PlayerQueuePollTokenManager.php
@@ -15,7 +15,7 @@ final readonly class PlayerQueuePollTokenManager
     {
         SessionManager::ensureStarted();
 
-        $token = bin2hex(random_bytes(32));
+        $token = random_bytes(32) |> bin2hex(...);
         $tokens = $this->readTokens();
         $this->purgeExpired($tokens);
         $tokens[$playerName] = [

--- a/wwwroot/classes/Psn100Logger.php
+++ b/wwwroot/classes/Psn100Logger.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-final class Psn100Logger
+final readonly class Psn100Logger
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/TrophyCalculator.php
+++ b/wwwroot/classes/TrophyCalculator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/TrophyMetaStatus.php';
 
-final class TrophyCalculator
+final readonly class TrophyCalculator
 {
     private const int BRONZE_SCORE = 15;
     private const int SILVER_SCORE = 30;
@@ -38,7 +38,7 @@ final class TrophyCalculator
             last_updated_date = %s';
 
     public function __construct(
-        private readonly PDO $database
+        final private PDO $database
     ) {
     }
 

--- a/wwwroot/classes/TrophyListService.php
+++ b/wwwroot/classes/TrophyListService.php
@@ -10,7 +10,7 @@ final readonly class TrophyListService
 {
     public const int PAGE_SIZE = 50;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/TrophyMergeMappingService.php
+++ b/wwwroot/classes/TrophyMergeMappingService.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 /**
  * Matches child trophies to parent merge-title trophies and persists trophy_merge rows.
  */
-final class TrophyMergeMappingService
+final readonly class TrophyMergeMappingService
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/TrophyMergeMetadataRepository.php
+++ b/wwwroot/classes/TrophyMergeMetadataRepository.php
@@ -10,11 +10,11 @@ require_once __DIR__ . '/GameAvailabilityStatus.php';
 /**
  * Persists trophy-title merge metadata: merged status, parent links, platform union, and changelog rows.
  */
-final class TrophyMergeMetadataRepository
+final readonly class TrophyMergeMetadataRepository
 {
     public function __construct(
-        private readonly PDO $database,
-        private readonly NestedDatabaseTransactionRunner $transactionRunner
+        final private PDO $database,
+        final private NestedDatabaseTransactionRunner $transactionRunner
     ) {
     }
 

--- a/wwwroot/classes/TrophyMergeParentOwnershipGuard.php
+++ b/wwwroot/classes/TrophyMergeParentOwnershipGuard.php
@@ -7,11 +7,11 @@ require_once __DIR__ . '/TrophyMergeMetadataRepository.php';
 /**
  * Enforces that a child trophy title may belong to at most one merge parent.
  */
-final class TrophyMergeParentOwnershipGuard
+final readonly class TrophyMergeParentOwnershipGuard
 {
     public function __construct(
-        private readonly PDO $database,
-        private readonly TrophyMergeMetadataRepository $metadataRepository
+        final private PDO $database,
+        final private TrophyMergeMetadataRepository $metadataRepository
     ) {
     }
 
@@ -38,7 +38,9 @@ final class TrophyMergeParentOwnershipGuard
         array $childNpCommunicationIds,
         string $parentNpCommunicationId
     ): void {
-        $uniqueChildNpCommunicationIds = array_values(array_unique($childNpCommunicationIds));
+        $uniqueChildNpCommunicationIds = $childNpCommunicationIds
+            |> array_unique(...)
+            |> array_values(...);
         sort($uniqueChildNpCommunicationIds, SORT_STRING);
 
         foreach ($uniqueChildNpCommunicationIds as $childNpCommunicationId) {

--- a/wwwroot/classes/TrophyMergeRelationshipResolver.php
+++ b/wwwroot/classes/TrophyMergeRelationshipResolver.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 /**
  * Resolves parent/child relationships for merged trophy titles from trophy_merge and trophy_title_meta.
  */
-final class TrophyMergeRelationshipResolver
+final readonly class TrophyMergeRelationshipResolver
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/TrophyService.php
+++ b/wwwroot/classes/TrophyService.php
@@ -6,9 +6,9 @@ require_once __DIR__ . '/TrophyDetails.php';
 require_once __DIR__ . '/PlayerTrophyProgress.php';
 require_once __DIR__ . '/TrophyAchiever.php';
 
-final class TrophyService
+final readonly class TrophyService
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/TrophyTitleCloneService.php
+++ b/wwwroot/classes/TrophyTitleCloneService.php
@@ -12,11 +12,11 @@ require_once __DIR__ . '/MergeNpCommunicationId.php';
  *
  * Encapsulates clone persistence that was previously embedded in TrophyMergeService.
  */
-final class TrophyTitleCloneService
+final readonly class TrophyTitleCloneService
 {
     public function __construct(
-        private readonly PDO $database,
-        private readonly NestedDatabaseTransactionRunner $transactionRunner,
+        final private PDO $database,
+        final private NestedDatabaseTransactionRunner $transactionRunner,
     ) {
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the PHP 8.5 modernization pass with no backward-compatibility constraints:

- Seal promotion-only services/handlers as `final readonly class` and convert promoted constructor deps from `private readonly` to `final private` (matching the established house style on already-readonly types).
- Prefer short pipes for message sanitization, CSRF/queue token generation (`random_bytes(...) |> bin2hex(...)`), and merge child NP ID dedupe (`array_unique` → `array_values`).
- Clean up the malformed Hamming-distance PHPDoc on `ImageHashCalculator`.

Classes with class-body caches, property defaults, or non-readonly parents were left unchanged so sealing stays sound.

## Test plan

- [x] `php -l` on all changed files
- [x] `php tests/run.php` — all 1069 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48a2e55a-936a-4833-864b-9341c192d6c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48a2e55a-936a-4833-864b-9341c192d6c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

