### PR TITLE
Fix admin rescan metadata refresh

### DIFF
--- a/tests/GameRescanCatalogUpdaterTest.php
+++ b/tests/GameRescanCatalogUpdaterTest.php
@@ -91,7 +91,7 @@ final class GameRescanCatalogUpdaterTest extends TestCase
         );
     }
 
-    public function testUpdateFromPsnSkipsWhenIncomingSetVersionIsLower(): void
+    public function testUpdateFromPsnRefreshesTitleWhenIncomingSetVersionIsLower(): void
     {
         $this->database->exec(
             "INSERT INTO trophy_title (np_communication_id, detail, icon_url, platform, set_version)
@@ -114,12 +114,14 @@ final class GameRescanCatalogUpdaterTest extends TestCase
         );
 
         $this->assertSame([], $groups);
-        $this->assertSame([], $differenceTracker->differences);
+        $this->assertSame(2, count($differenceTracker->differences));
 
-        $detail = $this->database->query(
-            "SELECT detail FROM trophy_title WHERE np_communication_id = 'NPWR00001_00'"
-        )->fetchColumn();
-        $this->assertSame('Old detail', $detail);
+        $title = $this->database->query(
+            "SELECT detail, icon_url, set_version FROM trophy_title WHERE np_communication_id = 'NPWR00001_00'"
+        )->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('New detail', $title['detail']);
+        $this->assertSame(md5('image-bytes') . '.png', $title['icon_url']);
+        $this->assertSame('01.10', $title['set_version']);
     }
 
     public function testUpdateFromPsnRecordsTitleDetailChanges(): void

--- a/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
+++ b/wwwroot/classes/Admin/GameRescanCatalogUpdater.php
@@ -38,12 +38,10 @@ final readonly class GameRescanCatalogUpdater
     ): array {
         $existingTitleInfo = $this->trophyCatalogSynchronizer->fetchExistingTrophyTitleInfo($npCommunicationId);
 
-        if (!self::isSetVersionAtLeastCurrent((string) $trophyTitle->trophySetVersion(), $existingTitleInfo['set_version'])) {
-            $progressReporter->notify(70, 'Skipping trophy refresh because incoming set version is lower.');
-
-            return [];
-        }
-
+        // A rescan is an explicit request to refresh the catalog. PSN can return
+        // corrected metadata without increasing (and occasionally while reporting
+        // an older) set version, so the version must not gate these updates. The
+        // service still prevents the stored set_version itself from being downgraded.
         $existingGroupData = $this->trophyCatalogSynchronizer->fetchExistingTrophyGroupData($npCommunicationId);
         $existingTrophyData = $this->trophyCatalogSynchronizer->fetchExistingTrophyData($npCommunicationId);
 


### PR DESCRIPTION
### Motivation
- Admin rescans should force-refresh trophy catalog metadata (title detail, icons, platform, groups, and trophies) even when PSN returns a lower or unchanged trophy set version because PSN can correct metadata without increasing the set version.

### Description
- Remove the early `isSetVersionAtLeastCurrent` check that returned early from `GameRescanCatalogUpdater::updateFromPsn`, allowing explicit admin rescans to refresh catalog fields.
- Add a clarifying comment in `GameRescanCatalogUpdater.php` explaining that rescans must not be gated by the incoming set version while still preventing stored `set_version` downgrades elsewhere.
- Update `tests/GameRescanCatalogUpdaterTest.php` to rename the version-gating test and assert that a rescan updates the title `detail` and downloaded `icon_url` while preserving the stored `set_version` and recording differences.

### Testing
- Ran PHP syntax lint across `wwwroot` and `tests` with `php -l` and all checked files passed (712 files linted).
- Ran the full test suite with `php tests/run.php` and all tests passed (1,082 tests).
- Ran `git diff --check` to validate there are no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a855f3f53b8832fbbf427a0d807d267)