### PR TITLE
Seal immutable PHP services as readonly and prefer short pipes

### DIFF
--- a/tests/GameHistoryPageTest.php
+++ b/tests/GameHistoryPageTest.php
@@ -70,7 +70,7 @@ final class GameHistoryPageTest extends TestCase
             'rarity_points' => 0,
         ]);
 
-        $gameService = new class ($game) extends GameService {
+        $gameService = new readonly class ($game) extends GameService {
             private GameDetails $game;
 
             public function __construct(GameDetails $game)
@@ -86,7 +86,7 @@ final class GameHistoryPageTest extends TestCase
 
         $historyService = new GameHistoryService($database);
 
-        $headerService = new class extends GameHeaderService {
+        $headerService = new readonly class extends GameHeaderService {
             public function __construct()
             {
             }

--- a/tests/GameLeaderboardPageTest.php
+++ b/tests/GameLeaderboardPageTest.php
@@ -82,7 +82,7 @@ final class GameLeaderboardPageTest extends TestCase
 
         $this->insertGame(1, 'NPWR00001_00', 'Example Game');
         $this->leaderboardService = new GameLeaderboardService($this->database);
-        $this->headerService = new class extends GameHeaderService {
+        $this->headerService = new readonly class extends GameHeaderService {
             public function __construct()
             {
             }

--- a/tests/PlayerAdvisorPageTest.php
+++ b/tests/PlayerAdvisorPageTest.php
@@ -75,7 +75,7 @@ final class PlayerAdvisorPageTest extends TestCase
         );
 
         $this->advisorService = new PlayerAdvisorService($this->database, new Utility());
-        $this->summaryService = new class($this->database) extends PlayerSummaryService {
+        $this->summaryService = new readonly class($this->database) extends PlayerSummaryService {
             public function getSummary(int $accountId): PlayerSummary
             {
                 return new PlayerSummary(0, 0, null, 0);

--- a/tests/PlayerLogPageContextTest.php
+++ b/tests/PlayerLogPageContextTest.php
@@ -110,7 +110,7 @@ final class PlayerLogPageContextTest extends TestCase
         PlayerStatus $playerStatus,
         int $accountId
     ): PlayerLogPage {
-        $service = new class($entries) extends PlayerLogService {
+        $service = new readonly class($entries) extends PlayerLogService {
             /** @var PlayerLogEntry[] */
             private array $entries;
 

--- a/tests/PlayerRandomGamesPageContextTest.php
+++ b/tests/PlayerRandomGamesPageContextTest.php
@@ -112,7 +112,7 @@ final class PlayerRandomGamesPageContextTest extends TestCase
         PlayerStatus $playerStatus,
         int $accountId
     ): PlayerRandomGamesPage {
-        $randomGamesService = new class($randomGames) extends PlayerRandomGamesService {
+        $randomGamesService = new readonly class($randomGames) extends PlayerRandomGamesService {
             /** @var PlayerRandomGame[] */
             private array $randomGames;
 
@@ -127,7 +127,7 @@ final class PlayerRandomGamesPageContextTest extends TestCase
             }
         };
 
-        $summaryService = new class($playerSummary) extends PlayerSummaryService {
+        $summaryService = new readonly class($playerSummary) extends PlayerSummaryService {
             private PlayerSummary $summary;
 
             public function __construct(PlayerSummary $summary)

--- a/tests/PlayerReportServiceTest.php
+++ b/tests/PlayerReportServiceTest.php
@@ -161,7 +161,7 @@ final class PlayerReportServiceTest extends TestCase
     }
 }
 
-final class UnavailableIpSubmissionLockExecutor extends IpSubmissionLockExecutor
+final readonly class UnavailableIpSubmissionLockExecutor extends IpSubmissionLockExecutor
 {
     public function __construct()
     {

--- a/tests/PlayerTimelinePageContextTest.php
+++ b/tests/PlayerTimelinePageContextTest.php
@@ -107,7 +107,7 @@ final class PlayerTimelinePageContextTest extends TestCase
         ?PlayerTimelineData $timelineData,
         PlayerStatus $status
     ): PlayerTimelinePage {
-        $summaryService = new class($summary) extends PlayerSummaryService {
+        $summaryService = new readonly class($summary) extends PlayerSummaryService {
             private PlayerSummary $summary;
 
             public function __construct(PlayerSummary $summary)

--- a/tests/PlayerTimelinePageTest.php
+++ b/tests/PlayerTimelinePageTest.php
@@ -82,7 +82,7 @@ final class PlayerTimelinePageTest extends TestCase
 
     private function createSummaryService(PlayerSummary $summary): PlayerSummaryService
     {
-        return new class($summary) extends PlayerSummaryService {
+        return new readonly class($summary) extends PlayerSummaryService {
             private PlayerSummary $summary;
 
             public function __construct(PlayerSummary $summary)

--- a/wwwroot/classes/AboutPageScanLogController.php
+++ b/wwwroot/classes/AboutPageScanLogController.php
@@ -11,19 +11,19 @@ require_once __DIR__ . '/IpRateLimitService.php';
 require_once __DIR__ . '/IpRateLimitBucket.php';
 require_once __DIR__ . '/IpAddressResolver.php';
 
-final class AboutPageScanLogController
+final readonly class AboutPageScanLogController
 {
     private const int DEFAULT_LIMIT = 30;
     private const int MIN_LIMIT = 1;
     private const int MAX_LIMIT = 100;
 
     public function __construct(
-        private readonly AboutPageDataProviderInterface $aboutPageService,
-        private readonly JsonResponseEmitter $jsonResponder,
-        private readonly ?IpRateLimitService $rateLimitService = null,
-        private readonly int $defaultLimit = self::DEFAULT_LIMIT,
-        private readonly int $minLimit = self::MIN_LIMIT,
-        private readonly int $maxLimit = self::MAX_LIMIT,
+        final private AboutPageDataProviderInterface $aboutPageService,
+        final private JsonResponseEmitter $jsonResponder,
+        final private ?IpRateLimitService $rateLimitService = null,
+        final private int $defaultLimit = self::DEFAULT_LIMIT,
+        final private int $minLimit = self::MIN_LIMIT,
+        final private int $maxLimit = self::MAX_LIMIT,
     ) {
     }
 

--- a/wwwroot/classes/Admin/GameRescanPsnAccessor.php
+++ b/wwwroot/classes/Admin/GameRescanPsnAccessor.php
@@ -10,15 +10,15 @@ require_once __DIR__ . '/PlayStationWorkerAuthenticator.php';
  * Extracted from GameRescanService so rescan orchestration stays separate from
  * database title resolution and PlayStation API player discovery.
  */
-final class GameRescanPsnAccessor
+final readonly class GameRescanPsnAccessor
 {
     private const string ORIGINAL_GAME_PREFIX = 'NPWR';
     private const int LOGIN_RETRY_DELAY_SECONDS = 300;
     private const int ACCESSIBLE_PLAYER_PROBE_BATCH_SIZE = 100;
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly PlayStationWorkerAuthenticator $workerAuthenticator,
+        final private PDO $database,
+        final private PlayStationWorkerAuthenticator $workerAuthenticator,
     ) {
     }
 

--- a/wwwroot/classes/Admin/MergeTrophyGroupCopier.php
+++ b/wwwroot/classes/Admin/MergeTrophyGroupCopier.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/TrophyGroupConflictResolver.php';
 /**
  * Copies trophy groups from a child title into a MERGE parent during admin copy.
  */
-final class MergeTrophyGroupCopier
+final readonly class MergeTrophyGroupCopier
 {
     private const string TROPHY_GROUP_UPDATE_QUERY = <<<'SQL'
         WITH
@@ -72,8 +72,8 @@ final class MergeTrophyGroupCopier
         SQL;
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly TrophyGroupConflictResolver $groupConflictResolver = new TrophyGroupConflictResolver()
+        final private PDO $database,
+        final private TrophyGroupConflictResolver $groupConflictResolver = new TrophyGroupConflictResolver()
     ) {
     }
 

--- a/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
+++ b/wwwroot/classes/Admin/PlayStationWorkerAuthenticator.php
@@ -13,7 +13,7 @@ use Tustin\PlayStation\Client;
  * Centralizes login orchestration that was previously duplicated across
  * PsnGameLookupService, GameRescanService, and ThirtyMinuteCronJob.
  */
-final class PlayStationWorkerAuthenticator
+final readonly class PlayStationWorkerAuthenticator
 {
     private const \Closure DEFAULT_CLIENT_FACTORY = static function (): object {
         return new Client();
@@ -30,27 +30,27 @@ final class PlayStationWorkerAuthenticator
     /**
      * @var \Closure(): iterable<Worker>
      */
-    private readonly \Closure $workerFetcher;
+    private \Closure $workerFetcher;
 
     /**
      * @var \Closure(): object
      */
-    private readonly \Closure $clientFactory;
+    private \Closure $clientFactory;
 
     /**
      * @var \Closure(int, string): void
      */
-    private readonly \Closure $refreshTokenSaver;
+    private \Closure $refreshTokenSaver;
 
     /**
      * @var \Closure(int): void
      */
-    private readonly \Closure $sleeper;
+    private \Closure $sleeper;
 
     /**
      * @var \Closure(int, string): void|null
      */
-    private readonly ?\Closure $refreshTokenPersistenceFailureHandler;
+    private ?\Closure $refreshTokenPersistenceFailureHandler;
 
     public function __construct(
         callable $workerFetcher,

--- a/wwwroot/classes/Admin/PossibleCheaterService.php
+++ b/wwwroot/classes/Admin/PossibleCheaterService.php
@@ -7,13 +7,13 @@ require_once __DIR__ . '/PossibleCheaterRulesCatalog.php';
 require_once __DIR__ . '/PossibleCheaterReport.php';
 require_once __DIR__ . '/../PlayerStatus.php';
 
-final class PossibleCheaterService
+final readonly class PossibleCheaterService
 {
-    private readonly PossibleCheaterRulesCatalog $rulesCatalog;
-    private readonly PossibleCheaterRuleConditionParser $conditionParser;
+    private PossibleCheaterRulesCatalog $rulesCatalog;
+    private PossibleCheaterRuleConditionParser $conditionParser;
 
     public function __construct(
-        private readonly PDO $database,
+        final private PDO $database,
         ?PossibleCheaterRulesCatalog $rulesCatalog = null,
         ?PossibleCheaterRuleConditionParser $conditionParser = null,
     ) {

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -14,14 +14,14 @@ require_once __DIR__ . '/../NpServiceName.php';
 
 use Tustin\PlayStation\Client;
 
-final class PsnGameLookupService
+final readonly class PsnGameLookupService
 {
-    private readonly PlayStationWorkerAuthenticator $workerAuthenticator;
-    private readonly PsnTrophyApiPayloadInspector $payloadInspector;
-    private readonly PsnTrophyGroupAssembler $trophyGroupAssembler;
+    private PlayStationWorkerAuthenticator $workerAuthenticator;
+    private PsnTrophyApiPayloadInspector $payloadInspector;
+    private PsnTrophyGroupAssembler $trophyGroupAssembler;
 
     public function __construct(
-        private readonly PDO $database,
+        final private PDO $database,
         callable $workerFetcher,
         ?callable $clientFactory = null,
         ?callable $refreshTokenSaver = null,

--- a/wwwroot/classes/Admin/PsnPlayerLookupService.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupService.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
 
 use Tustin\PlayStation\Client;
 
-final class PsnPlayerLookupService
+final readonly class PsnPlayerLookupService
 {
     private const \Closure DEFAULT_CLIENT_FACTORY = static function (): object {
         return new Client();
@@ -24,16 +24,16 @@ final class PsnPlayerLookupService
     /**
      * @var \Closure(): iterable<Worker>
      */
-    private readonly \Closure $workerFetcher;
+    private \Closure $workerFetcher;
 
     /**
      * @var \Closure(): object
      */
-    private readonly \Closure $clientFactory;
+    private \Closure $clientFactory;
     /**
      * @var \Closure(int, string): void
      */
-    private readonly \Closure $refreshTokenSaver;
+    private \Closure $refreshTokenSaver;
 
     /**
      * @param callable(): iterable<Worker> $workerFetcher

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/../PsnHttpExceptionClassifier.php';
 
 use Tustin\PlayStation\Client;
 
-final class PsnTrophyTitleComparisonService
+final readonly class PsnTrophyTitleComparisonService
 {
     public const string SOURCE_DIRECT = PsnTrophyTitleComparisonSource::Direct->value;
     public const string SOURCE_TUSTIN = PsnTrophyTitleComparisonSource::Tustin->value;
@@ -32,21 +32,21 @@ final class PsnTrophyTitleComparisonService
     /**
      * @var \Closure(): iterable<Worker>
      */
-    private readonly \Closure $workerFetcher;
+    private \Closure $workerFetcher;
 
     /**
      * @var \Closure(): object
      */
-    private readonly \Closure $clientFactory;
+    private \Closure $clientFactory;
     /**
      * @var \Closure(int, string): void
      */
-    private readonly \Closure $refreshTokenSaver;
+    private \Closure $refreshTokenSaver;
 
     /**
      * @var \Closure(): float
      */
-    private readonly \Closure $timeProvider;
+    private \Closure $timeProvider;
 
     /**
      * @param callable(): iterable<Worker> $workerFetcher

--- a/wwwroot/classes/Admin/PsnpPlusService.php
+++ b/wwwroot/classes/Admin/PsnpPlusService.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/PsnpPlusGame.php';
 require_once __DIR__ . '/../PsnpPlusClient.php';
 require_once __DIR__ . '/../TrophyMetaStatus.php';
 
-final class PsnpPlusService
+final readonly class PsnpPlusService
 {
     /**
      * @var list<int>
@@ -24,10 +24,10 @@ final class PsnpPlusService
         35758, 40301,
     ];
 
-    private readonly PsnpPlusClient $psnpPlusClient;
+    private PsnpPlusClient $psnpPlusClient;
 
     public function __construct(
-        private readonly PDO $database,
+        final private PDO $database,
         ?PsnpPlusClient $psnpPlusClient = null,
     ) {
         $this->psnpPlusClient = $psnpPlusClient ?? new PsnpPlusClient();

--- a/wwwroot/classes/Admin/TrophyStatusService.php
+++ b/wwwroot/classes/Admin/TrophyStatusService.php
@@ -6,12 +6,12 @@ require_once __DIR__ . '/TrophyStatusUpdateResult.php';
 require_once __DIR__ . '/TrophyStatusProgressRecalculator.php';
 require_once __DIR__ . '/../TrophyMetaStatus.php';
 
-final class TrophyStatusService
+final readonly class TrophyStatusService
 {
-    private readonly TrophyStatusProgressRecalculator $progressRecalculator;
+    private TrophyStatusProgressRecalculator $progressRecalculator;
 
     public function __construct(
-        private readonly PDO $database,
+        final private PDO $database,
         ?TrophyStatusProgressRecalculator $progressRecalculator = null,
     ) {
         $this->progressRecalculator = $progressRecalculator ?? new TrophyStatusProgressRecalculator($database);

--- a/wwwroot/classes/Admin/WorkerService.php
+++ b/wwwroot/classes/Admin/WorkerService.php
@@ -10,16 +10,16 @@ require_once __DIR__ . '/SystemCommandExecutor.php';
 require_once __DIR__ . '/WorkerSortField.php';
 require_once __DIR__ . '/WorkerSortDirection.php';
 
-final class WorkerService
+final readonly class WorkerService
 {
-    private readonly CommandExecutorInterface $commandExecutor;
+    private CommandExecutorInterface $commandExecutor;
 
     private const string WORKER_USERNAME = 'psn100';
 
     private const string WORKER_SCRIPT = '30th_minute.php';
 
     public function __construct(
-        private readonly PDO $database,
+        final private PDO $database,
         ?CommandExecutorInterface $commandExecutor = null,
     ) {
         $this->commandExecutor = $commandExecutor ?? new SystemCommandExecutor();

--- a/wwwroot/classes/Cron/CronJobApplication.php
+++ b/wwwroot/classes/Cron/CronJobApplication.php
@@ -11,9 +11,9 @@ require_once __DIR__ . '/CronJobRunner.php';
  * the scripts become easier to read and are now focused solely on describing
  * which job to execute.
  */
-final class CronJobApplication
+final readonly class CronJobApplication
 {
-    private function __construct(private readonly CronJobRunner $runner)
+    private function __construct(final private CronJobRunner $runner)
     {
     }
 

--- a/wwwroot/classes/Cron/CronWorkerLoginSession.php
+++ b/wwwroot/classes/Cron/CronWorkerLoginSession.php
@@ -12,16 +12,16 @@ require_once __DIR__ . '/WorkerScanCoordinator.php';
  * Extracted from ThirtyMinuteCronJob so login backoff and release behavior can be
  * tested without running the full player scan loop.
  */
-final class CronWorkerLoginSession
+final readonly class CronWorkerLoginSession
 {
     private const \Closure DEFAULT_SLEEPER = sleep(...);
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly PlayStationWorkerAuthenticator $workerAuthenticator,
-        private readonly WorkerScanCoordinator $workerScanCoordinator,
-        private readonly Psn100Logger $logger,
-        private readonly \Closure $sleeper = self::DEFAULT_SLEEPER,
+        final private PDO $database,
+        final private PlayStationWorkerAuthenticator $workerAuthenticator,
+        final private WorkerScanCoordinator $workerScanCoordinator,
+        final private Psn100Logger $logger,
+        final private \Closure $sleeper = self::DEFAULT_SLEEPER,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
@@ -12,12 +12,12 @@ require_once __DIR__ . '/../AvatarSize.php';
  * Encapsulates avatar filesystem and catalog logic that was previously embedded in
  * PlayerScanProfileSynchronizer.
  */
-final class PlayerAvatarSynchronizer
+final readonly class PlayerAvatarSynchronizer
 {
     public function __construct(
-        private readonly PDO $database,
-        private readonly ImageHashCalculator $imageHashCalculator,
-        private readonly string $avatarStorageDirectory = '/home/psn100/public_html/img/avatar/',
+        final private PDO $database,
+        final private ImageHashCalculator $imageHashCalculator,
+        final private string $avatarStorageDirectory = '/home/psn100/public_html/img/avatar/',
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerCountryResolver.php
+++ b/wwwroot/classes/Cron/PlayerCountryResolver.php
@@ -12,10 +12,10 @@ require_once __DIR__ . '/../PlayerCountryCode.php';
  * Encapsulates npId decoding, stored-country lookup, live PSN search, and
  * country persistence that were previously embedded in PlayerScanProfileSynchronizer.
  */
-final class PlayerCountryResolver
+final readonly class PlayerCountryResolver
 {
     public function __construct(
-        private readonly PDO $database,
+        final private PDO $database,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerEarnedTrophyPersister.php
+++ b/wwwroot/classes/Cron/PlayerEarnedTrophyPersister.php
@@ -10,12 +10,12 @@ require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
  *
  * Encapsulates trophy_earned upsert logic that was previously embedded in ThirtyMinuteCronJob.
  */
-final class PlayerEarnedTrophyPersister
+final readonly class PlayerEarnedTrophyPersister
 {
-    private readonly PlayerScanTitleMetadataHelper $titleMetadataHelper;
+    private PlayerScanTitleMetadataHelper $titleMetadataHelper;
 
     public function __construct(
-        private readonly PDO $database,
+        final private PDO $database,
         ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
     ) {
         $this->titleMetadataHelper = $titleMetadataHelper ?? new PlayerScanTitleMetadataHelper();

--- a/wwwroot/classes/Cron/PlayerRankingUpdater.php
+++ b/wwwroot/classes/Cron/PlayerRankingUpdater.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../Psn100Logger.php';
 require_once __DIR__ . '/../PlayerStatus.php';
 
-final class PlayerRankingUpdater
+final readonly class PlayerRankingUpdater
 {
     private const string TEMPORARY_TABLE = 'player_ranking_new';
     private const string PRIMARY_TABLE = 'player_ranking';
@@ -52,11 +52,11 @@ WHERE `status` =
 SQL . PlayerStatus::NORMAL->value;
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly int $retryDelaySeconds = self::DEFAULT_RETRY_DELAY_SECONDS,
-        private readonly int $maxRetryDelaySeconds = self::DEFAULT_MAX_RETRY_DELAY_SECONDS,
-        private readonly ?Psn100Logger $logger = null,
-        private readonly \Closure $sleeper = self::DEFAULT_SLEEPER,
+        final private PDO $database,
+        final private int $retryDelaySeconds = self::DEFAULT_RETRY_DELAY_SECONDS,
+        final private int $maxRetryDelaySeconds = self::DEFAULT_MAX_RETRY_DELAY_SECONDS,
+        final private ?Psn100Logger $logger = null,
+        final private \Closure $sleeper = self::DEFAULT_SLEEPER,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanCatalogSideEffects.php
+++ b/wwwroot/classes/Cron/PlayerScanCatalogSideEffects.php
@@ -15,12 +15,12 @@ require_once __DIR__ . '/PlayerScanNewTitleMergeHandler.php';
  * Encapsulates history recording, automatic merge triggers, and changelog insertion that
  * were previously embedded in PlayerScanTitleCatalogSynchronizer.
  */
-final class PlayerScanCatalogSideEffects
+final readonly class PlayerScanCatalogSideEffects
 {
     public function __construct(
-        private readonly PDO $database,
-        private readonly ?TrophyHistoryRecorder $historyRecorder = null,
-        private readonly ?PlayerScanNewTitleMergeHandler $newTitleMergeHandler = null,
+        final private PDO $database,
+        final private ?TrophyHistoryRecorder $historyRecorder = null,
+        final private ?PlayerScanNewTitleMergeHandler $newTitleMergeHandler = null,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanPrivacyService.php
+++ b/wwwroot/classes/Cron/PlayerScanPrivacyService.php
@@ -11,14 +11,14 @@ require_once __DIR__ . '/PlayerScanTrophySummaryAccessResult.php';
  * Encapsulates private-profile detection and persistence that were previously
  * embedded in ThirtyMinuteCronJob and PlayerScanProfileSynchronizer.
  */
-final class PlayerScanPrivacyService
+final readonly class PlayerScanPrivacyService
 {
     private const \Closure DEFAULT_SLEEPER = sleep(...);
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly WorkerScanCoordinator $workerScanCoordinator,
-        private readonly \Closure $sleeper = self::DEFAULT_SLEEPER,
+        final private PDO $database,
+        final private WorkerScanCoordinator $workerScanCoordinator,
+        final private \Closure $sleeper = self::DEFAULT_SLEEPER,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanProfileSynchronizer.php
@@ -20,19 +20,19 @@ use Tustin\PlayStation\Client;
  * Encapsulates profile lookup, country resolution, and player persistence that were
  * previously embedded in ThirtyMinuteCronJob.
  */
-final class PlayerScanProfileSynchronizer
+final readonly class PlayerScanProfileSynchronizer
 {
     private const int MAX_INVALID_API_RESPONSE_ATTEMPTS = 2;
 
-    private readonly PlayerAvatarSynchronizer $avatarSynchronizer;
-    private readonly PlayerCountryResolver $countryResolver;
-    private readonly PlayerScanPrivacyService $privacyService;
-    private readonly PlayerRepository $playerRepository;
+    private PlayerAvatarSynchronizer $avatarSynchronizer;
+    private PlayerCountryResolver $countryResolver;
+    private PlayerScanPrivacyService $privacyService;
+    private PlayerRepository $playerRepository;
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly Psn100Logger $logger,
-        private readonly WorkerScanCoordinator $workerScanCoordinator,
+        final private PDO $database,
+        final private Psn100Logger $logger,
+        final private WorkerScanCoordinator $workerScanCoordinator,
         ?PlayerAvatarSynchronizer $avatarSynchronizer = null,
         ?PlayerCountryResolver $countryResolver = null,
         ?PlayerScanPrivacyService $privacyService = null,

--- a/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleCatalogSynchronizer.php
@@ -23,24 +23,24 @@ require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
  * Encapsulates per-title catalog synchronization that was previously embedded in
  * ThirtyMinuteCronJob.
  */
-final class PlayerScanTitleCatalogSynchronizer
+final readonly class PlayerScanTitleCatalogSynchronizer
 {
     /**
      * @param null|\Closure(string, object): array<string, mixed> $trophyDataFetcher
      */
     public function __construct(
-        private readonly PDO $database,
-        private readonly Psn100Logger $logger,
-        private readonly ?PsnGameLookupService $psnGameLookupService = null,
-        private readonly ?TrophyImageDirectories $imageDirectories = null,
-        private readonly ?TrophyImageDownloader $imageDownloader = null,
-        private readonly ?TrophyTitleNameFormatter $trophyTitleNameFormatter = null,
-        private readonly ?TrophyCatalogSynchronizer $trophyCatalogSynchronizer = null,
-        private readonly ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
-        private readonly ?TrophyMetaRepository $trophyMetaRepository = null,
-        private readonly ?PlayerScanCatalogSideEffects $catalogSideEffects = null,
-        private readonly ?\Closure $trophyDataFetcher = null,
-        private readonly ?PlayerScanTitleHeaderSynchronizer $titleHeaderSynchronizer = null,
+        final private PDO $database,
+        final private Psn100Logger $logger,
+        final private ?PsnGameLookupService $psnGameLookupService = null,
+        final private ?TrophyImageDirectories $imageDirectories = null,
+        final private ?TrophyImageDownloader $imageDownloader = null,
+        final private ?TrophyTitleNameFormatter $trophyTitleNameFormatter = null,
+        final private ?TrophyCatalogSynchronizer $trophyCatalogSynchronizer = null,
+        final private ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
+        final private ?TrophyMetaRepository $trophyMetaRepository = null,
+        final private ?PlayerScanCatalogSideEffects $catalogSideEffects = null,
+        final private ?\Closure $trophyDataFetcher = null,
+        final private ?PlayerScanTitleHeaderSynchronizer $titleHeaderSynchronizer = null,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
@@ -16,15 +16,15 @@ require_once __DIR__ . '/PlayerScanTitleMetadataHelper.php';
  * Extracted from PlayerScanTitleCatalogSynchronizer so per-title catalog sync can
  * delegate title-row persistence separately from group and trophy iteration.
  */
-final class PlayerScanTitleHeaderSynchronizer
+final readonly class PlayerScanTitleHeaderSynchronizer
 {
     public function __construct(
-        private readonly PDO $database,
-        private readonly TrophyCatalogSynchronizer $catalogSynchronizer,
-        private readonly TrophyImageDirectories $imageDirectories,
-        private readonly TrophyImageDownloader $imageDownloader,
-        private readonly ?TrophyTitleNameFormatter $trophyTitleNameFormatter = null,
-        private readonly ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
+        final private PDO $database,
+        final private TrophyCatalogSynchronizer $catalogSynchronizer,
+        final private TrophyImageDirectories $imageDirectories,
+        final private TrophyImageDownloader $imageDownloader,
+        final private ?TrophyTitleNameFormatter $trophyTitleNameFormatter = null,
+        final private ?PlayerScanTitleMetadataHelper $titleMetadataHelper = null,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleLoop.php
@@ -17,21 +17,21 @@ require_once __DIR__ . '/WorkerScanCoordinator.php';
  * Encapsulates the per-title iteration, retry guards, and stale-game cleanup that
  * were previously embedded in ThirtyMinuteCronJob.
  */
-final class PlayerScanTrophyTitleLoop
+final readonly class PlayerScanTrophyTitleLoop
 {
     private const \Closure DEFAULT_SLEEPER = sleep(...);
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly Psn100Logger $logger,
-        private readonly WorkerScanCoordinator $workerScanCoordinator,
-        private readonly PlayerScanTitleMetadataHelper $titleMetadataHelper,
-        private readonly PlayerScanTitleCatalogSynchronizer $titleCatalogSynchronizer,
-        private readonly PlayerScanTrophyProgressSynchronizer $trophyProgressSynchronizer,
-        private readonly PlayerScanStaleGameDeletionService $staleGameDeletionService,
-        private readonly PlayerScanCompletionService $scanCompletionService,
-        private readonly PlayerScanTrophyTitleRefresher $trophyTitleRefresher,
-        private readonly \Closure $sleeper = self::DEFAULT_SLEEPER,
+        final private PDO $database,
+        final private Psn100Logger $logger,
+        final private WorkerScanCoordinator $workerScanCoordinator,
+        final private PlayerScanTitleMetadataHelper $titleMetadataHelper,
+        final private PlayerScanTitleCatalogSynchronizer $titleCatalogSynchronizer,
+        final private PlayerScanTrophyProgressSynchronizer $trophyProgressSynchronizer,
+        final private PlayerScanStaleGameDeletionService $staleGameDeletionService,
+        final private PlayerScanCompletionService $scanCompletionService,
+        final private PlayerScanTrophyTitleRefresher $trophyTitleRefresher,
+        final private \Closure $sleeper = self::DEFAULT_SLEEPER,
     ) {
     }
 

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -14,11 +14,11 @@ require_once __DIR__ . '/PsnpPlusClient.php';
 require_once __DIR__ . '/Html.php';
 require_once __DIR__ . '/TrophyMetaStatus.php';
 
-class GameHeaderService
+readonly class GameHeaderService
 {
     public function __construct(
-        private readonly PDO $database,
-        private readonly PsnpPlusClient $psnpPlusClient = new PsnpPlusClient()
+        final private PDO $database,
+        final private PsnpPlusClient $psnpPlusClient = new PsnpPlusClient()
     ) {
     }
 

--- a/wwwroot/classes/GameHistoryRenderer.php
+++ b/wwwroot/classes/GameHistoryRenderer.php
@@ -142,9 +142,9 @@ final readonly class GameHistoryRenderer
             return '<span class="history-diff__empty">&mdash;</span>';
         }
 
-        $escaped = Html::escape($value);
+        $escaped = $value |> Html::escape(...);
 
-        return $isMultiline ? nl2br($escaped) : $escaped;
+        return $isMultiline ? ($escaped |> nl2br(...)) : $escaped;
     }
 
     private function formatNumber(?int $value): string

--- a/wwwroot/classes/GameService.php
+++ b/wwwroot/classes/GameService.php
@@ -9,9 +9,9 @@ require_once __DIR__ . '/GameTrophySort.php';
 require_once __DIR__ . '/TrophyGroupId.php';
 require_once __DIR__ . '/TrophyType.php';
 
-class GameService
+readonly class GameService
 {
-    public function __construct(private readonly PDO $database) {}
+    public function __construct(final private PDO $database) {}
 
     public function getGame(int $gameId): ?GameDetails
     {

--- a/wwwroot/classes/IpSubmissionLockExecutor.php
+++ b/wwwroot/classes/IpSubmissionLockExecutor.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IpSubmissionLockUnavailableException.php';
 
-class IpSubmissionLockExecutor
+readonly class IpSubmissionLockExecutor
 {
     private const string LOCK_NAME_PREFIX = 'psn100:ip:';
 
     private const int MYSQL_LOCK_NAME_MAX_LENGTH = 64;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/MaintenancePageRenderer.php
+++ b/wwwroot/classes/MaintenancePageRenderer.php
@@ -14,7 +14,7 @@ final readonly class MaintenancePageRenderer
         $heading = $this->escape($page->getHeading());
         $description = $this->escape($page->getDescription());
         $author = $this->escape($page->getAuthor());
-        $message = nl2br($this->escape($page->getMessage()));
+        $message = $page->getMessage() |> $this->escape(...) |> nl2br(...);
         $stylesheets = $this->renderStylesheets($page->getStylesheets());
 
         return <<<HTML

--- a/wwwroot/classes/PlayerLogService.php
+++ b/wwwroot/classes/PlayerLogService.php
@@ -8,11 +8,11 @@ require_once __DIR__ . '/PlatformSql.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
 require_once __DIR__ . '/TrophyMetaStatus.php';
 
-class PlayerLogService
+readonly class PlayerLogService
 {
     public const int PAGE_SIZE = 50;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/PlayerQueueResponseFactory.php
+++ b/wwwroot/classes/PlayerQueueResponseFactory.php
@@ -11,14 +11,14 @@ require_once __DIR__ . '/PlayerQueueMessageBuilder.php';
 require_once __DIR__ . '/PlayerQueueMessagePartType.php';
 require_once __DIR__ . '/PlayerUrlBuilder.php';
 
-final class PlayerQueueResponseFactory
+final readonly class PlayerQueueResponseFactory
 {
     private const string EMPTY_NAME_MESSAGE = "PSN name can't be empty.";
 
 
     private const string BUSY_MESSAGE = 'The server is busy processing another request. Please try again in a moment.';
 
-    public function __construct(private readonly PlayerQueueService $service)
+    public function __construct(final private PlayerQueueService $service)
     {
     }
 

--- a/wwwroot/classes/PlayerRandomGamesService.php
+++ b/wwwroot/classes/PlayerRandomGamesService.php
@@ -7,13 +7,13 @@ use Random\Randomizer;
 require_once __DIR__ . '/PlatformSql.php';
 require_once __DIR__ . '/GameAvailabilityStatus.php';
 
-class PlayerRandomGamesService
+readonly class PlayerRandomGamesService
 {
-    private readonly Randomizer $randomizer;
+    private Randomizer $randomizer;
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly Utility $utility,
+        final private PDO $database,
+        final private Utility $utility,
         ?Randomizer $randomizer = null,
     ) {
         $this->randomizer = $randomizer ?? new Randomizer();

--- a/wwwroot/classes/PlayerReportHandler.php
+++ b/wwwroot/classes/PlayerReportHandler.php
@@ -8,11 +8,11 @@ require_once __DIR__ . '/PlayerReportRequest.php';
 require_once __DIR__ . '/IpRateLimitService.php';
 require_once __DIR__ . '/IpRateLimitBucket.php';
 
-final class PlayerReportHandler
+final readonly class PlayerReportHandler
 {
     public function __construct(
-        private readonly PlayerReportService $playerReportService,
-        private readonly ?IpRateLimitService $rateLimitService = null,
+        final private PlayerReportService $playerReportService,
+        final private ?IpRateLimitService $rateLimitService = null,
     ) {
     }
 

--- a/wwwroot/classes/PlayerSummaryService.php
+++ b/wwwroot/classes/PlayerSummaryService.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/GameAvailabilityStatus.php';
 
-class PlayerSummaryService
+readonly class PlayerSummaryService
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/TrophyCatalogSynchronizer.php
+++ b/wwwroot/classes/TrophyCatalogSynchronizer.php
@@ -7,10 +7,10 @@ require_once __DIR__ . '/CommaSeparatedValues.php';
 /**
  * Persists trophy catalog rows shared between player scans and admin rescans.
  */
-final class TrophyCatalogSynchronizer
+final readonly class TrophyCatalogSynchronizer
 {
     public function __construct(
-        private readonly PDO $database,
+        final private PDO $database,
     ) {
     }
 

--- a/wwwroot/classes/TrophyMergeEarnedCopier.php
+++ b/wwwroot/classes/TrophyMergeEarnedCopier.php
@@ -9,9 +9,9 @@ require_once __DIR__ . '/Admin/TrophyMergeProgressListener.php';
  *
  * Previously embedded in TrophyMergeService.
  */
-final class TrophyMergeEarnedCopier
+final readonly class TrophyMergeEarnedCopier
 {
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/TrophyMergePlayerProgressUpdater.php
+++ b/wwwroot/classes/TrophyMergePlayerProgressUpdater.php
@@ -12,13 +12,13 @@ require_once __DIR__ . '/MergeNpCommunicationId.php';
  * Resolves parent/child relationships, then delegates aggregate recalculation
  * to TrophyMergePlayerProgressRecalculator.
  */
-final class TrophyMergePlayerProgressUpdater
+final readonly class TrophyMergePlayerProgressUpdater
 {
-    private readonly TrophyMergeRelationshipResolver $relationshipResolver;
-    private readonly TrophyMergePlayerProgressRecalculator $progressRecalculator;
+    private TrophyMergeRelationshipResolver $relationshipResolver;
+    private TrophyMergePlayerProgressRecalculator $progressRecalculator;
 
     public function __construct(
-        private readonly PDO $database,
+        final private PDO $database,
         ?TrophyMergeRelationshipResolver $relationshipResolver = null,
         ?TrophyMergePlayerProgressRecalculator $progressRecalculator = null,
     ) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues PHP 8.5 modernization with no backward-compatibility constraints:

- Seal immutable cron/admin/player services and helpers as `final readonly class` (or `readonly class` when tests still subclass them for stubs), converting promoted constructor deps from `private readonly` to `final private` to match the established house style.
- Prefer short pipes for escape/`nl2br` chains in `GameHistoryRenderer` and `MaintenancePageRenderer`, consistent with existing template usage.

Classes with mutable caches, builders, lazy state, or non-readonly parents (including exceptions extending `RuntimeException`) were left unchanged. Test doubles that only hold constructor fixtures were updated to `readonly` subclasses; spies that mutate after construction keep non-readonly parents.

## Test plan

- [x] `php -l` on changed files
- [x] `php tests/run.php` — all 1069 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4bec89c1-9a73-4bda-88dd-d8c000af0fed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4bec89c1-9a73-4bda-88dd-d8c000af0fed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

