### PR TITLE
Persist and report trophy group name changes during admin rescans

### DIFF
--- a/tests/GameRescanCatalogUpdaterTest.php
+++ b/tests/GameRescanCatalogUpdaterTest.php
@@ -165,6 +165,52 @@ final class GameRescanCatalogUpdaterTest extends TestCase
         $this->assertSame('New detail', $detail);
     }
 
+    public function testUpdateFromPsnUpdatesAndRecordsTrophyGroupNameChanges(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, detail, icon_url, platform, set_version)
+            VALUES ('NPWR00001_00', 'Details', 'title.png', 'PS5', '01.00')"
+        );
+        $this->database->exec(
+            "INSERT INTO trophy_group (np_communication_id, group_id, name, detail, icon_url)
+            VALUES ('NPWR00001_00', 'default', 'Old group name', 'Group detail', 'group.png')"
+        );
+        $this->groupDataFetcher->setGroupData([[
+            'group' => new PsnTrophyGroupApiAdapter('default', [
+                'trophyGroupName' => 'New group name',
+                'trophyGroupDetail' => 'Group detail',
+                'trophyGroupIconUrl' => 'https://example.test/group.png',
+            ]),
+            'trophies' => [],
+        ]]);
+
+        $differenceTracker = new GameRescanDifferenceTracker();
+        $this->catalogUpdater->updateFromPsn(
+            new \Tustin\PlayStation\Client(),
+            new GameRescanCatalogUpdaterTestTrophyTitle('Details', '01.00'),
+            'NPWR00001_00',
+            new GameRescanProgressReporter(),
+            $differenceTracker,
+        );
+
+        $name = $this->database->query(
+            "SELECT name FROM trophy_group WHERE np_communication_id = 'NPWR00001_00' AND group_id = 'default'"
+        )->fetchColumn();
+
+        $this->assertSame('New group name', $name);
+        $nameDifference = null;
+        foreach ($differenceTracker->differences as $difference) {
+            if ($difference['field'] === 'Name' && str_contains($difference['context'], 'Group')) {
+                $nameDifference = $difference;
+                break;
+            }
+        }
+
+        $this->assertTrue($nameDifference !== null);
+        $this->assertSame('Old group name', $nameDifference['previous']);
+        $this->assertSame('New group name', $nameDifference['current']);
+    }
+
     public function testUpdateFromPsnPreservesPsvr2PlatformWhenMissingFromIncomingTitle(): void
     {
         $this->database->exec(

--- a/tests/GameRescanCatalogUpdaterTest.php
+++ b/tests/GameRescanCatalogUpdaterTest.php
@@ -211,6 +211,43 @@ final class GameRescanCatalogUpdaterTest extends TestCase
         $this->assertSame('New group name', $nameDifference['current']);
     }
 
+    public function testUpdateFromPsnPreservesTrophyGroupNameWhenIncomingNameIsMissing(): void
+    {
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, detail, icon_url, platform, set_version)
+            VALUES ('NPWR00001_00', 'Details', 'title.png', 'PS5', '01.00')"
+        );
+        $this->database->exec(
+            "INSERT INTO trophy_group (np_communication_id, group_id, name, detail, icon_url)
+            VALUES ('NPWR00001_00', 'default', 'Existing group name', 'Group detail', 'group.png')"
+        );
+        $this->groupDataFetcher->setGroupData([[
+            'group' => new PsnTrophyGroupApiAdapter('default', [
+                'trophyGroupDetail' => 'Group detail',
+                'trophyGroupIconUrl' => 'https://example.test/group.png',
+            ]),
+            'trophies' => [],
+        ]]);
+
+        $differenceTracker = new GameRescanDifferenceTracker();
+        $this->catalogUpdater->updateFromPsn(
+            new \Tustin\PlayStation\Client(),
+            new GameRescanCatalogUpdaterTestTrophyTitle('Details', '01.00'),
+            'NPWR00001_00',
+            new GameRescanProgressReporter(),
+            $differenceTracker,
+        );
+
+        $name = $this->database->query(
+            "SELECT name FROM trophy_group WHERE np_communication_id = 'NPWR00001_00' AND group_id = 'default'"
+        )->fetchColumn();
+
+        $this->assertSame('Existing group name', $name);
+        foreach ($differenceTracker->differences as $difference) {
+            $this->assertFalse($difference['field'] === 'Name' && str_contains($difference['context'], 'Group'));
+        }
+    }
+
     public function testUpdateFromPsnPreservesPsvr2PlatformWhenMissingFromIncomingTitle(): void
     {
         $this->database->exec(

--- a/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
+++ b/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
@@ -109,13 +109,17 @@ final readonly class GameRescanCatalogUpdater
                 ? $groupLabel
                 : ($existingGroup['name'] ?? ($existingGroup['detail'] ?? $groupId));
             $contextLabel = (string) $contextLabel;
+            $incomingGroupName = $trophyGroup->name();
+            $groupName = $incomingGroupName !== ''
+                ? $incomingGroupName
+                : (string) ($existingGroup['name'] ?? '');
 
             $differenceTracker->recordGroupChange(
                 $groupId,
                 $contextLabel,
                 'Name',
                 $existingGroup['name'],
-                $trophyGroup->name()
+                $groupName
             );
             $differenceTracker->recordGroupChange(
                 $groupId,
@@ -135,7 +139,7 @@ final readonly class GameRescanCatalogUpdater
             $this->trophyCatalogSynchronizer->upsertTrophyGroup(
                 $npCommunicationId,
                 (string) $trophyGroup->id(),
-                $trophyGroup->name(),
+                $groupName,
                 (string) $trophyGroup->detail(),
                 $groupIconFilename,
             );

--- a/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
+++ b/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
@@ -113,6 +113,13 @@ final readonly class GameRescanCatalogUpdater
             $differenceTracker->recordGroupChange(
                 $groupId,
                 $contextLabel,
+                'Name',
+                $existingGroup['name'],
+                $trophyGroup->name()
+            );
+            $differenceTracker->recordGroupChange(
+                $groupId,
+                $contextLabel,
                 'Detail',
                 $existingGroup['detail'],
                 (string) $trophyGroup->detail()
@@ -131,7 +138,6 @@ final readonly class GameRescanCatalogUpdater
                 $trophyGroup->name(),
                 (string) $trophyGroup->detail(),
                 $groupIconFilename,
-                false,
             );
 
             $processedGroups++;

--- a/wwwroot/classes/TrophyCatalogSynchronizer.php
+++ b/wwwroot/classes/TrophyCatalogSynchronizer.php
@@ -264,8 +264,7 @@ final readonly class TrophyCatalogSynchronizer
             ? 'name = new.name, detail = new.detail, icon_url = new.icon_url'
             : 'detail = new.detail, icon_url = new.icon_url';
 
-        $query = $this->database->prepare(
-            "INSERT INTO trophy_group (
+        $insert = "INSERT INTO trophy_group (
                 np_communication_id,
                 group_id,
                 name,
@@ -278,10 +277,13 @@ final readonly class TrophyCatalogSynchronizer
                 :name,
                 :detail,
                 :icon_url
-            ) AS new
-            ON DUPLICATE KEY UPDATE
-                {$duplicateUpdate}"
-        );
+            )";
+        $query = $this->database->prepare($this->database->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite'
+            ? $insert . ' ON CONFLICT (np_communication_id, group_id) DO UPDATE SET '
+                . ($updateNameOnDuplicate
+                    ? 'name = excluded.name, detail = excluded.detail, icon_url = excluded.icon_url'
+                    : 'detail = excluded.detail, icon_url = excluded.icon_url')
+            : $insert . " AS new ON DUPLICATE KEY UPDATE {$duplicateUpdate}");
         $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
         $query->bindValue(':group_id', $groupId, PDO::PARAM_STR);
         $query->bindValue(':name', $name, PDO::PARAM_STR);


### PR DESCRIPTION
### Motivation

- Admin rescans were not updating stored trophy group names when the PSN payload contained a different `trophyGroupName`, causing rescan results to omit expected name changes.
- The in-memory (SQLite) test suite needed to be able to exercise the upsert behavior used by rescans.

### Description

- Record and persist group-name changes during admin rescans by reporting the `Name` field to the difference tracker and passing the incoming name to the catalog upsert logic in `wwwroot/classes/Admin/GameRescanCatalogUpdater.php`.
- Make `TrophyCatalogSynchronizer::upsertTrophyGroup` compatible with SQLite by emitting an `ON CONFLICT ... DO UPDATE` variant when the PDO driver is `sqlite`, while preserving the MySQL `ON DUPLICATE KEY UPDATE` path for production in `wwwroot/classes/TrophyCatalogSynchronizer.php`.
- Add a regression unit test `testUpdateFromPsnUpdatesAndRecordsTrophyGroupNameChanges` to `tests/GameRescanCatalogUpdaterTest.php` that asserts the stored group name is replaced and that the change is recorded in the rescan differences.

### Testing

- Ran the full test suite with `php tests/run.php` and observed all tests passed (1081 tests), including the new `GameRescanCatalogUpdater` regression test.
- Linted modified files with `php -l` (checked `wwwroot/classes/Admin/GameRescanCatalogUpdater.php`, `wwwroot/classes/TrophyCatalogSynchronizer.php`, and `tests/GameRescanCatalogUpdaterTest.php`) with no syntax errors reported.
- Verified the new behavior via the added unit test which asserts the database row is updated and the `Name` diff is present (test passed as part of the full suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8554f1003c832f8bc3260db673ff8d)