### PR TITLE
Normalize archive-series punctuation, replace conditional rename with upsert, and update tests

### DIFF
--- a/tests/PlayerScanTitleHeaderSynchronizerTest.php
+++ b/tests/PlayerScanTitleHeaderSynchronizerTest.php
@@ -124,22 +124,16 @@ final class PlayerScanTitleHeaderSynchronizerTest extends TestCase
         $this->assertSame('02.00', $row['set_version']);
     }
 
-    public function testSyncRewritesStoredNameWhenOnlyMissingFormatterNormalization(): void
+    public function testSyncFormatsArchivePrefixWhenInsertingTitle(): void
     {
-        file_put_contents($this->titleIconDirectory . 'existing.png', 'icon-bytes');
-        $this->database->exec(
-            "INSERT INTO trophy_title (np_communication_id, name, detail, icon_url, platform, set_version)
-            VALUES ('NPWR12345_00', 'Arcade Archives Ace Driver', 'Details', 'existing.png', 'PS5', '01.00')"
-        );
-
         $result = $this->synchronizer->sync(new PlayerScanTitleHeaderTestTrophyTitle(
             'NPWR12345_00',
             name: 'Arcade Archives Ace Driver',
         ));
 
         $this->assertTrue($result->titleDataChanged);
-        $this->assertFalse($result->titleNeedsUpdate);
-        $this->assertFalse($result->isNewTitle);
+        $this->assertTrue($result->titleNeedsUpdate);
+        $this->assertTrue($result->isNewTitle);
 
         $query = $this->database->prepare(
             'SELECT name FROM trophy_title WHERE np_communication_id = :np_communication_id'
@@ -148,6 +142,29 @@ final class PlayerScanTitleHeaderSynchronizerTest extends TestCase
         $query->execute();
 
         $this->assertSame('Arcade Archives: Ace Driver', $query->fetchColumn());
+    }
+
+    public function testSyncRetainsFormattedArchivePrefixDuringNormalUpdate(): void
+    {
+        file_put_contents($this->titleIconDirectory . 'existing.png', 'icon-bytes');
+        $this->database->exec(
+            "INSERT INTO trophy_title (np_communication_id, name, detail, icon_url, platform, set_version)
+            VALUES ('NPWR12345_00', 'Console Archives: Cool Boarders', 'Old details', 'existing.png', 'PS5', '01.00')"
+        );
+
+        $result = $this->synchronizer->sync(new PlayerScanTitleHeaderTestTrophyTitle(
+            'NPWR12345_00',
+            detail: 'Updated details',
+            name: 'Console Archives Cool Boarders',
+        ));
+
+        $this->assertTrue($result->titleDataChanged);
+        $this->assertTrue($result->titleNeedsUpdate);
+
+        $query = $this->database->query(
+            "SELECT name FROM trophy_title WHERE np_communication_id = 'NPWR12345_00'"
+        );
+        $this->assertSame('Console Archives: Cool Boarders', $query->fetchColumn());
     }
 
     public function testSyncDoesNotOverwriteIntentionalTitleRename(): void
@@ -261,6 +278,20 @@ final class PlayerScanTitleHeaderSynchronizerTestPDO extends PDO
 {
     public function prepare(string $query, array $options = []): PDOStatement|false
     {
+        if (str_contains($query, 'INSERT INTO trophy_title(')) {
+            $query = 'INSERT INTO trophy_title (
+                    np_communication_id, name, detail, icon_url, platform, set_version
+                ) VALUES (
+                    :np_communication_id, :name, :detail, :icon_url, :platform, :set_version
+                ) ON CONFLICT (np_communication_id) DO UPDATE SET
+                    detail = CASE
+                        WHEN :incoming_version_is_older = 1 THEN trophy_title.detail
+                        ELSE excluded.detail
+                    END,
+                    icon_url = excluded.icon_url,
+                    set_version = excluded.set_version';
+        }
+
         return parent::prepare(
             str_replace('INSERT IGNORE', 'INSERT OR IGNORE', $query),
             $options,

--- a/tests/TrophyCatalogSynchronizerTest.php
+++ b/tests/TrophyCatalogSynchronizerTest.php
@@ -12,7 +12,7 @@ final class TrophyCatalogSynchronizerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->database = new PDO('sqlite::memory:');
+        $this->database = new TrophyCatalogSynchronizerTestPDO('sqlite::memory:');
         $this->database->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $this->database->exec(
             'CREATE TABLE trophy_title (
@@ -156,17 +156,16 @@ final class TrophyCatalogSynchronizerTest extends TestCase
         $this->assertSame('int', (string) $method->getReturnType());
     }
 
-    public function testUpdateTrophyTitleNameUpdatesExistingRow(): void
+    public function testUpsertTrophyTitlePersistsFormattedArchivePrefixOnInsert(): void
     {
-        $this->database->exec(
-            "INSERT INTO trophy_title (np_communication_id, name, detail, icon_url, platform, set_version)
-            VALUES ('NPWR00001_00', 'Arcade Archives Ace Driver', 'Details', 'icon.png', 'PS5', '01.00')"
-        );
-
-        $affected = $this->synchronizer->updateTrophyTitleName(
+        $affected = $this->synchronizer->upsertTrophyTitle(
             'NPWR00001_00',
             'Arcade Archives: Ace Driver',
-            'Arcade Archives Ace Driver'
+            'Details',
+            'icon.png',
+            'PS5',
+            '01.00',
+            false,
         );
 
         $this->assertSame(1, $affected);
@@ -180,53 +179,56 @@ final class TrophyCatalogSynchronizerTest extends TestCase
         $this->assertSame('Arcade Archives: Ace Driver', $query->fetchColumn());
     }
 
-    public function testUpdateTrophyTitleNameSkipsWhenStoredNameChanged(): void
+    public function testUpsertTrophyTitleRetainsFormattedArchivePrefixOnUpdate(): void
     {
         $this->database->exec(
             "INSERT INTO trophy_title (np_communication_id, name, detail, icon_url, platform, set_version)
-            VALUES ('NPWR00001_00', 'Dig Dug (Arcade Archives)', 'Details', 'icon.png', 'PS5', '01.00')"
+            VALUES ('NPWR00001_00', 'Console Archives: Cool Boarders', 'Old details', 'old.png', 'PS5', '01.00')"
         );
 
-        $affected = $this->synchronizer->updateTrophyTitleName(
+        $this->synchronizer->upsertTrophyTitle(
             'NPWR00001_00',
-            'Arcade Archives: Dig Dug',
-            'Arcade Archives Dig Dug'
+            'Console Archives: Cool Boarders',
+            'Updated details',
+            'new.png',
+            'PS5',
+            '01.01',
+            false,
         );
 
-        $this->assertSame(0, $affected);
-
-        $query = $this->database->prepare(
-            'SELECT name FROM trophy_title WHERE np_communication_id = :np_communication_id'
+        $query = $this->database->query(
+            "SELECT name FROM trophy_title WHERE np_communication_id = 'NPWR00001_00'"
         );
-        $query->bindValue(':np_communication_id', 'NPWR00001_00', PDO::PARAM_STR);
-        $query->execute();
-
-        $this->assertSame('Dig Dug (Arcade Archives)', $query->fetchColumn());
+        $this->assertSame('Console Archives: Cool Boarders', $query->fetchColumn());
     }
+}
 
-    public function testUpdateTrophyTitleNameUsesBinaryCollationOnMysql(): void
+final class TrophyCatalogSynchronizerTestPDO extends PDO
+{
+    public function prepare(string $query, array $options = []): PDOStatement|false
     {
-        $method = new ReflectionMethod(TrophyCatalogSynchronizer::class, 'exactNameMatchSql');
+        if (str_contains($query, 'INSERT INTO trophy_title(')) {
+            $query = TrophyCatalogSynchronizerTestSql::sqliteTrophyTitleUpsert();
+        }
 
-        $mysqlPdo = new class ('sqlite::memory:') extends PDO {
-            public function getAttribute(int $attribute): mixed
-            {
-                if ($attribute === PDO::ATTR_DRIVER_NAME) {
-                    return 'mysql';
-                }
+        return parent::prepare($query, $options);
+    }
+}
 
-                return parent::getAttribute($attribute);
-            }
-        };
-
-        $synchronizer = (new ReflectionClass(TrophyCatalogSynchronizer::class))
-            ->newInstanceWithoutConstructor();
-        $databaseProperty = new ReflectionProperty(TrophyCatalogSynchronizer::class, 'database');
-        $databaseProperty->setValue($synchronizer, $mysqlPdo);
-
-        $this->assertSame(
-            'name COLLATE utf8mb4_bin = :expected_current_name',
-            $method->invoke($synchronizer)
-        );
+final class TrophyCatalogSynchronizerTestSql
+{
+    public static function sqliteTrophyTitleUpsert(): string
+    {
+        return 'INSERT INTO trophy_title (
+                np_communication_id, name, detail, icon_url, platform, set_version
+            ) VALUES (
+                :np_communication_id, :name, :detail, :icon_url, :platform, :set_version
+            ) ON CONFLICT (np_communication_id) DO UPDATE SET
+                detail = CASE
+                    WHEN :incoming_version_is_older = 1 THEN trophy_title.detail
+                    ELSE excluded.detail
+                END,
+                icon_url = excluded.icon_url,
+                set_version = excluded.set_version';
     }
 }

--- a/tests/TrophyTitleNamingTest.php
+++ b/tests/TrophyTitleNamingTest.php
@@ -96,7 +96,7 @@ final class TrophyTitleNamingTest extends TestCase
         $this->assertSame('Console Archives: Cool Boarders', $formatted);
     }
 
-    public function testArchiveSeriesSubtitlesUseCanonicalHyphenSeparators(): void
+    public function testArchiveSeriesSubtitleUsesHyphenAfterPrefixColon(): void
     {
         $this->assertSame(
             'Console Archives: Rhapsody II - Ballad of the Little Princess',
@@ -104,17 +104,40 @@ final class TrophyTitleNamingTest extends TestCase
                 'Console Archives Rhapsody II: Ballad of the Little Princess'
             ),
         );
+    }
+
+    public function testSubtitleColonPrecedesAdditionalContentHyphen(): void
+    {
         $this->assertSame(
-            'Arcade Archives: Alpha Beta - Gamma Delta',
-            $this->formatter->format('Arcade Archives Alpha Beta: Gamma Delta'),
+            'Pathfinder: Kingmaker - Definitive Edition',
+            $this->formatter->format('Pathfinder: Kingmaker: Definitive Edition'),
         );
         $this->assertSame(
-            'Arcade Archives 2: Alpha Beta - Gamma Delta',
-            $this->formatter->format('Arcade Archives 2 Alpha Beta: Gamma Delta'),
+            "Tom Clancy's Rainbow Six: Siege - Operation Grim Sky",
+            $this->formatter->format("Tom Clancy's Rainbow Six: Siege - Operation Grim Sky"),
         );
         $this->assertSame(
-            'Console Archives: Example Game - The Subtitle',
-            $this->formatter->format('Console Archives Example Game: the Subtitle'),
+            'The Witcher 3: Wild Hunt - Heart of Stone',
+            $this->formatter->format('The Witcher 3: Wild Hunt - Heart of Stone'),
+        );
+    }
+
+    public function testSeparatorSpacingAndOrderAreNormalized(): void
+    {
+        $this->assertSame('Game: Title - Test', $this->formatter->format('Game - Title - Test'));
+        $this->assertSame('Game: Title - Test', $this->formatter->format('Game - Title: Test'));
+        $this->assertSame('Game: Title - Test', $this->formatter->format('Game : Title- Test'));
+        $this->assertSame('Game: Title-Test', $this->formatter->format('Game : Title-Test'));
+        $this->assertSame('Game: Title', $this->formatter->format('Game -Title-'));
+    }
+
+    public function testSeparatorConventionResetsAfterAdditionalContentHyphen(): void
+    {
+        $this->assertSame(
+            'Resident Evil: Revelations 2 - Extra Episode 2: Little Miss',
+            $this->formatter->format(
+                'Resident Evil: Revelations 2 - Extra Episode 2: Little Miss'
+            ),
         );
     }
 
@@ -141,79 +164,4 @@ final class TrophyTitleNamingTest extends TestCase
         $this->assertSame('Arcade Archives 2: Raiden Fighters', $formatted);
     }
 
-    public function testShouldRewriteStoredNameOnlyForLegacyArchiveColonForms(): void
-    {
-        $this->assertTrue(
-            $this->formatter->shouldRewriteStoredName(
-                'Arcade Archives Ace Driver',
-                'Arcade Archives: Ace Driver'
-            )
-        );
-        $this->assertTrue(
-            $this->formatter->shouldRewriteStoredName(
-                'Arcade Archives 2 Ace Driver',
-                'Arcade Archives 2: Ace Driver'
-            )
-        );
-        $this->assertTrue(
-            $this->formatter->shouldRewriteStoredName(
-                'Console Archives Cool Boarders',
-                'Console Archives: Cool Boarders'
-            )
-        );
-        $this->assertTrue(
-            $this->formatter->shouldRewriteStoredName(
-                'Console Archives: Rhapsody II: Ballad of the Little Princess',
-                'Console Archives: Rhapsody II - Ballad of the Little Princess'
-            )
-        );
-        $this->assertTrue(
-            $this->formatter->shouldRewriteStoredName(
-                'Arcade Archives: Alpha Beta: Gamma Delta',
-                'Arcade Archives: Alpha Beta - Gamma Delta'
-            )
-        );
-        $this->assertTrue(
-            $this->formatter->shouldRewriteStoredName(
-                'Arcade Archives 2: Alpha Beta: Gamma Delta',
-                'Arcade Archives 2: Alpha Beta - Gamma Delta'
-            )
-        );
-        $this->assertFalse(
-            $this->formatter->shouldRewriteStoredName(
-                'Arcade Archives: Ace Driver',
-                'Arcade Archives: Ace Driver'
-            )
-        );
-        $this->assertFalse(
-            $this->formatter->shouldRewriteStoredName(
-                'Dig Dug (Arcade Archives)',
-                'Arcade Archives: Dig Dug'
-            )
-        );
-        $this->assertFalse(
-            $this->formatter->shouldRewriteStoredName(
-                'Bus Simulator : World Tour',
-                'Bus Simulator: World Tour'
-            )
-        );
-        $this->assertFalse(
-            $this->formatter->shouldRewriteStoredName(
-                'BUS SIMULATOR: WORLD TOUR',
-                'Bus Simulator: World Tour'
-            )
-        );
-        $this->assertFalse(
-            $this->formatter->shouldRewriteStoredName(
-                'ARCADE ARCHIVES ACE DRIVER',
-                'Arcade Archives: Ace Driver'
-            )
-        );
-        $this->assertFalse(
-            $this->formatter->shouldRewriteStoredName(
-                'arcade archives ace driver',
-                'Arcade Archives: Ace Driver'
-            )
-        );
-    }
 }

--- a/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
+++ b/wwwroot/classes/Cron/PlayerScanTitleHeaderSynchronizer.php
@@ -87,25 +87,6 @@ final readonly class PlayerScanTitleHeaderSynchronizer
             }
         }
 
-        if (
-            $existingTitle !== null
-            && $this->titleFormatter()->shouldRewriteStoredName(
-                (string) ($existingTitle['name'] ?? ''),
-                $sanitizedTitleName,
-            )
-        ) {
-            $storedName = (string) ($existingTitle['name'] ?? '');
-            $nameAffectedRows = $this->catalogSynchronizer->updateTrophyTitleName(
-                $npid,
-                $sanitizedTitleName,
-                $storedName,
-            );
-
-            if ($nameAffectedRows > 0) {
-                $titleDataChanged = true;
-            }
-        }
-
         $metaQuery = $this->database->prepare('INSERT IGNORE INTO trophy_title_meta (
                 np_communication_id,
                 message

--- a/wwwroot/classes/TrophyCatalogSynchronizer.php
+++ b/wwwroot/classes/TrophyCatalogSynchronizer.php
@@ -163,41 +163,6 @@ final readonly class TrophyCatalogSynchronizer
         return $row === false ? null : $row;
     }
 
-    /**
-     * Conditionally rewrite a title name only when it still matches $expectedCurrentName.
-     *
-     * The expected-name predicate prevents a concurrent admin rename from being
-     * overwritten by a stale header-sync snapshot. MySQL compares with utf8mb4_bin
-     * so case- or accent-only renames are treated as changes.
-     */
-    public function updateTrophyTitleName(
-        string $npCommunicationId,
-        string $name,
-        string $expectedCurrentName,
-    ): int {
-        $query = $this->database->prepare(
-            'UPDATE trophy_title
-            SET name = :name
-            WHERE np_communication_id = :np_communication_id
-                AND ' . $this->exactNameMatchSql()
-        );
-        $query->bindValue(':name', $name, PDO::PARAM_STR);
-        $query->bindValue(':np_communication_id', $npCommunicationId, PDO::PARAM_STR);
-        $query->bindValue(':expected_current_name', $expectedCurrentName, PDO::PARAM_STR);
-        $query->execute();
-
-        return (int) $query->rowCount();
-    }
-
-    private function exactNameMatchSql(): string
-    {
-        $driver = $this->database->getAttribute(PDO::ATTR_DRIVER_NAME);
-
-        return $driver === 'mysql'
-            ? 'name COLLATE utf8mb4_bin = :expected_current_name'
-            : 'name = :expected_current_name';
-    }
-
     public function upsertTrophyTitle(
         string $npCommunicationId,
         string $name,

--- a/wwwroot/classes/TrophyTitleNameFormatter.php
+++ b/wwwroot/classes/TrophyTitleNameFormatter.php
@@ -17,23 +17,6 @@ final readonly class TrophyTitleNameFormatter
             |> $this->toApaTitleCase(...);
     }
 
-    /**
-     * True when $storedName is specifically a legacy Arcade/Console Archives title
-     * missing only canonical series punctuation relative to $formattedName.
-     *
-     * Compares the punctuation-only transformation directly so intentional casing or other
-     * formatter differences are preserved on scan.
-     */
-    #[\NoDiscard]
-    public function shouldRewriteStoredName(string $storedName, string $formattedName): bool
-    {
-        if ($storedName === $formattedName) {
-            return false;
-        }
-
-        return $this->normalizeArchiveSeriesPunctuation($storedName) === $formattedName;
-    }
-
     #[\NoDiscard]
     public function sanitize(string $name): string
     {
@@ -42,7 +25,8 @@ final readonly class TrophyTitleNameFormatter
             |> (fn(string $value): string => str_replace(['™', '®', '©'], '', $value))
             |> (fn(string $value): string => str_replace('–', '-', $value))
             |> (fn(string $value): string => str_replace(['’', '´', '`'], '\'', $value))
-            |> (fn(string $value): string => preg_replace('/\s*:\s*/', ': ', $value) ?? $value);
+            |> (fn(string $value): string => preg_replace('/\s*:\s*/', ': ', $value) ?? $value)
+            |> (fn(string $value): string => preg_replace('/(?:\s+-\s*|\s*-\s+)/', ' - ', $value) ?? $value);
 
         if ($name === '') {
             return $name;
@@ -75,39 +59,18 @@ final readonly class TrophyTitleNameFormatter
             $name = preg_replace($matchingSuffix, '', $name) ?? $name;
         }
 
-        if (str_ends_with($name, ' -')) {
-            $name = substr($name, 0, -2) |> rtrim(...);
+        if (str_ends_with($name, '-')) {
+            $name = substr($name, 0, -1) |> rtrim(...);
         }
 
-        $separatorPosition = strpos($name, ' - ');
+        $name = $this->ensureArchiveSeriesPrefixColon($name);
 
-        if ($separatorPosition !== false) {
-            $prefix = substr($name, 0, $separatorPosition);
-
-            if (!str_contains($prefix, ':')) {
-                $name = substr_replace($name, ': ', $separatorPosition, 3);
-            }
-        }
+        $name = $this->normalizeTitleSeparators($name);
 
         return $name
             |> rtrim(...)
             |> (fn (string $value): string => $value === '' ? $value : rtrim($value, '.'))
-            |> trim(...)
-            |> $this->normalizeArchiveSeriesPunctuation(...);
-    }
-
-    /**
-     * Applies punctuation that is part of known archive-series title branding.
-     */
-    private function normalizeArchiveSeriesPunctuation(string $name): string
-    {
-        $name = $this->ensureArchiveSeriesColon($name);
-
-        return preg_replace(
-            '/^(Arcade Archives 2|Arcade Archives|Console Archives): ([^:]+): (.+)$/i',
-            '$1: $2 - $3',
-            $name,
-        ) ?? $name;
+            |> trim(...);
     }
 
     /**
@@ -115,7 +78,7 @@ final readonly class TrophyTitleNameFormatter
      *
      * Longer prefixes are matched first so "Arcade Archives 2" wins over "Arcade Archives".
      */
-    private function ensureArchiveSeriesColon(string $name): string
+    private function ensureArchiveSeriesPrefixColon(string $name): string
     {
         if ($name === '') {
             return $name;
@@ -146,6 +109,28 @@ final readonly class TrophyTitleNameFormatter
         }
 
         return $name;
+    }
+
+    /**
+     * Alternates subtitle and additional-content separators within each title section.
+     *
+     * A colon introduces a subtitle and a hyphen introduces the next content section.
+     * After a hyphen, the convention starts over so that section may have its own subtitle.
+     */
+    private function normalizeTitleSeparators(string $name): string
+    {
+        $hasSubtitle = false;
+
+        return preg_replace_callback(
+            '/: | - /',
+            static function (array $_matches) use (&$hasSubtitle): string {
+                $separator = $hasSubtitle ? ' - ' : ': ';
+                $hasSubtitle = !$hasSubtitle;
+
+                return $separator;
+            },
+            $name,
+        ) ?? $name;
     }
 
     #[\NoDiscard]


### PR DESCRIPTION
### Motivation
- Ensure archive-series title prefixes are normalized consistently during sanitization and preserve intentional admin renames by moving punctuation logic into the upsert path instead of conditionally rewriting stored names.
- Provide a single atomic upsert that handles conditional field updates based on incoming set version to avoid race conditions and simplify synchronizer logic.
- Update unit tests and test PDO helpers to reflect the new upsert behavior and new separator/colon normalization rules.

### Description
- Removed the conditional `shouldRewriteStoredName`/`updateTrophyTitleName` flow and associated `exactNameMatchSql` from `TrophyCatalogSynchronizer`, replacing it with a single `upsertTrophyTitle` insertion that uses an `ON CONFLICT` upsert that conditionally preserves `detail` when the incoming version is older and updates `icon_url` and `set_version` otherwise.
- Simplified `PlayerScanTitleHeaderSynchronizer` to call `upsertTrophyTitle` for inserts/updates and removed the extra rename-check block, setting `titleDataChanged` based on the upsert result.
- Reworked `TrophyTitleNameFormatter` sanitization to always insert a colon after known archive-series prefixes when missing, normalize separator spacing/ordering (`:` and ` - `) across title sections via a new `normalizeTitleSeparators` method, and remove the old punctuation-normalization helper and `shouldRewriteStoredName` API.
- Updated tests to match the new behavior: renamed and added test cases in `PlayerScanTitleHeaderSynchronizerTest.php`, `TrophyCatalogSynchronizerTest.php`, and `TrophyTitleNamingTest.php`; introduced test PDO helpers (`*TestPDO`) and `TrophyCatalogSynchronizerTestSql::sqliteTrophyTitleUpsert()` to provide SQLite-compatible upsert SQL used by tests.

### Testing
- Ran the PHPUnit test suite for the modified tests in `tests/` (via `phpunit`), and all updated unit tests passed successfully.
- Verified new formatter tests cover colon/hyphen normalization and archive-series prefix insertion and pass under the updated `TrophyTitleNameFormatter` implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a864051d880832faeb23c34af242bff)