### PR TITLE
Modernize PSN trophy level calculations

### DIFF
--- a/tests/PlayStationTrophyLevelCalculatorTest.php
+++ b/tests/PlayStationTrophyLevelCalculatorTest.php
@@ -22,6 +22,14 @@ final class PlayStationTrophyLevelCalculatorTest extends TestCase
         $this->assertSame(0, $result['progress']);
     }
 
+    public function testCalculateUsesExactIntegerProgressWithinTier(): void
+    {
+        $result = PlayStationTrophyLevelCalculator::calculate(59);
+
+        $this->assertSame(1, $result['level']);
+        $this->assertSame(98, $result['progress']);
+    }
+
     public function testCalculateUsesSecondTierFormula(): void
     {
         $result = PlayStationTrophyLevelCalculator::calculate(6030);
@@ -36,5 +44,16 @@ final class PlayStationTrophyLevelCalculatorTest extends TestCase
 
         $this->assertSame(211, $result['level']);
         $this->assertSame(24, $result['progress']);
+    }
+
+    public function testCalculationMethodsRequireTheirResultsToBeUsed(): void
+    {
+        $pointsAttribute = new ReflectionMethod(PlayStationTrophyLevelCalculator::class, 'calculateTrophyPoints')
+            ->getAttributes(NoDiscard::class);
+        $levelAttribute = new ReflectionMethod(PlayStationTrophyLevelCalculator::class, 'calculate')
+            ->getAttributes(NoDiscard::class);
+
+        $this->assertSame(1, count($pointsAttribute));
+        $this->assertSame(1, count($levelAttribute));
     }
 }

--- a/wwwroot/classes/PlayStationTrophyLevelCalculator.php
+++ b/wwwroot/classes/PlayStationTrophyLevelCalculator.php
@@ -15,6 +15,7 @@ final readonly class PlayStationTrophyLevelCalculator
     /**
      * Returns the PSN trophy score for the given trophy counts.
      */
+    #[\NoDiscard('The calculated trophy points must be used.')]
     public static function calculateTrophyPoints(int $bronze, int $silver, int $gold, int $platinum): int
     {
         return ($bronze * self::BRONZE_POINTS)
@@ -26,20 +27,15 @@ final readonly class PlayStationTrophyLevelCalculator
     /**
      * @return array{level: int, progress: int}
      */
+    #[\NoDiscard('The calculated trophy level and progress must be used.')]
     public static function calculate(int $points): array
     {
         if ($points <= 5940) {
-            return [
-                'level' => (int) floor($points / 60) + 1,
-                'progress' => (int) (floor($points / 60 * 100) % 100),
-            ];
+            return self::calculateTier($points, 60, 1);
         }
 
         if ($points <= 14940) {
-            return [
-                'level' => (int) floor(($points - 5940) / 90) + 100,
-                'progress' => (int) (floor(($points - 5940) / 90 * 100) % 100),
-            ];
+            return self::calculateTier($points - 5940, 90, 100);
         }
 
         $stage = 1;
@@ -49,9 +45,17 @@ final readonly class PlayStationTrophyLevelCalculator
             $stage++;
         }
 
+        return self::calculateTier($leftovers, 450 * $stage, 100 + 100 * $stage);
+    }
+
+    /**
+     * @return array{level: int, progress: int}
+     */
+    private static function calculateTier(int $points, int $pointsPerLevel, int $baseLevel): array
+    {
         return [
-            'level' => (int) floor($leftovers / (450 * $stage)) + (100 + 100 * $stage),
-            'progress' => (int) (floor($leftovers / (450 * $stage) * 100) % 100),
+            'level' => intdiv($points, $pointsPerLevel) + $baseLevel,
+            'progress' => intdiv(($points % $pointsPerLevel) * 100, $pointsPerLevel),
         ];
     }
 }


### PR DESCRIPTION
### Motivation

- Improve clarity and safety of trophy point/level computations by adopting PHP 8.5 idioms. 
- Ensure callers cannot accidentally ignore returned calculation results by adding explicit `NoDiscard` guidance. 
- Replace floating-point `floor()` logic with exact integer arithmetic for predictable progress/level values.

### Description

- Added `#[\NoDiscard('...')]` attributes to `PlayStationTrophyLevelCalculator::calculateTrophyPoints` and `PlayStationTrophyLevelCalculator::calculate` to require results be used. 
- Consolidated repeated tier logic into a private helper `calculateTier(int $points, int $pointsPerLevel, int $baseLevel)` and switched to `intdiv()` and integer modulo arithmetic to compute exact `level` and `progress`. 
- Rewrote the top-level `calculate()` method to call `calculateTier()` for each tier instead of using floating-point `floor()` expressions. 
- Extended tests in `tests/PlayStationTrophyLevelCalculatorTest.php` with `testCalculateUsesExactIntegerProgressWithinTier` and `testCalculationMethodsRequireTheirResultsToBeUsed` to cover precise progress computation and the presence of the `NoDiscard` attributes.

### Testing

- Ran syntax checks with `php -l` on `wwwroot/classes/PlayStationTrophyLevelCalculator.php` and `tests/PlayStationTrophyLevelCalculatorTest.php`, both passed. 
- Executed the full test suite with `php tests/run.php`, and all automated tests passed (1089 tests). 
- Ran `composer validate --working-dir=wwwroot --no-check-publish` and `git diff --check` as part of validation, with no blocking issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a856d0a9d88832f966debebca04e81b)