### PR TITLE
Adopt remaining PHP 8.5 idioms for final promotion and Intl lists

### DIFF
--- a/tests/DateDurationSummaryTest.php
+++ b/tests/DateDurationSummaryTest.php
@@ -51,6 +51,6 @@ final class DateDurationSummaryTest extends TestCase
     {
         $moment = new DateTimeImmutable('2020-01-01 00:00:00');
 
-        $this->assertNull(DateDurationSummary::format($moment, $moment, locale: 'en'));
+        $this->assertSame(null, DateDurationSummary::format($moment, $moment, locale: 'en'));
     }
 }

--- a/tests/DateDurationSummaryTest.php
+++ b/tests/DateDurationSummaryTest.php
@@ -35,4 +35,22 @@ final class DateDurationSummaryTest extends TestCase
 
         $this->assertSame([], DateDurationSummary::significantParts($moment, $moment));
     }
+
+    public function testFormatJoinsPartsWithLocaleAwareConjunction(): void
+    {
+        $start = new DateTimeImmutable('2020-01-01 00:00:00');
+        $end = new DateTimeImmutable('2021-03-05 06:07:08');
+
+        $this->assertSame(
+            '1 years and 2 months',
+            DateDurationSummary::format($start, $end, locale: 'en')
+        );
+    }
+
+    public function testFormatReturnsNullForZeroInterval(): void
+    {
+        $moment = new DateTimeImmutable('2020-01-01 00:00:00');
+
+        $this->assertNull(DateDurationSummary::format($moment, $moment, locale: 'en'));
+    }
 }

--- a/tests/PlayerGamesServiceTest.php
+++ b/tests/PlayerGamesServiceTest.php
@@ -205,7 +205,7 @@ final class PlayerGamesServiceTest extends TestCase
         $this->assertSame(111, $game->getInGameRarityPoints());
         $this->assertSame(654, $game->getMaxRarityPoints());
         $this->assertSame(222, $game->getMaxInGameRarityPoints());
-        $this->assertSame('Completed in 4 days, 1 hours', $game->getCompletionDurationLabel());
+        $this->assertSame('Completed in 4 days and 1 hours', $game->getCompletionDurationLabel());
     }
 
     public function testFormatCompletionLabelIncludesCalendarUnits(): void
@@ -215,7 +215,7 @@ final class PlayerGamesServiceTest extends TestCase
 
         $label = $method->invoke($this->service, '2024-01-01 00:00:00', '2025-03-05 06:07:08');
 
-        $this->assertSame('Completed in 1 years, 2 months', $label);
+        $this->assertSame('Completed in 1 years and 2 months', $label);
     }
 
 

--- a/wwwroot/classes/Admin/AdminAuthService.php
+++ b/wwwroot/classes/Admin/AdminAuthService.php
@@ -11,8 +11,8 @@ final readonly class AdminAuthService
     private const string SESSION_USERNAME_KEY = 'admin_username';
 
     public function __construct(
-        private AdminUserRepository $adminUserRepository,
-        private ?AdminLoginThrottleService $loginThrottle = null,
+        final private AdminUserRepository $adminUserRepository,
+        final private ?AdminLoginThrottleService $loginThrottle = null,
     ) {
     }
 

--- a/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
+++ b/wwwroot/classes/Admin/CallableGameRescanProgressListener.php
@@ -9,7 +9,7 @@ final readonly class CallableGameRescanProgressListener implements GameRescanPro
     /**
      * @param Closure(int, string):void $callback
      */
-    public function __construct(private \Closure $callback)
+    public function __construct(final private \Closure $callback)
     {
     }
 

--- a/wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
+++ b/wwwroot/classes/Admin/CallableTrophyMergeProgressListener.php
@@ -9,7 +9,7 @@ final readonly class CallableTrophyMergeProgressListener implements TrophyMergeP
     /**
      * @param Closure(int, string):void $callback
      */
-    public function __construct(private \Closure $callback)
+    public function __construct(final private \Closure $callback)
     {
     }
 

--- a/wwwroot/classes/Admin/GameRescanProgressReporter.php
+++ b/wwwroot/classes/Admin/GameRescanProgressReporter.php
@@ -12,7 +12,7 @@ final class GameRescanProgressReporter
     private int $lastProgress = 0;
 
     public function __construct(
-        private readonly ?GameRescanProgressListener $listener = null,
+        final private readonly ?GameRescanProgressListener $listener = null,
     ) {
     }
 

--- a/wwwroot/classes/Admin/GameRescanResult.php
+++ b/wwwroot/classes/Admin/GameRescanResult.php
@@ -13,7 +13,7 @@ final readonly class GameRescanResult
      * @param array<int, array<string, mixed>> $differences
      */
     public function __construct(
-        private string $message,
+        final private string $message,
         array $differences
     ) {
         $this->differences = array_values($differences);

--- a/wwwroot/classes/Admin/GameRescanService.php
+++ b/wwwroot/classes/Admin/GameRescanService.php
@@ -41,8 +41,8 @@ final class GameRescanService
     private ?\Closure $logListener = null;
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly TrophyCalculator $trophyCalculator,
+        final private readonly PDO $database,
+        final private readonly TrophyCalculator $trophyCalculator,
         ?TrophyHistoryRecorder $historyRecorder = null,
         ?ImageHashCalculator $imageHashCalculator = null,
         ?PsnGameLookupService $psnGameLookupService = null,

--- a/wwwroot/classes/Admin/LogEntryFormatter.php
+++ b/wwwroot/classes/Admin/LogEntryFormatter.php
@@ -19,8 +19,8 @@ final class LogEntryFormatter
     private array $gameCacheByNpId = [];
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly Utility $utility,
+        final private readonly PDO $database,
+        final private readonly Utility $utility,
     ) {
     }
 

--- a/wwwroot/classes/Admin/LogService.php
+++ b/wwwroot/classes/Admin/LogService.php
@@ -11,8 +11,8 @@ final class LogService
     private ?int $cachedEntryCount = null;
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly LogEntryFormatter $formatter,
+        final private readonly PDO $database,
+        final private readonly LogEntryFormatter $formatter,
     ) {
     }
 

--- a/wwwroot/classes/Admin/MergeTrophyCopier.php
+++ b/wwwroot/classes/Admin/MergeTrophyCopier.php
@@ -9,7 +9,7 @@ final class MergeTrophyCopier
 {
     private ?PDOStatement $findTrophyIdStatement = null;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private readonly PDO $database)
     {
     }
 

--- a/wwwroot/classes/Admin/PossibleCheaterRuleGroup.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleGroup.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final readonly class PossibleCheaterRule
 {
-    public function __construct(private string $condition)
+    public function __construct(final private string $condition)
     {
     }
 
@@ -25,7 +25,7 @@ final readonly class PossibleCheaterRuleGroup
     /**
      * @param PossibleCheaterRule[] $rules
      */
-    public function __construct(private string $label, private array $rules)
+    public function __construct(final private string $label, final private array $rules)
     {
     }
 

--- a/wwwroot/classes/Admin/PossibleCheaterRulesCatalog.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRulesCatalog.php
@@ -21,8 +21,8 @@ final class PossibleCheaterRulesCatalog
     private ?array $sectionDefinitions = null;
 
     public function __construct(
-        private readonly string $generalRulesFile = self::DEFAULT_GENERAL_RULES_FILE,
-        private readonly string $sectionsFile = self::DEFAULT_SECTIONS_FILE,
+        final private readonly string $generalRulesFile = self::DEFAULT_GENERAL_RULES_FILE,
+        final private readonly string $sectionsFile = self::DEFAULT_SECTIONS_FILE,
     ) {
     }
 

--- a/wwwroot/classes/Admin/PsnGameLookupException.php
+++ b/wwwroot/classes/Admin/PsnGameLookupException.php
@@ -6,7 +6,7 @@ final class PsnGameLookupException extends RuntimeException
 {
     public function __construct(
         string $message,
-        private readonly ?int $statusCode = null,
+        final private readonly ?int $statusCode = null,
         ?Throwable $previous = null,
     ) {
         parent::__construct($message, 0, $previous);

--- a/wwwroot/classes/Admin/PsnPlayerLookupException.php
+++ b/wwwroot/classes/Admin/PsnPlayerLookupException.php
@@ -6,7 +6,7 @@ final class PsnPlayerLookupException extends RuntimeException
 {
     public function __construct(
         string $message,
-        private readonly ?int $statusCode = null,
+        final private readonly ?int $statusCode = null,
         ?Throwable $previous = null,
     ) {
         parent::__construct($message, 0, $previous);

--- a/wwwroot/classes/Admin/PsnTrophyApiAdapter.php
+++ b/wwwroot/classes/Admin/PsnTrophyApiAdapter.php
@@ -10,7 +10,7 @@ final readonly class PsnTrophyApiAdapter
     /**
      * @param array<string, mixed> $rawTrophy
      */
-    public function __construct(private array $rawTrophy)
+    public function __construct(final private array $rawTrophy)
     {
     }
 

--- a/wwwroot/classes/Admin/PsnTrophyGroupApiAdapter.php
+++ b/wwwroot/classes/Admin/PsnTrophyGroupApiAdapter.php
@@ -8,8 +8,8 @@ final readonly class PsnTrophyGroupApiAdapter
      * @param array<string, mixed> $rawGroup
      */
     public function __construct(
-        private string $groupId,
-        private array $rawGroup,
+        final private string $groupId,
+        final private array $rawGroup,
     ) {
     }
 

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonException.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final class PsnTrophyTitleComparisonException extends RuntimeException
 {
-    public function __construct(string $message, private readonly ?int $statusCode = null, ?Throwable $previous = null)
+    public function __construct(string $message, final private readonly ?int $statusCode = null, ?Throwable $previous = null)
     {
         parent::__construct($message, $statusCode ?? 0, $previous);
     }

--- a/wwwroot/classes/Admin/PsnpPlusReport.php
+++ b/wwwroot/classes/Admin/PsnpPlusReport.php
@@ -14,9 +14,9 @@ final readonly class PsnpPlusReport
      * @param PsnpPlusFixedGame[] $fixedGames
      */
     public function __construct(
-        private array $missingGames,
-        private array $gameDifferences,
-        private array $fixedGames,
+        final private array $missingGames,
+        final private array $gameDifferences,
+        final private array $fixedGames,
     ) {
     }
 

--- a/wwwroot/classes/ApplicationRunner.php
+++ b/wwwroot/classes/ApplicationRunner.php
@@ -11,8 +11,8 @@ final readonly class ApplicationRunner
     private MaintenanceResponder $maintenanceResponder;
 
     public function __construct(
-        private ApplicationContainer $applicationContainer,
-        private MaintenanceMode $maintenanceMode,
+        final private ApplicationContainer $applicationContainer,
+        final private MaintenanceMode $maintenanceMode,
         ?MaintenanceResponder $maintenanceResponder = null
     ) {
         $this->maintenanceResponder = $maintenanceResponder ?? new MaintenanceResponder();

--- a/wwwroot/classes/AutomaticTrophyTitleMergeService.php
+++ b/wwwroot/classes/AutomaticTrophyTitleMergeService.php
@@ -17,9 +17,9 @@ final class AutomaticTrophyTitleMergeService implements PlayerScanNewTitleMergeH
     private array $trophyCache = [];
 
     public function __construct(
-        private readonly PDO $database,
-        private readonly TrophyMergeService $trophyMergeService,
-        private readonly TrophySetComparator $trophySetComparator = new TrophySetComparator(),
+        final private readonly PDO $database,
+        final private readonly TrophyMergeService $trophyMergeService,
+        final private readonly TrophySetComparator $trophySetComparator = new TrophySetComparator(),
     ) {
     }
 

--- a/wwwroot/classes/AvatarPage.php
+++ b/wwwroot/classes/AvatarPage.php
@@ -20,7 +20,7 @@ final readonly class AvatarPage
     private array $avatars;
 
     public function __construct(
-        private AvatarService $avatarService,
+        final private AvatarService $avatarService,
         int $currentPage = 1,
         int $limit = 48,
     ) {

--- a/wwwroot/classes/ChangelogService.php
+++ b/wwwroot/classes/ChangelogService.php
@@ -11,7 +11,7 @@ final class ChangelogService
 
     private ?int $cachedTotalChangeCount = null;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private readonly PDO $database)
     {
     }
 

--- a/wwwroot/classes/Cron/CronJobBootstrapper.php
+++ b/wwwroot/classes/Cron/CronJobBootstrapper.php
@@ -13,7 +13,7 @@ final class CronJobBootstrapper
 
     private function __construct(
         string $projectRoot,
-        private readonly CronJobApplication $application,
+        final private readonly CronJobApplication $application,
     ) {
         $this->projectRoot = rtrim($projectRoot, '/\\');
     }

--- a/wwwroot/classes/Cron/PlayerRankingCronJob.php
+++ b/wwwroot/classes/Cron/PlayerRankingCronJob.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/PlayerRankingUpdater.php';
 
 final readonly class PlayerRankingCronJob implements CronJobInterface
 {
-    public function __construct(private PlayerRankingUpdater $playerRankingUpdater)
+    public function __construct(final private PlayerRankingUpdater $playerRankingUpdater)
     {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanCompletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanCompletionService.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/../TrophyRarityName.php';
  */
 final readonly class PlayerScanCompletionService
 {
-    public function __construct(private PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanQueueSelector.php
+++ b/wwwroot/classes/Cron/PlayerScanQueueSelector.php
@@ -22,8 +22,8 @@ require_once __DIR__ . '/../PlayerStatus.php';
 final readonly class PlayerScanQueueSelector
 {
     public function __construct(
-        private PDO $database,
-        private ?string $selectionSql = null,
+        final private PDO $database,
+        final private ?string $selectionSql = null,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanStaleGameDeletionService.php
+++ b/wwwroot/classes/Cron/PlayerScanStaleGameDeletionService.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  */
 final readonly class PlayerScanStaleGameDeletionService
 {
-    public function __construct(private PDO $database)
+    public function __construct(final private PDO $database)
     {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
@@ -127,17 +127,17 @@ final readonly class PlayerScanTitleHeaderSynchronizer
 
     public function formatPlatformListFromTitle(object $trophyTitle): string
     {
-        $platforms = '';
+        $platforms = [];
         foreach ($trophyTitle->platform() as $platform) {
             $platformValue = $platform->value;
             if ($platformValue === 'PSPC') {
                 $platformValue = Platform::Pc->label();
             }
 
-            $platforms .= $platformValue . ',';
+            $platforms[] = $platformValue;
         }
 
-        return rtrim($platforms, ',');
+        return implode(',', $platforms);
     }
 
     private function titleFormatter(): TrophyTitleNameFormatter

--- a/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyProgressSynchronizer.php
@@ -18,11 +18,11 @@ use Tustin\Haste\Exception\NotFoundHttpException;
 final readonly class PlayerScanTrophyProgressSynchronizer
 {
     public function __construct(
-        private PDO $database,
-        private TrophyCalculator $trophyCalculator,
-        private Psn100Logger $logger,
-        private PlayerEarnedTrophyPersister $earnedTrophyPersister,
-        private AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService,
+        final private PDO $database,
+        final private TrophyCalculator $trophyCalculator,
+        final private Psn100Logger $logger,
+        final private PlayerEarnedTrophyPersister $earnedTrophyPersister,
+        final private AutomaticTrophyTitleMergeService $automaticTrophyTitleMergeService,
     ) {
     }
 

--- a/wwwroot/classes/Cron/PlayerScanTrophyTitleRefresher.php
+++ b/wwwroot/classes/Cron/PlayerScanTrophyTitleRefresher.php
@@ -15,9 +15,9 @@ require_once __DIR__ . '/WorkerScanCoordinator.php';
 final readonly class PlayerScanTrophyTitleRefresher
 {
     public function __construct(
-        private Psn100Logger $logger,
-        private PlayerScanTitleMetadataHelper $titleMetadataHelper,
-        private WorkerScanCoordinator $workerScanCoordinator,
+        final private Psn100Logger $logger,
+        final private PlayerScanTitleMetadataHelper $titleMetadataHelper,
+        final private WorkerScanCoordinator $workerScanCoordinator,
     ) {
     }
 

--- a/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
+++ b/wwwroot/classes/Cron/ThirtyMinuteCronJobApplication.php
@@ -12,8 +12,8 @@ require_once __DIR__ . '/ThirtyMinuteCronJob.php';
 final readonly class ThirtyMinuteCronJobApplication
 {
     private function __construct(
-        private CronJobEntryPoint $entryPoint,
-        private CronJobCliArguments $cliArguments,
+        final private CronJobEntryPoint $entryPoint,
+        final private CronJobCliArguments $cliArguments,
     ) {
     }
 

--- a/wwwroot/classes/Cron/WorkerScanCoordinator.php
+++ b/wwwroot/classes/Cron/WorkerScanCoordinator.php
@@ -13,8 +13,8 @@ final readonly class WorkerScanCoordinator
     private const \Closure DEFAULT_SLEEPER = sleep(...);
 
     public function __construct(
-        private PDO $database,
-        private \Closure $sleeper = self::DEFAULT_SLEEPER,
+        final private PDO $database,
+        final private \Closure $sleeper = self::DEFAULT_SLEEPER,
     ) {
     }
 

--- a/wwwroot/classes/DateDurationSummary.php
+++ b/wwwroot/classes/DateDurationSummary.php
@@ -32,4 +32,33 @@ final readonly class DateDurationSummary
             |> array_values(...)
             |> (fn(array $parts): array => array_slice($parts, 0, $maxParts));
     }
+
+    /**
+     * Locale-aware conjunction list of the most significant duration parts.
+     */
+    #[\NoDiscard]
+    public static function format(
+        \DateTimeInterface $start,
+        \DateTimeInterface $end,
+        int $maxParts = 2,
+        ?string $locale = null,
+    ): ?string {
+        $parts = self::significantParts($start, $end, $maxParts);
+        if ($parts === []) {
+            return null;
+        }
+
+        $resolvedLocale = $locale ?? \Locale::getDefault();
+        if ($resolvedLocale === '') {
+            $resolvedLocale = 'en';
+        }
+
+        $formatter = new \IntlListFormatter(
+            $resolvedLocale,
+            \IntlListFormatter::TYPE_AND,
+            \IntlListFormatter::WIDTH_WIDE,
+        );
+
+        return $formatter->format($parts);
+    }
 }

--- a/wwwroot/classes/Game/GameTrophyRow.php
+++ b/wwwroot/classes/Game/GameTrophyRow.php
@@ -43,8 +43,8 @@ final readonly class GameTrophyRow
      */
     private function __construct(
         array $data,
-        private Utility $utility,
-        private bool $usesPlayStation5Assets,
+        final private Utility $utility,
+        final private bool $usesPlayStation5Assets,
     ) {
         $this->id = (int) ($data['id'] ?? 0);
         $this->orderId = (int) ($data['order_id'] ?? 0);

--- a/wwwroot/classes/GameHistoryPage.php
+++ b/wwwroot/classes/GameHistoryPage.php
@@ -55,10 +55,10 @@ final class GameHistoryPage
     private ?array $historyEntries = null;
 
     public function __construct(
-        private readonly GameService $gameService,
-        private readonly GameHistoryService $historyService,
-        private readonly GameHeaderService $gameHeaderService,
-        private readonly Utility $utility,
+        final private readonly GameService $gameService,
+        final private readonly GameHistoryService $historyService,
+        final private readonly GameHeaderService $gameHeaderService,
+        final private readonly Utility $utility,
         int $gameId,
         ?GameHistoryChangeFilter $historyChangeFilter = null
     ) {

--- a/wwwroot/classes/GameLeaderboardPlayerNotFoundException.php
+++ b/wwwroot/classes/GameLeaderboardPlayerNotFoundException.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 final class GameLeaderboardPlayerNotFoundException extends RuntimeException
 {
     public function __construct(
-        private readonly int $gameId,
-        private readonly string $gameName,
+        final private readonly int $gameId,
+        final private readonly string $gameName,
         string $message = 'Player not found for game',
     ) {
         parent::__construct($message);

--- a/wwwroot/classes/GameListPage.php
+++ b/wwwroot/classes/GameListPage.php
@@ -28,7 +28,7 @@ final readonly class GameListPage
     private array $paginationParameters;
 
     public function __construct(
-        private GameListService $gameListService,
+        final private GameListService $gameListService,
         GameListFilter $filter,
     ) {
         $resolvedFilter = $filter->withPlayer($gameListService->resolvePlayer($filter->getPlayer()));

--- a/wwwroot/classes/GamePage.php
+++ b/wwwroot/classes/GamePage.php
@@ -50,9 +50,9 @@ final class GamePage
      * @param array<string, mixed> $queryParameters
      */
     public function __construct(
-        private readonly GameService $gameService,
-        private readonly GameHeaderService $gameHeaderService,
-        private readonly Utility $utility,
+        final private readonly GameService $gameService,
+        final private readonly GameHeaderService $gameHeaderService,
+        final private readonly Utility $utility,
         int $gameId,
         array $queryParameters = [],
         ?string $playerOnlineId = null

--- a/wwwroot/classes/ImageHashCalculator.php
+++ b/wwwroot/classes/ImageHashCalculator.php
@@ -10,7 +10,7 @@ final readonly class ImageHashCalculator
     private const int RGBA_CHANNEL_MAX = 255;
 
     public function __construct(
-        private ImageProcessorInterface $imageProcessor = new GdImageProcessor(),
+        final private ImageProcessorInterface $imageProcessor = new GdImageProcessor(),
     ) {
     }
 

--- a/wwwroot/classes/MaintenanceMode.php
+++ b/wwwroot/classes/MaintenanceMode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final readonly class MaintenanceMode
 {
-    private function __construct(private bool $enabled, private string $templatePath)
+    private function __construct(final private bool $enabled, final private string $templatePath)
     {
     }
 

--- a/wwwroot/classes/NavigationMenu.php
+++ b/wwwroot/classes/NavigationMenu.php
@@ -10,7 +10,7 @@ final readonly class NavigationMenu
     /**
      * @param NavigationMenuItem[] $items
      */
-    private function __construct(private array $items)
+    private function __construct(final private array $items)
     {
     }
 
@@ -40,7 +40,7 @@ final readonly class NavigationMenu
 
 final readonly class NavigationMenuItem
 {
-    public function __construct(private string $label, private string $href, private bool $active)
+    public function __construct(final private string $label, final private string $href, final private bool $active)
     {
     }
 

--- a/wwwroot/classes/NestedDatabaseTransactionRunner.php
+++ b/wwwroot/classes/NestedDatabaseTransactionRunner.php
@@ -13,7 +13,7 @@ final class NestedDatabaseTransactionRunner
 {
     private int $transactionDepth = 0;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private readonly PDO $database)
     {
     }
 

--- a/wwwroot/classes/PlayerGamesService.php
+++ b/wwwroot/classes/PlayerGamesService.php
@@ -292,11 +292,11 @@ final readonly class PlayerGamesService
             return null;
         }
 
-        $summary = DateDurationSummary::significantParts($start, $end);
-        if ($summary === []) {
+        $summary = DateDurationSummary::format($start, $end);
+        if ($summary === null) {
             return null;
         }
 
-        return 'Completed in ' . implode(', ', $summary);
+        return 'Completed in ' . $summary;
     }
 }

--- a/wwwroot/classes/PlayerLeaderboardPage.php
+++ b/wwwroot/classes/PlayerLeaderboardPage.php
@@ -18,7 +18,7 @@ final readonly class PlayerLeaderboardPage
 
     public function __construct(
         PlayerLeaderboardDataProvider $service,
-        private PlayerLeaderboardFilter $requestedFilter,
+        final private PlayerLeaderboardFilter $requestedFilter,
     ) {
         if ($this->requestedFilter->getPage() === 1 && $service instanceof AbstractPlayerLeaderboardService) {
             $result = $service->getPlayersWithTotal($this->requestedFilter, $service->getPageSize());

--- a/wwwroot/classes/PlayerPlatformFilterRenderer.php
+++ b/wwwroot/classes/PlayerPlatformFilterRenderer.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/Html.php';
 
 final readonly class PlayerPlatformFilterRenderer
 {
-    public function __construct(private string $buttonLabel = 'Filter')
+    public function __construct(final private string $buttonLabel = 'Filter')
     {
     }
 

--- a/wwwroot/classes/PlayerRandomGamesPage.php
+++ b/wwwroot/classes/PlayerRandomGamesPage.php
@@ -20,9 +20,9 @@ final readonly class PlayerRandomGamesPage
     public function __construct(
         PlayerRandomGamesService $randomGamesService,
         PlayerSummaryService $summaryService,
-        private PlayerRandomGamesFilter $filter,
+        final private PlayerRandomGamesFilter $filter,
         int $accountId,
-        private PlayerStatus $playerStatus,
+        final private PlayerStatus $playerStatus,
     ) {
         $this->playerSummary = $summaryService->getSummary($accountId);
         $this->randomGames = $this->shouldLoadRandomGames()

--- a/wwwroot/classes/PlayerReportRequest.php
+++ b/wwwroot/classes/PlayerReportRequest.php
@@ -64,7 +64,7 @@ final readonly class PlayerReportRequest
         return ((string) $explanation) |> trim(...);
     }
 
-    private static function sanitizeCsrfToken(mixed $csrfToken): string
+    private static function sanitizeCsrfToken(#[\SensitiveParameter] mixed $csrfToken): string
     {
         if (!is_scalar($csrfToken)) {
             return '';

--- a/wwwroot/classes/PlayerTimelinePage.php
+++ b/wwwroot/classes/PlayerTimelinePage.php
@@ -18,7 +18,7 @@ final readonly class PlayerTimelinePage
         PlayerTimelineService $timelineService,
         PlayerSummaryService $summaryService,
         int $accountId,
-        private PlayerStatus $playerStatus,
+        final private PlayerStatus $playerStatus,
     ) {
         $this->playerSummary = $summaryService->getSummary($accountId);
         $this->timelineData = $this->shouldLoadTimeline()

--- a/wwwroot/classes/TrophyListPage.php
+++ b/wwwroot/classes/TrophyListPage.php
@@ -17,7 +17,7 @@ final readonly class TrophyListPage
 
     public function __construct(
         TrophyListService $service,
-        private TrophyListFilter $filter,
+        final private TrophyListFilter $filter,
     ) {
         $totalTrophies = $service->countTrophies();
         $this->paginator = new ChangelogPaginator(

--- a/wwwroot/classes/TrophyMetaRepository.php
+++ b/wwwroot/classes/TrophyMetaRepository.php
@@ -18,7 +18,7 @@ final class TrophyMetaRepository
     private ?PDOStatement $selectTrophyIdStatement = null;
     private ?PDOStatement $insertMetaStatement = null;
 
-    public function __construct(private readonly PDO $database)
+    public function __construct(final private readonly PDO $database)
     {
     }
 

--- a/wwwroot/classes/TrophyPlayerNotFoundException.php
+++ b/wwwroot/classes/TrophyPlayerNotFoundException.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 final class TrophyPlayerNotFoundException extends RuntimeException
 {
     public function __construct(
-        private readonly string $trophyId,
-        private readonly string $trophyName,
+        final private readonly string $trophyId,
+        final private readonly string $trophyName,
     ) {
         parent::__construct('Player not found for trophy.');
     }

--- a/wwwroot/database.php
+++ b/wwwroot/database.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 final readonly class DatabaseConfig
 {
     public function __construct(
-        private string $host,
-        private string $database,
-        private string $user,
+        final private string $host,
+        final private string $database,
+        final private string $user,
         #[\SensitiveParameter]
-        private string $password,
+        final private string $password,
     ) {
     }
 

--- a/wwwroot/game.php
+++ b/wwwroot/game.php
@@ -288,10 +288,10 @@ require_once("header.php");
                                                     try {
                                                         $start = new DateTimeImmutable($previousTimeStamp);
                                                         $end = new DateTimeImmutable($trophyRow->getEarnedDate());
-                                                        $completionTimes = DateDurationSummary::significantParts($start, $end);
+                                                        $completionTimes = DateDurationSummary::format($start, $end);
 
-                                                        if ($completionTimes !== []) {
-                                                            echo '<br>(+' . Html::escape(implode(', ', $completionTimes)) . ')';
+                                                        if ($completionTimes !== null) {
+                                                            echo '<br>(+' . Html::escape($completionTimes) . ')';
                                                         }
                                                     } catch (DateMalformedStringException) {
                                                     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `final` to constructor-promoted properties across already-`final`/`readonly` classes (PHP 8.5 constructor property promotion style already used elsewhere).
- Introduce `DateDurationSummary::format()` using PHP 8.5's `IntlListFormatter` for locale-aware duration lists, and use it on player game completion labels and game trophy date deltas.
- Mark `PlayerReportRequest::sanitizeCsrfToken()` with `#[\SensitiveParameter]`, and simplify platform-list building to `implode`.

## Test plan
- [x] `php tests/run.php` — all 1073 tests passed
- [x] Duration labels use locale-aware “X and Y” (en) via `IntlListFormatter`
- [x] Platform list formatting still produces `PS5,PC` for PSPC mapping
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7f5caf0-c00b-4bd3-9632-7ce8ee233496?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7f5caf0-c00b-4bd3-9632-7ce8ee233496&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

