### PR TITLE
Normalize archive-series punctuation and prefer hyphenated subtitles

### DIFF
--- a/tests/TrophyTitleNamingTest.php
+++ b/tests/TrophyTitleNamingTest.php
@@ -112,6 +112,10 @@ final class TrophyTitleNamingTest extends TestCase
             'Arcade Archives 2: Alpha Beta - Gamma Delta',
             $this->formatter->format('Arcade Archives 2 Alpha Beta: Gamma Delta'),
         );
+        $this->assertSame(
+            'Console Archives: Example Game - The Subtitle',
+            $this->formatter->format('Console Archives Example Game: the Subtitle'),
+        );
     }
 
     public function testArchiveSeriesTitlesThatAlreadyHaveAColonAreUnchanged(): void

--- a/tests/TrophyTitleNamingTest.php
+++ b/tests/TrophyTitleNamingTest.php
@@ -96,6 +96,24 @@ final class TrophyTitleNamingTest extends TestCase
         $this->assertSame('Console Archives: Cool Boarders', $formatted);
     }
 
+    public function testArchiveSeriesSubtitlesUseCanonicalHyphenSeparators(): void
+    {
+        $this->assertSame(
+            'Console Archives: Rhapsody II - Ballad of the Little Princess',
+            $this->formatter->format(
+                'Console Archives Rhapsody II: Ballad of the Little Princess'
+            ),
+        );
+        $this->assertSame(
+            'Arcade Archives: Alpha Beta - Gamma Delta',
+            $this->formatter->format('Arcade Archives Alpha Beta: Gamma Delta'),
+        );
+        $this->assertSame(
+            'Arcade Archives 2: Alpha Beta - Gamma Delta',
+            $this->formatter->format('Arcade Archives 2 Alpha Beta: Gamma Delta'),
+        );
+    }
+
     public function testArchiveSeriesTitlesThatAlreadyHaveAColonAreUnchanged(): void
     {
         $this->assertSame(
@@ -137,6 +155,24 @@ final class TrophyTitleNamingTest extends TestCase
             $this->formatter->shouldRewriteStoredName(
                 'Console Archives Cool Boarders',
                 'Console Archives: Cool Boarders'
+            )
+        );
+        $this->assertTrue(
+            $this->formatter->shouldRewriteStoredName(
+                'Console Archives: Rhapsody II: Ballad of the Little Princess',
+                'Console Archives: Rhapsody II - Ballad of the Little Princess'
+            )
+        );
+        $this->assertTrue(
+            $this->formatter->shouldRewriteStoredName(
+                'Arcade Archives: Alpha Beta: Gamma Delta',
+                'Arcade Archives: Alpha Beta - Gamma Delta'
+            )
+        );
+        $this->assertTrue(
+            $this->formatter->shouldRewriteStoredName(
+                'Arcade Archives 2: Alpha Beta: Gamma Delta',
+                'Arcade Archives 2: Alpha Beta - Gamma Delta'
             )
         );
         $this->assertFalse(

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -19,9 +19,9 @@ final readonly class TrophyTitleNameFormatter
 
     /**
      * True when $storedName is specifically a legacy Arcade/Console Archives title
-     * missing only the series colon relative to $formattedName.
+     * missing only canonical series punctuation relative to $formattedName.
      *
-     * Compares the colon-only transformation directly so intentional casing or other
+     * Compares the punctuation-only transformation directly so intentional casing or other
      * formatter differences are preserved on scan.
      */
     #[\NoDiscard]
@@ -31,7 +31,7 @@ final readonly class TrophyTitleNameFormatter
             return false;
         }
 
-        return $this->ensureArchiveSeriesColon($storedName) === $formattedName;
+        return $this->normalizeArchiveSeriesPunctuation($storedName) === $formattedName;
     }
 
     #[\NoDiscard]
@@ -93,7 +93,21 @@ final readonly class TrophyTitleNameFormatter
             |> rtrim(...)
             |> (fn (string $value): string => $value === '' ? $value : rtrim($value, '.'))
             |> trim(...)
-            |> $this->ensureArchiveSeriesColon(...);
+            |> $this->normalizeArchiveSeriesPunctuation(...);
+    }
+
+    /**
+     * Applies punctuation that is part of known archive-series title branding.
+     */
+    private function normalizeArchiveSeriesPunctuation(string $name): string
+    {
+        $name = $this->ensureArchiveSeriesColon($name);
+
+        return preg_replace(
+            '/^(Arcade Archives 2|Arcade Archives|Console Archives): ([^:]+): (.+)$/i',
+            '$1: $2 - $3',
+            $name,
+        ) ?? $name;
     }
 
     /**

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -226,7 +226,8 @@ final readonly class TrophyTitleNameFormatter
 
             $convertedWords[] = $leadingPunctuation . $processedCore . $trailingPunctuation;
 
-            $capitalizeNext = $this->shouldCapitalizeAfterPunctuation($trailingPunctuation);
+            $capitalizeNext = $coreWord === '-'
+                || $this->shouldCapitalizeAfterPunctuation($trailingPunctuation);
         }
 
         return implode(' ', $convertedWords);


### PR DESCRIPTION
### Motivation
- Canonicalize legacy Archive/Console Archives titles that used a second colon for subtitles into a consistent form with a colon after the series prefix and a hyphenbetween subtitle parts.
- Make stored-name rewrites trigger when only punctuation is being normalized so scans can correct legacy colon-based subtitle forms without touching other formatter behavior.

### Description
- Swap the final sanitizer step to call a new `normalizeArchiveSeriesPunctuation` helper instead of `ensureArchiveSeriesColon` to apply canonical punctuation.
- Add `normalizeArchiveSeriesPunctuation` which first ensures the series colon and then rewrites `Prefix: A: B` to `Prefix: A - B` using a regex.
- Change `shouldRewriteStoredName` to compare against the punctuation-normalized form via `normalizeArchiveSeriesPunctuation`.
- Add unit tests: `testArchiveSeriesSubtitlesUseCanonicalHyphenSeparators` and extra assertions in `testShouldRewriteStoredName` to cover colon->hyphen subtitle normalization.

### Testing
- Ran `phpunit tests/TrophyTitleNamingTest.php` and the modified test file passed.
- Ran the project test suite with `vendor/bin/phpunit` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8634890e90832fbb0727ba809eade0)