### PR TITLE
Show replaced titles in game header; add GameReplacedTitle and fetch logic

### DIFF
--- a/tests/GameHeaderServiceTest.php
+++ b/tests/GameHeaderServiceTest.php
@@ -126,6 +126,26 @@ final class GameHeaderServiceTest extends TestCase
         ]);
 
         $this->insertTrophyTitle([
+            'id' => 301,
+            'np_communication_id' => 'OBSOLETE-1',
+            'parent_np_communication_id' => null,
+            'name' => 'Older Game',
+            'platform' => 'PS4',
+            'region' => null,
+            'obsolete_ids' => '999, 1',
+        ]);
+
+        $this->insertTrophyTitle([
+            'id' => 302,
+            'np_communication_id' => 'OBSOLETE-OTHER',
+            'parent_np_communication_id' => null,
+            'name' => 'Unrelated Older Game',
+            'platform' => 'PS4',
+            'region' => null,
+            'obsolete_ids' => '11',
+        ]);
+
+        $this->insertTrophyTitle([
             'id' => 202,
             'np_communication_id' => 'REPL-2',
             'parent_np_communication_id' => null,
@@ -179,6 +199,10 @@ final class GameHeaderServiceTest extends TestCase
         $this->assertSame('Replacement Two', $headerData->getObsoleteReplacements()[0]->getName());
         $this->assertSame(201, $headerData->getObsoleteReplacements()[1]->getId());
         $this->assertSame('Replacement One', $headerData->getObsoleteReplacements()[1]->getName());
+        $this->assertTrue($headerData->hasReplacedTitles());
+        $this->assertCount(1, $headerData->getReplacedTitles());
+        $this->assertSame(301, $headerData->getReplacedTitles()[0]->getId());
+        $this->assertSame('Older Game', $headerData->getReplacedTitles()[0]->getName());
     }
 
     public function testBuildHeaderDataOmitsOptionalDataWhenNotAvailable(): void
@@ -199,6 +223,8 @@ final class GameHeaderServiceTest extends TestCase
         $this->assertFalse($headerData->hasUnobtainableTrophies());
         $this->assertFalse($headerData->hasObsoleteReplacements());
         $this->assertSame([], $headerData->getObsoleteReplacements());
+        $this->assertFalse($headerData->hasReplacedTitles());
+        $this->assertSame([], $headerData->getReplacedTitles());
         $this->assertFalse($headerData->hasPsnpPlusNote());
     }
 

--- a/wwwroot/classes/Game/GameHeaderData.php
+++ b/wwwroot/classes/Game/GameHeaderData.php
@@ -14,6 +14,8 @@ final readonly class GameHeaderData
         final private int $unobtainableTrophyCount,
         final private array $obsoleteReplacements,
         final private ?string $psnpPlusNote,
+        /** @var GameReplacedTitle[] */
+        final private array $replacedTitles = [],
     ) {
     }
 
@@ -61,6 +63,19 @@ final readonly class GameHeaderData
     public function hasObsoleteReplacements(): bool
     {
         return $this->obsoleteReplacements !== [];
+    }
+
+    /**
+     * @return GameReplacedTitle[]
+     */
+    public function getReplacedTitles(): array
+    {
+        return $this->replacedTitles;
+    }
+
+    public function hasReplacedTitles(): bool
+    {
+        return $this->replacedTitles !== [];
     }
 
     public function getPsnpPlusNote(): ?string

--- a/wwwroot/classes/Game/GameReplacedTitle.php
+++ b/wwwroot/classes/Game/GameReplacedTitle.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+final readonly class GameReplacedTitle
+{
+    private function __construct(
+        final private int $id,
+        final private string $name,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    #[\NoDiscard]
+    public static function fromArray(array $row): self
+    {
+        return new self(
+            (int) ($row['id'] ?? 0),
+            (string) ($row['name'] ?? '')
+        );
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/Game/GameObsoleteReplacement.php';
+require_once __DIR__ . '/Game/GameReplacedTitle.php';
 require_once __DIR__ . '/Game/GameDetails.php';
 require_once __DIR__ . '/Game/GameHeaderData.php';
 require_once __DIR__ . '/Game/GameHeaderParent.php';
@@ -51,7 +52,9 @@ readonly class GameHeaderService
 
         $psnpPlusNote = $this->findPsnpPlusNote($game);
 
-        return new GameHeaderData($parentGame, $stacks, $unobtainableTrophyCount, $obsoleteReplacements, $psnpPlusNote);
+        $replacedTitles = $this->fetchReplacedTitles($game->getId());
+
+        return new GameHeaderData($parentGame, $stacks, $unobtainableTrophyCount, $obsoleteReplacements, $psnpPlusNote, $replacedTitles);
     }
 
     private function fetchParentGame(string $npCommunicationId): ?GameHeaderParent
@@ -179,6 +182,42 @@ readonly class GameHeaderService
         }
 
         return $ordered;
+    }
+
+    /**
+     * @return GameReplacedTitle[]
+     */
+    private function fetchReplacedTitles(int $gameId): array
+    {
+        $obsoleteIdCondition = $this->database->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite'
+            ? "INSTR(',' || REPLACE(ttm.obsolete_ids, ' ', '') || ',', ',' || :game_id || ',') > 0"
+            : "FIND_IN_SET(:game_id, REPLACE(ttm.obsolete_ids, ' ', '')) > 0";
+
+        $query = $this->database->prepare(
+            <<<SQL
+            SELECT
+                tt.id,
+                tt.`name`
+            FROM
+                trophy_title tt
+                JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
+            WHERE
+                {$obsoleteIdCondition}
+            ORDER BY
+                tt.`name`,
+                tt.id
+            SQL
+        );
+
+        $query->bindValue(':game_id', $gameId, PDO::PARAM_INT);
+        $query->execute();
+
+        $rows = $query->fetchAll(PDO::FETCH_ASSOC);
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        return array_map(GameReplacedTitle::fromArray(...), $rows);
     }
 
     private function findPsnpPlusNote(GameDetails $game): ?string

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -152,11 +152,15 @@ $escapedPlayer = isset($player) ? Html::escape((string) $player) : null;
                     </div>
 
                     <?php
-                    if ($gameHeaderData->hasStacks()) {
-                        $stacks = $gameHeaderData->getStacks();
+                    if ($gameHeaderData->hasStacks() || $gameHeaderData->hasReplacedTitles()) {
                         ?>
-                        <!-- Stacks -->
-                        <div class="dropdown ms-auto align-self-start">
+                        <div class="hstack gap-2 ms-auto align-self-start">
+                        <?php
+                        if ($gameHeaderData->hasStacks()) {
+                            $stacks = $gameHeaderData->getStacks();
+                            ?>
+                            <!-- Stacks -->
+                            <div class="dropdown">
                             <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 Stacks (<?= count($stacks); ?>)
                             </button>
@@ -187,6 +191,37 @@ $escapedPlayer = isset($player) ? Html::escape((string) $player) : null;
                                 }
                                 ?>
                             </ul>
+                            </div>
+                            <?php
+                        }
+
+                        if ($gameHeaderData->hasReplacedTitles()) {
+                            $replacedTitles = $gameHeaderData->getReplacedTitles();
+                            ?>
+                            <!-- Replaced games -->
+                            <div class="dropdown">
+                                <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                    Replaces (<?= count($replacedTitles); ?>)
+                                </button>
+                                <ul class="dropdown-menu">
+                                    <?php
+                                    foreach ($replacedTitles as $replacedTitle) {
+                                        $replacedTitleLink = $replacedTitle->getId() . '-' . $utility->slugify($replacedTitle->getName());
+                                        if ($encodedPlayer !== null) {
+                                            $replacedTitleLink .= '/' . $encodedPlayer;
+                                        }
+                                        ?>
+                                        <li>
+                                            <a class="dropdown-item" href="/game/<?= $replacedTitleLink; ?>"><?= Html::escape($replacedTitle->getName()); ?></a>
+                                        </li>
+                                        <?php
+                                    }
+                                    ?>
+                                </ul>
+                            </div>
+                            <?php
+                        }
+                        ?>
                         </div>
                         <?php
                     }


### PR DESCRIPTION
### Motivation

- Expose titles that a game replaces (from `trophy_title_meta.obsolete_ids`) in the header data and surface them in the UI alongside stacks to provide clearer lineage information to users.

### Description

- Add a new `GameReplacedTitle` value object in `wwwroot/classes/Game/GameReplacedTitle.php` with `fromArray`, `getId`, and `getName` methods.
- Extend `GameHeaderData` to carry an array of `GameReplacedTitle` and add `getReplacedTitles()` and `hasReplacedTitles()` accessors, and include the new property in the constructor signature.
- Implement `fetchReplacedTitles` in `GameHeaderService` to query `trophy_title` joined with `trophy_title_meta` and detect the numeric `game_id` in the comma-separated `obsolete_ids`, using a driver-aware condition for SQLite (`INSTR`) vs MySQL (`FIND_IN_SET`), and map results to `GameReplacedTitle` objects; include the new require and pass replaced titles into `GameHeaderData` in `buildHeaderData`.
- Update the view `wwwroot/game_header.php` to render a new "Replaces" dropdown next to the existing "Stacks" dropdown when replaced titles exist, preserving player link encoding and ordering behavior.
- Update tests in `tests/GameHeaderServiceTest.php` to insert sample `trophy_title` rows with `obsolete_ids` and assert presence and absence of replaced titles in header data.

### Testing

- Ran the PHPUnit test `GameHeaderServiceTest` which was expanded to cover replaced titles, and the tests passed locally.
- Existing header-related assertions were kept and validated by the updated unit test run which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89584d83cc832fb523780a432d1315)