### PR TITLE
Fix admin rescan mapping PSPC platform to PC

### DIFF
--- a/tests/GameRescanCatalogUpdaterTest.php
+++ b/tests/GameRescanCatalogUpdaterTest.php
@@ -195,6 +195,40 @@ final class GameRescanCatalogUpdaterTest extends TestCase
 
         $this->assertSame('PSVR2', $platform);
     }
+
+    public function testUpdateFromPsnMapsPspcPlatformToPc(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, detail, icon_url, platform, set_version)
+            VALUES ('NPWR00001_00', 'Details', 'title.png', 'PS5', '01.00')"
+        );
+        $this->groupDataFetcher->setGroupData([]);
+
+        $differenceTracker = new GameRescanDifferenceTracker();
+        $progressReporter = new GameRescanProgressReporter();
+        $trophyTitle = new GameRescanCatalogUpdaterTestTrophyTitle(
+            detail: 'Details',
+            setVersion: '01.00',
+            platforms: [
+                new GameRescanCatalogUpdaterTestPlatform('PS5'),
+                new GameRescanCatalogUpdaterTestPlatform('PSPC'),
+            ],
+        );
+
+        $this->catalogUpdater->updateFromPsn(
+            new \Tustin\PlayStation\Client(),
+            $trophyTitle,
+            'NPWR00001_00',
+            $progressReporter,
+            $differenceTracker,
+        );
+
+        $platform = $this->database->query(
+            "SELECT platform FROM trophy_title WHERE np_communication_id = 'NPWR00001_00'"
+        )->fetchColumn();
+
+        $this->assertSame('PS5,PC', $platform);
+    }
 }
 
 final class StubGameRescanGroupDataFetcher implements GameRescanGroupDataFetcher

--- a/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
+++ b/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
@@ -327,7 +327,12 @@ final readonly class GameRescanCatalogUpdater
     {
         $platforms = [];
         foreach ($trophyTitle->platform() as $platform) {
-            $platforms[] = $platform->value;
+            $platformValue = $platform->value;
+            if ($platformValue === 'PSPC') {
+                $platformValue = Platform::Pc->label();
+            }
+
+            $platforms[] = $platformValue;
         }
 
         $platforms = $platforms


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Admin game rescans now normalize Sony's `PSPC` platform value to `PC`, matching the existing player-scan behavior.
- Added a regression test covering the rescan platform mapping path.

## Test plan
- [x] `GameRescanCatalogUpdaterTest::testUpdateFromPsnMapsPspcPlatformToPc`
- [x] Full suite via `php tests/run.php` (unrelated preexisting failure in `PlayerScanTrophyTitleLoopTest` only)
- [x] Manually rescan a PC title that returns `PSPC` from PSN and confirm platform is stored as `PC`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44332057-d826-48d2-92aa-c64bd05b1522?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44332057-d826-48d2-92aa-c64bd05b1522&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

