### PR TITLE
Adopt remaining PHP 8.5 idiom cleanups

### DIFF
--- a/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
+++ b/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
@@ -316,8 +316,7 @@ final readonly class GameRescanCatalogUpdater
             return true;
         }
 
-        return trim($newVersion)
-            |> (fn (string $version): bool => version_compare($version, $normalizedCurrentVersion, '>='));
+        return version_compare(trim($newVersion), $normalizedCurrentVersion, '>=');
     }
 
     /**

--- a/wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php
+++ b/wwwroot/classes/Admin/PossibleCheaterRuleConditionParser.php
@@ -10,6 +10,7 @@ final readonly class PossibleCheaterRuleConditionParser
 {
     private const string CONDITION_PATTERN = '/^te\.np_communication_id = \'([^\']+)\' AND te\.order_id = (\d+)(?: AND te\.earned_date (>=|<=|<) \'([^\']+)\')?$/';
 
+    #[\NoDiscard]
     public function parse(string $condition): PossibleCheaterRuleTuple
     {
         if (preg_match(self::CONDITION_PATTERN, $condition, $matches) !== 1) {
@@ -27,6 +28,7 @@ final readonly class PossibleCheaterRuleConditionParser
     /**
      * @param PossibleCheaterRuleGroup[] $groups
      */
+    #[\NoDiscard]
     public function buildRuleDerivedTableSql(array $groups): string
     {
         $selects = [];

--- a/wwwroot/classes/Admin/PsnGameLookupService.php
+++ b/wwwroot/classes/Admin/PsnGameLookupService.php
@@ -47,7 +47,7 @@ final readonly class PsnGameLookupService
             $database,
             static fn (): array => $workerService->fetchWorkers(),
             null,
-            static fn (int $workerId, string $refreshToken): bool => $workerService->updateWorkerRefreshToken($workerId, $refreshToken),
+            static fn (int $workerId, #[\SensitiveParameter] string $refreshToken): bool => $workerService->updateWorkerRefreshToken($workerId, $refreshToken),
             PlayStationWorkerAuthenticator::fromWorkerService($workerService),
         );
     }

--- a/wwwroot/classes/Admin/PsnTrophyApiPayloadInspector.php
+++ b/wwwroot/classes/Admin/PsnTrophyApiPayloadInspector.php
@@ -12,6 +12,7 @@ final readonly class PsnTrophyApiPayloadInspector
     /**
      * @return array<string, mixed>
      */
+    #[\NoDiscard]
     public function normalize(mixed $response): array
     {
         if (is_array($response)) {

--- a/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
+++ b/wwwroot/classes/Admin/PsnTrophyTitleComparisonService.php
@@ -108,6 +108,7 @@ final readonly class PsnTrophyTitleComparisonService
         ];
     }
 
+    #[\NoDiscard]
     public static function normalizeSource(string $source): ?PsnTrophyTitleComparisonSource
     {
         return PsnTrophyTitleComparisonSource::tryFrom($source |> trim(...) |> strtolower(...));

--- a/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerAvatarSynchronizer.php
@@ -61,8 +61,9 @@ final readonly class PlayerAvatarSynchronizer
                     $newPHash = $matchedPHash;
                 }
 
-                $path = Uri\WhatWg\Url::parse($avatarUrl)?->getPath() ?? '';
-                $extension = pathinfo($path, PATHINFO_EXTENSION) |> strtolower(...);
+                $extension = (Uri\WhatWg\Url::parse($avatarUrl)?->getPath() ?? '')
+                    |> (fn (string $path): string => pathinfo($path, PATHINFO_EXTENSION))
+                    |> strtolower(...);
                 $avatarFilename = $newPHash . '.' . $extension;
                 $avatarPath = $this->avatarStorageDirectory . $avatarFilename;
 

--- a/wwwroot/classes/Cron/PlayerScanTitleMetadataHelper.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleMetadataHelper.php
@@ -104,26 +104,24 @@ final readonly class PlayerScanTitleMetadataHelper
             return false;
         }
 
-        return trim($newVersion)
-            |> (fn (string $version): bool => version_compare($version, $normalizedCurrentVersion, '<'));
+        return version_compare(trim($newVersion), $normalizedCurrentVersion, '<');
     }
 
+    #[\NoDiscard]
     public function resolveSetVersionForUpdate(string $newVersion, mixed $currentVersion): string
     {
+        $trimmedNewVersion = trim($newVersion);
         $normalizedCurrentVersion = $this->normalizeSetVersion($currentVersion);
 
         if ($normalizedCurrentVersion === null) {
-            return trim($newVersion);
+            return $trimmedNewVersion;
         }
 
-        if (
-            trim($newVersion)
-                |> (fn (string $version): bool => version_compare($version, $normalizedCurrentVersion, '<'))
-        ) {
+        if (version_compare($trimmedNewVersion, $normalizedCurrentVersion, '<')) {
             return $normalizedCurrentVersion;
         }
 
-        return trim($newVersion);
+        return $trimmedNewVersion;
     }
 
     #[\NoDiscard]

--- a/wwwroot/classes/GameListFilter.php
+++ b/wwwroot/classes/GameListFilter.php
@@ -71,12 +71,7 @@ final readonly class GameListFilter
     #[\NoDiscard]
     public function withPlayer(?string $player): self
     {
-        if ($player !== null) {
-            $player = trim($player);
-            $player = $player === '' ? null : $player;
-        }
-
-        return clone($this, ['player' => $player]);
+        return clone($this, ['player' => self::sanitizeNullableString($player)]);
     }
 
     #[\NoDiscard]
@@ -137,10 +132,7 @@ final readonly class GameListFilter
 
     public function hasPlatformFilters(): bool
     {
-        return array_any(
-            $this->platformFilters,
-            static fn (bool $selected): bool => $selected
-        );
+        return in_array(true, $this->platformFilters, true);
     }
 
     public function isPlatformSelected(string $platform): bool
@@ -154,10 +146,7 @@ final readonly class GameListFilter
     public function getSelectedPlatforms(): array
     {
         return $this->platformFilters
-            |> (fn (array $filters): array => array_filter(
-                $filters,
-                static fn (bool $selected): bool => $selected,
-            ))
+            |> array_filter(...)
             |> array_keys(...);
     }
 

--- a/wwwroot/classes/TrophyImageDownloader.php
+++ b/wwwroot/classes/TrophyImageDownloader.php
@@ -31,6 +31,7 @@ final readonly class TrophyImageDownloader
      * Player-scan flow: log download failures when no usable cache exists and
      * fall back to the shared placeholder filename.
      */
+    #[\NoDiscard]
     public function downloadMandatoryForScan(
         string $url,
         string $directory,
@@ -54,6 +55,7 @@ final readonly class TrophyImageDownloader
     /**
      * Player-scan flow for optional reward images.
      */
+    #[\NoDiscard]
     public function downloadOptionalForScan(
         ?string $url,
         string $directory,
@@ -82,6 +84,7 @@ final readonly class TrophyImageDownloader
      * Admin rescan flow: reuse an existing cached filename when the remote file
      * is unavailable, otherwise throw so the rescan can abort visibly.
      */
+    #[\NoDiscard]
     public function downloadMandatoryForRescan(
         string $url,
         string $directory,
@@ -108,6 +111,7 @@ final readonly class TrophyImageDownloader
     /**
      * Admin rescan flow for optional reward images.
      */
+    #[\NoDiscard]
     public function downloadOptionalForRescan(
         ?string $url,
         string $directory,
@@ -173,14 +177,11 @@ final readonly class TrophyImageDownloader
     #[\NoDiscard]
     public function buildFilename(string $url, string $contents): string
     {
-        $hash = $this->imageHashCalculator->calculate($contents);
-        if ($hash === null) {
-            $hash = md5($contents);
-        }
-
-        $path = Uri\WhatWg\Url::parse($url)?->getPath() ?? '';
-        $extension = pathinfo($path, PATHINFO_EXTENSION) |> strtolower(...);
-        $extension = $extension === '' ? '' : '.' . $extension;
+        $hash = $this->imageHashCalculator->calculate($contents) ?? md5($contents);
+        $extension = (Uri\WhatWg\Url::parse($url)?->getPath() ?? '')
+            |> (fn (string $path): string => pathinfo($path, PATHINFO_EXTENSION))
+            |> strtolower(...)
+            |> (fn (string $ext): string => $ext === '' ? '' : '.' . $ext);
 
         return $hash . $extension;
     }

--- a/wwwroot/classes/TrophyMergeParentOwnershipGuard.php
+++ b/wwwroot/classes/TrophyMergeParentOwnershipGuard.php
@@ -76,7 +76,7 @@ final readonly class TrophyMergeParentOwnershipGuard
             );
         }
 
-        $mergeParent = $mergeParents === [] ? null : array_first($mergeParents);
+        $mergeParent = array_first($mergeParents);
 
         if (
             $metaParent !== null

--- a/wwwroot/database.php
+++ b/wwwroot/database.php
@@ -63,8 +63,9 @@ final readonly class DatabaseConfig
                 return $value;
             }
 
-            if (trim($value) !== '') {
-                return trim($value);
+            $trimmed = trim($value);
+            if ($trimmed !== '') {
+                return $trimmed;
             }
         }
 
@@ -74,8 +75,9 @@ final readonly class DatabaseConfig
                 return $fallback;
             }
 
-            if (trim($fallback) !== '') {
-                return trim($fallback);
+            $trimmedFallback = trim($fallback);
+            if ($trimmedFallback !== '') {
+                return $trimmedFallback;
             }
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues PHP 8.5 modernization on top of prior idiom work. The codebase already uses `array_first`/`array_last`, `clone($obj, [...])`, pipes, URI extension, enums, `match`, and `#[\NoDiscard]` extensively; this PR picks up remaining clear local wins:

- Trim env/config and set-version strings once instead of repeating `trim()`
- Drop redundant `$arr === [] ? null : array_first($arr)` (empty arrays already yield `null`)
- Reuse `GameListFilter::sanitizeNullableString()` in `withPlayer()`, and simplify platform filter selection with `array_filter(...)` / `in_array`
- Prefer left-to-right URI path → extension pipes in image download/avatar sync helpers
- Align `#[\SensitiveParameter]` on `PsnGameLookupService` with sibling PSN lookup services
- Fill remaining `#[\NoDiscard]` gaps on parse/normalize/download helpers

Remaining unsealed service classes are intentionally left alone: they are extended by mutable test stubs, so `final`/`readonly` would require a broader test double refactor rather than an idiom cleanup.

## Test plan

- [x] `php -l` on changed files
- [x] `php tests/run.php` — all 1073 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f604a3da-6003-4ab9-849c-883ee4913a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f604a3da-6003-4ab9-849c-883ee4913a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

