### PR TITLE
Include platform and region for replaced game titles and show them in Replaces dropdown

### DIFF
--- a/tests/GameHeaderServiceTest.php
+++ b/tests/GameHeaderServiceTest.php
@@ -131,7 +131,7 @@ final class GameHeaderServiceTest extends TestCase
             'parent_np_communication_id' => null,
             'name' => 'Older Game',
             'platform' => 'PS4',
-            'region' => null,
+            'region' => 'EU',
             'obsolete_ids' => '999, 1',
         ]);
 
@@ -203,6 +203,8 @@ final class GameHeaderServiceTest extends TestCase
         $this->assertCount(1, $headerData->getReplacedTitles());
         $this->assertSame(301, $headerData->getReplacedTitles()[0]->getId());
         $this->assertSame('Older Game', $headerData->getReplacedTitles()[0]->getName());
+        $this->assertSame('PS4', $headerData->getReplacedTitles()[0]->getPlatform());
+        $this->assertSame('EU', $headerData->getReplacedTitles()[0]->getRegion());
     }
 
     public function testBuildHeaderDataOmitsOptionalDataWhenNotAvailable(): void

--- a/wwwroot/classes/Game/GameReplacedTitle.php
+++ b/wwwroot/classes/Game/GameReplacedTitle.php
@@ -7,6 +7,8 @@ final readonly class GameReplacedTitle
     private function __construct(
         final private int $id,
         final private string $name,
+        final private string $platform,
+        final private ?string $region,
     ) {
     }
 
@@ -16,9 +18,19 @@ final readonly class GameReplacedTitle
     #[\NoDiscard]
     public static function fromArray(array $row): self
     {
+        $region = $row['region'] ?? null;
+        if ($region !== null) {
+            $region = ((string) $region) |> trim(...);
+            if ($region === '') {
+                $region = null;
+            }
+        }
+
         return new self(
             (int) ($row['id'] ?? 0),
-            (string) ($row['name'] ?? '')
+            (string) ($row['name'] ?? ''),
+            (string) ($row['platform'] ?? ''),
+            $region
         );
     }
 
@@ -30,5 +42,15 @@ final readonly class GameReplacedTitle
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getPlatform(): string
+    {
+        return $this->platform;
+    }
+
+    public function getRegion(): ?string
+    {
+        return $this->region;
     }
 }

--- a/wwwroot/classes/GameHeaderService.php
+++ b/wwwroot/classes/GameHeaderService.php
@@ -197,7 +197,9 @@ readonly class GameHeaderService
             <<<SQL
             SELECT
                 tt.id,
-                tt.`name`
+                tt.`name`,
+                tt.platform,
+                ttm.region
             FROM
                 trophy_title tt
                 JOIN trophy_title_meta ttm ON ttm.np_communication_id = tt.np_communication_id
@@ -205,6 +207,8 @@ readonly class GameHeaderService
                 {$obsoleteIdCondition}
             ORDER BY
                 tt.`name`,
+                tt.platform,
+                ttm.region,
                 tt.id
             SQL
         );

--- a/wwwroot/game_header.php
+++ b/wwwroot/game_header.php
@@ -210,9 +210,21 @@ $escapedPlayer = isset($player) ? Html::escape((string) $player) : null;
                                         if ($encodedPlayer !== null) {
                                             $replacedTitleLink .= '/' . $encodedPlayer;
                                         }
+
+                                        $region = $replacedTitle->getRegion();
                                         ?>
                                         <li>
-                                            <a class="dropdown-item" href="/game/<?= $replacedTitleLink; ?>"><?= Html::escape($replacedTitle->getName()); ?></a>
+                                            <a class="dropdown-item" href="/game/<?= $replacedTitleLink; ?>">
+                                                <?= Html::escape($replacedTitle->getName()); ?>
+                                                <span class="badge rounded-pill text-bg-primary"><?= Html::escape($replacedTitle->getPlatform()); ?></span>
+                                                <?php
+                                                if ($region !== null) {
+                                                    ?>
+                                                    <span class="badge rounded-pill text-bg-primary"><?= Html::escape($region); ?></span>
+                                                    <?php
+                                                }
+                                                ?>
+                                            </a>
                                         </li>
                                         <?php
                                     }


### PR DESCRIPTION
### Motivation

- Ensure `GameReplacedTitle` carries the same `platform`/`region` metadata as `GameHeaderStack` so replaced-title items can show the same contextual badges in the UI.  
- Make replaced-title ordering deterministic by including `platform`/`region` in the query ordering.  

### Description

- Add `platform` and nullable `region` properties to `GameReplacedTitle`, normalize blank region to `null` in `fromArray`, and add `getPlatform()` and `getRegion()` accessors.  
- Update `GameHeaderService::fetchReplacedTitles()` to select `tt.platform` and `ttm.region` and include them in the `ORDER BY` clause.  
- Render platform and (when present) region badges for each item in the Replaces dropdown in `wwwroot/game_header.php`, matching how stacks are displayed.  
- Update `tests/GameHeaderServiceTest.php` to assert the replaced-title `platform` and `region` values are populated.  

### Testing

- Ran PHP syntax checks with `php -l` on the modified files and there were no syntax errors.  
- Ran the full test suite with `php tests/run.php`; the suite executed successfully except for two unrelated rate-limit tests that failed: `IpRateLimitServiceTest::testCheckAndRecordBlocksRequestsAboveLimit` and `PlayerQueueControllerTest::testHandleQueuePositionReturnsRateLimitedResponseWhenIpLimitExceeded`.  
- The modified unit test (`GameHeaderServiceTest`) passes locally as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a895e49ef88832fb4240c1b5ea30ea3)