### PR TITLE
Fix queue-poll rate limit tests

### DIFF
--- a/tests/IpRateLimitServiceTest.php
+++ b/tests/IpRateLimitServiceTest.php
@@ -39,7 +39,7 @@ final class IpRateLimitServiceTest extends TestCase
 
     public function testCheckAndRecordBlocksRequestsAboveLimit(): void
     {
-        for ($index = 0; $index < 60; $index++) {
+        for ($index = 0; $index < 120; $index++) {
             (void) $this->service->checkAndRecord('192.0.2.11', IpRateLimitBucket::QueuePoll);
         }
 

--- a/tests/PlayerQueueControllerTest.php
+++ b/tests/PlayerQueueControllerTest.php
@@ -128,7 +128,7 @@ final class PlayerQueueControllerTest extends TestCase
         $handler = new PlayerQueueHandlerSpy(PlayerQueueResponse::complete('unused'));
         $controller = new PlayerQueueController($handler, $rateLimitService);
 
-        for ($index = 0; $index < 60; $index++) {
+        for ($index = 0; $index < 120; $index++) {
             $controller->handleQueuePosition(['q' => 'QueueUser', 'poll_token' => 'token'], ['REMOTE_ADDR' => '192.0.2.44']);
         }
 


### PR DESCRIPTION
### Motivation

- Two tests were failing because they assumed a 60-request allowance for the queue-poll bucket while the production limits use a 120-request window, causing off-by-one failures when asserting a blocked request.

### Description

- Updated `tests/IpRateLimitServiceTest.php` to exhaust the `QueuePoll` bucket by iterating 120 times instead of 60 before asserting the next request is blocked.
- Updated `tests/PlayerQueueControllerTest.php` to perform 120 poll requests in the rate-limit scenario before expecting the controller to return HTTP 429.

### Testing

- Ran `git diff --check` and `php -l` on the modified test files to verify no syntax or diff issues, both succeeded.
- Ran the full test suite with `php tests/run.php`, and all tests passed (1,096 tests).
- Verified that the rate-limit scenario assertions now exercise the configured `QueuePoll` limits and that the failing tests are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8961dc57e0832f9705e7738c6edde2)